### PR TITLE
ci: fix KDB integration workflow — venv, cache key, doctest

### DIFF
--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -67,8 +67,9 @@ jobs:
 
       - name: Install maturin and build Python bindings
         run: |
-          pip install maturin pytest
-          cd wingfoil-python && maturin develop
+          python -m venv wingfoil-python/.venv
+          wingfoil-python/.venv/bin/pip install maturin pytest
+          cd wingfoil-python && .venv/bin/maturin develop
 
       - name: Run Python KDB integration tests
         env:
@@ -76,7 +77,7 @@ jobs:
           KDB_TEST_PORT: 5000
           RUST_LOG: INFO
         run: |
-          cd wingfoil-python && pytest tests/test_kdb.py -v
+          cd wingfoil-python && .venv/bin/pytest tests/test_kdb.py -v
 
       - name: Dump KDB logs on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,8 +262,9 @@ jobs:
 
       - name: Install maturin and build Python bindings
         run: |
-          pip install maturin pytest
-          cd wingfoil-python && maturin develop
+          python -m venv wingfoil-python/.venv
+          wingfoil-python/.venv/bin/pip install maturin pytest
+          cd wingfoil-python && .venv/bin/maturin develop
 
       - name: Run Python KDB integration tests
         env:
@@ -271,7 +272,7 @@ jobs:
           KDB_TEST_PORT: 5000
           RUST_LOG: INFO
         run: |
-          cd wingfoil-python && pytest tests/test_kdb.py -v
+          cd wingfoil-python && .venv/bin/pytest tests/test_kdb.py -v
 
       - name: Dump KDB logs on failure
         if: failure()


### PR DESCRIPTION
## Summary

Three fixes accumulated from CI failures on the KDB integration workflow:

1. **Cache key bug** — `kdb_read_cached` included host/port in the cache key, causing cache misses when the second run used a different connection (e.g. the closed-port test). Key on query only.
2. **Doctest failure** — bare code block in `breadth_first/README.md` was being compiled as Rust. Tagged as `text`.
3. **Maturin venv** — `maturin develop` requires a virtualenv. Create `.venv` explicitly, matching `py-test.yml`.

## Test plan

- [ ] All 96 Rust KDB integration tests pass
- [ ] All 13 doctests pass  
- [ ] Python KDB tests pass