### PR TITLE
Remove misleading log in ChannelReceiverStream setup

### DIFF
--- a/wingfoil/src/nodes/channel.rs
+++ b/wingfoil/src/nodes/channel.rs
@@ -233,8 +233,6 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
                 if let Some(chan) = self.notifier_channel.take() {
                     chan.send(state.ready_notifier())
                         .map_err(|e| anyhow::anyhow!(e))?;
-                } else {
-                    info!("state.ready_notifier() is None")
                 }
             }
             RunMode::HistoricalFrom(time) => {


### PR DESCRIPTION
## Summary
- Removes a spurious `info!` log that fired during ZMQ subscriber setup in real-time mode
- The log message ("state.ready_notifier() is None") was misleading — the condition was that `notifier_channel` was `None`, which is expected for `ReceiverStream`-based nodes (ZMQ, async_io) that wire the notifier directly on the sender side