### PR TITLE
Add code coverage tracking for Python and Rust components

### DIFF
--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -24,9 +24,13 @@ jobs:
         with:
           toolchain: stable
           override: true
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Install system dependencies
         run: sudo apt-get install -y protobuf-compiler
@@ -39,14 +43,33 @@ jobs:
       - name: Create virtualenv and install dependencies
         run: |
           python -m venv wingfoil-python/.venv
-          wingfoil-python/.venv/bin/pip install maturin pytest pandas pyzmq
+          wingfoil-python/.venv/bin/pip install maturin pytest pandas pyzmq pytest-cov
 
-      - name: Build and install Python bindings
+      - name: Build and test Python bindings with Rust coverage
         run: |
+          source <(cargo llvm-cov show-env --export-prefix)
           cd wingfoil-python
           .venv/bin/maturin develop
+          .venv/bin/pytest tests/ \
+            --cov=wingfoil \
+            --cov-report=lcov:lcov-python.info
+          cd ..
+          cargo llvm-cov report -p wingfoil -p wingfoil-python \
+            --lcov \
+            --output-path wingfoil-python/lcov-rust.info
 
-      - name: Run pytest
-        run: |
-          cd wingfoil-python
-          .venv/bin/pytest tests/
+      - name: Upload Python coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: wingfoil-python/lcov-python.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: python
+          fail_ci_if_error: true
+
+      - name: Upload Rust-from-Python coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: wingfoil-python/lcov-rust.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: python-rust
+          fail_ci_if_error: true

--- a/wingfoil-python/pyproject.toml
+++ b/wingfoil-python/pyproject.toml
@@ -29,3 +29,9 @@ features = ["pyo3/extension-module"]
 python-source = "python"
 module-name = "wingfoil._wingfoil"
 include = ["Cargo.toml"]
+
+[tool.coverage.run]
+source = ["wingfoil"]
+
+[tool.coverage.report]
+omit = ["*/_wingfoil*"]


### PR DESCRIPTION
## Summary
This PR adds comprehensive code coverage tracking for both Python and Rust components of the project using `cargo-llvm-cov` and `pytest-cov`, with automated uploads to Codecov.

## Key Changes
- **CI/CD Pipeline Updates**:
  - Added `llvm-tools-preview` component to Rust toolchain setup
  - Installed `cargo-llvm-cov` for unified coverage reporting across Rust and Python
  - Added `pytest-cov` dependency for Python test coverage measurement
  - Consolidated build and test steps into a single workflow job that captures coverage for both languages

- **Coverage Collection**:
  - Python coverage is collected via `pytest --cov` and exported to `lcov-python.info`
  - Rust coverage (from Python bindings) is collected via `cargo llvm-cov` and exported to `lcov-rust.info`
  - Both coverage reports are uploaded separately to Codecov with distinct flags (`python` and `python-rust`)

- **Coverage Configuration**:
  - Added `[tool.coverage.run]` and `[tool.coverage.report]` sections to `pyproject.toml`
  - Configured coverage to track the `wingfoil` source module while omitting generated `_wingfoil` bindings

## Notable Implementation Details
- The workflow uses `cargo llvm-cov show-env --export-prefix` to set up the coverage environment before building and testing
- Coverage reports are generated in LCOV format for better integration with Codecov
- Separate Codecov uploads allow tracking coverage metrics independently for Python and Rust components
- The `fail_ci_if_error: true` flag ensures the CI pipeline fails if coverage upload fails

https://claude.ai/code/session_01KPUXj1CKvg7cABRGmpd7ec