### PR TITLE
Fix documentation typos, broken URLs, and inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Wingfoil simplifies receiving, processing and distributing streaming data across
 
 ## Features
 
-- **Fast**: Ultra-low latency and high throughput with a efficent [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) based execution engine.  
+- **Fast**: Ultra-low latency and high throughput with an efficient [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) based execution engine.  
 - **Simple and obvious to use**: Define your graph of calculations; Wingfoil manages its execution.  
 - **Multi-language**: currently available as a Rust crate and as a beta release, [python package](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil-python) with plans to add WASM/JavaScript/TypeScript support.
 - **Backtesting**: [Replay historical](https://docs.rs/wingfoil/latest/wingfoil/#historical-vs-realtime) data to backtest and optimise strategies.

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 publish = ["wingfoil", "crates-io"]
 license = "Apache-2.0"
 keywords = ["graph", "stream", "dag", "trading", "python"]
-homepage = "https://github.com/wingfoil-io/wingfoil/wingfoil-python"
+homepage = "https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil-python"
 documentation = "https://docs.rs/wingfoil-python"
 description = "python bindings for wingfoil - graph based stream processing framework"
 

--- a/wingfoil-python/README.md
+++ b/wingfoil-python/README.md
@@ -1,6 +1,6 @@
 # 🚀 Wingfoil
 
-Wingfoil is a **blazingly fast** [stream processing framework](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/benches/), highly scalable stream processing framework designed for **latency-critical** use cases such as electronic trading and real-time AI systems.
+Wingfoil is a **blazingly fast**, highly scalable [stream processing framework](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/benches/) designed for **latency-critical** use cases such as electronic trading and real-time AI systems.
 
 Wingfoil simplifies receiving, processing and distributing streaming data across your entire stack.
 
@@ -58,7 +58,7 @@ Produces this output:
 
 ### Building from source
 
-You can follow these instructions to [build from source](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil-python/build.md>).
+You can follow these instructions to [build from source](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil-python/build.md).
 
 ### Contact us
 

--- a/wingfoil-python/build.md
+++ b/wingfoil-python/build.md
@@ -11,7 +11,7 @@ sudo apt-get install python3-venv
 
 python3 -m venv ~/.venv
 
-# activate the virutal env
+# activate the virtual env
 
 source ~/.venv/bin/activate
 
@@ -20,7 +20,7 @@ source ~/.venv/bin/activate
 pip install patchelf
 pip install maturin
 
-# under virtual env, build the fluvial wheel
+# under virtual env, build the wingfoil wheel
 
 maturin develop --release
 

--- a/wingfoil/examples/async/README.md
+++ b/wingfoil/examples/async/README.md
@@ -1,7 +1,7 @@
 ## async / tokio integration
 
 In this example, we demonstrate wingfoil's integration with tokio / async.
-This makes building IO adapters at the the graph edge a breeze, giving 
+This makes building IO adapters at the graph edge a breeze, giving 
 the best of sync and async worlds.   
 
 Async streams are a useful abstraction for IO but are not as powerful or 
@@ -9,7 +9,7 @@ as easy to use for implementing complex business logic as wingfoil.  Async
 uses an implicit, depth first graph execution strategy.  In
 contrast wingfoil's explicit, breadth first graph execution algorithm, 
 is easier to reason about, encourages re-use and provides a more 
-structured and productive development environment.   Wingfoils 
+structured and productive development environment.   Wingfoil's
 explicit modelling of time with support for historical and realtime 
 modes, is also huge win in terms of productivity and ability to 
 backtest strategies over async streams.
@@ -19,7 +19,7 @@ The key methods here are produce_async which maps an async futures stream
 into a wingfoil stream and consume_async which takes a wingfoil stream
 and consumes it with a supplied async closure.
 
-This hybrid sync-async approach enforces clear seperation 
+This hybrid sync-async approach enforces clear separation 
 between IO and business logic, which can often be problematic in 
 async oriented systems.   
 

--- a/wingfoil/examples/breadth_first/README.md
+++ b/wingfoil/examples/breadth_first/README.md
@@ -6,7 +6,7 @@ In this example we illustrate the power of wingfoil's breadth-first graph execut
 algorithm and compare with ReactiveX's depth-first approach.   Depth first execution
 is also problematic for async streams.
 
-Also note that wingfoil's depth first approach, by constsuction, eliminates
+Also note that wingfoil's breadth first approach, by construction, eliminates
 "reactive glitches" (potential logic defects due to inconsistent intermediate state).
 See [StackOverflow](https://stackoverflow.com/questions/25139257/terminology-what-is-a-glitch-in-functional-reactive-programming-rx)
 and [Wikipedia](https://en.wikipedia.org/wiki/Reactive_programming#Glitches)

--- a/wingfoil/examples/rfq/README.md
+++ b/wingfoil/examples/rfq/README.md
@@ -3,7 +3,7 @@
 ## RFQ Example
 
 In this example, we sketch out a Request For Quote (RFQ) responder, receiving messages from [paradigm](https://www.paradigm.co/)
-over a an async websocket and using the demux pattern to ruote RFQs to pool of statically wired sub-graphs, where business 
+over an async websocket and using the demux pattern to route RFQs to pool of statically wired sub-graphs, where business 
 logic can be implemented to respond to them.
 
 This example can be run with:

--- a/wingfoil/src/lib.rs
+++ b/wingfoil/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Graph Execution
 
 //! Wingfoil abstracts away the details of how to co-ordinate the calculation of your
-//! application, parts of which may executing at different frequencies.
+//! application, parts of which may be executing at different frequencies.
 
 //! Only the nodes that actually require cycling are executed which allows wingfoil to
 //! efficiently scale to very large graphs.
@@ -51,7 +51,7 @@
 //!
 //! ## Historical vs RealTime
 //! Time is a first-class citizen in wingfoil.  Engine time is measured in nanoseconds from the
-//! [UNIX epoch](https://!en.wikipedia.org/wiki/Unix_time) and represented by a [NanoTime].
+//! [UNIX epoch](https://en.wikipedia.org/wiki/Unix_time) and represented by a [NanoTime].
 //!
 //! In this example we compare and contrast RealTime vs Historical RunMode.   RealTime is used for
 //! production deployment.   Historical is used for development, unit-testing, integration-testing
@@ -92,17 +92,17 @@
 //! immediately.   In both cases engine time advances by 1 second between each tick.
 //!
 #![doc = include_str!("../examples/order_book/README.md")]
-//! See the [order book example](https://github.com/wingfoil-io/wingfoil/blob/main/examples/order_book/) for more details.
+//! See the [order book example](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/order_book/) for more details.
 #![doc = include_str!("../examples/async/README.md")]
-//! See the [async example](https://github.com/wingfoil-io/wingfoil/blob/main/examples/async/) for more details.
+//! See the [async example](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/async/) for more details.
 #![doc = include_str!("../examples/breadth_first/README.md")]
-//! See the [breadth first example](https://github.com/wingfoil-io/wingfoil/blob/main/examples/breadth_first/) for more details.
+//! See the [breadth first example](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/breadth_first/) for more details.
 #![doc = include_str!("../examples/rfq/README.md")]
-//! See the [rfq example](https://github.com/wingfoil-io/wingfoil/blob/main/examples/rfq/) for more details.
+//! See the [rfq example](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/rfq/) for more details.
 //!
 //! ## Multithreading
 //!
-//! Wingfoils supports multi-threading to distribute workloads across cores.  The approach
+//! Wingfoil supports multi-threading to distribute workloads across cores.  The approach
 //! is to compose sub-graphs, each running in its own dedicated thread.
 //!
 //! ## Messaging
@@ -125,11 +125,11 @@
 //!  
 //! For best performance we recommend using **cheaply cloneable** types:
 //!
-//! - For small strings: [`arraystring`](https://!crates.io/crates/arraystring)
-//! - For small vectors: [`tinyvec`](https://!crates.io/crates/tinyvec)
+//! - For small strings: [`arraystring`](https://crates.io/crates/arraystring)
+//! - For small vectors: [`tinyvec`](https://crates.io/crates/tinyvec)
 //! - For larger or heap-allocated types:
-//!   - Use [`Rc<T>`](https://!doc.rust-lang.org/std/rc/struct.Rc.html) for single threaded contexts.
-//!   - Use [`Arc<T>`](https://!doc.rust-lang.org/std) for multithreaded contexts.
+//!   - Use [`Rc<T>`](https://doc.rust-lang.org/std/rc/struct.Rc.html) for single threaded contexts.
+//!   - Use [`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) for multithreaded contexts.
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
## Summary

- Fix 11 broken URLs (removed extra `!` characters, added missing `wingfoil/` path segments)
- Fix 10 typos across documentation files
- Fix 2 inconsistencies (duplicate phrase removed, corrected algorithm name)

## Test plan

- [x] Ran `cargo fmt` - passed
- [x] Ran `cargo clippy` - passed
- [ ] Verify GitHub URLs render correctly by clicking them
- [ ] Run `cargo doc --open` to verify Rust doc links