### PR TITLE
Add KDB+ adapter and bump to v2.0.0

### DIFF
--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -62,8 +62,7 @@ tinyvec = { version = "1.10.0", features = ["alloc"] }
 arrayvec = { version = "0.7", features = ["serde"] }
 criterion = {version = "0.8.1", features = ["async_tokio"]}
 quanta = "0.9.3"
-# https://github.com/rollo-b2c2/kdbplus/commit/1b9bf2dca1f8b71ca898ba2108d1f233e379e1aa
-kdbplus = { git = "https://github.com/rollo-b2c2/kdbplus.git/", rev = "1b9bf2dca1f8b71ca898ba2108d1f233e379e1aa",  features = ["ipc"] }
+kdb-plus-fixed = { version = "0.4.0", features = ["ipc"] }
 
 
 

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -15,7 +15,7 @@ use super::*;
 use crate::{RunFor, RunMode, nodes::*, types::*};
 use anyhow::{Context, Result};
 use derive_new::new;
-use kdbplus::ipc::{ConnectionMethod, K, QStream};
+use kdb_plus_fixed::ipc::{ConnectionMethod, K, QStream};
 use log::Level;
 use tokio::runtime::Runtime;
 

--- a/wingfoil/src/adapters/kdb/mod.rs
+++ b/wingfoil/src/adapters/kdb/mod.rs
@@ -52,7 +52,7 @@ pub use read::*;
 pub use write::*;
 
 /// Re-export kdbplus error type for convenience.
-pub use kdbplus::ipc::error::Error as KdbError;
+pub use kdb_plus_fixed::ipc::error::Error as KdbError;
 
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -4,9 +4,9 @@ use super::{KdbConnection, Sym, SymbolInterner};
 use crate::nodes::produce_async;
 use crate::types::*;
 use anyhow::{Result, bail};
-use kdbplus::ipc::error::Error as KdbError;
-use kdbplus::ipc::{ConnectionMethod, K, QStream};
-use kdbplus::qtype;
+use kdb_plus_fixed::ipc::error::Error as KdbError;
+use kdb_plus_fixed::ipc::{ConnectionMethod, K, QStream};
+use kdb_plus_fixed::qtype;
 use std::rc::Rc;
 
 /// Extension trait for extracting data from K objects.

--- a/wingfoil/src/adapters/kdb/write.rs
+++ b/wingfoil/src/adapters/kdb/write.rs
@@ -4,7 +4,7 @@ use super::KdbConnection;
 use crate::nodes::{FutStream, StreamOperators};
 use crate::types::*;
 use futures::StreamExt;
-use kdbplus::ipc::{ConnectionMethod, K, QStream};
+use kdb_plus_fixed::ipc::{ConnectionMethod, K, QStream};
 use std::pin::Pin;
 use std::rc::Rc;
 
@@ -133,7 +133,7 @@ where
 
             // Build insert query as K object: (insert; `tablename; values)
             let query = K::new_compound_list(vec![
-                K::new_string("insert".to_string(), kdbplus::qattribute::NONE),
+                K::new_string("insert".to_string(), kdb_plus_fixed::qattribute::NONE),
                 K::new_symbol(table_name.clone()),
                 full_row,
             ]);
@@ -170,7 +170,7 @@ impl<T: Element + Send + KdbSerialize + 'static> KdbWriteOperators<T> for dyn St
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kdbplus::qtype;
+    use kdb_plus_fixed::qtype;
 
     #[test]
     fn test_kdb_serialize_trait() {


### PR DESCRIPTION
## Summary

- Add KDB+ adapter for reading/writing kdb+ data with symbol string interning support
- Introduce `Burst<T>` type alias for `TinyVec<[T; 1]>` for burst-mode data
- Refactor active/passive upstream tracking to use bimap with improved error propagation
- Bump major version to 2.0.0 (wingfoil and wingfoil-python)
- Switch kdb dependency from pinned git fork to published `kdb-plus-fixed` crate

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy` is clean
- [ ] `cargo fmt --check` passes
- [ ] Python tests pass (`cd wingfoil-python && maturin develop && pytest`)