### PR TITLE
release-notes: remove KDB+ caching from call to arms

### DIFF
--- a/releases/release-notes-v3.txt
+++ b/releases/release-notes-v3.txt
@@ -28,7 +28,6 @@ Thank you.
 We're looking for contributors to tackle:
 
   🔧 ZMQ — Service discovery for dynamic service registration
-  🗄 KDB+ caching — faster reads
   📦 Binary file I/O — Arrow, Parquet, and more
   ⚡ Kafka I/O — streaming integration
   🐍 wingfoil-python - full parity with core rust crate
@@ -61,8 +60,6 @@ New to open source or Rust? These are a great starting point.
 
   🔧 ZMQ service discovery
       https://github.com/wingfoil-io/wingfoil/issues/103
-  🗄  KDB+ caching
-      https://github.com/wingfoil-io/wingfoil/issues/90
   📦 Binary file I/O (Arrow, Parquet)
       https://github.com/wingfoil-io/wingfoil/issues/104
   🛢  SQL I/O


### PR DESCRIPTION
KDB+ caching (issue #90) already has an open PR (#133), so it shouldn't appear as an open call for contributors in the v3 release notes.

Removes it from both the "WHERE WE'RE GOING NEXT" blurb and the "FULL ROADMAP ISSUES" list.