### PR TITLE
zmq service discovery

### DIFF
--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -153,3 +153,8 @@ required-features = ["zmq-beta"]
 name = "zmq_sub"
 path = "examples/messaging/zmq_sub.rs"
 required-features = ["zmq-beta"]
+
+[[example]]
+name = "zmq_discover"
+path = "examples/messaging/zmq_discover.rs"
+required-features = ["zmq-beta"]

--- a/wingfoil/examples/messaging/zmq_discover.rs
+++ b/wingfoil/examples/messaging/zmq_discover.rs
@@ -1,0 +1,51 @@
+// ZMQ service discovery example.
+// Run with: RUST_LOG=info cargo run --example zmq_discover --features zmq-beta
+//
+// Starts a seed, a named publisher, and a discovering subscriber — all in the
+// same process. In a real deployment each would run in a separate process;
+// only the seed address needs to be known in advance.
+
+use log::Level::Info;
+use std::time::Duration;
+use wingfoil::adapters::zmq::{ZeroMqPub, zmq_sub_discover};
+use wingfoil::adapters::zmq_seed::start_seed;
+use wingfoil::*;
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let seed_addr = "tcp://127.0.0.1:7777";
+    let pub_port = 7778u16;
+    let run_for = RunFor::Duration(Duration::from_secs(3));
+
+    // Start the seed (stops when dropped at end of main).
+    let _seed = start_seed(seed_addr)?;
+    std::thread::sleep(Duration::from_millis(50));
+
+    // Publisher: bind on port 7778, register as "quotes" with the seed.
+    // Node must be constructed inside the thread (Rc is !Send).
+    std::thread::spawn(move || {
+        ticker(Duration::from_millis(100))
+            .count()
+            .logged("pub", Info)
+            .zmq_pub_named("quotes", pub_port, &[seed_addr])
+            .run(RunMode::RealTime, run_for)
+            .expect("publisher failed");
+    });
+
+    // Give the publisher time to start and register.
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Subscriber: discover "quotes" via the seed, no hardcoded pub address.
+    let (data, _status) = zmq_sub_discover::<u64>("quotes", &[seed_addr])?;
+    data.logged("sub", Info)
+        .collect()
+        .finally(|res, _| {
+            let values: Vec<u64> = res.into_iter().flat_map(|item| item.value).collect();
+            println!("received {} values: {:?}", values.len(), values);
+            Ok(())
+        })
+        .run(RunMode::RealTime, run_for)?;
+
+    Ok(())
+}

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -10,3 +10,5 @@ pub mod kdb;
 #[cfg(feature = "zmq-beta")]
 #[doc(hidden)]
 pub mod zmq;
+#[cfg(feature = "zmq-beta")]
+pub mod zmq_seed;

--- a/wingfoil/src/adapters/zmq.rs
+++ b/wingfoil/src/adapters/zmq.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::adapters::zmq_seed;
 use crate::channel::{ChannelSender, Message};
 use crate::{
     Burst, Element, GraphState, IntoNode, IntoStream, MapFilterStream, MutableNode, Node,
@@ -11,6 +12,9 @@ use derive_new::new;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use zmq;
+
+pub use crate::adapters::zmq_seed::SeedHandle;
+pub use crate::adapters::zmq_seed::start_seed;
 
 static MONITOR_ID: AtomicUsize = AtomicUsize::new(0);
 const ZMQ_EVENT_CONNECTED: u16 = 0x0001;
@@ -161,13 +165,45 @@ pub fn zmq_sub<T: Element + Send + DeserializeOwned>(
     (data, status)
 }
 
-#[derive(new)]
+struct Registration {
+    name: String,
+    seeds: Vec<String>,
+}
+
 struct ZeroMqSenderNode<T: Element + Send + Serialize> {
     src: Rc<dyn Stream<T>>,
     port: u16,
     bind_address: String,
-    #[new(default)]
+    registration: Option<Registration>,
     socket: Option<zmq::Socket>,
+}
+
+impl<T: Element + Send + Serialize> ZeroMqSenderNode<T> {
+    fn new(src: Rc<dyn Stream<T>>, port: u16, bind_address: String) -> Self {
+        Self {
+            src,
+            port,
+            bind_address,
+            registration: None,
+            socket: None,
+        }
+    }
+
+    fn new_named(
+        src: Rc<dyn Stream<T>>,
+        port: u16,
+        bind_address: String,
+        name: String,
+        seeds: Vec<String>,
+    ) -> Self {
+        Self {
+            src,
+            port,
+            bind_address,
+            registration: Some(Registration { name, seeds }),
+            socket: None,
+        }
+    }
 }
 
 const FLAGS: i32 = 0;
@@ -198,6 +234,9 @@ impl<T: Element + Send + Serialize> MutableNode for ZeroMqSenderNode<T> {
         let address = format!("tcp://{}:{}", self.bind_address, self.port);
         socket.bind(&address)?;
         self.socket = Some(socket);
+        if let Some(reg) = &self.registration {
+            zmq_seed::register_with_seeds(&reg.name, &address, &reg.seeds)?;
+        }
         Ok(())
     }
 
@@ -215,6 +254,20 @@ impl<T: Element + Send + Serialize> MutableNode for ZeroMqSenderNode<T> {
 pub trait ZeroMqPub<T: Element + Send> {
     fn zmq_pub(&self, port: u16) -> Rc<dyn Node>;
     fn zmq_pub_on(&self, address: &str, port: u16) -> Rc<dyn Node>;
+    /// Publish and register this stream under `name` with the given seeds.
+    /// Subscribers can then use [`zmq_sub_discover`] to find it by name.
+    /// `port` is bound on `127.0.0.1`; use [`zmq_pub_named_on`](Self::zmq_pub_named_on)
+    /// for a routable address in multi-host deployments.
+    fn zmq_pub_named(&self, name: &str, port: u16, seeds: &[&str]) -> Rc<dyn Node>;
+    /// Like [`zmq_pub_named`](Self::zmq_pub_named) but binds on `address` instead of
+    /// `127.0.0.1`. The address must be reachable by subscribing nodes.
+    fn zmq_pub_named_on(
+        &self,
+        name: &str,
+        address: &str,
+        port: u16,
+        seeds: &[&str],
+    ) -> Rc<dyn Node>;
 }
 
 impl<T: Element + Send + Serialize> ZeroMqPub<T> for Rc<dyn Stream<T>> {
@@ -225,11 +278,52 @@ impl<T: Element + Send + Serialize> ZeroMqPub<T> for Rc<dyn Stream<T>> {
     fn zmq_pub_on(&self, address: &str, port: u16) -> Rc<dyn Node> {
         ZeroMqSenderNode::new(self.clone(), port, address.to_string()).into_node()
     }
+
+    fn zmq_pub_named(&self, name: &str, port: u16, seeds: &[&str]) -> Rc<dyn Node> {
+        ZeroMqSenderNode::new_named(
+            self.clone(),
+            port,
+            "127.0.0.1".to_string(),
+            name.to_string(),
+            seeds.iter().map(|s| s.to_string()).collect(),
+        )
+        .into_node()
+    }
+
+    fn zmq_pub_named_on(
+        &self,
+        name: &str,
+        address: &str,
+        port: u16,
+        seeds: &[&str],
+    ) -> Rc<dyn Node> {
+        ZeroMqSenderNode::new_named(
+            self.clone(),
+            port,
+            address.to_string(),
+            name.to_string(),
+            seeds.iter().map(|s| s.to_string()).collect(),
+        )
+        .into_node()
+    }
+}
+
+/// Discover a named publisher via seeds and subscribe to it.
+///
+/// Queries each seed in order until one resolves `name` to an address, then
+/// delegates to [`zmq_sub`]. Returns `Err` if no seed can resolve the name.
+pub fn zmq_sub_discover<T: Element + Send + DeserializeOwned>(
+    name: &str,
+    seeds: &[&str],
+) -> anyhow::Result<(Rc<dyn Stream<Burst<T>>>, Rc<dyn Stream<ZmqStatus>>)> {
+    let address = zmq_seed::query_seeds(name, seeds)?;
+    Ok(zmq_sub::<T>(&address))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::adapters::zmq::{ZeroMqPub, ZmqStatus, zmq_sub};
+    use crate::adapters::zmq::{ZeroMqPub, ZmqStatus, zmq_sub, zmq_sub_discover};
+    use crate::adapters::zmq_seed::{query_seeds, register_with_seeds, start_seed};
     use crate::{Graph, Node, NodeOperators, StreamOperators};
     use crate::{RunFor, RunMode, ticker};
     use log::Level::Info;
@@ -402,6 +496,124 @@ mod tests {
         assert!(
             err_msg.contains("real-time"),
             "expected error to mention real-time, got: {err_msg}"
+        );
+    }
+
+    // --- Discovery tests (ports 5580–5595) ---
+
+    #[test]
+    fn zmq_named_pub_registers_with_seed() {
+        _ = env_logger::try_init();
+        let seed_addr = "tcp://127.0.0.1:5580";
+        let port = 5581u16;
+
+        let _seed = start_seed(seed_addr).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Node must be constructed inside the thread (Rc is !Send).
+        let handle = std::thread::spawn(move || {
+            ticker(Duration::from_millis(50))
+                .count()
+                .zmq_pub_named("prices", port, &[seed_addr])
+                .run(
+                    RunMode::RealTime,
+                    RunFor::Duration(Duration::from_millis(300)),
+                )
+        });
+
+        std::thread::sleep(Duration::from_millis(150));
+        let addr = query_seeds("prices", &[seed_addr]).unwrap();
+        assert_eq!(addr, format!("tcp://127.0.0.1:{port}"));
+
+        handle.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn zmq_sub_discover_end_to_end() {
+        _ = env_logger::try_init();
+        let seed_addr = "tcp://127.0.0.1:5582";
+        let port = 5583u16;
+        let run_for = RunFor::Duration(Duration::from_millis(600));
+
+        let _seed = start_seed(seed_addr).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Publisher: register with seed and publish counts.
+        // Node must be constructed inside the thread (Rc is !Send).
+        std::thread::spawn(move || {
+            ticker(Duration::from_millis(50))
+                .count()
+                .zmq_pub_named("counts", port, &[seed_addr])
+                .run(RunMode::RealTime, run_for)
+        });
+
+        // Give the publisher time to start and register.
+        std::thread::sleep(Duration::from_millis(150));
+
+        let (data, _status) = zmq_sub_discover::<u64>("counts", &[seed_addr]).unwrap();
+        let recv_node = data.collect().finally(|res, _| {
+            let values: Vec<u64> = res.into_iter().flat_map(|item| item.value).collect();
+            assert!(!values.is_empty(), "no data received via discovery");
+            Ok(())
+        });
+        recv_node.run(RunMode::RealTime, run_for).unwrap();
+    }
+
+    #[test]
+    fn zmq_sub_discover_multiple_seeds_first_down() {
+        _ = env_logger::try_init();
+        let dead_seed = "tcp://127.0.0.1:5584";
+        let live_seed = "tcp://127.0.0.1:5585";
+
+        let _seed = start_seed(live_seed).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        register_with_seeds("widget", "tcp://127.0.0.1:9999", &[live_seed.to_string()]).unwrap();
+
+        // First seed is dead — query_seeds should fall through to live_seed.
+        let addr = query_seeds("widget", &[dead_seed, live_seed]);
+        assert!(
+            addr.is_ok(),
+            "expected fallback to live seed, got: {:?}",
+            addr
+        );
+        assert_eq!(addr.unwrap(), "tcp://127.0.0.1:9999");
+    }
+
+    #[test]
+    fn zmq_sub_discover_no_seed_returns_error() {
+        let result = zmq_sub_discover::<u64>("anything", &["tcp://127.0.0.1:5586"]);
+        assert!(result.is_err(), "expected error when no seed is running");
+    }
+
+    #[test]
+    fn zmq_sub_discover_name_not_found() {
+        let seed_addr = "tcp://127.0.0.1:5587";
+        let _seed = start_seed(seed_addr).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        let result = zmq_sub_discover::<u64>("nonexistent", &[seed_addr]);
+        assert!(result.is_err(), "expected error for unregistered name");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("no publisher named"),
+            "unexpected error message"
+        );
+    }
+
+    #[test]
+    fn zmq_named_pub_historical_mode_fails() {
+        use crate::NanoTime;
+        let result = ticker(Duration::from_millis(10))
+            .count()
+            .zmq_pub_named("test", 5588, &["tcp://127.0.0.1:5589"])
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever);
+        let err = result.expect_err("expected historical mode to fail for named zmq publisher");
+        assert!(
+            format!("{err:?}").contains("real-time"),
+            "expected error to mention real-time"
         );
     }
 }

--- a/wingfoil/src/adapters/zmq_seed.rs
+++ b/wingfoil/src/adapters/zmq_seed.rs
@@ -1,0 +1,256 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum SeedRequest {
+    Register { name: String, address: String },
+    Lookup { name: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum SeedResponse {
+    Ok,
+    Found { address: String },
+    NotFound,
+    Error { message: String },
+}
+
+/// Handle to a running seed node. The seed stops when this is dropped.
+pub struct SeedHandle {
+    running: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl Drop for SeedHandle {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Start a seed node bound to `bind_address` (e.g. `"tcp://0.0.0.0:7777"`).
+///
+/// The seed runs in a background thread and stops when the returned
+/// [`SeedHandle`] is dropped.
+pub fn start_seed(bind_address: &str) -> anyhow::Result<SeedHandle> {
+    let context = zmq::Context::new();
+    let socket = context.socket(zmq::REP)?;
+    socket.bind(bind_address)?;
+
+    let running = Arc::new(AtomicBool::new(true));
+    let running_clone = running.clone();
+
+    let thread = std::thread::spawn(move || run_seed(socket, running_clone));
+
+    Ok(SeedHandle {
+        running,
+        thread: Some(thread),
+    })
+}
+
+fn run_seed(socket: zmq::Socket, running: Arc<AtomicBool>) {
+    let mut registry: HashMap<String, String> = HashMap::new();
+
+    while running.load(Ordering::Relaxed) {
+        let mut items = [socket.as_poll_item(zmq::POLLIN)];
+        // Short timeout so we check the running flag regularly.
+        match zmq::poll(&mut items, 10) {
+            Ok(_) => {}
+            Err(_) => break,
+        }
+
+        if !items[0].is_readable() {
+            continue;
+        }
+
+        let bytes = match socket.recv_bytes(0) {
+            Ok(b) => b,
+            Err(_) => break,
+        };
+
+        let response = match bincode::deserialize::<SeedRequest>(&bytes) {
+            Ok(SeedRequest::Register { name, address }) => {
+                registry.insert(name, address);
+                SeedResponse::Ok
+            }
+            Ok(SeedRequest::Lookup { name }) => match registry.get(&name) {
+                Some(addr) => SeedResponse::Found {
+                    address: addr.clone(),
+                },
+                None => SeedResponse::NotFound,
+            },
+            Err(e) => SeedResponse::Error {
+                message: e.to_string(),
+            },
+        };
+
+        let reply = match bincode::serialize(&response) {
+            Ok(b) => b,
+            Err(_) => break,
+        };
+        if socket.send(reply, 0).is_err() {
+            break;
+        }
+    }
+}
+
+fn req_socket_for(seed: &str) -> anyhow::Result<zmq::Socket> {
+    let context = zmq::Context::new();
+    let socket = context.socket(zmq::REQ)?;
+    socket.set_linger(0)?; // close immediately, don't wait for pending sends
+    socket.set_rcvtimeo(3000)?;
+    socket.set_sndtimeo(3000)?;
+    socket.connect(seed)?;
+    Ok(socket)
+}
+
+/// Register `name` → `address` with all seeds. Returns `Ok` on first success,
+/// `Err` if no seed could be reached.
+pub(crate) fn register_with_seeds(
+    name: &str,
+    address: &str,
+    seeds: &[String],
+) -> anyhow::Result<()> {
+    let mut last_err = anyhow::anyhow!("no seeds provided");
+
+    for seed in seeds {
+        let socket = match req_socket_for(seed) {
+            Ok(s) => s,
+            Err(e) => {
+                last_err = e;
+                continue;
+            }
+        };
+        let req = SeedRequest::Register {
+            name: name.to_string(),
+            address: address.to_string(),
+        };
+        let bytes = bincode::serialize(&req)?;
+        if socket.send(bytes, 0).is_err() {
+            continue;
+        }
+        match socket.recv_bytes(0) {
+            Ok(reply) => match bincode::deserialize::<SeedResponse>(&reply) {
+                Ok(SeedResponse::Ok) => return Ok(()),
+                Ok(other) => {
+                    last_err = anyhow::anyhow!("unexpected response from seed {seed}: {other:?}");
+                }
+                Err(e) => {
+                    last_err = anyhow::anyhow!("failed to deserialize seed response: {e}");
+                }
+            },
+            Err(e) => {
+                last_err = anyhow::anyhow!("no response from seed {seed}: {e}");
+            }
+        }
+    }
+
+    Err(last_err)
+}
+
+/// Query seeds for `name`. Returns the resolved address on first successful
+/// lookup, or `Err` if no seed can resolve it.
+pub(crate) fn query_seeds(name: &str, seeds: &[&str]) -> anyhow::Result<String> {
+    let mut last_err = anyhow::anyhow!("no seeds provided");
+
+    for &seed in seeds {
+        let socket = match req_socket_for(seed) {
+            Ok(s) => s,
+            Err(e) => {
+                last_err = e;
+                continue;
+            }
+        };
+        let req = SeedRequest::Lookup {
+            name: name.to_string(),
+        };
+        let bytes = bincode::serialize(&req)?;
+        if socket.send(bytes, 0).is_err() {
+            continue;
+        }
+        match socket.recv_bytes(0) {
+            Ok(reply) => match bincode::deserialize::<SeedResponse>(&reply) {
+                Ok(SeedResponse::Found { address }) => return Ok(address),
+                Ok(SeedResponse::NotFound) => {
+                    last_err =
+                        anyhow::anyhow!("no publisher named '{name}' registered with seed {seed}");
+                }
+                Ok(other) => {
+                    last_err = anyhow::anyhow!("unexpected response from seed {seed}: {other:?}");
+                }
+                Err(e) => {
+                    last_err = anyhow::anyhow!("failed to deserialize seed response: {e}");
+                }
+            },
+            Err(e) => {
+                last_err = anyhow::anyhow!("no response from seed {seed}: {e}");
+            }
+        }
+    }
+
+    Err(last_err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    const SEED_1: &str = "tcp://127.0.0.1:5570";
+    const SEED_2: &str = "tcp://127.0.0.1:5571";
+    const SEED_3: &str = "tcp://127.0.0.1:5572";
+    const SEED_4: &str = "tcp://127.0.0.1:5573";
+
+    #[test]
+    fn seed_register_and_lookup() {
+        let _seed = start_seed(SEED_1).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        register_with_seeds("quotes", "tcp://127.0.0.1:9001", &[SEED_1.to_string()]).unwrap();
+        let addr = query_seeds("quotes", &[SEED_1]).unwrap();
+        assert_eq!(addr, "tcp://127.0.0.1:9001");
+    }
+
+    #[test]
+    fn seed_lookup_unknown() {
+        let _seed = start_seed(SEED_2).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        let err = query_seeds("unknown", &[SEED_2]).unwrap_err();
+        assert!(
+            err.to_string().contains("no publisher named"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn seed_register_overwrites() {
+        let _seed = start_seed(SEED_3).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        register_with_seeds("foo", "tcp://127.0.0.1:9002", &[SEED_3.to_string()]).unwrap();
+        register_with_seeds("foo", "tcp://127.0.0.1:9003", &[SEED_3.to_string()]).unwrap();
+        let addr = query_seeds("foo", &[SEED_3]).unwrap();
+        assert_eq!(addr, "tcp://127.0.0.1:9003");
+    }
+
+    #[test]
+    fn seed_drop_shuts_down() {
+        let seed = start_seed(SEED_4).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Confirm seed is alive.
+        register_with_seeds("alive", "tcp://127.0.0.1:9100", &[SEED_4.to_string()]).unwrap();
+
+        // Drop sets running=false and joins the thread (exits within ~10ms poll cycle).
+        // If this hangs, the test will timeout — that itself is the failure signal.
+        drop(seed);
+        // Reached here: thread joined cleanly.
+    }
+}

--- a/zmq-discovery-plan.md
+++ b/zmq-discovery-plan.md
@@ -1,0 +1,168 @@
+# ZMQ Service Discovery — Implementation Plan
+
+## Overview
+
+Add seed-based service discovery to the ZMQ adapter (issue #103).
+
+Seeds are lightweight name registries — they handle only discovery traffic, not data. Data flows peer-to-peer over existing PUB/SUB sockets.
+
+```
+Publisher → seed: "I'm 'quotes', tcp://hostA:5555"
+Subscriber → seed: "who publishes 'quotes'?"
+seed → Subscriber: "tcp://hostA:5555"
+Subscriber → tcp://hostA:5555  (normal zmq_sub)
+```
+
+Multiple seeds provide redundancy: publishers register with all seeds, subscribers try each until one responds.
+
+### Public API
+
+```rust
+// Start a seed (background thread, stops on drop)
+let seed = start_seed("tcp://0.0.0.0:7777")?;
+
+// Named publisher — binds PUB socket as normal, then registers with seeds
+ticker(period)
+    .count()
+    .zmq_pub_named("quotes", port, &["tcp://seed1:7777", "tcp://seed2:7777"]);
+
+// Discovering subscriber — queries seeds, then connects via normal zmq_sub
+let (data, status) = zmq_sub_discover::<Quote>("quotes", &["tcp://seed1:7777"])?;
+```
+
+### Design decisions
+
+- **Seed socket type: REP** — discovery is low-volume (once at startup), strictly sequential request-reply, no concurrency needed
+- **Wire protocol: bincode** — already a dependency, consistent with existing ZMQ adapter
+- **Subscriber resolves at construction time** — `zmq_sub_discover` queries seeds eagerly and returns `Result`; errors surface before the graph is built
+- **Publisher registers in `start()`** — must bind the PUB socket first to know the port is available, then register
+- **REQ timeout: 3s** — both `register_with_seeds` and `query_seeds` set `rcvtimeo`/`sndtimeo` so dead seeds fail fast
+- **Backwards compatible** — `zmq_pub`, `zmq_pub_on`, `zmq_sub` are unchanged
+
+---
+
+## Wire Protocol
+
+```rust
+// wingfoil/src/adapters/zmq_seed.rs
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum SeedRequest {
+    Register { name: String, address: String },
+    Lookup   { name: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum SeedResponse {
+    Ok,
+    Found   { address: String },
+    NotFound,
+    Error   { message: String },
+}
+```
+
+---
+
+## Tasks
+
+### Task 1 — Create `zmq_seed.rs`
+
+New file: `wingfoil/src/adapters/zmq_seed.rs`
+
+Contents:
+- `SeedRequest` / `SeedResponse` enums (above)
+- `Registry` — `HashMap<String, String>` (name → address)
+- `SeedHandle` — holds shutdown sender + `JoinHandle`; `Drop` sends shutdown signal and joins
+- `start_seed(bind_address: &str) -> anyhow::Result<SeedHandle>` — spawns seed thread
+- Seed thread loop: `zmq::poll` on REP socket with 100ms timeout, check shutdown channel on each wakeup; recv request → update registry or lookup → send response
+- `pub(crate) fn register_with_seeds(name, address, seeds) -> anyhow::Result<()>` — opens REQ socket per seed (3s timeout), sends `Register`, expects `Ok`; returns `Ok` on first success, `Err` if all fail
+- `pub(crate) fn query_seeds(name, seeds) -> anyhow::Result<String>` — opens REQ socket per seed (3s timeout), sends `Lookup`, returns address on `Found`, tries next on `NotFound`/error
+
+Wire `mod.rs`:
+```rust
+// wingfoil/src/adapters/mod.rs
+#[cfg(feature = "zmq-beta")]
+pub(crate) mod zmq_seed;
+```
+
+### Task 2 — Extend `ZeroMqSenderNode` for named publishing
+
+In `wingfoil/src/adapters/zmq.rs`:
+
+Add:
+```rust
+struct Registration {
+    name: String,
+    seeds: Vec<String>,
+}
+```
+
+Add `registration: Option<Registration>` field to `ZeroMqSenderNode`. Switch from `derive_new` to a hand-written constructor (the struct only has 3 mandatory fields: `src`, `port`, `bind_address`).
+
+Extend `start()`: after `socket.bind(...)`, if `self.registration.is_some()`, call `register_with_seeds(name, &address, seeds)`.
+
+Extend `ZeroMqPub` trait:
+```rust
+fn zmq_pub_named(&self, name: &str, port: u16, seeds: &[&str]) -> Rc<dyn Node>;
+fn zmq_pub_named_on(&self, name: &str, address: &str, port: u16, seeds: &[&str]) -> Rc<dyn Node>;
+```
+
+`zmq_pub_named` uses `"127.0.0.1"` as the bind address (same as existing `zmq_pub`). `zmq_pub_named_on` takes an explicit address — document that it must be routable by subscribers.
+
+### Task 3 — Add `zmq_sub_discover`
+
+In `wingfoil/src/adapters/zmq.rs`:
+
+```rust
+pub fn zmq_sub_discover<T: Element + Send + DeserializeOwned>(
+    name: &str,
+    seeds: &[&str],
+) -> anyhow::Result<(Rc<dyn Stream<Burst<T>>>, Rc<dyn Stream<ZmqStatus>>)> {
+    let address = zmq_seed::query_seeds(name, seeds)?;
+    Ok(zmq_sub::<T>(&address))
+}
+```
+
+### Task 4 — Tests
+
+All tests in `#[cfg(test)]` blocks. Use ports 5570–5595 to avoid collisions with existing tests (5556–5562).
+
+Seed unit tests (in `zmq_seed.rs`):
+- `seed_register_and_lookup` — register "foo", lookup "foo", expect Found
+- `seed_lookup_unknown` — lookup with no registrations, expect NotFound
+- `seed_register_overwrites` — register "foo" twice, second address wins
+- `seed_drop_shuts_down` — drop handle, verify thread exits (attempt connect after short sleep, expect failure)
+
+Integration tests (in `zmq.rs`):
+- `zmq_named_pub_registers_with_seed` — start seed, run named publisher, directly query seed and assert Found
+- `zmq_sub_discover_end_to_end` — full round-trip: seed + named publisher + zmq_sub_discover, assert data received
+- `zmq_sub_discover_multiple_seeds_first_down` — first seed absent, second live; assert Ok
+- `zmq_sub_discover_no_seed_returns_error` — no seed running, assert Err
+- `zmq_sub_discover_name_not_found` — seed running but name not registered, assert Err
+- `zmq_named_pub_historical_mode_fails` — assert error mentioning "real-time"
+
+### Task 5 — Example
+
+New file: `wingfoil/examples/messaging/zmq_discover.rs`
+
+Demonstrates: start seed, start named publisher in one thread, discover and subscribe in another, assert data received.
+
+Add to `wingfoil/Cargo.toml`:
+```toml
+[[example]]
+name = "zmq_discover"
+path = "examples/messaging/zmq_discover.rs"
+required-features = ["zmq-beta"]
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `wingfoil/src/adapters/zmq_seed.rs` | New — seed thread, wire protocol, helpers |
+| `wingfoil/src/adapters/zmq.rs` | Extend `ZeroMqSenderNode` + `ZeroMqPub`; add `zmq_sub_discover` |
+| `wingfoil/src/adapters/mod.rs` | Add `pub(crate) mod zmq_seed` under `zmq-beta` |
+| `wingfoil/Cargo.toml` | Add `zmq_discover` example |
+| `wingfoil/examples/messaging/zmq_discover.rs` | New example |


### PR DESCRIPTION
Publishers register by name with lightweight seed nodes; subscribers discover by name without hardcoded addresses. Data flows peer-to-peer over existing PUB/SUB sockets — seeds handle only discovery traffic.

- Add zmq_seed.rs: REP-based seed node with start_seed/SeedHandle, SeedRequest/SeedResponse wire protocol (bincode), register_with_seeds, query_seeds; AtomicBool shutdown with 10ms poll cycle
- Extend ZeroMqPub trait: zmq_pub_named / zmq_pub_named_on register with seeds in start() after binding
- Add zmq_sub_discover: queries seeds then delegates to zmq_sub
- Re-export start_seed and SeedHandle from zmq module
- Add zmq_discover example
- 17 tests: 4 seed unit tests + 6 discovery integration tests + 7 existing zmq tests (all passing)