### PR TITLE
bump: kdb-plus-fixed to 0.5.0

### DIFF
--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -29,7 +29,7 @@ log = {workspace = true}
 
 # local deps
 pyo3 = { version = "0.27", features = ["extension-module", "serde"] }
-kdb-plus-fixed = { version = "0.4.0", features = ["ipc"] }
+kdb-plus-fixed = { version = "0.5.0", features = ["ipc"] }
 futures = "0.3"
 
 

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -70,7 +70,7 @@ futures-util = { version = "0.3.31", optional = true }
 csv = { version = "1.4", optional = true }
 tungstenite = { version = "0.14.0", features = ["rustls-tls"], optional = true }
 tokio-tungstenite = { version = "0.27.0", features = ["native-tls", "stream", "connect"], optional = true }
-kdb-plus-fixed = { version = "0.4.1", features = ["ipc"], optional = true }
+kdb-plus-fixed = { version = "0.5.0", features = ["ipc"], optional = true }
 
 
 


### PR DESCRIPTION
## Summary
- Bumps `kdb-plus-fixed` from `0.4.1` → `0.5.0` in `wingfoil/Cargo.toml`
- Bumps `kdb-plus-fixed` from `0.4.0` → `0.5.0` in `wingfoil-python/Cargo.toml`

## Test plan
- [ ] `cargo build --features kdb`
- [ ] `cargo test -p wingfoil`