### PR TITLE
Enable flag carryforward in codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,7 @@ coverage:
     patch:
       default:
         informational: true
+
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## Summary
Updated the codecov configuration to enable flag carryforward functionality by default.

## Changes
- Added `flag_management` section to codecov.yml
- Enabled `carryforward: true` under `default_rules` to allow flags to persist across commits

## Details
This configuration change enables Codecov's flag carryforward feature, which allows coverage flags to carry forward to subsequent commits when they are not explicitly reported. This is useful for maintaining coverage context across builds where certain flags may not be present in every commit.

https://claude.ai/code/session_01T6yfS9HF8SZtnNuqVaTAj1