### PR TITLE
kdb_read: time-range filtering, chunking improvements, and integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Cargo.lock
 /target
 .vscode
+.idea
 flamegraph.svg
 .venv
 __pycache__

--- a/wingfoil-python/src/py_kdb.rs
+++ b/wingfoil-python/src/py_kdb.rs
@@ -109,7 +109,7 @@ pub fn py_kdb_read(
 ) -> PyStream {
     let conn = KdbConnection::new(host, port);
     let stream: Rc<dyn Stream<Burst<PyKdbRow>>> =
-        kdb_read::<PyKdbRow>(conn, query, time_col, chunk_size);
+        kdb_read::<PyKdbRow>(conn, query, time_col, None::<&str>, chunk_size);
 
     // Collapse burst to single row, convert to PyElement (dict)
     let collapsed = stream.collapse();

--- a/wingfoil/examples/kdb/main.rs
+++ b/wingfoil/examples/kdb/main.rs
@@ -90,7 +90,7 @@ fn main() -> Result<()> {
         .run(run_mode, run_for)?;
     let baseline = generate(num_rows);
     // read
-    let read = kdb_read(conn, query, time_col, chunk);
+    let read = kdb_read(conn, query, time_col, None::<&str>, chunk);
     // tie-out
     let check = validate(baseline, read);
     Graph::new(check, run_mode, run_for).run()?;

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -16,14 +16,23 @@ kdb/
 
 ### Reading from KDB+
 
-- `kdb_read()` - Execute a q query and stream results with time-based chunking
-  - Uses adaptive chunking to handle arbitrarily large result sets with bounded memory
+- `kdb_read_chunks()` - Primitive chunking function driven by a caller-supplied closure
+  - `FnMut(Option<usize>) -> Option<String>`: called before each chunk with last row count
+  - `None` on first call, `Some(n)` after each chunk; return `None` to stop
+  - Caller owns all query logic: offset arithmetic, date advancement, termination
+  - Use for splayed tables where you advance through date partitions manually
+- `kdb_read()` - Convenience wrapper over `kdb_read_chunks` with offset-based chunking
+  - Uses `(offset;N) sublist query` pagination to handle arbitrarily large result sets with bounded memory
   - Parameters:
     - `connection` - KDB connection configuration
     - `query` - Base q query (can include WHERE clauses)
-    - `time_col` - Name of the time column for chunking (time is extracted automatically)
+    - `time_col` - Name of the timestamp column; extracted per-row for stream ordering
+    - `date_col` - `Option<&str>`: name of the date partition column, or `None` for in-memory tables.
+      When `Some("date")`, injects `date within (start;end)` (bounded) or `date >= start` (unbounded)
+      into the query so KDB+ can prune irrelevant date partitions on disk.
     - `rows_per_chunk` - Maximum rows per query (controls memory usage)
   - Time is automatically extracted from the time column and propagated on-graph
+  - Date range is derived from `RunMode`/`RunFor` — no need to pass dates explicitly
 - `KdbDeserialize` trait - Convert KDB+ rows to Rust types
   - **IMPORTANT**: Do NOT extract the time column - it's handled automatically
   - Your struct should only contain business data (sym, price, qty, etc.)
@@ -157,18 +166,19 @@ The `kdb_read()` function uses time-based chunking to handle large result sets:
 - Smaller chunks = more queries but less memory
 
 **Query construction:**
-- User query is wrapped as subquery: `select[N] from (user_query) where time >= start and time <= end`
+- Pagination uses `select[offset,N] ...` — the offset/count hint is injected directly into the
+  `select` statement so KDB+ applies it at scan time (no materialisation of the full result)
+- Falls back to `(offset;N) sublist query` for non-`select` queries (exec, functional forms, etc.)
+- Optionally injects a date partition filter into the base query before pagination:
+  - `RunFor::Duration` → `date within (start_date;end_date)` (bounded)
+  - `RunFor::Forever` or `RunFor::Cycles` → `date >= start_date` (no upper bound)
 - Preserves existing WHERE clauses, joins, and other query logic
-- Time-based filtering leverages KDB+'s time column indexing for efficiency
 
 **Example:**
 ```rust
-// Read 1M rows with 10K row chunks (bounded ~10 MB memory)
-// Note: Trade struct does not contain time field
-let stream = kdb_read(
-    conn,
-    "select from trades where sym=`AAPL",
-    "time",    // Time column name - extracted automatically
-    10000      // 10K rows per chunk
-);
+// In-memory table: no date filter
+let stream = kdb_read(conn.clone(), "select from trades where sym=`AAPL", "time", None::<&str>, 10000);
+
+// Splayed/partitioned table: inject date filter for partition pruning
+let stream = kdb_read(conn, "select from trades", "time", Some("date"), 10000);
 ```

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -5,7 +5,7 @@
 //! ```
 //! The tests are disabled by default and require this feature flag to enable:
 //! ```
-//! cargo test kdb::integration_tests  --features kdb-integration-test -p wingfoil -- --test-threads=1 --no-capture
+//! RUST_LOG=INFO cargo test kdb::integration_tests  --features kdb-integration-test -p wingfoil -- --test-threads=1 --no-capture
 //! ```
 //!
 //!
@@ -16,10 +16,15 @@ use crate::{RunFor, RunMode, nodes::*, types::*};
 use anyhow::{Context, Result};
 use derive_new::new;
 use kdb_plus_fixed::ipc::{ConnectionMethod, K, QStream};
-use log::Level;
+use log::{Level, LevelFilter};
 use tokio::runtime::Runtime;
 
+/// Read tests table: (date, time, sym, price, qty)
 const TABLE_NAME: &str = "test_trades";
+/// Write tests table: (time, sym, price, qty) — no date, since kdb_write only prepends time
+const WRITE_TABLE_NAME: &str = "test_trades_write";
+/// Date-filter tests table: (date, time, sym, price, qty)
+const DATED_TABLE_NAME: &str = "test_trades_dated";
 
 #[derive(Debug, Clone, Default)]
 pub struct TestTrade {
@@ -45,10 +50,60 @@ impl KdbDeserialize for TestTrade {
         interner: &mut SymbolInterner,
     ) -> Result<Self, KdbError> {
         Ok(TestTrade {
-            // Skip column 0 (time) - it's handled by the adapter
+            // col 0: date (skip), col 1: time (handled by adapter)
+            sym: row.get_sym(2, interner)?,
+            price: row.get(3)?.get_float()?,
+            qty: row.get(4)?.get_long()?,
+        })
+    }
+}
+
+/// TestTrade variant for the write table, which has no date column: (time, sym, price, qty).
+#[derive(Debug, Clone, Default)]
+pub struct TestTradeWrite {
+    sym: Sym,
+    price: f64,
+    qty: i64,
+}
+
+impl KdbDeserialize for TestTradeWrite {
+    fn from_kdb_row(
+        row: Row<'_>,
+        _columns: &[String],
+        interner: &mut SymbolInterner,
+    ) -> Result<Self, KdbError> {
+        Ok(TestTradeWrite {
+            // col 0: time (handled by adapter)
             sym: row.get_sym(1, interner)?,
             price: row.get(2)?.get_float()?,
             qty: row.get(3)?.get_long()?,
+        })
+    }
+}
+
+/// Trade struct for tables with an explicit date column: (date, time, sym, price, qty).
+///
+/// Used to test date-partitioned table reads where the schema includes a `date` column
+/// before the `time` column (e.g., splayed tables or in-memory tables with a date column).
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct TestTradeDate {
+    sym: Sym,
+    price: f64,
+    qty: i64,
+}
+
+impl KdbDeserialize for TestTradeDate {
+    fn from_kdb_row(
+        row: Row<'_>,
+        _columns: &[String],
+        interner: &mut SymbolInterner,
+    ) -> Result<Self, KdbError> {
+        Ok(TestTradeDate {
+            // col 0: date (skip), col 1: time (adapter handles)
+            sym: row.get_sym(2, interner)?,
+            price: row.get(3)?.get_float()?,
+            qty: row.get(4)?.get_long()?,
         })
     }
 }
@@ -96,25 +151,56 @@ impl TestDataBuilder {
         Ok(())
     }
 
+    /// Create the read table with a date column: (date, time, sym, price, qty).
     async fn create_table(&self) -> Result<()> {
         self.execute(&format!(
-            "{}:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())",
+            "{}:([]date:`date$();time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())",
             TABLE_NAME
         ))
         .await?;
         Ok(())
     }
 
-    async fn write_rows(&self, n: usize, sorted: bool) -> Result<()> {
-        // Generate timestamps - sorted uses til, unsorted uses neg n?n to shuffle
-        let time_expr = if sorted {
-            format!("til {}", n)
+    /// Insert rows into TABLE_NAME, parameterised by records per day and number of days.
+    ///
+    /// For sorted data, timestamps ascend within each day and days are in calendar order.
+    /// For unsorted data, all rows land on 2000.01.01 with shuffled nanosecond offsets
+    /// (sufficient to trigger the adapter's time-ordering check).
+    async fn write_rows(
+        &self,
+        records_per_day: usize,
+        num_days: usize,
+        sorted: bool,
+    ) -> Result<()> {
+        let n = records_per_day * num_days;
+        let (date_expr, time_expr) = if sorted {
+            (
+                // Each date repeated records_per_day times, num_days dates in order
+                format!(
+                    "raze {{{}#2000.01.01+x}} each til {}",
+                    records_per_day, num_days
+                ),
+                // Within each day d: evenly distribute records across 24 hours so that
+                // timestamps never spill into the next day regardless of records_per_day.
+                // Interval = floor(86400s / records_per_day) in nanoseconds.
+                format!(
+                    "raze {{(`timestamp$2000.01.01+x)+(86400000000000j div {}j)*til {}}} each til {}",
+                    records_per_day, records_per_day, num_days
+                ),
+            )
         } else {
-            format!("neg {}?{}", n, n)
+            (
+                // All rows on the same date; shuffled timestamps will go backwards
+                format!("{}#2000.01.01", n),
+                format!("2000.01.01D00:00:00.000000000+1000000000j*neg {}?{}", n, n),
+            )
         };
         let query = format!(
-            "insert[`{};(2000.01.01D00:00:00.000000000+1000000000*{};{}?`AAPL`GOOG`MSFT;{}?100.0;{}?1000j)]",
-            TABLE_NAME, time_expr, n, n, n
+            "insert[`{table};({dates};{times};{n}?`AAPL`GOOG`MSFT;{n}?100.0;{n}?1000j)]",
+            table = TABLE_NAME,
+            dates = date_expr,
+            times = time_expr,
+            n = n,
         );
         self.execute(&query).await?;
         Ok(())
@@ -126,10 +212,64 @@ impl TestDataBuilder {
         Ok(())
     }
 
-    fn setup(&self, n: usize, sorted: bool) -> Result<()> {
+    /// Create the write table without a date column: (time, sym, price, qty).
+    async fn create_write_table(&self) -> Result<()> {
+        self.execute(&format!(
+            "{}:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())",
+            WRITE_TABLE_NAME
+        ))
+        .await?;
+        Ok(())
+    }
+
+    /// Insert `n` sorted rows into WRITE_TABLE_NAME (for write-append test setup).
+    async fn write_rows_to_write_table(&self, n: usize) -> Result<()> {
+        let query = format!(
+            "insert[`{table};(2000.01.01D00:00:00.000000000+1000000000j*til {n};{n}?`AAPL`GOOG`MSFT;{n}?100.0;{n}?1000j)]",
+            table = WRITE_TABLE_NAME,
+            n = n,
+        );
+        self.execute(&query).await?;
+        Ok(())
+    }
+
+    async fn drop_write_table(&self) -> Result<()> {
+        self.execute(&format!("delete {} from `.", WRITE_TABLE_NAME))
+            .await?;
+        Ok(())
+    }
+
+    /// Create a table with an explicit date column: (date, time, sym, price, qty).
+    /// Used to test date partition filtering without requiring a true splayed DB on disk.
+    async fn create_dated_table(&self) -> Result<()> {
+        self.execute(&format!(
+            "{}:([]date:`date$();time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())",
+            DATED_TABLE_NAME
+        ))
+        .await
+    }
+
+    /// Insert `n` rows into the dated table on the given q date literal (e.g. `"2000.01.01"`).
+    /// Timestamps are at midnight + 0s, 1s, 2s, ... on that date.
+    async fn write_rows_on_date(&self, date_q: &str, n: usize) -> Result<()> {
+        let query = format!(
+            "insert[`{table};({n}#{date};{date}D00:00:00.000000000+1000000000j*til {n};{n}?`AAPL`GOOG`MSFT;{n}?100.0;{n}?1000j)]",
+            table = DATED_TABLE_NAME,
+            n = n,
+            date = date_q,
+        );
+        self.execute(&query).await
+    }
+
+    async fn drop_dated_table(&self) -> Result<()> {
+        self.execute(&format!("delete {} from `.", DATED_TABLE_NAME))
+            .await
+    }
+
+    fn setup(&self, records_per_day: usize, num_days: usize, sorted: bool) -> Result<()> {
         self.tokio.block_on(async {
             self.create_table().await?;
-            self.write_rows(n, sorted).await?;
+            self.write_rows(records_per_day, num_days, sorted).await?;
             Ok(())
         })
     }
@@ -139,16 +279,76 @@ impl TestDataBuilder {
     }
 }
 
-fn with_test_data<F>(n: usize, sorted: bool, test: F) -> anyhow::Result<()>
+fn with_test_data<F>(
+    records_per_day: usize,
+    num_days: usize,
+    sorted: bool,
+    test: F,
+) -> anyhow::Result<()>
 where
     F: FnOnce(usize, KdbConnection) -> anyhow::Result<()>,
 {
     let conn = TestDataBuilder::connection();
     let rt = tokio::runtime::Runtime::new()?;
     let builder = TestDataBuilder::new(conn.clone(), rt);
-    builder.setup(n, sorted)?;
-    let test_result = test(n, conn);
+    builder.setup(records_per_day, num_days, sorted)?;
+    let test_result = test(records_per_day * num_days, conn);
     let teardown_result = builder.teardown();
+    test_result?;
+    teardown_result?;
+    Ok(())
+}
+
+/// Helper: creates a dated table, populates it with `rows_per_day` rows on each of the
+/// given `dates` (q date literals like `"2000.01.01"`), runs the test, then drops the table.
+fn with_dated_test_data<F>(rows_per_day: usize, dates: &[&str], test: F) -> anyhow::Result<()>
+where
+    F: FnOnce(KdbConnection) -> anyhow::Result<()>,
+{
+    let conn = TestDataBuilder::connection();
+    let rt = tokio::runtime::Runtime::new()?;
+    let builder = TestDataBuilder::new(conn.clone(), rt);
+    builder.tokio.block_on(async {
+        builder.create_dated_table().await?;
+        for &date in dates {
+            builder.write_rows_on_date(date, rows_per_day).await?;
+        }
+        Ok::<_, anyhow::Error>(())
+    })?;
+    let test_result = test(conn);
+    let teardown_result = builder.tokio.block_on(builder.drop_dated_table());
+    test_result?;
+    teardown_result?;
+    Ok(())
+}
+
+/// Helper: creates an empty TABLE_NAME (with date column), runs the test, then drops it.
+fn with_empty_table<F>(test: F) -> Result<()>
+where
+    F: FnOnce(KdbConnection) -> Result<()>,
+{
+    let conn = TestDataBuilder::connection();
+    let rt = tokio::runtime::Runtime::new()?;
+    let builder = TestDataBuilder::new(conn.clone(), rt);
+    builder.tokio.block_on(builder.create_table())?;
+    let test_result = test(conn);
+    let teardown_result = builder.teardown();
+    test_result?;
+    teardown_result?;
+    Ok(())
+}
+
+/// Helper: creates an empty WRITE_TABLE_NAME (no date column), runs the test, then drops it.
+fn with_empty_write_table<F>(test: F) -> Result<()>
+where
+    F: FnOnce(KdbConnection) -> Result<()>,
+{
+    let conn = TestDataBuilder::connection();
+    let rt = tokio::runtime::Runtime::new()?;
+    let builder = TestDataBuilder::new(conn.clone(), rt);
+    builder.tokio.block_on(builder.create_write_table())?;
+    let test_result = test(conn);
+    let teardown_result = builder.tokio.block_on(builder.drop_write_table());
     test_result?;
     teardown_result?;
     Ok(())
@@ -157,13 +357,14 @@ where
 fn read(
     query: &str,
     time_col: &str,
-    n: usize,
+    records_per_day: usize,
+    num_days: usize,
     chunk_size: usize,
     sorted: bool,
 ) -> anyhow::Result<usize> {
     let mut count = 0;
-    with_test_data(n, sorted, |_n, conn| {
-        let trades = kdb_read::<TestTrade>(conn, query, time_col, chunk_size);
+    with_test_data(records_per_day, num_days, sorted, |n, conn| {
+        let trades = kdb_read::<TestTrade>(conn, query, time_col, None::<&str>, chunk_size);
         let collected = trades.collapse().logged("trades", Level::Info).collect();
         collected
             .clone()
@@ -182,8 +383,18 @@ bacon test -- --features kdb-integration-test -p wingfoil kdb::integration_tests
 #[test]
 fn test_kdb_sorted_data() -> Result<()> {
     let _ = env_logger::try_init();
-    let count = read(&format!("select from {}", TABLE_NAME), "time", 6, 2, true)?;
-    assert_eq!(count, 6, "Should read all 6 rows from sorted data");
+    let count = read(
+        &format!("select from {}", TABLE_NAME),
+        "time",
+        3, // records_per_day
+        2, // num_days
+        2, // chunk_size
+        true,
+    )?;
+    assert_eq!(
+        count, 6,
+        "Should read all 6 rows (3 per day × 2 days) from sorted data"
+    );
     Ok(())
 }
 
@@ -191,21 +402,26 @@ fn test_kdb_sorted_data() -> Result<()> {
 fn test_kdb_unsorted_data_fails() -> Result<()> {
     let _ = env_logger::try_init();
     // With unsorted data, the adapter detects time going backwards
-    let result = read(&format!("select from {}", TABLE_NAME), "time", 10, 3, false);
+    let result = read(
+        &format!("select from {}", TABLE_NAME),
+        "time",
+        5, // records_per_day
+        2, // num_days
+        3, // chunk_size
+        false,
+    );
     assert!(
         result.is_err(),
         "Unsorted data should cause time ordering error"
     );
     let err = result.unwrap_err();
     let err_msg = format!("{:?}", err);
+    // Unsorted data is caught either by the KDB adapter (within a chunk → "not sorted by time"
+    // + "xasc" hint) or by the graph engine (between chunks → "time less than graph time").
+    // Both are valid detections of the same underlying problem.
     assert!(
-        err_msg.contains("not sorted by time"),
-        "Expected unsorted data error, got: {}",
-        err_msg
-    );
-    assert!(
-        err_msg.contains("xasc"),
-        "Error should suggest using xasc to sort, got: {}",
+        err_msg.contains("not sorted by time") || err_msg.contains("time less than graph time"),
+        "Expected time ordering error, got: {}",
         err_msg
     );
     println!("As expected, unsorted data caused error with helpful message");
@@ -226,7 +442,8 @@ impl KdbDeserialize for BadTrade {
         _interner: &mut SymbolInterner,
     ) -> Result<Self, KdbError> {
         Ok(BadTrade {
-            sym: row.get(1)?.get_long()?, // sym column is symbol, get_long will fail
+            // col 0: date (skip), col 1: time (handled by adapter), col 2: sym (symbol → get_long fails)
+            sym: row.get(2)?.get_long()?,
         })
     }
 }
@@ -234,11 +451,12 @@ impl KdbDeserialize for BadTrade {
 fn read_with_type<T: Element + Send + KdbDeserialize>(
     query: &str,
     time_col: &str,
-    n: usize,
+    records_per_day: usize,
+    num_days: usize,
     chunk_size: usize,
 ) -> anyhow::Result<()> {
-    with_test_data(n, true, |_n, conn| {
-        let stream = kdb_read::<T>(conn, query, time_col, chunk_size);
+    with_test_data(records_per_day, num_days, true, |_n, conn| {
+        let stream = kdb_read::<T>(conn, query, time_col, None::<&str>, chunk_size);
         let collected = stream.collapse().logged("trades", Level::Info).collect();
         collected.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
         Ok(())
@@ -248,7 +466,7 @@ fn read_with_type<T: Element + Send + KdbDeserialize>(
 #[test]
 fn test_kdb_bad_query() -> Result<()> {
     let _ = env_logger::try_init();
-    let result = read("select from nonexistent_table_xyz", "time", 6, 2, true);
+    let result = read("select from nonexistent_table_xyz", "time", 3, 2, 2, true);
     assert!(result.is_err(), "Bad query should return an error");
     let err_msg = format!("{:?}", result.unwrap_err());
     println!("Bad query error: {}", err_msg);
@@ -263,13 +481,14 @@ fn test_kdb_bad_query() -> Result<()> {
 #[test]
 fn test_kdb_bad_time_column() -> Result<()> {
     let _ = env_logger::try_init();
-    // The bad column name gets injected into the chunk query's WHERE clause,
-    // causing KDB to reject the entire query (not a "column not found" from our code).
+    // The time column name is injected into the WHERE clause as a time filter, so KDB+
+    // rejects the query with a -128 error when the column doesn't exist.
     let result = read(
         &format!("select from {}", TABLE_NAME),
         "nonexistent_col",
-        6,
-        2,
+        3, // records_per_day
+        2, // num_days
+        2, // chunk_size
         true,
     );
     assert!(result.is_err(), "Bad time column should return an error");
@@ -277,7 +496,7 @@ fn test_kdb_bad_time_column() -> Result<()> {
     println!("Bad time column error: {}", err_msg);
     assert!(
         err_msg.contains("kdb query failed"),
-        "Expected query failure from bad column, got: {}",
+        "Expected kdb query failed error, got: {}",
         err_msg
     );
     Ok(())
@@ -286,7 +505,13 @@ fn test_kdb_bad_time_column() -> Result<()> {
 #[test]
 fn test_kdb_deserialization_error() -> Result<()> {
     let _ = env_logger::try_init();
-    let result = read_with_type::<BadTrade>(&format!("select from {}", TABLE_NAME), "time", 6, 2);
+    let result = read_with_type::<BadTrade>(
+        &format!("select from {}", TABLE_NAME),
+        "time",
+        3, // records_per_day
+        2, // num_days
+        2, // chunk_size
+    );
     assert!(
         result.is_err(),
         "Type mismatch should return a deserialization error"
@@ -301,18 +526,115 @@ fn test_kdb_deserialization_error() -> Result<()> {
     Ok(())
 }
 
-fn read_rows(connection: KdbConnection, chunk_size: usize) -> Result<(u64, std::time::Duration)> {
+fn read_rows(
+    connection: KdbConnection,
+    chunk_size: usize,
+    log: bool,
+) -> Result<(u64, std::time::Duration)> {
     let start = std::time::Instant::now();
-    let trades = kdb_read::<TestTrade>(
+    let mut trades = kdb_read::<TestTrade>(
         connection,
         &format!("select from {}", TABLE_NAME),
         "time",
+        None::<&str>,
         chunk_size,
-    )
-    .count();
+    );
+    if log {
+        trades = trades.logged(">>", Level::Info)
+    };
+    let trades = trades.count();
     trades.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
     let count = trades.peek_value();
     Ok((count, start.elapsed()))
+}
+
+#[test]
+fn kdb_read_works() -> Result<()> {
+    let _ = env_logger::try_init();
+    with_test_data(5, 2, true, |_n, conn| {
+        let _ = read_rows(conn.clone(), 5, true)?;
+        Ok(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn kdb_read_splayed_works() -> Result<()> {
+    let _ = env_logger::try_init();
+    with_dated_test_data(3, &["2000.01.01", "2000.01.02"], |conn| {
+        let trades = kdb_read::<TestTradeDate>(
+            conn,
+            &format!("select from {}", DATED_TABLE_NAME),
+            "time",
+            Some("date"),
+            2, // chunk smaller than total rows to exercise multi-chunk reads
+        );
+        let trades = trades.logged(">>", Level::Info).count();
+        trades.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+        let count = trades.peek_value();
+        assert_eq!(count, 6, "Should read all 6 rows (3 per day × 2 days)");
+        Ok(())
+    })
+}
+
+#[test]
+fn kdb_read_splayed_from_to_multi_day() -> Result<()> {
+    let _ = env_logger::try_init();
+    // 9 rows: 3 per day on 2000.01.01, 2000.01.02, 2000.01.03 at t=0s, 1s, 2s.
+    // start = KDB epoch + 0.5s  → excludes row 1 (2000.01.01D00:00:00), includes rows 2–9
+    // end   = start + 2 days    → 2000.01.03D00:00:00.5, includes row 7, excludes rows 8–9
+    // Expected: rows 2–7 = 6 rows (truncated 1 at start, 2 at end)
+    with_dated_test_data(3, &["2000.01.01", "2000.01.02", "2000.01.03"], |conn| {
+        let trades = kdb_read::<TestTradeDate>(
+            conn,
+            &format!("select from {}", DATED_TABLE_NAME),
+            "time",
+            Some("date"),
+            10,
+        );
+        let trades = trades.logged(">>", Level::Info).count();
+        let start = NanoTime::from_kdb_timestamp(500_000_000); // 2000.01.01D00:00:00.5
+        trades.run(
+            RunMode::HistoricalFrom(start),
+            RunFor::Duration(std::time::Duration::from_secs(172_800)), // 2 days
+        )?;
+        let count = trades.peek_value();
+        assert_eq!(
+            count, 6,
+            "Should read 6 rows: first and last 2 truncated by start/end filter"
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn kdb_read_splayed_from_to() -> Result<()> {
+    let _ = env_logger::try_init();
+    // 6 rows total: day 1 at 00:00:00, 00:00:01, 00:00:02 and day 2 the same.
+    // start = 2000.01.01D00:00:01 → excludes row 1 (truncates 1 from start)
+    // end   = start + 12h        → 2000.01.01D12:00:01, excludes all 3 day-2 rows (truncates 3 from end)
+    // Expected: rows 2–3 = 2 rows
+    with_dated_test_data(3, &["2000.01.01", "2000.01.02"], |conn| {
+        let trades = kdb_read::<TestTradeDate>(
+            conn,
+            &format!("select from {}", DATED_TABLE_NAME),
+            "time",
+            Some("date"),
+            10,
+        );
+        let trades = trades.logged(">>", Level::Info).count();
+        let start = NanoTime::from_kdb_timestamp(1_000_000_000); // 2000.01.01D00:00:01
+        trades.run(
+            RunMode::HistoricalFrom(start),
+            RunFor::Duration(std::time::Duration::from_secs(43200)), // 12 hours
+        )?;
+        let count = trades.peek_value();
+        assert_eq!(
+            count, 2,
+            "Row 1 truncated by start, all 3 day-2 rows truncated by end"
+        );
+        Ok(())
+    })
 }
 
 #[test]
@@ -321,10 +643,11 @@ fn test_read_read_perf() -> Result<()> {
     cargo flamegraph --open --unit-test -p wingfoil --features kdb-integration-test -- kdb::integration_tests::test_read_read_perf --nocapture
     cargo test --release  -p wingfoil --features kdb-integration-test -- kdb::integration_tests::test_read_read_perf --nocapture
      */
-    let _ = env_logger::try_init();
-    let n = 1_000_000;
+    log::set_max_level(LevelFilter::Off);
+    let records_per_day = 100_000;
+    let num_days = 10;
 
-    with_test_data(n, true, |n, conn| {
+    with_test_data(records_per_day, num_days, true, |n, conn| {
         let chunk_sizes = [
             //100,
             1_000, 10_000, 100_000, 1_000_000, 10_000_000,
@@ -334,7 +657,7 @@ fn test_read_read_perf() -> Result<()> {
         println!("{}", "-".repeat(45));
 
         for &chunk_size in &chunk_sizes {
-            let (count, elapsed) = read_rows(conn.clone(), chunk_size)?;
+            let (count, elapsed) = read_rows(conn.clone(), chunk_size, false)?;
             assert_eq!(count as usize, n);
             println!("{:<15} {:?}", chunk_size, elapsed);
         }
@@ -350,14 +673,152 @@ fn test_kdb_connection_refused() {
     // Connection failure currently panics in the channel layer (kanal_chan recv().unwrap())
     // rather than propagating as a clean Err. This test documents that behavior.
     let conn = KdbConnection::new("localhost", 59999);
-    let stream = kdb_read::<TestTrade>(conn, &format!("select from {}", TABLE_NAME), "time", 100);
+    let stream = kdb_read::<TestTrade>(
+        conn,
+        &format!("select from {}", TABLE_NAME),
+        "time",
+        None::<&str>,
+        100,
+    );
     let collected = stream.collapse().collect();
     let _ = collected.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever);
 }
 
+#[test]
+fn test_kdb_empty_table_returns_zero_rows() -> Result<()> {
+    let _ = env_logger::try_init();
+    with_empty_table(|conn| {
+        let trades = kdb_read::<TestTrade>(
+            conn,
+            &format!("select from {}", TABLE_NAME),
+            "time",
+            None::<&str>,
+            1000,
+        );
+        let collected = trades.collapse().collect();
+        collected
+            .clone()
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+        let rows = collected.peek_value();
+        assert_eq!(rows.len(), 0, "Empty table should return 0 rows");
+        Ok(())
+    })
+}
+
+/// Test that `date_col=Some("date")` restricts results to the specified date partition,
+/// and `date_col=None` returns all rows regardless of date.
+///
+/// Uses an in-memory table with an explicit `date` column to simulate partitioned table
+/// behaviour without requiring a splayed database on disk.
+#[test]
+fn test_kdb_date_filter() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    // 3 rows on 2000-01-01 (kdb_date=0) and 3 rows on 2000-01-02 (kdb_date=1)
+    with_dated_test_data(3, &["2000.01.01", "2000.01.02"], |conn| {
+        // date_col=Some("date"), half-day duration starting at KDB epoch (2000-01-01):
+        //   start_kdb_date = 0, end_kdb_date = 0 → `date within (2000.01.01;2000.01.01)`
+        //   → only day-0 rows returned → 3 rows
+        let stream = kdb_read::<TestTradeDate>(
+            conn.clone(),
+            &format!("select from {}", DATED_TABLE_NAME),
+            "time",
+            Some("date"),
+            1000,
+        );
+        let collected = stream.collapse().collect();
+        collected.clone().run(
+            RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
+            RunFor::Duration(std::time::Duration::from_secs(43200)), // 0.5 day → end_date still day 0
+        )?;
+        let rows = collected.peek_value();
+        assert_eq!(
+            rows.len(),
+            3,
+            "date filter (2000.01.01;2000.01.01) should return 3 rows, got {}",
+            rows.len()
+        );
+
+        // date_col=None: no date filter → all 6 rows returned
+        let stream2 = kdb_read::<TestTradeDate>(
+            conn,
+            &format!("select from {}", DATED_TABLE_NAME),
+            "time",
+            None::<&str>,
+            1000,
+        );
+        let collected2 = stream2.collapse().collect();
+        collected2
+            .clone()
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+        let rows2 = collected2.peek_value();
+        assert_eq!(
+            rows2.len(),
+            6,
+            "no date filter should return all 6 rows, got {}",
+            rows2.len()
+        );
+
+        Ok(())
+    })
+}
+
+/// Test that `kdb_read_chunks` correctly advances through date partitions.
+///
+/// Uses a chunk size larger than the rows-per-date so each query returns a partial
+/// chunk, signalling to the closure that the date is exhausted and it should advance.
+#[test]
+fn test_kdb_read_chunks_date_advance() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    // 3 rows on each of 2 dates; chunk=10 ensures each query is partial (3 < 10)
+    with_dated_test_data(3, &["2000.01.01", "2000.01.02"], |conn| {
+        let dates = ["2000.01.01", "2000.01.02"];
+        let chunk = 10usize;
+        let mut di = 0usize;
+        let mut offset = 0usize;
+
+        let stream = kdb_read_chunks::<TestTradeDate, _>(
+            conn,
+            move |last_count| {
+                match last_count {
+                    None => {} // first call: use date[0], offset 0
+                    Some(n) if n < chunk => {
+                        // partial chunk: date exhausted
+                        di += 1;
+                        offset = 0;
+                    }
+                    Some(n) => offset += n, // full chunk: more rows on same date
+                }
+                if di >= dates.len() {
+                    return None;
+                }
+                Some(format!(
+                    "select[{},{}] from {} where date={}",
+                    offset, chunk, DATED_TABLE_NAME, dates[di]
+                ))
+            },
+            "time",
+        );
+
+        let collected = stream.collapse().collect();
+        collected
+            .clone()
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+        let rows = collected.peek_value();
+        assert_eq!(
+            rows.len(),
+            6,
+            "should read 3 rows × 2 dates = 6 rows, got {}",
+            rows.len()
+        );
+        Ok(())
+    })
+}
+
 // --- Write integration tests ---
 
-/// Helper: creates an empty table, writes trades via the graph, queries KDB to verify.
+/// Helper: creates an empty WRITE_TABLE_NAME, writes trades via the graph, queries KDB to verify.
 fn write_and_verify(conn: KdbConnection, trades: Vec<TestTrade>) -> Result<usize> {
     let n = trades.len();
 
@@ -377,7 +838,7 @@ fn write_and_verify(conn: KdbConnection, trades: Vec<TestTrade>) -> Result<usize
     });
 
     // Write to KDB
-    let writer = kdb_write(write_conn, TABLE_NAME, &stream);
+    let writer = kdb_write(write_conn, WRITE_TABLE_NAME, &stream);
     writer.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
 
     // Read back via raw KDB query to verify
@@ -392,7 +853,7 @@ fn write_and_verify(conn: KdbConnection, trades: Vec<TestTrade>) -> Result<usize
             &creds,
         )
         .await?;
-        let query = format!("count {}", TABLE_NAME);
+        let query = format!("count {}", WRITE_TABLE_NAME);
         let result = socket.send_sync_message(&query.as_str()).await?;
         let count = result.get_long()?;
         Ok::<i64, anyhow::Error>(count)
@@ -414,34 +875,23 @@ fn make_test_trades(n: usize) -> Vec<TestTrade> {
         .collect()
 }
 
-/// Helper: creates empty table, runs test, drops table.
-fn with_empty_table<F>(test: F) -> Result<()>
-where
-    F: FnOnce(KdbConnection) -> Result<()>,
-{
-    let conn = TestDataBuilder::connection();
-    let rt = tokio::runtime::Runtime::new()?;
-    let builder = TestDataBuilder::new(conn.clone(), rt);
-    builder.tokio.block_on(builder.create_table())?;
-    let test_result = test(conn);
-    let teardown_result = builder.teardown();
-    test_result?;
-    teardown_result?;
-    Ok(())
-}
-
 #[test]
 fn test_kdb_write_round_trip() -> Result<()> {
     let _ = env_logger::try_init();
     let trades = make_test_trades(5);
 
-    with_empty_table(|conn| {
+    with_empty_write_table(|conn| {
         let count = write_and_verify(conn.clone(), trades)?;
         assert_eq!(count, 5, "Should have written 5 trades");
 
         // Verify data correctness by reading back via kdb_read
-        let read_stream =
-            kdb_read::<TestTrade>(conn, &format!("select from {}", TABLE_NAME), "time", 10000);
+        let read_stream = kdb_read::<TestTradeWrite>(
+            conn,
+            &format!("select from {}", WRITE_TABLE_NAME),
+            "time",
+            None::<&str>,
+            10000,
+        );
         let collected = read_stream
             .collapse()
             .logged("readback", Level::Info)
@@ -466,8 +916,17 @@ fn test_kdb_write_round_trip() -> Result<()> {
 fn test_kdb_write_append() -> Result<()> {
     let _ = env_logger::try_init();
 
-    with_test_data(3, true, |_n, conn| {
-        // Table already has 3 rows from with_test_data
+    let conn = TestDataBuilder::connection();
+    let rt = tokio::runtime::Runtime::new()?;
+    let builder = TestDataBuilder::new(conn.clone(), rt);
+
+    // Create write table and pre-populate with 3 rows
+    builder.tokio.block_on(async {
+        builder.create_write_table().await?;
+        builder.write_rows_to_write_table(3).await
+    })?;
+
+    let test_result: anyhow::Result<()> = (|| {
         let new_trades = make_test_trades(2);
 
         // Write 2 more trades via the graph - use timestamps after existing data
@@ -485,7 +944,7 @@ fn test_kdb_write_append() -> Result<()> {
             }
         });
 
-        let writer = kdb_write(write_conn, TABLE_NAME, &stream);
+        let writer = kdb_write(write_conn, WRITE_TABLE_NAME, &stream);
         writer.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
 
         // Verify total count = 3 original + 2 new = 5
@@ -494,7 +953,7 @@ fn test_kdb_write_append() -> Result<()> {
             let creds = conn.credentials_string();
             let mut socket =
                 QStream::connect(ConnectionMethod::TCP, &conn.host, conn.port, &creds).await?;
-            let query = format!("count {}", TABLE_NAME);
+            let query = format!("count {}", WRITE_TABLE_NAME);
             let result = socket.send_sync_message(&query.as_str()).await?;
             result.get_long().map_err(anyhow::Error::new)
         })?;
@@ -502,5 +961,10 @@ fn test_kdb_write_append() -> Result<()> {
         assert_eq!(count, 5, "Should have 3 original + 2 appended = 5 rows");
         println!("Append test: 3 + 2 = {} rows", count);
         Ok(())
-    })
+    })();
+
+    let teardown_result = builder.tokio.block_on(builder.drop_write_table());
+    test_result?;
+    teardown_result?;
+    Ok(())
 }

--- a/wingfoil/src/adapters/kdb/mod.rs
+++ b/wingfoil/src/adapters/kdb/mod.rs
@@ -29,11 +29,12 @@
 //! let conn = KdbConnection::new("localhost", 5000)
 //!     .with_credentials("user", "pass");
 //!
-//! // Read with time-based chunking for memory-bounded streaming
+//! // Read with offset-based chunking for memory-bounded streaming
 //! kdb_read(
 //!     conn,
-//!     "select from trades where date=.z.d",
-//!     "time",                  // time column for chunking
+//!     "select from trades",
+//!     "time",                  // time column (extracted per-row for stream ordering)
+//!     Some("date"),            // date column for partition pruning (None for in-memory tables)
 //!     10000,                   // rows_per_chunk (controls memory usage)
 //! )
 //!     .map(|trades| trades.first().map(|t| t.price).unwrap_or(0.0))

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -7,6 +7,7 @@ use anyhow::{Result, bail};
 use kdb_plus_fixed::ipc::error::Error as KdbError;
 use kdb_plus_fixed::ipc::{ConnectionMethod, K, QStream};
 use kdb_plus_fixed::qtype;
+use log::info;
 use std::rc::Rc;
 
 /// Extension trait for extracting data from K objects.
@@ -281,57 +282,341 @@ pub trait KdbDeserialize: Sized {
     ) -> Result<Self, KdbError>;
 }
 
-/// Read data from a KDB+ database with time-based chunking to handle large result sets.
+/// Convert a [`NanoTime`] to a KDB date integer (days since 2000-01-01).
 ///
-/// This function connects to a KDB+ instance and streams data in chunks, ensuring
-/// bounded memory usage regardless of the total result size. It uses time-based
-/// pagination to read rows sequentially within the specified time range.
+/// KDB dates are i32 values counting days from the KDB epoch (2000-01-01).
+/// The Unix epoch (1970-01-01) is 10,957 days before the KDB epoch.
+fn nano_to_kdb_date(t: NanoTime) -> i32 {
+    let unix_days = (u64::from(t) / 1_000_000_000 / 86400) as i64;
+    (unix_days - 10957) as i32
+}
+
+/// Format a KDB date integer as a q date literal (`YYYY.MM.DD`).
 ///
-/// Start and end times are derived from the graph's [`RunMode`] and [`RunFor`]:
-/// - Start time comes from `RunMode::HistoricalFrom(t)` or current time for `RealTime`
-/// - End time is `start + duration` for `RunFor::Duration`, or unbounded otherwise
+/// Uses Howard Hinnant's civil_from_days algorithm.
+fn format_kdb_date(kdb_date: i32) -> String {
+    // Shift to days since 0000-03-01 (the reference point for this algorithm)
+    let z = kdb_date as i64 + 10957 + 719_468;
+    let era = if z >= 0 {
+        z / 146_097
+    } else {
+        (z - 146_096) / 146_097
+    };
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{}.{:02}.{:02}", y, m, d)
+}
+
+/// Format a KDB timestamp (nanoseconds since 2000-01-01) as a q timestamp literal.
 ///
-/// # Type Parameters
-/// * `T` - The record type, must implement `Element`, `Send`, and `KdbDeserialize`
+/// Produces the form `YYYY.MM.DDDhh:mm:ss.nnnnnnnnn`, which q parses as a timestamp atom.
+/// Handles timestamps before the KDB epoch (negative values) correctly via floor division.
+fn format_kdb_timestamp(kdb_nanos: i64) -> String {
+    const DAY_NANOS: i64 = 86_400_000_000_000;
+    let kdb_day = kdb_nanos.div_euclid(DAY_NANOS) as i32;
+    let time_nanos = kdb_nanos.rem_euclid(DAY_NANOS);
+    let h = time_nanos / 3_600_000_000_000;
+    let m = (time_nanos % 3_600_000_000_000) / 60_000_000_000;
+    let s = (time_nanos % 60_000_000_000) / 1_000_000_000;
+    let ns = time_nanos % 1_000_000_000;
+    format!(
+        "{}D{:02}:{:02}:{:02}.{:09}",
+        format_kdb_date(kdb_day),
+        h,
+        m,
+        s,
+        ns
+    )
+}
+
+/// Inject a timestamp range filter into a q query's WHERE clause.
+///
+/// Injects `time_col within (start;end)` (bounded) or `time_col >= start` (unbounded).
+/// Uses `0Wp` (KDB+ positive timestamp infinity) when `end` is `i64::MAX`, since that
+/// value is KDB+'s `0Wp` and must be written as such — not as a date literal.
+fn inject_time_filter(query: &str, time_col: &str, start: i64, end: Option<i64>) -> String {
+    let start_ts = format_kdb_timestamp(start);
+    let filter = match end {
+        Some(i64::MAX) => format!("{} within ({};0Wp)", time_col, start_ts),
+        Some(end_ts) => format!(
+            "{} within ({};{})",
+            time_col,
+            start_ts,
+            format_kdb_timestamp(end_ts)
+        ),
+        None => format!("{} >= {}", time_col, start_ts),
+    };
+    let lower = query.to_lowercase();
+    if lower.contains(" where ") {
+        format!("{}, {}", query, filter)
+    } else {
+        format!("{} where {}", query, filter)
+    }
+}
+
+/// Build a paginated q query using `select[offset,count]` syntax.
+///
+/// This injects the offset and row limit directly into the `select` statement so KDB+
+/// can apply them at scan time — avoiding the materialisation penalty of
+/// `(offset;count) sublist (full_query)`, where the inner query runs in full before
+/// the subset is taken.
+///
+/// Falls back to `sublist` for non-`select` queries (functional forms, `exec`, etc.).
+fn build_chunk_query(query: &str, offset: usize, rows_per_chunk: usize) -> String {
+    let trimmed = query.trim_start();
+    if trimmed
+        .get(..6)
+        .is_some_and(|s| s.eq_ignore_ascii_case("select"))
+    {
+        let after_select = trimmed[6..].trim_start();
+        if after_select.starts_with('[') {
+            // User already has select[...] — replace it with our offset/count
+            let close = after_select
+                .find(']')
+                .map(|i| i + 1)
+                .unwrap_or(after_select.len());
+            format!(
+                "select[{},{}] {}",
+                offset,
+                rows_per_chunk,
+                after_select[close..].trim_start()
+            )
+        } else {
+            format!("select[{},{}] {}", offset, rows_per_chunk, after_select)
+        }
+    } else {
+        // Fallback: sublist on non-select queries
+        format!("({};{}) sublist {}", offset, rows_per_chunk, query)
+    }
+}
+
+/// Inject a date partition filter into a q query's WHERE clause.
+///
+/// For splayed/partitioned KDB+ tables, this injects `date within (start;end)` (bounded)
+/// or `date >= start` (unbounded) so KDB+ can skip irrelevant date partitions on disk.
+///
+/// # Arguments
+/// * `query` - The base q query (may already contain a WHERE clause)
+/// * `date_col` - Name of the date column (typically `"date"`)
+/// * `start` - Start KDB date (inclusive), as days since 2000-01-01
+/// * `end` - End KDB date (inclusive), or `None` for no upper bound
+fn inject_date_filter(query: &str, date_col: &str, start: i32, end: Option<i32>) -> String {
+    let filter = match end {
+        Some(end_date) => format!(
+            "{} within ({};{})",
+            date_col,
+            format_kdb_date(start),
+            format_kdb_date(end_date)
+        ),
+        None => format!("{} >= {}", date_col, format_kdb_date(start)),
+    };
+    let lower = query.to_lowercase();
+    if lower.contains(" where ") {
+        format!("{}, {}", query, filter)
+    } else {
+        format!("{} where {}", query, filter)
+    }
+}
+
+/// Core streaming loop driven by a caller-supplied query closure.
+///
+/// Calls `query_fn(last_count)` before each chunk:
+/// - `None` on the first call
+/// - `Some(n)` on subsequent calls, where `n` is the row count returned by the previous query
+///
+/// Returns `None` to stop, or `Some(query_string)` to execute next.
+/// Also stops automatically when a query returns 0 rows.
+///
+/// `prev_time` is reset each chunk so time-of-day columns work correctly when
+/// advancing across date partitions (timestamps restart at midnight on each new date).
+fn chunk_stream<T>(
+    mut socket: QStream,
+    time_col: String,
+    mut query_fn: impl FnMut(Option<usize>) -> Option<String> + Send + 'static,
+) -> impl futures::Stream<Item = anyhow::Result<(NanoTime, T)>> + Send + 'static
+where
+    T: KdbDeserialize + Send + 'static,
+{
+    async_stream::stream! {
+        let mut last_count: Option<usize> = None;
+        let mut interner = SymbolInterner::default();
+
+        while let Some(query) = query_fn(last_count) {
+            let result: K = match socket.send_sync_message(&query.as_str()).await {
+                Ok(r) => r,
+                Err(e) => {
+                    yield Err(anyhow::Error::new(e).context(format!("KDB query failed: {}", query)));
+                    break;
+                }
+            };
+
+            let (columns, rows) = match (result.column_names(), result.rows()) {
+                (Ok(cols), Ok(rows)) => (cols, rows),
+                (Err(e), _) | (_, Err(e)) => {
+                    yield Err(anyhow::anyhow!("{}\nkdb query failed with\n{}", query, e));
+                    break;
+                }
+            };
+
+            let row_count = rows.len();
+            info!("KDB query: {} ({} records)", query, row_count);
+            if row_count == 0 {
+                break;
+            }
+
+            let time_col_idx = match columns.iter().position(|c| c == &time_col) {
+                Some(idx) => idx,
+                None => {
+                    yield Err(anyhow::anyhow!(
+                        "time column '{}' not found in result columns: {:?}",
+                        time_col, columns
+                    ));
+                    break;
+                }
+            };
+
+            let mut prev_time: Option<i64> = None;
+            let mut row_error = false;
+            for row in &rows {
+                let time_kdb = match row.get(time_col_idx).and_then(|v| v.get_long()) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        yield Err(anyhow::Error::new(e).context(format!("failed to extract time from KDB row: {}", query)));
+                        row_error = true;
+                        break;
+                    }
+                };
+
+                if let Some(prev) = prev_time
+                    && time_kdb < prev
+                {
+                    yield Err(anyhow::anyhow!(
+                        "KDB data is not sorted by time column '{}': got {} after {}. \
+                        Add `{} xasc` to your query to sort the data.\nQuery: {}",
+                        time_col, time_kdb, prev, time_col, query
+                    ));
+                    row_error = true;
+                    break;
+                }
+                prev_time = Some(time_kdb);
+
+                let time = NanoTime::from_kdb_timestamp(time_kdb);
+
+                let record = match T::from_kdb_row(row, &columns, &mut interner) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        yield Err(anyhow::Error::new(e).context(format!("KDB deserialization failed: {}", query)));
+                        row_error = true;
+                        break;
+                    }
+                };
+
+                yield Ok((time, record));
+            }
+            if row_error {
+                break;
+            }
+
+            last_count = Some(row_count);
+        }
+    }
+}
+
+/// Stream data from KDB+ using a caller-supplied query closure for full control over
+/// chunking strategy.
+///
+/// The closure receives `Option<usize>`:
+/// - `None` on the first call — return the initial query
+/// - `Some(n)` after each chunk — `n` is the row count from the last query
+///
+/// Return `Some(query_string)` to execute the next chunk, or `None` to stop.
+/// The stream also stops automatically when a query returns 0 rows.
+///
+/// This is the primitive that [`kdb_read`] is built on. Use it directly when you need
+/// query-level control, such as advancing through date partitions:
+///
+/// ```ignore
+/// let dates = vec!["2024.01.01", "2024.01.02"];
+/// let chunk = 10_000usize;
+/// let mut di = 0usize;
+/// let mut offset = 0usize;
+///
+/// kdb_read_chunks::<Trade, _>(conn, move |last_count| {
+///     match last_count {
+///         None => {}
+///         Some(n) if n < chunk => { di += 1; offset = 0; } // date exhausted, advance
+///         Some(n) => { offset += n; }                       // more on this date
+///     }
+///     if di >= dates.len() { return None; }
+///     Some(format!("select[{},{}] from trades where date={}", offset, chunk, dates[di]))
+/// }, "time")
+/// ```
+#[must_use]
+pub fn kdb_read_chunks<T, F>(
+    connection: KdbConnection,
+    query_fn: F,
+    time_col: impl Into<String>,
+) -> Rc<dyn Stream<Burst<T>>>
+where
+    T: Element + Send + KdbDeserialize + 'static,
+    F: FnMut(Option<usize>) -> Option<String> + Send + 'static,
+{
+    let time_col = time_col.into();
+    produce_async(move |_ctx| async move {
+        let creds = connection.credentials_string();
+        let socket = QStream::connect(
+            ConnectionMethod::TCP,
+            &connection.host,
+            connection.port,
+            &creds,
+        )
+        .await?;
+        Ok(chunk_stream::<T>(socket, time_col, query_fn))
+    })
+}
+
+/// Stream data from KDB+ using offset-based chunking with optional date partition filtering.
+///
+/// Builds a `select[offset,N]` query per chunk so KDB+ applies the row limit at scan time,
+/// avoiding materialisation of the full result. Implemented via [`kdb_read_chunks`].
+///
+/// Date filter is derived automatically from [`RunMode`] and [`RunFor`]:
+/// - `date_col = Some("date")` injects `date within (start;end)` for `RunFor::Duration`,
+///   or `date >= start` for `RunFor::Forever`, enabling KDB+ to prune date partitions.
+/// - `date_col = None` — no date filter (use for in-memory tables).
 ///
 /// # Arguments
 /// * `connection` - KDB connection configuration
-/// * `query` - The base q query to execute (e.g., "select from trades" or "select from trades where sym=`AAPL")
-/// * `time_col` - Name of the time column used for chunking (also used to extract time from rows)
-/// * `rows_per_chunk` - Maximum number of rows to fetch per query (controls memory usage)
-///
-/// # Memory Usage
-/// Memory usage is bounded by `rows_per_chunk`. For example, with 10,000 rows per chunk:
-/// - Small records (~100 bytes): ~1 MB per chunk
-/// - Large records (~1 KB): ~10 MB per chunk
-///
-/// # Returns
-/// A stream of records bundled by timestamp using TinyVec.
+/// * `query` - Base q query (e.g., `"select from trades"` or `"select from trades where sym=\`AAPL"`)
+/// * `time_col` - Timestamp column name; extracted per-row for stream ordering
+/// * `date_col` - Date partition column name, or `None` for in-memory tables
+/// * `rows_per_chunk` - Maximum rows per query (controls memory usage)
 ///
 /// # Example
 ///
 /// ```ignore
 /// let conn = KdbConnection::new("localhost", 5000);
 ///
-/// // Read trades - time range from RunMode/RunFor
-/// let stream = kdb_read(
-///     conn,
-///     "select from trades",           // Base query
-///     "time",                          // Time column name
-///     10000                            // 10K rows per chunk
-/// );
+/// // In-memory table
+/// let stream = kdb_read::<Trade>(conn.clone(), "select from trades", "time", None::<&str>, 10000);
 ///
-/// // Run with historical mode and duration
-/// stream.run(
-///     RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
-///     RunFor::Duration(Duration::from_secs(86400))  // 24 hours
-/// );
+/// // Splayed/partitioned table
+/// let stream = kdb_read::<Trade>(conn, "select from trades", "time", Some("date"), 10000);
+///
+/// stream.run(RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)), RunFor::Forever);
 /// ```
 #[must_use]
 pub fn kdb_read<T>(
     connection: KdbConnection,
     query: impl Into<String>,
     time_col: impl Into<String>,
+    date_col: Option<impl Into<String>>,
     rows_per_chunk: usize,
 ) -> Rc<dyn Stream<Burst<T>>>
 where
@@ -339,18 +624,30 @@ where
 {
     let query = query.into();
     let time_col = time_col.into();
+    let date_col = date_col.map(|d| d.into());
 
     produce_async(move |ctx| {
-        // Derive start/end times from RunParams
-        let start_time = ctx.start_time.to_kdb_timestamp();
-        let end_time = ctx.end_time().map(|t| t.to_kdb_timestamp());
+        let start_time = ctx.start_time;
+        // Cycles returns Err → no upper bound. Forever/Duration always inject an end filter.
+        let end_time = ctx.end_time().ok();
 
         async move {
-            let end_time = end_time?;
-            let creds = connection.credentials_string();
+            let base_query = {
+                let q = match &date_col {
+                    Some(dc) => {
+                        let start_kdb_date = nano_to_kdb_date(start_time);
+                        let end_kdb_date = end_time.map(nano_to_kdb_date);
+                        inject_date_filter(&query, dc, start_kdb_date, end_kdb_date)
+                    }
+                    None => query.clone(),
+                };
+                let start_kdb_ts = start_time.to_kdb_timestamp();
+                let end_kdb_ts = end_time.map(|t| t.to_kdb_timestamp());
+                inject_time_filter(&q, &time_col, start_kdb_ts, end_kdb_ts)
+            };
 
-            // Connect to KDB
-            let mut socket = QStream::connect(
+            let creds = connection.credentials_string();
+            let socket = QStream::connect(
                 ConnectionMethod::TCP,
                 &connection.host,
                 connection.port,
@@ -358,116 +655,17 @@ where
             )
             .await?;
 
-            // Stream rows in chunks
-            Ok(async_stream::stream! {
-                let mut current_time = start_time;
-                let mut interner = SymbolInterner::default();
-
-                loop {
-                    // Build chunk query with time constraint and row limit
-                    let chunk_query = format!(
-                        "select[{}] from ({}) where {} >= {}, {} <= {}",
-                        rows_per_chunk,
-                        query,
-                        time_col,
-                        current_time,
-                        time_col,
-                        end_time
-                    );
-
-                    let result: K = match socket.send_sync_message(&chunk_query.as_str()).await {
-                        Ok(r) => r,
-                        Err(e) => {
-                            yield Err(anyhow::Error::new(e).context(format!("KDB query failed: {}", chunk_query)));
-                            break;
-                        }
-                    };
-
-                    // Extract metadata once per chunk
-                    let (columns, rows) = match (result.column_names(), result.rows()) {
-                        (Ok(cols), Ok(rows)) => (cols, rows),
-                        (Err(e), _) | (_, Err(e)) => {
-                            yield Err(anyhow::anyhow!("{}\nkdb query failed with\n{}", chunk_query, e));
-                            break;
-                        }
-                    };
-
-                    let row_count = rows.len();
-                    if row_count == 0 {
-                        break;  // No more data
-                    }
-
-                    // Find time column index once per chunk
-                    let time_col_idx = match columns.iter().position(|c| c == &time_col) {
-                        Some(idx) => idx,
-                        None => {
-                            yield Err(anyhow::anyhow!("time column '{}' not found", time_col));
-                            break;
-                        }
-                    };
-
-                    // Process rows and track last timestamp
-                    let mut prev_time: Option<i64> = None;
-                    let mut last_time = current_time;
-                    let mut row_error = false;
-                    for row in &rows {
-                        // Extract time from KDB row directly
-                        let time_kdb = match row.get(time_col_idx).and_then(|v| v.get_long()) {
-                            Ok(t) => t,
-                            Err(e) => {
-                                yield Err(anyhow::Error::new(e).context("failed to extract time from KDB row"));
-                                row_error = true;
-                                break;
-                            }
-                        };
-
-                        // Check for unsorted data
-                        if let Some(prev) = prev_time
-                            && time_kdb < prev
-                        {
-                            yield Err(anyhow::anyhow!(
-                                "KDB data is not sorted by time column '{}': got {} after {}. \
-                                Add `{} xasc` to your query to sort the data.",
-                                time_col, time_kdb, prev, time_col
-                            ));
-                            row_error = true;
-                            break;
-                        }
-                        prev_time = Some(time_kdb);
-
-                        let time = NanoTime::from_kdb_timestamp(time_kdb);
-
-                        // Deserialize record (without time)
-                        let record = match T::from_kdb_row(row, &columns, &mut interner) {
-                            Ok(r) => r,
-                            Err(e) => {
-                                yield Err(anyhow::Error::new(e).context("KDB deserialization failed"));
-                                row_error = true;
-                                break;
-                            }
-                        };
-
-                        last_time = time_kdb;
-                        yield Ok((time, record));
-                    }
-                    if row_error {
-                        break;
-                    }
-
-                    // If we got fewer rows than requested, we're done
-                    if row_count < rows_per_chunk {
-                        break;
-                    }
-
-                    // Start next chunk right after the last row
-                    current_time = last_time + 1;
-
-                    // Safety check: don't go past end_time
-                    if current_time > end_time {
-                        break;
-                    }
+            let mut offset = 0usize;
+            let query_fn = move |last_count: Option<usize>| -> Option<String> {
+                match last_count {
+                    None => {}
+                    Some(n) if n < rows_per_chunk => return None,
+                    Some(n) => offset += n,
                 }
-            })
+                Some(build_chunk_query(&base_query, offset, rows_per_chunk))
+            };
+
+            Ok(chunk_stream::<T>(socket, time_col, query_fn))
         }
     })
 }
@@ -505,5 +703,176 @@ mod tests {
         // Test with values after KDB epoch
         let after_epoch = NanoTime::new(946_684_801_000_000_000); // 1 second after
         assert_eq!(after_epoch.to_kdb_timestamp(), 1_000_000_000);
+    }
+
+    #[test]
+    fn test_format_kdb_date() {
+        assert_eq!(format_kdb_date(0), "2000.01.01");
+        assert_eq!(format_kdb_date(1), "2000.01.02");
+        assert_eq!(format_kdb_date(31), "2000.02.01");
+        // 2000 is a leap year (366 days), so day 366 = 2001-01-01
+        assert_eq!(format_kdb_date(366), "2001.01.01");
+        assert_eq!(format_kdb_date(-1), "1999.12.31");
+        assert_eq!(format_kdb_date(-365), "1999.01.01");
+    }
+
+    #[test]
+    fn test_nano_to_kdb_date() {
+        // NanoTime::from_kdb_timestamp(0) = 2000-01-01 → kdb_date 0
+        let t = NanoTime::from_kdb_timestamp(0);
+        assert_eq!(nano_to_kdb_date(t), 0);
+
+        // One day later: 86400 seconds = 86_400_000_000_000 ns after KDB epoch
+        let t2 = NanoTime::from_kdb_timestamp(86_400_000_000_000);
+        assert_eq!(nano_to_kdb_date(t2), 1);
+
+        // NanoTime::ZERO = unix epoch (1970-01-01) = kdb_date -10957
+        assert_eq!(nano_to_kdb_date(NanoTime::ZERO), -10957);
+    }
+
+    #[test]
+    fn test_build_chunk_query_basic_select() {
+        let q = build_chunk_query("select from trades", 0, 10000);
+        assert_eq!(q, "select[0,10000] from trades");
+    }
+
+    #[test]
+    fn test_build_chunk_query_with_offset() {
+        let q = build_chunk_query("select from trades", 30000, 10000);
+        assert_eq!(q, "select[30000,10000] from trades");
+    }
+
+    #[test]
+    fn test_build_chunk_query_preserves_where_clause() {
+        let q = build_chunk_query("select from trades where sym=`AAPL", 0, 1000);
+        assert_eq!(q, "select[0,1000] from trades where sym=`AAPL");
+    }
+
+    #[test]
+    fn test_build_chunk_query_preserves_columns() {
+        let q = build_chunk_query("select price,qty from trades", 5000, 1000);
+        assert_eq!(q, "select[5000,1000] price,qty from trades");
+    }
+
+    #[test]
+    fn test_build_chunk_query_replaces_existing_bracket() {
+        // User accidentally passed select[5] — we replace it with our offset/count
+        let q = build_chunk_query("select[5] from trades", 0, 10000);
+        assert_eq!(q, "select[0,10000] from trades");
+    }
+
+    #[test]
+    fn test_build_chunk_query_case_insensitive() {
+        let q = build_chunk_query("SELECT FROM trades", 0, 100);
+        assert_eq!(q, "select[0,100] FROM trades");
+    }
+
+    #[test]
+    fn test_build_chunk_query_non_select_fallback() {
+        // exec and functional queries fall back to sublist
+        let q = build_chunk_query("exec price from trades", 0, 100);
+        assert_eq!(q, "(0;100) sublist exec price from trades");
+    }
+
+    #[test]
+    fn test_inject_date_filter_bounded_no_existing_where() {
+        let q = inject_date_filter("select from trades", "date", 0, Some(1));
+        assert_eq!(
+            q,
+            "select from trades where date within (2000.01.01;2000.01.02)"
+        );
+    }
+
+    #[test]
+    fn test_inject_date_filter_bounded_with_existing_where() {
+        let q = inject_date_filter("select from trades where sym=`AAPL", "date", 0, Some(1));
+        assert_eq!(
+            q,
+            "select from trades where sym=`AAPL, date within (2000.01.01;2000.01.02)"
+        );
+    }
+
+    #[test]
+    fn test_inject_date_filter_unbounded_no_existing_where() {
+        let q = inject_date_filter("select from trades", "date", 0, None);
+        assert_eq!(q, "select from trades where date >= 2000.01.01");
+    }
+
+    #[test]
+    fn test_inject_date_filter_unbounded_with_existing_where() {
+        let q = inject_date_filter("select from trades where sym=`AAPL", "date", 0, None);
+        assert_eq!(q, "select from trades where sym=`AAPL, date >= 2000.01.01");
+    }
+
+    #[test]
+    fn test_inject_date_filter_same_start_end() {
+        // Single-day filter
+        let q = inject_date_filter("select from trades", "date", 5, Some(5));
+        assert_eq!(
+            q,
+            "select from trades where date within (2000.01.06;2000.01.06)"
+        );
+    }
+
+    #[test]
+    fn test_format_kdb_timestamp_epoch() {
+        assert_eq!(format_kdb_timestamp(0), "2000.01.01D00:00:00.000000000");
+    }
+
+    #[test]
+    fn test_format_kdb_timestamp_one_second() {
+        assert_eq!(
+            format_kdb_timestamp(1_000_000_000),
+            "2000.01.01D00:00:01.000000000"
+        );
+    }
+
+    #[test]
+    fn test_format_kdb_timestamp_one_day() {
+        assert_eq!(
+            format_kdb_timestamp(86_400_000_000_000),
+            "2000.01.02D00:00:00.000000000"
+        );
+    }
+
+    #[test]
+    fn test_format_kdb_timestamp_before_epoch() {
+        assert_eq!(format_kdb_timestamp(-1), "1999.12.31D23:59:59.999999999");
+    }
+
+    #[test]
+    fn test_inject_time_filter_unbounded() {
+        let q = inject_time_filter("select from trades", "time", 0, None);
+        assert_eq!(
+            q,
+            "select from trades where time >= 2000.01.01D00:00:00.000000000"
+        );
+    }
+
+    #[test]
+    fn test_inject_time_filter_bounded() {
+        let q = inject_time_filter("select from trades", "time", 0, Some(86_400_000_000_000));
+        assert_eq!(
+            q,
+            "select from trades where time within (2000.01.01D00:00:00.000000000;2000.01.02D00:00:00.000000000)"
+        );
+    }
+
+    #[test]
+    fn test_inject_time_filter_max_uses_0wp() {
+        let q = inject_time_filter("select from trades", "time", 0, Some(i64::MAX));
+        assert_eq!(
+            q,
+            "select from trades where time within (2000.01.01D00:00:00.000000000;0Wp)"
+        );
+    }
+
+    #[test]
+    fn test_inject_time_filter_with_existing_where() {
+        let q = inject_time_filter("select from trades where sym=`AAPL", "time", 0, None);
+        assert_eq!(
+            q,
+            "select from trades where sym=`AAPL, time >= 2000.01.01D00:00:00.000000000"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Time-range filtering**: `kdb_read` now injects `time_col within (start; end)` (or `>= start` for unbounded) into every query using the `RunMode`/`RunFor` window. Uses `0Wp` for `NanoTime::MAX`. Date partition filter (`date_col`) is applied first for splayed tables.
- **Chunking**: Refactored to `select[offset,count]` syntax for scan-time pagination. Added `kdb_read_chunks` closure-driven primitive for full query control.
- **Logging**: Each query now logs with record count (`KDB query: ... (N records)`). Query string propagated into all row-level errors.
- **Integration tests**: Parameterised test data generation; added splayed-table test helpers and new tests covering `kdb_read_splayed_works`, `kdb_read_splayed_from_to`, `kdb_read_splayed_from_to_multi_day`.
- **Fixes**: Missing `date_col` arg in kdb example and Python bindings; clippy warnings; `.idea` in `.gitignore`.

## Test plan

- [ ] Run unit tests: `cargo test -p wingfoil --features kdb`
- [ ] Run integration tests with live KDB+ on port 5000: `cargo test --features kdb-integration-test -p wingfoil -- --test-threads=1 --no-capture`
- [ ] Run clippy: `cargo clippy --workspace --all-targets --all-features`