### PR TITLE
ci: add Python test workflow

### DIFF
--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -1,0 +1,46 @@
+name: Python Tests
+
+on:
+  push:
+    paths:
+      - "wingfoil-python/**"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  test:
+    name: Python Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install maturin and test dependencies
+        run: pip install maturin pytest pandas
+
+      - name: Build and install Python bindings
+        run: |
+          cd wingfoil-python
+          maturin develop
+
+      - name: Run pytest
+        run: |
+          cd wingfoil-python
+          pytest tests/


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/py-test.yml` to run pytest against the `wingfoil-python` crate
- Triggers on push to any path under `wingfoil-python/**` or manually via `workflow_dispatch`
- Builds the PyO3 bindings with `maturin develop` before running tests

## Test plan
- [ ] Trigger manually via Actions tab to verify the workflow runs
- [ ] Push a change to `wingfoil-python/` and confirm the workflow triggers automatically