### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,226 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  preflight:
+    name: Preflight — version check
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep -m 1 '^version' wingfoil/Cargo.toml | awk -F'"' '{print $2}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Fail if tag already exists
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          if git ls-remote --tags origin | grep -q "refs/tags/${TAG}$"; then
+            echo "::error::Tag ${TAG} already exists. Bump the version before releasing."
+            exit 1
+          fi
+
+  rust-ci:
+    name: Rust — Build, Test & Lint
+    needs: preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install clippy-sarif
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: clippy-sarif
+
+      - name: Install sarif-fmt
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: sarif-fmt
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run tests
+        run: cargo nextest run --no-capture
+        env:
+          RUST_LOG: INFO
+
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy (default features)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Run clippy (all features)
+        run: |
+          set -o pipefail
+          set -e
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
+          cargo clippy --workspace --all-targets --all-features --message-format=json \
+            | clippy-sarif \
+            | tee rust-clippy-results.sarif \
+            | sarif-fmt
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: rust-clippy-results.sarif
+          wait-for-processing: true
+
+  python-tests:
+    name: Python Tests
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Create virtualenv and install dependencies
+        run: |
+          python -m venv wingfoil-python/.venv
+          wingfoil-python/.venv/bin/pip install maturin pytest pandas pyzmq
+
+      - name: Build and install Python bindings
+        run: |
+          cd wingfoil-python
+          .venv/bin/maturin develop
+
+      - name: Run pytest
+        run: |
+          cd wingfoil-python
+          .venv/bin/pytest tests/
+
+  grafana-integration:
+    name: Grafana Integration Tests
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Start Grafana + Prometheus stack
+        run: docker compose up -d
+        working-directory: docker/grafana
+
+      - name: Wait for Grafana to be healthy
+        run: |
+          for i in $(seq 1 24); do
+            if curl -sf http://localhost:3000/api/health > /dev/null; then
+              echo "Grafana is up"
+              break
+            fi
+            echo "Waiting for Grafana... ($i/24)"
+            sleep 5
+          done
+          curl -sf http://localhost:3000/api/health || (echo "Grafana never became healthy" && exit 1)
+
+      - name: Create Grafana service account token
+        id: grafana-token
+        run: |
+          SA_ID=$(curl -sf -X POST http://admin:admin@localhost:3000/api/serviceaccounts \
+            -H 'Content-Type: application/json' \
+            -d '{"name":"ci-wingfoil","role":"Editor"}' \
+            | jq -r '.id')
+          TOKEN=$(curl -sf -X POST http://admin:admin@localhost:3000/api/serviceaccounts/${SA_ID}/tokens \
+            -H 'Content-Type: application/json' \
+            -d '{"name":"ci-token"}' \
+            | jq -r '.key')
+          echo "token=${TOKEN}" >> $GITHUB_OUTPUT
+
+      - name: Wait for Prometheus to be healthy
+        run: |
+          for i in $(seq 1 12); do
+            if curl -sf http://localhost:9090/-/healthy > /dev/null; then
+              echo "Prometheus is up"
+              break
+            fi
+            echo "Waiting for Prometheus... ($i/12)"
+            sleep 5
+          done
+
+      - name: Run Grafana integration tests
+        run: |
+          cargo test --features grafana-integration-test -p wingfoil \
+            -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO
+          GRAFANA_TEST_URL: http://localhost:3000
+          GRAFANA_TEST_API_KEY: ${{ steps.grafana-token.outputs.token }}
+          PROMETHEUS_TEST_URL: http://localhost:9090
+          WINGFOIL_METRICS_PORT: "9091"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose logs
+        working-directory: docker/grafana
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down
+        working-directory: docker/grafana
+
+  tag:
+    name: Cut release tag
+    needs: [rust-ci, python-tests, grafana-integration]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ needs.preflight.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- New `release.yml` workflow, triggered manually via `workflow_dispatch`
- Reads the current version from `wingfoil/Cargo.toml` and fails immediately if `v<version>` tag already exists
- Runs four jobs in parallel (after preflight): Rust build/test/clippy/fmt, Python pytest, Grafana integration tests
- Only cuts the tag if all jobs pass

## Flow
```
preflight (version check + duplicate tag guard)
    ├── rust-ci
    ├── python-tests
    └── grafana-integration
            ↓ (all must pass)
         tag (git tag + push)
```