### PR TITLE
feat: add Kafka adapter

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,3 +54,13 @@ jobs:
     name: Fluvio Integration Tests
     uses: ./.github/workflows/fluvio-integration.yml
     secrets: inherit
+
+  kafka-integration:
+    name: Kafka Integration Tests
+    uses: ./.github/workflows/kafka-integration.yml
+    secrets: inherit
+
+  kafka-python-integration:
+    name: Kafka Python Integration Tests
+    uses: ./.github/workflows/kafka-python-integration.yml
+    secrets: inherit

--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -1,0 +1,36 @@
+name: Kafka Integration Tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'wingfoil/src/adapters/kafka/**'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  kafka-integration:
+    name: Kafka Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run Kafka integration tests
+        run: |
+          cargo test --features kafka-integration-test -p wingfoil \
+            -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO

--- a/.github/workflows/kafka-python-integration.yml
+++ b/.github/workflows/kafka-python-integration.yml
@@ -1,0 +1,65 @@
+name: Kafka Python Integration Tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'wingfoil-python/src/py_kafka.rs'
+      - 'wingfoil-python/tests/test_kafka.py'
+      - 'wingfoil/src/adapters/kafka/**'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  kafka-python-integration:
+    name: Kafka Python Integration Tests
+    runs-on: ubuntu-latest
+
+    services:
+      redpanda:
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
+        ports:
+          - 9092:9092
+        options: >-
+          --health-cmd "rpk cluster health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Create virtualenv and install dependencies
+        run: |
+          python -m venv wingfoil-python/.venv
+          wingfoil-python/.venv/bin/pip install maturin pytest
+
+      - name: Build and install Python bindings
+        run: |
+          cd wingfoil-python
+          .venv/bin/maturin develop
+
+      - name: Run Kafka Python integration tests
+        run: |
+          cd wingfoil-python
+          .venv/bin/pytest tests/test_kafka.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ perf.data*
 .codex
 wingfoil-python/.python-version
 worktrees
+*.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,33 +3,6 @@
 version = 4
 
 [[package]]
-name = "adaptive_backoff"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd5e23cd33dd73c030d1c424967eb2fbdc917d89e0bdcf1162edc4cf504f756"
-dependencies = [
- "anyhow",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,87 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f937e26114b93193065fd44f507aa2e9169ad0cdabbb996920b1fe1ddea7ba"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "tokio",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +124,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -254,14 +146,8 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -271,27 +157,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version",
-]
-
-[[package]]
-name = "atoi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
-dependencies = [
- "num-traits",
+ "syn",
 ]
 
 [[package]]
@@ -305,28 +171,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
 
 [[package]]
 name = "axum"
@@ -373,12 +217,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -415,7 +253,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -431,36 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bitvec"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fcd36dda4e17b7d7abc64cb549bf0201f4ab71e00700c798ca7e62ed3761fa"
-dependencies = [
- "funty",
- "radium",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -490,7 +304,7 @@ dependencies = [
  "num",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -501,8 +315,8 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.18",
- "tonic 0.14.5",
+ "tokio-util",
+ "tonic",
  "tower-service",
  "url",
  "winapi",
@@ -514,9 +328,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "prost-types",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
  "ureq",
 ]
@@ -530,7 +344,7 @@ dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_json",
  "serde_repr",
@@ -547,37 +361,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "bytesize"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "cargo-husky"
@@ -627,12 +420,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -712,15 +499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,40 +514,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "content_inspector"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -795,39 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
-
-[[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -960,60 +677,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1025,30 +694,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core 0.12.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -1057,9 +704,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1086,38 +733,7 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1139,7 +755,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1151,7 +767,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1166,47 +781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +788,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1229,34 +803,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "educe"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "either"
@@ -1277,24 +827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1314,27 +855,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1383,10 +904,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ed900ba953ca6bf1fadb75e0c6b73d8463b9e2bb6bdb7b4573e8e7295852fbe"
 dependencies = [
  "http",
- "prost 0.14.3",
+ "prost",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic",
  "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
@@ -1405,91 +926,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
- "pin-project-lite",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fefix"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a74fd6a403e05448eb0e4372102f4bdbd7a1b0692fb4859c34012d534c39d3"
-dependencies = [
- "bitvec",
- "bytes",
- "chrono",
- "fefix_derive",
- "fnv",
- "futures",
- "futures-timer",
- "heck 0.3.3",
- "indoc 1.0.9",
- "lazy_static",
- "nohash-hasher",
- "openssl",
- "quick-xml",
- "rayon",
- "roxmltree",
- "serde",
- "serde_json",
- "sqlx",
- "strum 0.22.0",
- "strum_macros 0.22.0",
- "thiserror 1.0.69",
- "tokio-util 0.6.10",
- "uuid",
-]
-
-[[package]]
-name = "fefix_derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31463d4f7708a7b04d5997eadaa96e4d99680e0b096936386250aa7635a75bcb"
-dependencies = [
- "darling 0.12.4",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferroid"
@@ -1524,325 +964,6 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fluvio"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2438d6e8107fa01356234ad0e4da50422dca6bd62036e61116befbbadf7d4187"
-dependencies = [
- "adaptive_backoff",
- "anyhow",
- "async-channel",
- "async-lock",
- "async-trait",
- "cfg-if",
- "chrono",
- "derive_builder",
- "dirs 6.0.0",
- "event-listener 5.4.1",
- "fluvio-compression",
- "fluvio-future",
- "fluvio-protocol",
- "fluvio-sc-schema",
- "fluvio-smartmodule",
- "fluvio-socket",
- "fluvio-spu-schema",
- "fluvio-stream-dispatcher",
- "fluvio-types",
- "futures-util",
- "once_cell",
- "parking_lot 0.12.5",
- "pin-project",
- "rustls 0.23.37",
- "semver",
- "serde",
- "siphasher",
- "thiserror 2.0.18",
- "tokio",
- "toml 0.8.23",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "fluvio-compression"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac2a78ba630aaba295f925bede1aa55ab7685f81d62372e18c7228381dec0b0"
-dependencies = [
- "bytes",
- "flate2",
- "fluvio-types",
- "lz4_flex",
- "serde",
- "snap",
- "thiserror 2.0.18",
- "zstd",
-]
-
-[[package]]
-name = "fluvio-controlplane-metadata"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb5a9cc48693cecd5303f6ec63b3c1cebc8a6818d75bad390fe7e4f577fe14f"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bytes",
- "bytesize",
- "cfg-if",
- "derive_builder",
- "flate2",
- "fluvio-protocol",
- "fluvio-stream-model",
- "fluvio-types",
- "flv-util",
- "humantime-serde",
- "lenient_semver",
- "schemars 1.2.1",
- "semver",
- "serde",
- "serde_yaml",
- "thiserror 2.0.18",
- "toml 0.8.23",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-future"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404e1beb0ba16331eb7b82b4e4e586f03e7de9438368880a3b9870f53105b2b0"
-dependencies = [
- "anyhow",
- "async-global-executor",
- "async-io",
- "async-net",
- "async-task",
- "async-trait",
- "cfg-if",
- "fluvio-wasm-timer",
- "futures-lite",
- "futures-rustls",
- "futures-util",
- "pin-project",
- "rustls-pemfile",
- "socket2 0.5.10",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasm-bindgen-futures",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "fluvio-protocol"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fdc736c98b204aeac7b2416af7f7589afd76da12799c941a17cf39a8061cb0"
-dependencies = [
- "bytes",
- "cfg-if",
- "content_inspector",
- "crc32c",
- "eyre",
- "fluvio-compression",
- "fluvio-future",
- "fluvio-protocol-derive",
- "fluvio-types",
- "flv-util",
- "once_cell",
- "semver",
- "thiserror 2.0.18",
- "tokio-util 0.7.18",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-protocol-derive"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d16052eeee04bcb6d68cf9e565cc504e7c2d69a4e758f9844974a8d3d1f0aa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-sc-schema"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1083f4657bbe5b0d8389f5747493ea3ce73c3b18b03b875b0fc4f930941be9"
-dependencies = [
- "anyhow",
- "fluvio-controlplane-metadata",
- "fluvio-protocol",
- "fluvio-socket",
- "fluvio-stream-model",
- "paste",
- "static_assertions",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-smartmodule"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc29b7f867ac122f393fc1f39f5e14bd77cd874febdeb136d8309901e69a4a3"
-dependencies = [
- "eyre",
- "fluvio-protocol",
- "fluvio-smartmodule-derive",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-smartmodule-derive"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35af0ba75ba657d41252e0417cc5424e5dbf174c4ccdf59b8347d428ff6e9f46"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "fluvio-socket"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e92beb4e1dbb0406af81d947a326de7c8f9750237dba8d1b256ce092d7c0564"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-trait",
- "built",
- "bytes",
- "cfg-if",
- "event-listener 5.4.1",
- "fluvio-future",
- "fluvio-protocol",
- "futures-util",
- "nix",
- "once_cell",
- "pin-project",
- "semver",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util 0.7.18",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-spu-schema"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf906f9af088b1d94a4d93b93706a6f28ead49e2ee16485a6358ca619f06072"
-dependencies = [
- "bytes",
- "derive_builder",
- "educe",
- "flate2",
- "fluvio-future",
- "fluvio-protocol",
- "fluvio-smartmodule",
- "fluvio-types",
- "serde",
- "static_assertions",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-stream-dispatcher"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba40604cefb09f608810a46115c015a170b6c2ae170a29fb8f184ec195a766e"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-lock",
- "async-trait",
- "cfg-if",
- "fluvio-future",
- "fluvio-stream-model",
- "fluvio-types",
- "futures-util",
- "once_cell",
- "parking_lot 0.12.5",
- "serde",
- "serde_yaml",
- "tempfile",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-stream-model"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe86e211fee1f3780350def1361de0a5725cf68894022157ee23abfbef84e6ec"
-dependencies = [
- "async-lock",
- "event-listener 5.4.1",
- "k8-types",
- "once_cell",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-types"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe5675758c2ae542f6c2c64cca1f187b26c22708c2a7358d6454dd9c6d8561d"
-dependencies = [
- "event-listener 5.4.1",
- "schemars 1.2.1",
- "serde",
- "thiserror 2.0.18",
- "toml 0.8.23",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "flv-util"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de89447c8b4aecfa4c0614d1a7be1c6ab4a0266b59bb2713fd746901f28d124e"
-dependencies = [
- "log",
- "tracing",
-]
 
 [[package]]
 name = "fnv"
@@ -1887,18 +1008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f6f3299260c1f4180ce881f8bb2bfc1195ceeafd54eea899af5859a6f882ad"
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,34 +1050,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-intrusive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604f7a68fbf8103337523b1fadc8ade7361ee3f112f7c680ad179651616aed5"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot 0.11.2",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1978,18 +1063,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "futures-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
-dependencies = [
- "futures-io",
- "rustls 0.23.37",
- "rustls-pki-types",
+ "syn",
 ]
 
 [[package]]
@@ -2003,12 +1077,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2106,7 +1174,7 @@ dependencies = [
  "indexmap 2.13.1",
  "slab",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2119,15 +1187,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -2152,43 +1211,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
-name = "hashlink"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
-dependencies = [
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2232,31 +1258,13 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot",
  "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
 ]
 
 [[package]]
@@ -2314,22 +1322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
-
-[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,10 +1367,10 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -2396,44 +1388,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
- "system-configuration",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2533,7 +1504,7 @@ dependencies = [
  "iceoryx2-bb-elementary-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2834,12 +1805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,12 +1829,6 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
-
-[[package]]
-name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
@@ -2878,24 +1837,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -2909,29 +1856,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2978,7 +1906,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3014,16 +1942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "k8-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03d75bcb5555871dcffa40538fee4e59d38e3d21457c7c19108a31a76a69122"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "kanal"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,7 +1973,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -3063,35 +1981,6 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "lenient_semver"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
-dependencies = [
- "lenient_semver_parser",
- "semver",
-]
-
-[[package]]
-name = "lenient_semver_parser"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
-dependencies = [
- "lenient_semver_version_builder",
- "semver",
-]
-
-[[package]]
-name = "lenient_semver_version_builder"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "libc"
@@ -3119,6 +2008,18 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3170,15 +2071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,16 +2093,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
-]
 
 [[package]]
 name = "memchr"
@@ -3238,16 +2120,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "mio"
@@ -3282,24 +2154,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3409,6 +2263,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,7 +2325,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3469,90 +2345,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "opentelemetry"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry",
- "reqwest",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
-dependencies = [
- "async-trait",
- "futures-core",
- "http",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry_sdk",
- "prost 0.13.5",
- "reqwest",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
-dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
- "prost 0.13.5",
- "tonic 0.12.3",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "opentelemetry",
- "percent-encoding",
- "rand 0.8.5",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -3583,44 +2375,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3658,14 +2419,8 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -3685,16 +2440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3711,7 +2456,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3719,23 +2464,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkg-config"
@@ -3775,20 +2503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3849,7 +2563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3865,12 +2579,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -3884,22 +2597,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3908,32 +2611,19 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.14.3",
+ "prost",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.117",
+ "syn",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3946,7 +2636,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3955,7 +2645,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -3984,7 +2674,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
- "indoc 2.0.7",
+ "indoc",
  "libc",
  "memoffset",
  "once_cell",
@@ -4024,7 +2714,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4033,11 +2723,11 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4054,15 +2744,6 @@ dependencies = [
  "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4085,12 +2766,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
@@ -4190,12 +2865,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "rdkafka"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "14b52c81ac3cac39c9639b95c20452076e74b8d9a71bc6fc4d83407af2ea6fff"
 dependencies = [
- "bitflags 1.3.2",
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.10.0+2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
+dependencies = [
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -4217,28 +2913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4255,7 +2929,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4288,67 +2962,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
 
 [[package]]
 name = "ring"
@@ -4360,17 +2977,8 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "roxmltree"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
-dependencies = [
- "xmlparser",
 ]
 
 [[package]]
@@ -4403,27 +3011,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4443,15 +3037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4466,10 +3051,9 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
- "aws-lc-rs",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -4539,21 +3123,8 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4563,23 +3134,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4600,16 +3161,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -4660,18 +3211,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4695,7 +3235,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4753,34 +3293,10 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.13.1",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "syn",
 ]
 
 [[package]]
@@ -4826,18 +3342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4848,22 +3352,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -4877,147 +3365,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "sqlformat"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
-dependencies = [
- "itertools 0.10.5",
- "nom 7.1.3",
- "unicode_categories",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551873805652ba0d912fec5bbb0f8b4cdd96baf8e2ebf5970e5671092966019b"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48c61941ccf5ddcada342cd59e3e5173b007c509e1e8e990dafc830294d9dc5"
-dependencies = [
- "ahash",
- "atoi",
- "base64 0.13.1",
- "bitflags 1.3.2",
- "byteorder",
- "bytes",
- "crc",
- "crossbeam-queue",
- "dirs 4.0.0",
- "either",
- "event-listener 2.5.3",
- "futures-channel",
- "futures-core",
- "futures-intrusive",
- "futures-util",
- "hashlink",
- "hex",
- "hkdf",
- "hmac",
- "indexmap 1.9.3",
- "itoa",
- "libc",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "paste",
- "percent-encoding",
- "rand 0.8.5",
- "rustls 0.19.1",
- "serde",
- "serde_json",
- "sha-1",
- "sha2",
- "smallvec",
- "sqlformat",
- "sqlx-rt",
- "stringprep",
- "thiserror 1.0.69",
- "tokio-stream",
- "url",
- "webpki",
- "webpki-roots 0.21.1",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0fba2b0cae21fc00fe6046f8baa4c7fcb49e379f0f592b04696607f69ed2e1"
-dependencies = [
- "dotenv",
- "either",
- "heck 0.4.1",
- "once_cell",
- "proc-macro2",
- "quote",
- "sha2",
- "sqlx-core",
- "sqlx-rt",
- "syn 1.0.109",
- "url",
-]
-
-[[package]]
-name = "sqlx-rt"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db708cd3e459078f85f39f96a00960bd841f66ee2a669e90bf36907f5a79aae"
-dependencies = [
- "once_cell",
- "tokio",
- "tokio-rustls 0.22.0",
-]
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -5034,7 +3390,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5045,14 +3401,8 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "strum"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 
 [[package]]
 name = "strum"
@@ -5060,19 +3410,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "strum_macros",
 ]
 
 [[package]]
@@ -5081,10 +3419,10 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5092,17 +3430,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -5120,9 +3447,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -5132,28 +3456,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "syn",
 ]
 
 [[package]]
@@ -5163,7 +3466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
  "cfg-expr",
- "heck 0.5.0",
+ "heck",
  "pkg-config",
  "toml 0.8.23",
  "version-compare",
@@ -5221,7 +3524,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.18",
+ "tokio-util",
  "url",
 ]
 
@@ -5251,7 +3554,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5262,7 +3565,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5357,7 +3660,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5370,7 +3673,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5385,22 +3688,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -5417,28 +3709,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5450,7 +3726,6 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "indexmap 2.13.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5490,14 +3765,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.19.15"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "indexmap 2.13.1",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
+ "serde_core",
 ]
 
 [[package]]
@@ -5510,8 +3783,19 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+dependencies = [
+ "indexmap 2.13.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5524,37 +3808,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
 name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "tonic"
@@ -5575,7 +3832,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -5594,7 +3851,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5604,8 +3861,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.5",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -5619,7 +3876,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn",
  "tempfile",
  "tonic-build",
 ]
@@ -5637,28 +3894,10 @@ dependencies = [
  "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util 0.7.18",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -5693,7 +3932,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5742,12 +3981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
 name = "tynm"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5769,31 +4002,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5808,28 +4020,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -5846,7 +4040,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -5894,15 +4088,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "valuable"
@@ -5978,12 +4163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6025,7 +4204,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -6093,54 +4272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
- "web-sys",
-]
-
-[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6198,7 +4329,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6209,7 +4340,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6397,7 +4528,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wingfoil"
-version = "4.0.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -6412,9 +4543,6 @@ dependencies = [
  "derive_more",
  "env_logger",
  "etcd-client",
- "fefix",
- "fluvio",
- "fluvio-controlplane-metadata",
  "formato",
  "futures",
  "futures-util",
@@ -6428,15 +4556,11 @@ dependencies = [
  "num",
  "num-traits",
  "once_cell",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "ordered-float 4.6.0",
  "priority-queue",
  "quanta",
  "rand 0.9.2",
- "reqwest",
- "rustls 0.23.37",
+ "rdkafka",
  "rxrust",
  "scopeguard",
  "serde",
@@ -6444,8 +4568,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum",
+ "strum_macros",
  "testcontainers",
  "thiserror 2.0.18",
  "tinyvec",
@@ -6453,23 +4577,22 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tynm",
- "webpki-roots 0.26.11",
  "wingfoil-derive",
  "zmq",
 ]
 
 [[package]]
 name = "wingfoil-derive"
-version = "4.0.1"
+version = "3.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "wingfoil-python"
-version = "4.0.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6486,15 +4609,6 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -6507,6 +4621,9 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -6524,7 +4641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -6535,10 +4652,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.13.1",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6554,7 +4671,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6603,31 +4720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "ws_stream_wasm"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "log",
- "pharos",
- "rustc_version",
- "send_wrapper",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6636,12 +4728,6 @@ dependencies = [
  "libc",
  "rustix",
 ]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
@@ -6662,7 +4748,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6683,7 +4769,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6703,7 +4789,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6753,7 +4839,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6782,32 +4868,4 @@ dependencies = [
  "libc",
  "system-deps",
  "zeromq-src",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -22,7 +22,7 @@ iceoryx2-beta = ["wingfoil/iceoryx2-beta"]
 [dependencies]
 
 # parent
-wingfoil = { path = "../wingfoil", features = ["csv", "kdb", "zmq", "etcd", "fluvio", "prometheus", "otlp", "fix", "web"] }
+wingfoil = { path = "../wingfoil", features = ["csv", "kdb", "zmq", "etcd", "fluvio", "prometheus", "otlp", "fix", "web", "kafka"] }
 
 # workspace deps
 anyhow = {workspace = true}

--- a/wingfoil-python/python/wingfoil/__init__.py
+++ b/wingfoil-python/python/wingfoil/__init__.py
@@ -31,6 +31,9 @@ zmq_sub_etcd = getattr(_ext, "py_zmq_sub_etcd", None)
 # User-friendly aliases for Fluvio functions
 fluvio_sub = _ext.py_fluvio_sub
 
+# User-friendly aliases for Kafka functions
+kafka_sub = _ext.py_kafka_sub
+
 # User-friendly aliases for KDB+ functions
 kdb_read = _ext.py_kdb_read
 kdb_write = _ext.py_kdb_write

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -7,6 +7,7 @@ mod py_fix;
 mod py_fluvio;
 #[cfg(feature = "iceoryx2-beta")]
 mod py_iceoryx2;
+mod py_kafka;
 mod py_kdb;
 mod py_latency;
 mod py_otlp;
@@ -191,6 +192,7 @@ fn _wingfoil(module: &Bound<'_, PyModule>) -> PyResult<()> {
     #[cfg(feature = "etcd")]
     module.add_function(wrap_pyfunction!(py_etcd::py_etcd_sub, module)?)?;
     module.add_function(wrap_pyfunction!(py_fluvio::py_fluvio_sub, module)?)?;
+    module.add_function(wrap_pyfunction!(py_kafka::py_kafka_sub, module)?)?;
     module.add_function(wrap_pyfunction!(py_kdb::py_kdb_read, module)?)?;
     module.add_function(wrap_pyfunction!(py_kdb::py_kdb_write, module)?)?;
     module.add_function(wrap_pyfunction!(py_zmq::py_zmq_sub, module)?)?;

--- a/wingfoil-python/src/py_kafka.rs
+++ b/wingfoil-python/src/py_kafka.rs
@@ -1,0 +1,111 @@
+//! Python bindings for the Kafka adapter.
+
+use crate::py_element::PyElement;
+use crate::py_stream::PyStream;
+
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyList};
+use std::rc::Rc;
+use wingfoil::adapters::kafka::{KafkaConnection, KafkaRecord, kafka_pub, kafka_sub};
+use wingfoil::{Burst, Node, Stream, StreamOperators};
+
+/// Subscribe to a Kafka topic.
+///
+/// Each tick yields a `list` of event dicts:
+/// `{"topic": str, "partition": int, "offset": int, "key": bytes | None, "value": bytes}`
+///
+/// Args:
+///     brokers: Kafka bootstrap servers, e.g. `"localhost:9092"`
+///     topic: Topic to subscribe to
+///     group_id: Consumer group ID
+#[pyfunction]
+pub fn py_kafka_sub(brokers: String, topic: String, group_id: String) -> PyStream {
+    let conn = KafkaConnection::new(brokers);
+    let stream = kafka_sub(conn, topic, group_id);
+
+    let py_stream = stream.map(|burst| {
+        Python::attach(|py| {
+            let items: Vec<Py<PyAny>> = burst
+                .into_iter()
+                .map(|event| {
+                    let dict = PyDict::new(py);
+                    dict.set_item("topic", &event.topic).unwrap();
+                    dict.set_item("partition", event.partition).unwrap();
+                    dict.set_item("offset", event.offset).unwrap();
+                    match &event.key {
+                        Some(k) => {
+                            dict.set_item("key", PyBytes::new(py, k)).unwrap();
+                        }
+                        None => {
+                            dict.set_item("key", py.None()).unwrap();
+                        }
+                    }
+                    dict.set_item("value", PyBytes::new(py, &event.value))
+                        .unwrap();
+                    dict.into_any().unbind()
+                })
+                .collect();
+            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+        })
+    });
+
+    PyStream(py_stream)
+}
+
+/// Inner implementation for the `.kafka_pub()` stream method.
+///
+/// The stream must yield either:
+/// - a single `dict` with `"topic"` (str), `"value"` (bytes), and optionally `"key"` (bytes), or
+/// - a `list` of such dicts for multiple writes per tick.
+pub fn py_kafka_pub_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    brokers: String,
+    topic: String,
+) -> Rc<dyn Node> {
+    let conn = KafkaConnection::new(brokers);
+    let default_topic = topic;
+
+    let burst_stream: Rc<dyn Stream<Burst<KafkaRecord>>> = stream.map(move |elem| {
+        let default_topic = default_topic.clone();
+        Python::attach(|py| {
+            let obj = elem.as_ref().bind(py);
+            if let Ok(dict) = obj.cast_exact::<PyDict>() {
+                std::iter::once(dict_to_record(dict, &default_topic)).collect()
+            } else if let Ok(list) = obj.cast_exact::<PyList>() {
+                list.iter()
+                    .filter_map(|item| {
+                        item.cast_exact::<PyDict>()
+                            .ok()
+                            .map(|d| dict_to_record(d, &default_topic))
+                    })
+                    .collect()
+            } else {
+                log::error!("kafka_pub: stream value must be a dict or list of dicts");
+                Burst::new()
+            }
+        })
+    });
+
+    kafka_pub(conn, &burst_stream)
+}
+
+fn dict_to_record(dict: &Bound<'_, PyDict>, default_topic: &str) -> KafkaRecord {
+    let topic = dict
+        .get_item("topic")
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<String>().ok())
+        .unwrap_or_else(|| default_topic.to_string());
+    let key = dict
+        .get_item("key")
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<Vec<u8>>().ok());
+    let value = dict
+        .get_item("value")
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<Vec<u8>>().ok())
+        .unwrap_or_default();
+    KafkaRecord { topic, key, value }
+}

--- a/wingfoil-python/src/py_kdb.rs
+++ b/wingfoil-python/src/py_kdb.rs
@@ -83,7 +83,7 @@ impl KdbDeserialize for PyKdbRow {
                 | qtype::SECOND_ATOM => PyKdbValue::Int(k.get_int()?),
                 // Datetime stored as f64 (days since KDB epoch)
                 qtype::DATETIME_ATOM => PyKdbValue::Float(k.get_float()?),
-                _ => PyKdbValue::Symbol(format!("{:?}", k)),
+                _ => PyKdbValue::Symbol(format!("{k:?}")),
             };
             result.push((col_name.clone(), value));
         }
@@ -219,12 +219,12 @@ async fn py_kdb_write_consumer(
             let obj = py_element.as_ref().bind(py);
             let dict: &pyo3::Bound<'_, PyDict> = obj
                 .cast::<PyDict>()
-                .map_err(|e| anyhow::anyhow!("expected dict, got: {}", e))?;
+                .map_err(|e| anyhow::anyhow!("expected dict, got: {e}"))?;
 
             for (col_name, col_type) in &columns {
                 let value = dict
                     .get_item(col_name)?
-                    .ok_or_else(|| anyhow::anyhow!("missing column '{}' in dict", col_name))?;
+                    .ok_or_else(|| anyhow::anyhow!("missing column '{col_name}' in dict"))?;
 
                 let frag = match col_type.as_str() {
                     "symbol" => {
@@ -248,11 +248,7 @@ async fn py_kdb_write_consumer(
                         format!("enlist {}b", if b { 1 } else { 0 })
                     }
                     other => {
-                        anyhow::bail!(
-                            "unsupported column type '{}' for column '{}'",
-                            other,
-                            col_name
-                        );
+                        anyhow::bail!("unsupported column type '{other}' for column '{col_name}'");
                     }
                 };
                 col_frags.push(frag);

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -399,6 +399,22 @@ impl PyStream {
         ))
     }
 
+    /// Produce this stream of dicts to Kafka.
+    ///
+    /// Stream values must be dicts with `"value"` (bytes) and optionally
+    /// `"topic"` (str) and `"key"` (bytes), or lists of such dicts for
+    /// multi-message writes per tick.
+    ///
+    /// Args:
+    ///     brokers: Kafka bootstrap servers, e.g. `"localhost:9092"`
+    ///     topic: Default topic for records that don't specify one
+    ///
+    /// Returns:
+    ///     A Node that drives the produce operation.
+    fn kafka_pub(&self, brokers: String, topic: String) -> PyNode {
+        PyNode::new(crate::py_kafka::py_kafka_pub_inner(&self.0, brokers, topic))
+    }
+
     /// Publish this stream of bytes to a ZMQ PUB socket bound on the given port.
     ///
     /// The stream values must be `bytes` objects. Only supported in real-time mode.

--- a/wingfoil-python/tests/test_kafka.py
+++ b/wingfoil-python/tests/test_kafka.py
@@ -1,0 +1,114 @@
+"""Integration tests for Kafka sub/pub Python bindings.
+
+Requires a running Kafka-compatible broker on localhost:9092. Tests are
+automatically skipped if no broker is available, making them safe to include
+in a general pytest run. In CI, these are exercised by the
+kafka-python-integration workflow which spins up a Redpanda service container.
+
+Local setup (Redpanda):
+    docker run --rm -p 9092:9092 \\
+      docker.redpanda.com/redpandadata/redpanda:v24.1.1 \\
+      redpanda start --overprovisioned --smp 1 --memory 512M \\
+      --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr localhost:9092
+"""
+
+import socket
+import unittest
+
+BROKERS = "localhost:9092"
+TOPIC_PREFIX = "wingfoil_pytest_"
+
+
+def kafka_available():
+    try:
+        with socket.create_connection(("localhost", 9092), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+KAFKA_AVAILABLE = kafka_available()
+
+
+@unittest.skipUnless(KAFKA_AVAILABLE, "Kafka not running on localhost:9092")
+class TestKafkaSub(unittest.TestCase):
+    def test_sub_returns_expected_shape(self):
+        from wingfoil import kafka_sub
+
+        topic = f"{TOPIC_PREFIX}sub_shape"
+        stream = kafka_sub(BROKERS, topic, "pytest-sub-group").collect()
+        stream.run(realtime=True, duration=3.0)
+        result = stream.peek_value()
+        self.assertIsInstance(result, list)
+
+    def test_sub_dict_has_correct_fields(self):
+        from wingfoil import kafka_sub
+
+        topic = f"{TOPIC_PREFIX}sub_fields"
+        # Pre-produce a message via the pub binding
+        from wingfoil import constant
+
+        constant({"topic": topic, "value": b"check"}).kafka_pub(
+            BROKERS, topic
+        ).run(realtime=True, cycles=1)
+
+        stream = kafka_sub(BROKERS, topic, "pytest-fields-group").collect()
+        stream.run(realtime=True, duration=5.0)
+        ticks = stream.peek_value()
+        all_events = [e for tick in ticks for e in tick]
+        self.assertTrue(all_events, "expected at least one event")
+        for e in all_events:
+            self.assertIn("topic", e)
+            self.assertIn("partition", e)
+            self.assertIn("offset", e)
+            self.assertIn("key", e)
+            self.assertIn("value", e)
+            self.assertIsInstance(e["topic"], str)
+            self.assertIsInstance(e["partition"], int)
+            self.assertIsInstance(e["offset"], int)
+            self.assertIsInstance(e["value"], bytes)
+
+
+@unittest.skipUnless(KAFKA_AVAILABLE, "Kafka not running on localhost:9092")
+class TestKafkaPub(unittest.TestCase):
+    def test_pub_single_dict_round_trip(self):
+        from wingfoil import constant
+
+        topic = f"{TOPIC_PREFIX}pub_single"
+        constant({"topic": topic, "key": b"k", "value": b"hello_from_python"}).kafka_pub(
+            BROKERS, topic
+        ).run(realtime=True, cycles=1)
+
+        # Verify via sub
+        from wingfoil import kafka_sub
+
+        stream = kafka_sub(BROKERS, topic, "pytest-pub-verify").collect()
+        stream.run(realtime=True, duration=5.0)
+        ticks = stream.peek_value()
+        all_events = [e for tick in ticks for e in tick]
+        values = [e["value"] for e in all_events]
+        self.assertIn(b"hello_from_python", values)
+
+    def test_pub_list_of_dicts_round_trip(self):
+        from wingfoil import constant
+
+        topic = f"{TOPIC_PREFIX}pub_multi"
+        entries = [
+            {"topic": topic, "key": b"a", "value": b"aaa"},
+            {"topic": topic, "key": b"b", "value": b"bbb"},
+        ]
+        constant(entries).kafka_pub(BROKERS, topic).run(realtime=True, cycles=1)
+
+        from wingfoil import kafka_sub
+
+        stream = kafka_sub(BROKERS, topic, "pytest-multi-verify").collect()
+        stream.run(realtime=True, duration=5.0)
+        ticks = stream.peek_value()
+        all_events = [e for tick in ticks for e in tick]
+        values = {e["value"] for e in all_events}
+        self.assertIn(b"aaa", values)
+        self.assertIn(b"bbb", values)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -1,6 +1,6 @@
 [features]
 default = ["async"]
-full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2-beta", "prometheus", "otlp", "fix", "web"]
+full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2-beta", "prometheus", "otlp", "fix", "web", "kafka"]
 dynamic-graph-beta = []
 kdb-integration-test = ["kdb"]
 async = ["dep:tokio", "dep:futures", "dep:async-stream", "dep:futures-util", "tokio/time"]
@@ -13,6 +13,8 @@ zmq-cross-lang-test = ["zmq-integration-test"]
 zmq-cross-lang-etcd-test = ["zmq-cross-lang-test", "zmq-etcd-integration-test"]
 etcd = ["dep:etcd-client", "async"]
 etcd-integration-test = ["etcd", "dep:testcontainers"]
+kafka = ["dep:rdkafka", "async"]
+kafka-integration-test = ["kafka", "dep:testcontainers"]
 tracing = ["dep:tracing"]
 instrument-run = ["tracing"]
 instrument-cycle = ["tracing"]
@@ -103,6 +105,7 @@ csv = { version = "1.4", optional = true }
 kdb-plus-fixed = { version = "0.5.0", features = ["ipc"], optional = true }
 zmq = { version = "0.10.0", optional = true }
 etcd-client = { version = "0.18", optional = true }
+rdkafka = { version = "0.37", optional = true }
 testcontainers = { version = "0.27", features = ["blocking"], optional = true }
 tracing = { workspace = true, features = ["log", "attributes"], optional = true }
 fluvio = { version = "0.50.1", optional = true }
@@ -297,3 +300,8 @@ required-features = ["web"]
 name = "fluvio"
 path = "examples/fluvio/main.rs"
 required-features = ["fluvio"]
+
+[[example]]
+name = "kafka"
+path = "examples/kafka/main.rs"
+required-features = ["kafka"]

--- a/wingfoil/examples/kafka/README.md
+++ b/wingfoil/examples/kafka/README.md
@@ -1,0 +1,36 @@
+# Kafka Adapter Example
+
+Demonstrates a full round-trip with the Kafka adapter:
+
+1. **Seed** — writes two messages to `example-source` via `kafka_pub`
+2. **Round-trip** — consumes `example-source` with `kafka_sub`, uppercases each value, writes to `example-dest` via `kafka_pub`
+
+## Setup
+
+### Local (Docker)
+
+Using Redpanda (Kafka-compatible, fast startup):
+
+```sh
+docker run --rm -p 9092:9092 \
+  docker.redpanda.com/redpandadata/redpanda:v24.1.1 \
+  redpanda start --overprovisioned --smp 1 --memory 512M \
+  --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr localhost:9092
+```
+
+## Run
+
+```sh
+cargo run --example kafka --features kafka
+```
+
+## Code
+
+See `main.rs` for the full source.
+
+## Output
+
+```
+  greeting → HELLO
+  subject → WORLD
+```

--- a/wingfoil/examples/kafka/main.rs
+++ b/wingfoil/examples/kafka/main.rs
@@ -1,0 +1,71 @@
+//! Kafka adapter example — produce messages, consume and transform, write back.
+//!
+//! Two independent graph roots:
+//! - `seed`        — writes source messages once via `constant` + `kafka_pub`
+//! - `round_trip`  — consumes the source topic, uppercases values, writes to dest topic
+//!
+//! # Prerequisites
+//!
+//! A running Kafka-compatible broker (Redpanda recommended):
+//! ```sh
+//! docker run --rm -p 9092:9092 \
+//!   docker.redpanda.com/redpandadata/redpanda:v24.1.1 \
+//!   redpanda start --overprovisioned --smp 1 --memory 512M \
+//!   --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr localhost:9092
+//! ```
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run --example kafka --features kafka
+//! ```
+
+use wingfoil::adapters::kafka::*;
+use wingfoil::*;
+
+const BROKERS: &str = "localhost:9092";
+const SOURCE_TOPIC: &str = "example-source";
+const DEST_TOPIC: &str = "example-dest";
+
+fn main() -> anyhow::Result<()> {
+    let conn = KafkaConnection::new(BROKERS);
+
+    let seed = constant(burst![
+        KafkaRecord {
+            topic: SOURCE_TOPIC.into(),
+            key: Some(b"greeting".to_vec()),
+            value: b"hello".to_vec(),
+        },
+        KafkaRecord {
+            topic: SOURCE_TOPIC.into(),
+            key: Some(b"subject".to_vec()),
+            value: b"world".to_vec(),
+        },
+    ])
+    .kafka_pub(conn.clone());
+
+    let round_trip = kafka_sub(conn.clone(), SOURCE_TOPIC, "example-group")
+        .map(|burst| {
+            burst
+                .into_iter()
+                .map(|event| {
+                    let upper = event.value_str().unwrap_or("").to_uppercase().into_bytes();
+                    println!(
+                        "  {} → {}",
+                        event.key_str().and_then(|r| r.ok()).unwrap_or("?"),
+                        String::from_utf8_lossy(&upper)
+                    );
+                    KafkaRecord {
+                        topic: DEST_TOPIC.into(),
+                        key: event.key,
+                        value: upper,
+                    }
+                })
+                .collect::<Burst<KafkaRecord>>()
+        })
+        .kafka_pub(conn);
+
+    Graph::new(vec![seed, round_trip], RunMode::RealTime, RunFor::Cycles(3)).run()?;
+
+    Ok(())
+}

--- a/wingfoil/examples/order_book/main.rs
+++ b/wingfoil/examples/order_book/main.rs
@@ -172,6 +172,6 @@ fn parse_order(msg: Message) -> lobster::OrderType {
             price,
         }
     } else {
-        panic!("unrecognised order type: {:}", message_type);
+        panic!("unrecognised order type: {message_type:}");
     }
 }

--- a/wingfoil/src/adapters/cache/file_cache.rs
+++ b/wingfoil/src/adapters/cache/file_cache.rs
@@ -89,7 +89,7 @@ impl<T> FileCache<T> {
         let tmp = path.with_extension("tmp");
 
         let serializable: Vec<(u64, &T)> = data.iter().map(|(t, v)| (u64::from(*t), v)).collect();
-        let mut buf = format!("{}\n", query).into_bytes();
+        let mut buf = format!("{query}\n").into_bytes();
         buf.extend(bincode::serialize(&serializable)?);
         tokio::fs::write(&tmp, &buf).await?;
 

--- a/wingfoil/src/adapters/fluvio/read.rs
+++ b/wingfoil/src/adapters/fluvio/read.rs
@@ -43,8 +43,7 @@ pub fn fluvio_sub(
     let validation_error = if let Some(n) = start_offset {
         if n < 0 {
             Some(anyhow::anyhow!(
-                "start_offset must be non-negative, got {}",
-                n
+                "start_offset must be non-negative, got {n}"
             ))
         } else {
             None

--- a/wingfoil/src/adapters/kafka/CLAUDE.md
+++ b/wingfoil/src/adapters/kafka/CLAUDE.md
@@ -1,0 +1,92 @@
+# Kafka Adapter
+
+Streams messages from Kafka topics (`kafka_sub`) and produces messages to
+Kafka topics (`kafka_pub`).
+
+## Module Structure
+
+```
+kafka/
+  mod.rs               # KafkaConnection, KafkaRecord, KafkaEvent, public re-exports
+  read.rs              # kafka_sub() producer
+  write.rs             # kafka_pub() consumer, KafkaPubOperators trait
+  integration_tests.rs # Integration tests (requires Docker, gated by feature)
+  CLAUDE.md            # This file
+```
+
+## Key Components
+
+### Reading from Kafka — `kafka_sub`
+
+- `kafka_sub(conn, topic, group_id)` — produces `Burst<KafkaEvent>`
+  - Creates a `StreamConsumer` in the given consumer group
+  - Subscribes to the topic and streams messages as they arrive
+  - Each message becomes a `KafkaEvent` with topic, partition, offset, key, and value
+  - Uses `auto.offset.reset = earliest` to read from the beginning for new groups
+
+### Writing to Kafka — `kafka_pub`
+
+- `kafka_pub(conn, upstream)` — consumes `Burst<KafkaRecord>`, produces one message per record
+- `KafkaPubOperators::kafka_pub(conn)` — fluent API on `Rc<dyn Stream<Burst<KafkaRecord>>>`
+- Each `KafkaRecord` specifies its target topic, allowing multi-topic writes from a single consumer
+- Uses `FutureProducer` with delivery confirmation (5s timeout)
+
+### Types
+
+- `KafkaConnection::new(brokers)` — broker string (e.g. `"localhost:9092"`)
+- `KafkaRecord { topic, key: Option<Vec<u8>>, value: Vec<u8> }` — message to produce
+- `KafkaEvent { topic, partition, offset, key, value }` — consumed message
+
+## Dependencies
+
+- `rdkafka` with `cmake-build` feature — compiles librdkafka from source, no system dependency needed
+- Redpanda for integration tests — Kafka-compatible, fast startup
+
+## Pre-Commit Requirements
+
+1. **Run integration tests (requires Docker):**
+
+   ```bash
+   cargo test --features kafka-integration-test -p wingfoil \
+     -- --test-threads=1 kafka::integration_tests
+   ```
+
+2. **Run standard checks:**
+
+   ```bash
+   cargo fmt --all
+   cargo clippy --workspace --all-targets --all-features
+   cargo test -p wingfoil
+   ```
+
+## Integration Test Details
+
+Tests use `testcontainers` (`SyncRunner`) to start a
+`docker.redpanda.com/redpandadata/redpanda:v24.1.1` container per test.
+Docker must be running.
+
+Feature flag: `kafka-integration-test` (implies `kafka`).
+
+Tests must be run with `--test-threads=1` to avoid port conflicts between containers.
+
+### Test coverage
+
+| Test | What it proves |
+|------|----------------|
+| `test_connection_refused` | Handles unreachable broker gracefully |
+| `test_sub_receives_pre_seeded_messages` | Pre-produced messages are consumed correctly |
+| `test_sub_live_messages` | Live messages arrive during consumption |
+| `test_pub_round_trip` | `kafka_pub` writes are readable via direct consumer |
+| `test_pub_multiple_records_in_burst` | Multiple records in a single burst are all produced |
+| `test_sub_event_fields` | All `KafkaEvent` fields are populated correctly |
+| `test_kafka_record_value_str` | UTF-8 value interpretation works |
+| `test_kafka_event_no_key` | Events without keys handled correctly |
+
+## Notes
+
+- `rdkafka` bundles `librdkafka` via the `cmake-build` feature flag. This requires
+  `cmake` to be installed on the build system.
+- Redpanda is used for tests instead of Apache Kafka because it starts much faster
+  and is fully Kafka-protocol compatible.
+- `kafka_sub` is designed for `RunMode::RealTime`. Using it in `HistoricalFrom` mode is
+  technically valid but timestamps will be wall-clock `NanoTime::now()`, not historical.

--- a/wingfoil/src/adapters/kafka/integration_tests.rs
+++ b/wingfoil/src/adapters/kafka/integration_tests.rs
@@ -1,0 +1,307 @@
+//! Integration tests for the Kafka adapter.
+//!
+//! Requires Docker. Run with:
+//! ```sh
+//! cargo test --features kafka-integration-test -p wingfoil \
+//!   -- --test-threads=1 kafka::integration_tests
+//! ```
+
+use super::*;
+use crate::nodes::{NodeOperators, StreamOperators};
+use crate::types::Burst;
+use crate::{RunFor, RunMode, burst};
+use rdkafka::Message;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::rc::Rc;
+use std::time::Duration;
+use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::SyncRunner};
+
+const REDPANDA_PORT: u16 = 9092;
+const REDPANDA_IMAGE: &str = "docker.redpanda.com/redpandadata/redpanda";
+const REDPANDA_TAG: &str = "v24.1.1";
+
+/// Start a Redpanda container and return the host endpoint.
+/// The returned container must be kept alive for the duration of the test.
+fn start_redpanda() -> anyhow::Result<(impl Drop, String)> {
+    let container = GenericImage::new(REDPANDA_IMAGE, REDPANDA_TAG)
+        .with_wait_for(WaitFor::message_on_stderr("Started Kafka API server"))
+        .with_mapped_port(REDPANDA_PORT, REDPANDA_PORT.into())
+        .with_cmd(vec![
+            "redpanda".to_string(),
+            "start".to_string(),
+            "--overprovisioned".to_string(),
+            "--smp".to_string(),
+            "1".to_string(),
+            "--memory".to_string(),
+            "512M".to_string(),
+            "--reserve-memory".to_string(),
+            "0M".to_string(),
+            "--node-id".to_string(),
+            "0".to_string(),
+            "--check=false".to_string(),
+            "--kafka-addr".to_string(),
+            format!("0.0.0.0:{REDPANDA_PORT}"),
+            "--advertise-kafka-addr".to_string(),
+            format!("127.0.0.1:{REDPANDA_PORT}"),
+        ])
+        .start()?;
+    let endpoint = format!("127.0.0.1:{REDPANDA_PORT}");
+    Ok((container, endpoint))
+}
+
+/// Create a topic via the admin API.
+fn create_topic(brokers: &str, topic: &str, partitions: i32) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let admin: AdminClient<rdkafka::client::DefaultClientContext> = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .create()
+            .map_err(|e| anyhow::anyhow!("admin create failed: {e}"))?;
+        let new_topic = NewTopic::new(topic, partitions, TopicReplication::Fixed(1));
+        admin
+            .create_topics(&[new_topic], &AdminOptions::new())
+            .await
+            .map_err(|e| anyhow::anyhow!("create topic failed: {e}"))?;
+        // Give the broker a moment to propagate metadata.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Ok(())
+    })
+}
+
+/// Produce messages directly via the client.
+fn produce_messages(brokers: &str, topic: &str, messages: &[(&str, &str)]) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("message.timeout.ms", "5000")
+            .create()
+            .map_err(|e| anyhow::anyhow!("producer create failed: {e}"))?;
+        for (key, value) in messages {
+            producer
+                .send(
+                    FutureRecord::to(topic).key(*key).payload(*value),
+                    Duration::from_secs(5),
+                )
+                .await
+                .map_err(|(e, _)| anyhow::anyhow!("produce failed: {e}"))?;
+        }
+        Ok(())
+    })
+}
+
+/// Consume messages directly via the client, returning up to `max` messages.
+fn consume_messages(
+    brokers: &str,
+    topic: &str,
+    group_id: &str,
+    max: usize,
+) -> anyhow::Result<Vec<(Option<Vec<u8>>, Vec<u8>)>> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("group.id", group_id)
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000")
+            .create()
+            .map_err(|e| anyhow::anyhow!("consumer create failed: {e}"))?;
+        consumer
+            .subscribe(&[topic])
+            .map_err(|e| anyhow::anyhow!("subscribe failed: {e}"))?;
+
+        let mut results = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if results.len() >= max || tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            match tokio::time::timeout(Duration::from_secs(2), consumer.recv()).await {
+                Ok(Ok(msg)) => {
+                    results.push((
+                        msg.key().map(|k| k.to_vec()),
+                        msg.payload().unwrap_or_default().to_vec(),
+                    ));
+                }
+                Ok(Err(e)) => return Err(anyhow::anyhow!("consume error: {e}")),
+                Err(_) => break, // timeout
+            }
+        }
+        Ok(results)
+    })
+}
+
+/// Build a one-shot `constant` stream containing a single [`KafkaRecord`].
+fn make_burst(topic: &str, key: &[u8], value: &[u8]) -> Rc<dyn crate::Stream<Burst<KafkaRecord>>> {
+    crate::nodes::constant(burst![KafkaRecord {
+        topic: topic.to_string(),
+        key: Some(key.to_vec()),
+        value: value.to_vec(),
+    }])
+}
+
+// ---- Tests ----
+
+#[test]
+fn test_connection_refused() {
+    // Error propagates correctly without a running broker.
+    let conn = KafkaConnection::new("127.0.0.1:59999");
+    let result = kafka_sub(conn, "nonexistent", "test-group")
+        .collapse()
+        .collect()
+        .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(5)));
+    // rdkafka may not immediately error on a bad broker — it retries.
+    // We just verify it doesn't panic and eventually terminates.
+    // The graph should either error or complete after the duration.
+    let _ = result;
+}
+
+#[test]
+fn test_sub_receives_pre_seeded_messages() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-sub-seeded";
+    create_topic(&brokers, topic, 1)?;
+    produce_messages(&brokers, topic, &[("k1", "v1"), ("k2", "v2")])?;
+
+    let conn = KafkaConnection::new(&brokers);
+    let collected = kafka_sub(conn, topic, "sub-seeded-group")
+        .collapse()
+        .collect();
+    collected
+        .clone()
+        .run(RunMode::RealTime, RunFor::Cycles(2))?;
+
+    let events = collected.peek_value();
+    assert_eq!(events.len(), 2);
+    let values: Vec<Vec<u8>> = events.iter().map(|e| e.value.value.clone()).collect();
+    assert!(values.contains(&b"v1".to_vec()));
+    assert!(values.contains(&b"v2".to_vec()));
+    Ok(())
+}
+
+#[test]
+fn test_sub_live_messages() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-sub-live";
+    create_topic(&brokers, topic, 1)?;
+
+    let conn = KafkaConnection::new(&brokers);
+
+    let brokers_clone = brokers.clone();
+    let topic_owned = topic.to_string();
+    let handle = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(500));
+        produce_messages(&brokers_clone, &topic_owned, &[("live-key", "live-value")]).unwrap();
+    });
+
+    let collected = kafka_sub(conn, topic, "sub-live-group")
+        .collapse()
+        .collect();
+    collected
+        .clone()
+        .run(RunMode::RealTime, RunFor::Cycles(1))?;
+    handle.join().unwrap();
+
+    let events = collected.peek_value();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].value.value, b"live-value");
+    Ok(())
+}
+
+#[test]
+fn test_pub_round_trip() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-pub-rt";
+    create_topic(&brokers, topic, 1)?;
+
+    let conn = KafkaConnection::new(&brokers);
+    let source = make_burst(topic, b"rt-key", b"rt-value");
+    kafka_pub(conn, &source).run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    // Verify via direct consumer read.
+    let messages = consume_messages(&brokers, topic, "rt-verify-group", 1)?;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].0.as_deref(), Some(b"rt-key".as_ref()));
+    assert_eq!(messages[0].1, b"rt-value");
+    Ok(())
+}
+
+#[test]
+fn test_pub_multiple_records_in_burst() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-pub-multi";
+    create_topic(&brokers, topic, 1)?;
+
+    let conn = KafkaConnection::new(&brokers);
+    let source = crate::nodes::constant(burst![
+        KafkaRecord {
+            topic: topic.to_string(),
+            key: Some(b"k1".to_vec()),
+            value: b"v1".to_vec(),
+        },
+        KafkaRecord {
+            topic: topic.to_string(),
+            key: Some(b"k2".to_vec()),
+            value: b"v2".to_vec(),
+        },
+    ]);
+    kafka_pub(conn, &source).run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let messages = consume_messages(&brokers, topic, "multi-verify-group", 2)?;
+    assert_eq!(messages.len(), 2);
+    let values: Vec<Vec<u8>> = messages.iter().map(|(_, v)| v.clone()).collect();
+    assert!(values.contains(&b"v1".to_vec()));
+    assert!(values.contains(&b"v2".to_vec()));
+    Ok(())
+}
+
+#[test]
+fn test_sub_event_fields() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-sub-fields";
+    create_topic(&brokers, topic, 1)?;
+    produce_messages(&brokers, topic, &[("field-key", "field-value")])?;
+
+    let conn = KafkaConnection::new(&brokers);
+    let collected = kafka_sub(conn, topic, "fields-group").collapse().collect();
+    collected
+        .clone()
+        .run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let events = collected.peek_value();
+    assert_eq!(events.len(), 1);
+    let event = &events[0].value;
+    assert_eq!(event.topic, topic);
+    assert_eq!(event.partition, 0);
+    assert!(event.offset >= 0);
+    assert_eq!(event.key.as_deref(), Some(b"field-key".as_ref()));
+    assert_eq!(event.value, b"field-value");
+    assert_eq!(event.value_str().unwrap(), "field-value");
+    assert_eq!(event.key_str().unwrap().unwrap(), "field-key");
+    Ok(())
+}
+
+#[test]
+fn test_kafka_record_value_str() {
+    let record = KafkaRecord {
+        topic: "t".to_string(),
+        key: Some(b"k".to_vec()),
+        value: b"hello".to_vec(),
+    };
+    assert_eq!(record.value_str().unwrap(), "hello");
+}
+
+#[test]
+fn test_kafka_event_no_key() {
+    let event = KafkaEvent {
+        topic: "t".to_string(),
+        partition: 0,
+        offset: 0,
+        key: None,
+        value: b"val".to_vec(),
+    };
+    assert!(event.key_str().is_none());
+}

--- a/wingfoil/src/adapters/kafka/mod.rs
+++ b/wingfoil/src/adapters/kafka/mod.rs
@@ -1,0 +1,162 @@
+//! Kafka adapter — streaming reads (consume) and writes (produce) for Apache Kafka.
+//!
+//! Provides two graph nodes:
+//!
+//! - [`kafka_sub`] — producer that consumes messages from a Kafka topic and emits them as events
+//! - [`kafka_pub`] — consumer that produces messages to a Kafka topic
+//!
+//! # Setup
+//!
+//! ## Local (Docker)
+//!
+//! Using Redpanda (Kafka-compatible, faster startup):
+//!
+//! ```sh
+//! docker run --rm -p 9092:9092 \
+//!   -e REDPANDA_ADVERTISE_KAFKA_ADDRESS=localhost:9092 \
+//!   docker.redpanda.com/redpandadata/redpanda:v24.1.1 \
+//!   redpanda start --overprovisioned --smp 1 --memory 512M \
+//!   --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr localhost:9092
+//! ```
+//!
+//! # Subscribing to a topic
+//!
+//! [`kafka_sub`] consumes messages from a Kafka topic, starting from the configured offset.
+//! Each message becomes a [`KafkaEvent`] containing the key, value, topic, partition, and offset.
+//!
+//! ```ignore
+//! use wingfoil::adapters::kafka::*;
+//! use wingfoil::*;
+//!
+//! let conn = KafkaConnection::new("localhost:9092");
+//!
+//! kafka_sub(conn, "my-topic", "my-group")
+//!     .collapse()
+//!     .for_each(|event, _| {
+//!         println!("{}: {:?}", event.topic, event.value_str())
+//!     })
+//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .unwrap();
+//! ```
+//!
+//! # Publishing messages
+//!
+//! [`kafka_pub`] (or the fluent `.kafka_pub()` method) consumes a
+//! `Burst<KafkaRecord>` stream and produces each record to Kafka.
+//!
+//! ```ignore
+//! use wingfoil::adapters::kafka::*;
+//! use wingfoil::*;
+//!
+//! let conn = KafkaConnection::new("localhost:9092");
+//!
+//! constant(burst![
+//!     KafkaRecord { topic: "my-topic".into(), key: Some(b"key1".to_vec()), value: b"hello".to_vec() },
+//! ])
+//! .kafka_pub(conn)
+//! .run(RunMode::RealTime, RunFor::Cycles(1))
+//! .unwrap();
+//! ```
+//!
+//! # Round-trip example
+//!
+//! See [`examples/kafka`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/kafka)
+//! for a full working example that produces messages, consumes them, transforms
+//! the values, and writes the results to a second topic.
+//!
+//! ```ignore
+//! use wingfoil::adapters::kafka::*;
+//! use wingfoil::*;
+//!
+//! let conn = KafkaConnection::new("localhost:9092");
+//!
+//! let seed = constant(burst![
+//!     KafkaRecord { topic: "source".into(), key: Some(b"greeting".to_vec()), value: b"hello".to_vec() },
+//!     KafkaRecord { topic: "source".into(), key: Some(b"subject".to_vec()), value: b"world".to_vec() },
+//! ])
+//! .kafka_pub(conn.clone());
+//!
+//! let round_trip = kafka_sub(conn.clone(), "source", "example-group")
+//!     .map(|burst| {
+//!         burst.into_iter().map(|event| {
+//!             let upper = event.value_str().unwrap_or("").to_uppercase().into_bytes();
+//!             KafkaRecord { topic: "dest".into(), key: event.key, value: upper }
+//!         })
+//!         .collect::<Burst<KafkaRecord>>()
+//!     })
+//!     .kafka_pub(conn);
+//!
+//! Graph::new(vec![seed, round_trip], RunMode::RealTime, RunFor::Cycles(3)).run().unwrap();
+//! ```
+
+mod read;
+mod write;
+
+#[cfg(all(test, feature = "kafka-integration-test"))]
+mod integration_tests;
+
+pub use read::*;
+pub use write::*;
+
+/// Connection configuration for Kafka.
+#[derive(Debug, Clone)]
+pub struct KafkaConnection {
+    /// Kafka bootstrap servers, e.g. `"localhost:9092"`.
+    pub brokers: String,
+}
+
+impl KafkaConnection {
+    /// Create a connection config with a broker string.
+    ///
+    /// Multiple brokers can be separated by commas: `"host1:9092,host2:9092"`.
+    pub fn new(brokers: impl Into<String>) -> Self {
+        Self {
+            brokers: brokers.into(),
+        }
+    }
+}
+
+/// A record to be produced to Kafka.
+#[derive(Debug, Clone, Default)]
+pub struct KafkaRecord {
+    /// The target topic.
+    pub topic: String,
+    /// Optional message key (used for partitioning).
+    pub key: Option<Vec<u8>>,
+    /// The message payload.
+    pub value: Vec<u8>,
+}
+
+impl KafkaRecord {
+    /// Interpret the value as a UTF-8 string.
+    pub fn value_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.value)
+    }
+}
+
+/// An event consumed from a Kafka topic.
+#[derive(Debug, Clone, Default)]
+pub struct KafkaEvent {
+    /// The source topic.
+    pub topic: String,
+    /// The partition from which this message was consumed.
+    pub partition: i32,
+    /// The offset of this message within the partition.
+    pub offset: i64,
+    /// The message key, if present.
+    pub key: Option<Vec<u8>>,
+    /// The message payload.
+    pub value: Vec<u8>,
+}
+
+impl KafkaEvent {
+    /// Interpret the value as a UTF-8 string.
+    pub fn value_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.value)
+    }
+
+    /// Interpret the key as a UTF-8 string, if present.
+    pub fn key_str(&self) -> Option<Result<&str, std::str::Utf8Error>> {
+        self.key.as_deref().map(std::str::from_utf8)
+    }
+}

--- a/wingfoil/src/adapters/kafka/read.rs
+++ b/wingfoil/src/adapters/kafka/read.rs
@@ -1,0 +1,74 @@
+//! Kafka consumer producer — streams messages from a Kafka topic.
+
+use super::{KafkaConnection, KafkaEvent};
+use crate::nodes::{RunParams, produce_async};
+use crate::types::*;
+use rdkafka::Message;
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use std::rc::Rc;
+
+/// Consume messages from a Kafka `topic` as [`KafkaEvent`]s.
+///
+/// Creates a consumer in the given `group_id` consumer group and subscribes to
+/// the topic. Messages are emitted as they arrive from the broker.
+///
+/// Emits `Burst<KafkaEvent>`. Use `.collapse()` for single-event processing.
+///
+/// # Consumer group
+///
+/// The `group_id` determines offset tracking. Using the same group across
+/// multiple graph runs continues from the last committed offset. Use a unique
+/// group to read from the beginning each time.
+///
+/// # Delivery semantics
+///
+/// This consumer uses `enable.auto.commit = true`, which provides **at-most-once**
+/// delivery: offsets are committed periodically in the background, so if the graph
+/// errors after a message is fetched but before it is fully processed, that message
+/// will not be re-delivered. If you need at-least-once guarantees, disable auto-commit
+/// and manage offsets manually via the rdkafka API.
+#[must_use]
+pub fn kafka_sub(
+    connection: KafkaConnection,
+    topic: impl Into<String>,
+    group_id: impl Into<String>,
+) -> Rc<dyn Stream<Burst<KafkaEvent>>> {
+    let topic = topic.into();
+    let group_id = group_id.into();
+    produce_async(move |_ctx: RunParams| async move {
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("bootstrap.servers", &connection.brokers)
+            .set("group.id", &group_id)
+            .set("auto.offset.reset", "earliest")
+            .set("enable.auto.commit", "true")
+            .set("session.timeout.ms", "6000")
+            .create()
+            .map_err(|e| anyhow::anyhow!("kafka consumer create failed: {e}"))?;
+
+        consumer
+            .subscribe(&[&topic])
+            .map_err(|e| anyhow::anyhow!("kafka subscribe failed: {e}"))?;
+
+        Ok(async_stream::stream! {
+            loop {
+                match consumer.recv().await {
+                    Ok(msg) => {
+                        let event = KafkaEvent {
+                            topic: msg.topic().to_string(),
+                            partition: msg.partition(),
+                            offset: msg.offset(),
+                            key: msg.key().map(|k| k.to_vec()),
+                            value: msg.payload().unwrap_or_default().to_vec(),
+                        };
+                        yield Ok((NanoTime::now(), event));
+                    }
+                    Err(e) => {
+                        yield Err(anyhow::anyhow!("kafka consume error: {e}"));
+                        break;
+                    }
+                }
+            }
+        })
+    })
+}

--- a/wingfoil/src/adapters/kafka/write.rs
+++ b/wingfoil/src/adapters/kafka/write.rs
@@ -1,0 +1,74 @@
+//! Kafka producer consumer — writes messages to Kafka topics.
+
+use super::{KafkaConnection, KafkaRecord};
+use crate::RunParams;
+use crate::burst;
+use crate::nodes::{FutStream, StreamOperators};
+use crate::types::*;
+use futures::StreamExt;
+use rdkafka::config::ClientConfig;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use std::pin::Pin;
+use std::rc::Rc;
+use std::time::Duration;
+
+/// Write a `Burst<KafkaRecord>` stream to Kafka.
+///
+/// Connects once at startup and produces one message per [`KafkaRecord`] in each burst.
+/// Each record specifies its target topic, allowing writes to multiple topics from
+/// a single consumer. Messages are produced with delivery confirmation; any
+/// delivery failure terminates the consumer and propagates to the graph.
+#[must_use]
+pub fn kafka_pub(
+    connection: KafkaConnection,
+    upstream: &Rc<dyn Stream<Burst<KafkaRecord>>>,
+) -> Rc<dyn Node> {
+    upstream.consume_async(Box::new(
+        move |_ctx: RunParams, source: Pin<Box<dyn FutStream<Burst<KafkaRecord>>>>| async move {
+            let producer: FutureProducer = ClientConfig::new()
+                .set("bootstrap.servers", &connection.brokers)
+                .set("message.timeout.ms", "5000")
+                .create()
+                .map_err(|e| anyhow::anyhow!("kafka producer create failed: {e}"))?;
+
+            let mut source = source;
+            while let Some((_time, burst)) = source.next().await {
+                for record in burst {
+                    let mut fut_record = FutureRecord::to(&record.topic).payload(&record.value);
+                    if let Some(ref key) = record.key {
+                        fut_record = fut_record.key(key.as_slice());
+                    }
+                    producer
+                        .send(fut_record, Duration::from_secs(5))
+                        .await
+                        .map_err(|(e, _)| anyhow::anyhow!("kafka produce failed: {e}"))?;
+                }
+            }
+
+            Ok(())
+        },
+    ))
+}
+
+/// Extension trait providing a fluent API for writing streams to Kafka.
+///
+/// Implemented for both `Burst<KafkaRecord>` (multi-item) and `KafkaRecord` (single-item)
+/// streams, so burst wrapping is never required in user code.
+pub trait KafkaPubOperators {
+    /// Write this stream to Kafka.
+    #[must_use]
+    fn kafka_pub(self: &Rc<Self>, conn: KafkaConnection) -> Rc<dyn Node>;
+}
+
+impl KafkaPubOperators for dyn Stream<Burst<KafkaRecord>> {
+    fn kafka_pub(self: &Rc<Self>, conn: KafkaConnection) -> Rc<dyn Node> {
+        kafka_pub(conn, self)
+    }
+}
+
+impl KafkaPubOperators for dyn Stream<KafkaRecord> {
+    fn kafka_pub(self: &Rc<Self>, conn: KafkaConnection) -> Rc<dyn Node> {
+        let burst_stream = self.map(|record| burst![record]);
+        kafka_pub(conn, &burst_stream)
+    }
+}

--- a/wingfoil/src/adapters/kdb/cache_integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/cache_integration_tests.rs
@@ -125,7 +125,7 @@ fn test_kdb_read_cached_corrupt_fallback() -> Result<()> {
             .path();
         std::fs::write(
             &corrupt_path,
-            format!("select from {}\ngarbage not valid bincode", TABLE_NAME),
+            format!("select from {TABLE_NAME}\ngarbage not valid bincode"),
         )?;
 
         // Re-run with real connection: corrupt file triggers fallback, then

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -119,7 +119,7 @@ impl TestDataBuilder {
             .context("Failed to send query to KDB+")?;
 
         if result.get_type() == -128 {
-            anyhow::bail!("KDB+ query error: {:?}", result);
+            anyhow::bail!("KDB+ query error: {result:?}");
         }
         Ok(())
     }
@@ -127,8 +127,7 @@ impl TestDataBuilder {
     /// Create the read table with a date column: (date, time, sym, price, qty).
     async fn create_table(&self) -> Result<()> {
         self.execute(&format!(
-            "{}:([]date:`date$();time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())",
-            TABLE_NAME
+            "{TABLE_NAME}:([]date:`date$();time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())"
         ))
         .await?;
         Ok(())
@@ -149,38 +148,30 @@ impl TestDataBuilder {
         let (date_expr, time_expr) = if sorted {
             (
                 // Each date repeated records_per_day times, num_days dates in order
-                format!(
-                    "raze {{{}#2000.01.01+x}} each til {}",
-                    records_per_day, num_days
-                ),
+                format!("raze {{{records_per_day}#2000.01.01+x}} each til {num_days}"),
                 // Within each day d: evenly distribute records across 24 hours so that
                 // timestamps never spill into the next day regardless of records_per_day.
                 // Interval = floor(86400s / records_per_day) in nanoseconds.
                 format!(
-                    "raze {{(`timestamp$2000.01.01+x)+(86400000000000j div {}j)*til {}}} each til {}",
-                    records_per_day, records_per_day, num_days
+                    "raze {{(`timestamp$2000.01.01+x)+(86400000000000j div {records_per_day}j)*til {records_per_day}}} each til {num_days}"
                 ),
             )
         } else {
             (
                 // All rows on the same date; shuffled timestamps will go backwards
-                format!("{}#2000.01.01", n),
-                format!("2000.01.01D00:00:00.000000000+1000000000j*neg {}?{}", n, n),
+                format!("{n}#2000.01.01"),
+                format!("2000.01.01D00:00:00.000000000+1000000000j*neg {n}?{n}"),
             )
         };
         let query = format!(
-            "insert[`{table};({dates};{times};{n}?`AAPL`GOOG`MSFT;{n}?100.0;{n}?1000j)]",
-            table = TABLE_NAME,
-            dates = date_expr,
-            times = time_expr,
-            n = n,
+            "insert[`{TABLE_NAME};({date_expr};{time_expr};{n}?`AAPL`GOOG`MSFT;{n}?100.0;{n}?1000j)]",
         );
         self.execute(&query).await?;
         Ok(())
     }
 
     async fn drop_table(&self) -> Result<()> {
-        self.execute(&format!("delete {} from `.", TABLE_NAME))
+        self.execute(&format!("delete {TABLE_NAME} from `."))
             .await?;
         Ok(())
     }
@@ -188,8 +179,7 @@ impl TestDataBuilder {
     /// Create the write table without a date column: (time, sym, price, qty).
     async fn create_write_table(&self) -> Result<()> {
         self.execute(&format!(
-            "{}:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())",
-            WRITE_TABLE_NAME
+            "{WRITE_TABLE_NAME}:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())"
         ))
         .await?;
         Ok(())
@@ -198,16 +188,14 @@ impl TestDataBuilder {
     /// Insert `n` sorted rows into WRITE_TABLE_NAME (for write-append test setup).
     async fn write_rows_to_write_table(&self, n: usize) -> Result<()> {
         let query = format!(
-            "insert[`{table};(2000.01.01D00:00:00.000000000+1000000000j*til {n};{n}?`AAPL`GOOG`MSFT;{n}?100.0;{n}?1000j)]",
-            table = WRITE_TABLE_NAME,
-            n = n,
+            "insert[`{WRITE_TABLE_NAME};(2000.01.01D00:00:00.000000000+1000000000j*til {n};{n}?`AAPL`GOOG`MSFT;{n}?100.0;{n}?1000j)]",
         );
         self.execute(&query).await?;
         Ok(())
     }
 
     async fn drop_write_table(&self) -> Result<()> {
-        self.execute(&format!("delete {} from `.", WRITE_TABLE_NAME))
+        self.execute(&format!("delete {WRITE_TABLE_NAME} from `."))
             .await?;
         Ok(())
     }
@@ -427,7 +415,7 @@ fn test_kdb_connection_refused() -> Result<()> {
     let stream = kdb_read::<TestTrade, _>(
         conn,
         std::time::Duration::from_secs(24 * 3600),
-        |_, _, _| format!("select from {}", TABLE_NAME),
+        |_, _, _| format!("select from {TABLE_NAME}"),
     );
     let collected = stream.collapse().collect();
     let result = collected.run(
@@ -540,13 +528,13 @@ fn write_and_verify(conn: KdbConnection, trades: Vec<TestTrade>) -> Result<usize
             &creds,
         )
         .await?;
-        let query = format!("count {}", WRITE_TABLE_NAME);
+        let query = format!("count {WRITE_TABLE_NAME}");
         let result = socket.send_sync_message(&query.as_str()).await?;
         let count = result.get_long()?;
         Ok::<i64, anyhow::Error>(count)
     })?;
 
-    println!("Wrote {} trades, verified {} in KDB", n, count);
+    println!("Wrote {n} trades, verified {count} in KDB");
     Ok(count as usize)
 }
 
@@ -647,13 +635,13 @@ fn test_kdb_write_append() -> Result<()> {
             let creds = conn.credentials_string();
             let mut socket =
                 QStream::connect(ConnectionMethod::TCP, &conn.host, conn.port, &creds).await?;
-            let query = format!("count {}", WRITE_TABLE_NAME);
+            let query = format!("count {WRITE_TABLE_NAME}");
             let result = socket.send_sync_message(&query.as_str()).await?;
             result.get_long().map_err(anyhow::Error::new)
         })?;
 
         assert_eq!(count, 5, "Should have 3 original + 2 appended = 5 rows");
-        println!("Append test: 3 + 2 = {} rows", count);
+        println!("Append test: 3 + 2 = {count} rows");
         Ok(())
     })();
 

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -304,7 +304,7 @@ where
         let mut interner = SymbolInterner::default();
 
         'outer: while let Some(query) = query_fn() {
-            info!("KDB query: {}", query);
+            info!("KDB query: {query}");
             let fetch_start = std::time::Instant::now();
             let result: K = match socket.send_sync_message(&query.as_str()).await {
                 Ok(r) => r,
@@ -330,9 +330,8 @@ where
                     && time < prev
                 {
                     yield Err(anyhow::anyhow!(
-                        "KDB data is not sorted by time: got {:?} after {:?}. \
-                        Add `xasc` to your query to sort the data.",
-                        time, prev
+                        "KDB data is not sorted by time: got {time:?} after {prev:?}. \
+                        Add `xasc` to your query to sort the data."
                     ));
                     break 'outer;
                 }

--- a/wingfoil/src/adapters/kdb/read_cached.rs
+++ b/wingfoil/src/adapters/kdb/read_cached.rs
@@ -140,7 +140,7 @@ where
                     }
                     let sock = socket.as_mut().unwrap();
 
-                    info!("KDB query: {}", query);
+                    info!("KDB query: {query}");
                     let fetch_start = std::time::Instant::now();
                     let result: K = match sock.send_sync_message(&query.as_str()).await {
                         Ok(r) => r,
@@ -177,10 +177,8 @@ where
                             && time < prev
                         {
                             yield Err(anyhow::anyhow!(
-                                "KDB data is not sorted by time: got {:?} after {:?}. \
-                                Add `xasc` to your query to sort the data.",
-                                time,
-                                prev
+                                "KDB data is not sorted by time: got {time:?} after {prev:?}. \
+                                Add `xasc` to your query to sort the data."
                             ));
                             break 'slices;
                         }

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -14,6 +14,8 @@ pub mod fluvio;
 #[cfg(feature = "iceoryx2-beta")]
 #[doc(hidden)]
 pub mod iceoryx2;
+#[cfg(feature = "kafka")]
+pub mod kafka;
 #[cfg(feature = "kdb")]
 pub mod kdb;
 #[cfg(feature = "otlp")]

--- a/wingfoil/src/adapters/zmq/registry.rs
+++ b/wingfoil/src/adapters/zmq/registry.rs
@@ -260,8 +260,7 @@ mod etcd_impl {
                     Ok(addr)
                 }
                 None => Err(anyhow::anyhow!(
-                    "no publisher named {:?} found in etcd",
-                    name
+                    "no publisher named {name:?} found in etcd"
                 )),
             }
         })

--- a/wingfoil/src/graph.rs
+++ b/wingfoil/src/graph.rs
@@ -1230,8 +1230,8 @@ mod tests {
         //.unwrap();
         let captured_data = captured.peek_value();
         println!();
-        println!("captured_data  {:?}", captured_data);
-        println!("expected       {:?}", expected);
+        println!("captured_data  {captured_data:?}");
+        println!("expected       {expected:?}");
         println!();
         assert_eq!(captured_data, expected);
     }
@@ -1270,7 +1270,7 @@ mod tests {
         graph.print();
         let result = graph.run();
 
-        assert!(result.is_err(), "Expected error but got: {:?}", result);
+        assert!(result.is_err(), "Expected error but got: {result:?}");
         let err_msg = format!("{:?}", result.unwrap_err());
 
         let expected = r#"Error in node [14]:

--- a/wingfoil/src/nodes/async_io.rs
+++ b/wingfoil/src/nodes/async_io.rs
@@ -99,7 +99,7 @@ where
                 }
                 Err(e) => {
                     // Task panicked or was cancelled
-                    anyhow::bail!("consumer task panicked or was cancelled: {}", e);
+                    anyhow::bail!("consumer task panicked or was cancelled: {e}");
                 }
             }
         }
@@ -405,7 +405,7 @@ where
                     Message::Error(err) => {
                         // Log the error and stop the stream.
                         // This error likely came from an async producer or consumer task.
-                        log::error!("Error in async stream: {:#?}", err);
+                        log::error!("Error in async stream: {err:#?}");
                         break;
                     },
                 }

--- a/wingfoil/src/nodes/buffer.rs
+++ b/wingfoil/src/nodes/buffer.rs
@@ -55,7 +55,7 @@ mod tests {
                 let buffer = buffer.peek_value();
                 let src = count.peek_value();
                 let buffered = buffer[buffer.len() - 1];
-                info!("{:?}, {:?}, {:?}, {:?}", mode, run_for, src, buffered);
+                info!("{mode:?}, {run_for:?}, {src:?}, {buffered:?}");
                 assert_eq!(src, buffered);
             }
         }

--- a/wingfoil/src/nodes/combine.rs
+++ b/wingfoil/src/nodes/combine.rs
@@ -65,7 +65,7 @@ mod tests {
             .accumulate()
             .finally(|res, _| {
                 let expected = vec![burst![1, 10, 100], burst![2, 20, 200], burst![3, 30, 300]];
-                println!("{:?}", res);
+                println!("{res:?}");
                 assert_eq!(res, expected);
                 Ok(())
             })

--- a/wingfoil/src/nodes/demux.rs
+++ b/wingfoil/src/nodes/demux.rs
@@ -573,7 +573,7 @@ mod tests {
         println!("n_msgs = {n_msgs:?}");
         println!("ntopics:");
         sorted_topics.iter().for_each(|item| {
-            println!("{:?}", item);
+            println!("{item:?}");
         });
         println!();
         for rw in sorted_topics {
@@ -609,10 +609,7 @@ mod tests {
     fn run_demux_vec(with_overflow: bool) {
         let capacity = capacity(with_overflow);
         for run_mode in &*RUN_MODES {
-            println!(
-                "demux_vec\n{:?}\nwith_overflow={:?}",
-                run_mode, with_overflow
-            );
+            println!("demux_vec\n{run_mode:?}\nwith_overflow={with_overflow:?}");
             let streams = (0..N_STREAMS)
                 .map(|i| message_source(i, None))
                 .collect::<Vec<_>>();
@@ -632,7 +629,7 @@ mod tests {
     fn run_demux(with_overflow: bool) {
         let capacity = capacity(with_overflow);
         for run_mode in &*RUN_MODES {
-            println!("demux\n{:?}\nwith_overflow={:?}", run_mode, with_overflow);
+            println!("demux\n{run_mode:?}\nwith_overflow={with_overflow:?}");
             let streams = (0..N_STREAMS)
                 .map(|i| message_source(i, Some(DELAY * i as u32)))
                 .collect::<Vec<_>>();

--- a/wingfoil/src/nodes/graph_node.rs
+++ b/wingfoil/src/nodes/graph_node.rs
@@ -341,8 +341,8 @@ mod tests {
                         let expected = (1..=actual.len())
                             .map(|x| x as u64 * 100)
                             .collect::<Vec<_>>();
-                        println!("expected {:?}", expected);
-                        println!("actual   {:?}", actual);
+                        println!("expected {expected:?}");
+                        println!("actual   {actual:?}");
                         println!();
                         let tol = if run_mode == RunMode::RealTime { 4 } else { 0 };
                         assert!(actual.len() + tol >= n_ticks as usize);

--- a/wingfoil/src/nodes/map.rs
+++ b/wingfoil/src/nodes/map.rs
@@ -64,7 +64,7 @@ mod tests {
         captured
             .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
             .unwrap();
-        println!("{:?}", expected);
+        println!("{expected:?}");
         println!("{:?}", captured.peek_value());
         assert_eq!(expected, captured.peek_value());
     }

--- a/wingfoil/src/nodes/timed.rs
+++ b/wingfoil/src/nodes/timed.rs
@@ -61,16 +61,12 @@ impl<T: Element> MutableNode for TimedStream<T> {
                     f64::INFINITY
                 };
                 info!(
-                    "{} ticks processed in {:?}, {:?} average.   \
-                     Covered {:?} of historical data (x{:.1}).",
-                    cycles_fmt, wall, avg, engine_elapsed, speedup,
+                    "{cycles_fmt} ticks processed in {wall:?}, {avg:?} average.   \
+                     Covered {engine_elapsed:?} of historical data (x{speedup:.1}).",
                 );
             }
             _ => {
-                info!(
-                    "{} ticks processed in {:?}, {:?} average.",
-                    cycles_fmt, wall, avg,
-                );
+                info!("{cycles_fmt} ticks processed in {wall:?}, {avg:?} average.",);
             }
         }
         Ok(())

--- a/wingfoil/src/nodes/window.rs
+++ b/wingfoil/src/nodes/window.rs
@@ -70,7 +70,7 @@ mod tests {
             .window(Duration::from_millis(250))
             .collect()
             .finally(|res, _| {
-                println!("{:#?}", res);
+                println!("{res:#?}");
                 let expected = vec![
                     ValueAt {
                         value: vec![1, 2, 3],


### PR DESCRIPTION
## Summary

- Adds a new Kafka I/O adapter (`kafka_sub` / `kafka_pub`) using `rdkafka` with bundled librdkafka
- Follows the established adapter pattern (etcd, kdb, zmq) with full module structure: types, producer, consumer, fluent API trait, integration tests, example, CI workflow, and Python bindings
- Fixes all pre-existing clippy `uninlined_format_args` warnings across the workspace

## Changes

**Core adapter** (`wingfoil/src/adapters/kafka/`):
- `mod.rs` — `KafkaConnection`, `KafkaRecord`, `KafkaEvent` types + module docs
- `read.rs` — `kafka_sub(conn, topic, group_id)` producer via `produce_async`
- `write.rs` — `kafka_pub(conn, upstream)` consumer via `consume_async` + `KafkaPubOperators` fluent trait
- `integration_tests.rs` — 8 tests using Redpanda via testcontainers
- `CLAUDE.md` — design docs and pre-commit requirements

**Python bindings**:
- `py_kafka.rs` — `py_kafka_sub` + `py_kafka_pub_inner`
- Stream method `.kafka_pub(brokers, topic)` on `PyStream`
- Python alias `kafka_sub` in `__init__.py`
- Integration tests in `test_kafka.py`

**CI**: standalone `kafka-integration.yml` + registered in `integration-tests.yml`

**Example**: `wingfoil/examples/kafka/` — produce → consume → uppercase → produce round-trip

## Test plan

- [x] `cargo build --features kafka -p wingfoil` passes
- [x] `cargo test -p wingfoil` — all unit tests pass
- [x] `cargo clippy --workspace --all-targets --all-features` — zero warnings
- [x] `cargo check -p wingfoil-python` — compiles cleanly
- [ ] `cargo test --features kafka-integration-test -p wingfoil -- --test-threads=1` (requires Docker)
- [ ] `cargo run --example kafka --features kafka` (requires running broker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)