### PR TITLE
ci: fix maturin develop by using explicit venv

### DIFF
--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -32,15 +32,17 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install maturin and test dependencies
-        run: pip install maturin pytest pandas
+      - name: Create virtualenv and install dependencies
+        run: |
+          python -m venv wingfoil-python/.venv
+          wingfoil-python/.venv/bin/pip install maturin pytest pandas
 
       - name: Build and install Python bindings
         run: |
           cd wingfoil-python
-          maturin develop
+          .venv/bin/maturin develop
 
       - name: Run pytest
         run: |
           cd wingfoil-python
-          pytest tests/
+          .venv/bin/pytest tests/


### PR DESCRIPTION
## Summary
- Fixes `maturin develop` failure caused by no active virtualenv in the CI environment
- Creates an explicit `.venv` inside `wingfoil-python/` and uses it for all subsequent steps

## Root cause
`maturin develop` requires a virtualenv (via `VIRTUAL_ENV`, `CONDA_PREFIX`, or a `.venv` folder). The previous workflow ran it in the bare system Python environment.