### PR TITLE
ci: add default-features clippy run to catch feature-gated dead code

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,10 @@ jobs:
           set -o pipefail
           set -e
 
-          # First run Clippy with -D warnings to fail on any warnings
+          # Run with no features to catch warnings hidden by feature flags
+          cargo clippy --workspace --all-targets -- -D warnings
+
+          # Run with all features and -D warnings
           cargo clippy --workspace --all-targets --all-features -- -D warnings
 
           # Then run it again with JSON output for SARIF reporting


### PR DESCRIPTION
## Summary
- Add a `cargo clippy --workspace --all-targets -- -D warnings` run (no features) before the existing `--all-features` run

## Why
Items only used inside `#[cfg(feature = "...")]` blocks appear as dead code / unused imports when building without that feature. The existing `--all-features` run never sees these warnings, so they slip through until something like `maturin develop` exposes them.