### PR TITLE
ci: fix Python test failures (remove bad httpcore import, add pyzmq)

### DIFF
--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Create virtualenv and install dependencies
         run: |
           python -m venv wingfoil-python/.venv
-          wingfoil-python/.venv/bin/pip install maturin pytest pandas
+          wingfoil-python/.venv/bin/pip install maturin pytest pandas pyzmq
 
       - name: Build and install Python bindings
         run: |

--- a/wingfoil-python/tests/test_streams.py
+++ b/wingfoil-python/tests/test_streams.py
@@ -1,6 +1,5 @@
 import unittest
 
-from httpcore import stream
 from wingfoil import constant, ticker
 
 class TestStreams(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Remove stale `from httpcore import stream` import in `test_streams.py` (unused — `stream` is immediately shadowed by a local variable)
- Add `pyzmq` to pip install in the workflow for `test_zmq.py`