### PR TITLE
ci: install protoc before maturin develop in kdb-integration workflow

### DIFF
--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install system dependencies
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Install maturin and build Python bindings
         run: |
           python -m venv wingfoil-python/.venv


### PR DESCRIPTION
## Summary

- `kdb-integration.yml` is a standalone push-triggered workflow (separate from the reusable `integration-tests.yml`) that also runs `maturin develop` on the Python bindings
- `wingfoil-python` enables the `etcd` feature, which pulls in `etcd-client`, which requires `protoc` at build time
- The previous fix (in #172) only patched `integration-tests.yml`; `kdb-integration.yml` was missing the same step and kept failing

## Test plan

- [ ] `kdb-integration.yml` now installs `protobuf-compiler` before `maturin develop`, matching `integration-tests.yml` and `py-test.yml`