### PR TITLE
Clean up: consolidate borrow in feedback, update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,11 +15,11 @@ wingfoil/           # Core Rust library
     types.rs        # Core traits: Element, Node, MutableNode, Stream
     graph.rs        # Graph execution engine
     time.rs         # NanoTime (nanoseconds from UNIX epoch)
-    nodes/          # 27 node implementations (map, filter, fold, etc.)
-    adapters/       # I/O adapters (ZMQ, CSV, sockets)
+    nodes/          # 37 node implementations (map, filter, fold, etc.)
+    adapters/       # I/O adapters (CSV, sockets, KDB+, iterators)
     channel/        # Inter-node communication (kanal)
     queue/          # Data structures (TimeQueue, HashByRef)
-  examples/         # Usage examples (order_book, rfq, async, breadth_first)
+  examples/         # Usage examples (order_book, rfq, async, breadth_first, circuit_breaker, threading)
   benches/          # Criterion benchmarks
 
 wingfoil-python/    # PyO3 Python bindings

--- a/wingfoil/src/nodes/feedback.rs
+++ b/wingfoil/src/nodes/feedback.rs
@@ -24,8 +24,12 @@ impl<T: Element + Hash + Eq> StreamPeekRef<T> for FeedbackStream<T> {
 impl<T: Element + Hash + Eq> MutableNode for FeedbackStream<T> {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
         let mut ticked = false;
-        while self.queue.borrow().pending(state.time()) {
-            self.value = self.queue.borrow_mut().pop();
+        loop {
+            let mut q = self.queue.borrow_mut();
+            if !q.pending(state.time()) {
+                break;
+            }
+            self.value = q.pop();
             ticked = true;
         }
         Ok(ticked)


### PR DESCRIPTION
## Summary
- Replace `borrow()` + `borrow_mut()` with a single `borrow_mut()` per loop iteration in `FeedbackStream::cycle`
- Fix outdated root CLAUDE.md: node count (27→37), adapters list (removed non-existent ZMQ, added KDB+ and iterators), examples list (added circuit_breaker and threading)

## Test plan
- [x] `cargo test -p wingfoil -- feedback` — all 3 unit tests + 1 doctest pass
- [x] `cargo fmt` and `cargo clippy` clean