### PR TITLE
feat: add initially node

### DIFF
--- a/wingfoil/src/nodes/initially.rs
+++ b/wingfoil/src/nodes/initially.rs
@@ -1,0 +1,27 @@
+use crate::types::*;
+use derive_new::new;
+use std::rc::Rc;
+
+#[derive(new)]
+pub struct InitiallyNode<T: Element, F: FnOnce(&GraphState) -> anyhow::Result<()>> {
+    source: Rc<dyn Stream<T>>,
+    initially: Option<F>,
+    #[new(default)]
+    value: T,
+}
+
+impl<T: Element, F: FnOnce(&GraphState) -> anyhow::Result<()>> MutableNode for InitiallyNode<T, F> {
+    fn start(&mut self, state: &mut GraphState) -> anyhow::Result<()> {
+        if let Some(f) = self.initially.take() {
+            f(state)?;
+        }
+        Ok(())
+    }
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.value = self.source.peek_value();
+        Ok(true)
+    }
+    fn upstreams(&self) -> UpStreams {
+        UpStreams::new(vec![self.source.clone().as_node()], vec![])
+    }
+}

--- a/wingfoil/src/nodes/mod.rs
+++ b/wingfoil/src/nodes/mod.rs
@@ -27,6 +27,7 @@ mod fold;
 #[cfg(feature = "async")]
 mod graph_node;
 mod graph_state;
+mod initially;
 mod inspect;
 mod limit;
 mod map;
@@ -75,6 +76,7 @@ use filter::*;
 use finally::*;
 use fold::*;
 use graph_state::*;
+use initially::*;
 use inspect::*;
 use limit::*;
 use map::*;
@@ -388,6 +390,11 @@ pub trait StreamOperators<T: Element> {
         FUT: Future<Output = anyhow::Result<()>> + Send + 'static;
     #[must_use]
     fn finally<F: FnOnce(T, &GraphState) -> anyhow::Result<()> + 'static>(
+        self: &Rc<Self>,
+        func: F,
+    ) -> Rc<dyn Node>;
+    #[must_use]
+    fn initially<F: FnOnce(&GraphState) -> anyhow::Result<()> + 'static>(
         self: &Rc<Self>,
         func: F,
     ) -> Rc<dyn Node>;
@@ -731,6 +738,13 @@ where
         func: F,
     ) -> Rc<dyn Node> {
         FinallyNode::new(self.clone(), Some(func)).into_node()
+    }
+
+    fn initially<F: FnOnce(&GraphState) -> anyhow::Result<()> + 'static>(
+        self: &Rc<Self>,
+        func: F,
+    ) -> Rc<dyn Node> {
+        InitiallyNode::new(self.clone(), Some(func)).into_node()
     }
 
     fn fold<OUT: Element>(


### PR DESCRIPTION
## Summary
- Adds `InitiallyNode` in `nodes/initially.rs`, mirroring the `finally` pattern
- Calls a `FnOnce(&GraphState)` closure in `start()`, before the first cycle
- Wired into `StreamOperators` trait and its blanket impl

## Test plan
- [ ] `cargo build` passes
- [ ] `cargo clippy` clean
- [ ] Manual verification: closure fires once before any cycles tick