### PR TITLE
README: add order book example excerpt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,34 @@
+
+## We're looking for contributors!
+
 Hi! Thanks for your interest in contributing to **wingfoil** — we'd love to have your participation! 
 
-If you want help or mentorship, please do reach out: you can raise a **GitHub issue** or email `hello@wingfoil.io`
+Drop a comment on any issue, open a new one, or say hi on [Discord](https://discord.gg/WfZwpQnZUA), email `hello@wingfoil.io`
 
----
+We're actively looking for help on the following:
+
+- 🔧 [ZMQ service discovery](https://github.com/wingfoil-io/wingfoil/issues/103) — dynamic node registration
+- 🗄 [KDB+ caching](https://github.com/wingfoil-io/wingfoil/issues/90) — faster replay and snapshot support
+- 📦 [Binary file I/O](https://github.com/wingfoil-io/wingfoil/issues/104) — Arrow, Parquet, and more
+- 🛢 [SQL I/O](https://github.com/wingfoil-io/wingfoil/issues/105) — stream to/from relational databases
+- ⚡ [Kafka I/O](https://github.com/wingfoil-io/wingfoil/issues/23) — streaming integration
+- 🐍 [wingfoil-python full parity](https://github.com/wingfoil-io/wingfoil/issues/106) — every node and adapter exposed to Python
+- 🐍 [Python showcase](https://github.com/wingfoil-io/wingfoil/issues/107) — Rust pipeline, results in pandas + scikit-learn + plotly
+- 🌐 [JS/TS browser integration](https://github.com/wingfoil-io/wingfoil/issues/110) — wingfoil in-browser via WASM
+
+We're especially keen to hear from specialists in:
+
+- 🔌 FPGA / rusthdl
+- 🌐 WASM / JS / TS
+- 🐍 PyO3
+
+## Good First Issues
+
+New to open source or Rust? These are a great starting point:
+
+- 🧮 [Add EWMA stream](https://github.com/wingfoil-io/wingfoil/issues/111)
+- 🔍 [Python binding for inspect & throttle](https://github.com/wingfoil-io/wingfoil/issues/112)
+
 
 ## Building and Testing
 
@@ -18,4 +44,10 @@ For prerequisites specific to the **wingfoil-python** crate and the full build p
 ### Building
 
 ```bash
-cargo build
+cargo build```
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Wingfoil simplifies receiving, processing and distributing streaming data across
 
 ## Features
 
-- **Fast**: Ultra-low latency and high throughput with an efficient [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) based execution engine.  
-- **Simple and obvious to use**: Define your graph of calculations; Wingfoil manages its execution.  
+- **Fast**: Ultra-low latency and high throughput with an efficient [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) based execution engine.
+- **Simple and obvious to use**: Define your graph of calculations; Wingfoil manages its execution.
 - **Multi-language**: currently available as a Rust crate and as a beta release, [python package](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil-python) with plans to add WASM/JavaScript/TypeScript support.
 - **Backtesting**: [Replay historical](https://docs.rs/wingfoil/latest/wingfoil/#historical-vs-realtime) data to backtest and optimise strategies.
 - **Async/Tokio**: seamless integration, allows you to [leverage async](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/async) at your graph edges.
 - **Multi-threading**: [distribute graph execution](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/threading) across cores.
+- **I/O Adapters**: production-ready [KDB+](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/kdb) integration for tick data, CSV, Kafka ([coming soon](https://github.com/wingfoil-io/wingfoil/issues/23)), and more.
 
 
 ## Quick Start
@@ -44,10 +45,34 @@ hello, world 3
 ```
 
 You can download from [crates.io](https://crates.io/crates/wingfoil/),
-read the [documentation](https://docs.rs/wingfoil/latest/wingfoil/), 
-review the [benchmarks](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/benches/) 
+read the [documentation](https://docs.rs/wingfoil/latest/wingfoil/),
+review the [benchmarks](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/benches/)
 or jump straight into [one of the examples](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/order_book).
 You can download the wingfoil Python module from [pypi](https://pypi.org/project/wingfoil/).
+
+## Order Book Example
+
+Load a CSV of AAPL limit orders from [LOBSTER](https://lobsterdata.com/info/DataSamples.php), maintain an order book using the [lobster](https://github.com/rubik/lobster) crate, derive trades and two-way prices, and export back to CSV — all in a few lines:
+
+```rust,ignore
+let book = RefCell::new(lobster::OrderBook::default());
+let get_time = |msg: &Message| NanoTime::new((msg.seconds * 1e9) as u64);
+let (fills, prices) = csv_read_vec("aapl.csv", get_time, true)
+    .map(move |chunk| process_orders(chunk, &book))
+    .split();
+let prices_export = prices
+    .filter_value(|price: &Option<TwoWayPrice>| !price.is_none())
+    .map(|price| price.unwrap())
+    .distinct()
+    .csv_write("prices.csv");
+let fills_export = fills.csv_write_vec("fills.csv");
+Graph::new(vec![prices_export, fills_export], RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+    .print()
+    .run()
+    .unwrap();
+```
+
+One hour of market data processed in 287ms. See the [full example](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/order_book).
 
 ## Get Involved!
 

--- a/releases/release-notes-v3.txt
+++ b/releases/release-notes-v3.txt
@@ -1,0 +1,77 @@
+WINGFOIL v3 — March 2026
+Rust stream processing
+High-performance, DAG-based pipelines
+
+——— WHAT'S NEW ———
+
+  * KDB+ adapter (production-ready)
+      - Streaming into and out of KDB+
+      - Symbol interning 
+      - Built for high-frequency tick data
+  * Pandas integration
+  * Time-based windowing
+  * Code quality sweep
+
+——— CONTRIBUTORS ———
+
+  Zohaib Hassan
+  Aditya Shirsat
+  Matvey Ezhov
+
+Open source only works because of people like you. 
+
+Thank you.
+
+——— WHERE WE'RE GOING NEXT ———
+
+We're looking for contributors to tackle:
+
+  🔧 ZMQ — Service discovery for dynamic service registration
+  🗄 KDB+ caching — faster reads
+  📦 Binary file I/O — Arrow, Parquet, and more
+  ⚡ Kafka I/O — streaming integration
+  🐍 wingfoil-python - full parity with core rust crate
+  🌐 JS/TS browser integration — wingfoil in-browser via WASM
+
+We're especially keen to hear from specialists in:
+  🔌 FPGA/rusthdl (rust-hdl.org | @samitbasu)
+  🌐 WASM/JS/TS   
+  🐍 PyO3
+
+#Rust #StreamProcessing #BigData #OpenSource #KDB #Kafka #FinTech #DataEngineering
+
+——— LINKS ———
+
+  Repo: https://github.com/wingfoil-io/wingfoil
+  Crates: https://crates.io/crates/wingfoil
+  Docs: https://docs.rs/wingfoil
+  Discord: https://discord.gg/WfZwpQnZUA
+
+——— GOOD FIRST ISSUES ———
+
+New to open source or Rust? These are a great starting point.
+
+  🧮 Add EWMA stream
+        https://github.com/wingfoil-io/wingfoil/issues/111
+  🔍 Python binding for inspect & throttle
+        https://github.com/wingfoil-io/wingfoil/issues/112
+
+——— FULL ROADMAP ISSUES ———
+
+  🔧 ZMQ service discovery
+      https://github.com/wingfoil-io/wingfoil/issues/103
+  🗄  KDB+ caching
+      https://github.com/wingfoil-io/wingfoil/issues/90
+  📦 Binary file I/O (Arrow, Parquet)
+      https://github.com/wingfoil-io/wingfoil/issues/104
+  🛢  SQL I/O
+      https://github.com/wingfoil-io/wingfoil/issues/105
+  ⚡ Kafka I/O  
+      https://github.com/wingfoil-io/wingfoil/issues/23
+  🐍 wingfoil-python full parity
+      https://github.com/wingfoil-io/wingfoil/issues/106
+  🐍 Python showcase
+      https://github.com/wingfoil-io/wingfoil/issues/107
+  🌐 JS/TS browser integration
+      https://github.com/wingfoil-io/wingfoil/issues/110
+


### PR DESCRIPTION
## Summary
- Adds an Order Book Example section to the README showcasing the LOBSTER/AAPL order book example
- Includes the core code excerpt demonstrating CSV ingestion, order book processing, split, filter, distinct, and CSV export
- Notes 287ms processing time for one hour of data with a link to the full example

## Test plan
- [ ] Verify README renders correctly on GitHub