### PR TITLE
Make StreamOperators::feedback a pass-through returning Rc<dyn Stream…

### DIFF
--- a/wingfoil/src/nodes/feedback.rs
+++ b/wingfoil/src/nodes/feedback.rs
@@ -63,6 +63,34 @@ impl<T: Element + Hash + Eq> FeedbackSink<T> {
     }
 }
 
+/// Pass-through node that forwards upstream values unchanged while also sending
+/// each value to a [FeedbackSink] as a side effect. Created by
+/// [StreamOperators::feedback].
+pub(crate) struct FeedbackSendStream<T: Element + Hash + Eq> {
+    upstream: Rc<dyn Stream<T>>,
+    value: T,
+    sink: FeedbackSink<T>,
+}
+
+impl<T: Element + Hash + Eq> FeedbackSendStream<T> {
+    pub fn new(upstream: Rc<dyn Stream<T>>, sink: FeedbackSink<T>) -> Self {
+        Self {
+            upstream,
+            value: T::default(),
+            sink,
+        }
+    }
+}
+
+#[node(active = [upstream], output = value: T)]
+impl<T: Element + Hash + Eq> MutableNode for FeedbackSendStream<T> {
+    fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
+        self.value = self.upstream.peek_value();
+        self.sink.send(self.value.clone(), state);
+        Ok(true)
+    }
+}
+
 /// Creates a feedback channel. Returns a ([FeedbackSink], [Stream])
 /// pair. The sink pushes values onto a shared [TimeQueue]; the source
 /// stream pops them on the next engine cycle.
@@ -80,6 +108,7 @@ impl<T: Element + Hash + Eq> FeedbackSink<T> {
 /// );
 ///
 /// let writer = sum.feedback(tx);
+/// // writer is Rc<dyn Stream<u64>> — values pass through, feedback is a side effect
 /// ```
 #[must_use]
 pub fn feedback<T: Element + Hash + Eq>() -> (FeedbackSink<T>, Rc<dyn Stream<T>>) {
@@ -127,7 +156,7 @@ mod tests {
         });
 
         Graph::new(
-            vec![fb, res],
+            vec![fb.as_node(), res],
             RunMode::HistoricalFrom(NanoTime::ZERO),
             RunFor::Duration(period * 5),
         )
@@ -157,7 +186,7 @@ mod tests {
         });
 
         Graph::new(
-            vec![fb, res],
+            vec![fb.as_node(), res],
             RunMode::HistoricalFrom(NanoTime::ZERO),
             RunFor::Cycles(5),
         )

--- a/wingfoil/src/nodes/mod.rs
+++ b/wingfoil/src/nodes/mod.rs
@@ -57,6 +57,7 @@ pub use channel::ChannelReceiverStream;
 pub use demux::*;
 #[cfg(feature = "dynamic-graph-beta")]
 pub use dynamic_group::*;
+use feedback::FeedbackSendStream;
 pub use feedback::{FeedbackSink, feedback, feedback_node};
 #[cfg(feature = "async")]
 pub use graph_node::*;
@@ -397,9 +398,10 @@ pub trait StreamOperators<T: Element> {
     /// executes supplied closure on each tick
     #[must_use]
     fn for_each(self: &Rc<Self>, func: impl Fn(T, NanoTime) + 'static) -> Rc<dyn Node>;
-    /// Sends each value to a [FeedbackSink].
+    /// Sends each value to a [FeedbackSink] and passes the value through unchanged.
+    /// Like [inspect](StreamOperators::inspect) but for feedback channels.
     #[must_use]
-    fn feedback(self: &Rc<Self>, sink: FeedbackSink<T>) -> Rc<dyn Node>
+    fn feedback(self: &Rc<Self>, sink: FeedbackSink<T>) -> Rc<dyn Stream<T>>
     where
         T: Hash + Eq;
     /// executes supplied fallible closure on each tick.
@@ -658,19 +660,11 @@ where
         ConsumerNode::new(self.clone(), Box::new(func)).into_node()
     }
 
-    fn feedback(self: &Rc<Self>, sink: FeedbackSink<T>) -> Rc<dyn Node>
+    fn feedback(self: &Rc<Self>, sink: FeedbackSink<T>) -> Rc<dyn Stream<T>>
     where
         T: Hash + Eq,
     {
-        let upstream = self.clone();
-        GraphStateStream::new(
-            self.clone().as_node(),
-            Box::new(move |state: &mut GraphState| {
-                sink.send(upstream.peek_value(), state);
-            }),
-        )
-        .into_stream()
-        .as_node()
+        FeedbackSendStream::new(self.clone(), sink).into_stream()
     }
 
     fn try_for_each(


### PR DESCRIPTION
…<T>>

Previously feedback() returned Rc<dyn Node>, dropping the stream type and breaking method chains. It now behaves like inspect() — values pass through unchanged while the FeedbackSink receives each value as a side effect.

Callers that used the result as a graph root node now call .as_node() on it.

https://claude.ai/code/session_01Mp3ZgS5kyvx7go6ZjGa1P9