### PR TITLE
fix: ticker first callback uses engine start time instead of epoch

### DIFF
--- a/wingfoil/src/nodes/tick.rs
+++ b/wingfoil/src/nodes/tick.rs
@@ -33,7 +33,7 @@ impl MutableNode for TickNode {
     }
 
     fn start(&mut self, state: &mut GraphState) -> anyhow::Result<()> {
-        state.add_callback(NanoTime::ZERO);
+        state.add_callback(state.start_time());
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- `TickNode::start()` was scheduling the first callback at `NanoTime::ZERO` (Unix epoch) unconditionally
- Changed to use `state.start_time()` so the first tick fires at the actual engine start time
- Fixes incorrect behaviour when using `HistoricalFrom(t)` with a non-zero `t`, where the first tick would fire at t=0 instead of the configured start time

## Test plan

- [ ] Existing `tick_node_works_in_realtime` test passes
- [ ] Verify historical mode with non-zero start time produces first tick at `start_time`, not at epoch