### PR TITLE
fix: resolve clippy errors breaking CI build (iceoryx2 adapter)

### DIFF
--- a/wingfoil/src/adapters/iceoryx2/mod.rs
+++ b/wingfoil/src/adapters/iceoryx2/mod.rs
@@ -340,7 +340,7 @@ mod tests {
         let upstream = ticker(Duration::from_millis(20)).produce(move || {
             let mut b: Burst<Vec<u8>> = Burst::default();
             let s = step.fetch_add(1, Ordering::Relaxed);
-            if s % 2 == 0 {
+            if s.is_multiple_of(2) {
                 b.push(vec![1, 2, 3]);
             } else {
                 b.push(vec![4, 5, 6, 7]);
@@ -391,7 +391,7 @@ mod tests {
         let upstream = ticker(Duration::from_millis(20)).produce(move || {
             let mut b: Burst<Vec<u8>> = Burst::default();
             let s = step.fetch_add(1, Ordering::Relaxed);
-            if s % 2 == 0 {
+            if s.is_multiple_of(2) {
                 b.push(vec![10, 20]);
             } else {
                 b.push(vec![30, 40, 50]);

--- a/wingfoil/src/adapters/iceoryx2/read.rs
+++ b/wingfoil/src/adapters/iceoryx2/read.rs
@@ -339,7 +339,7 @@ where
                     return Ok(false);
                 };
 
-                if self.cycles % 10 == 0 {
+                if self.cycles.is_multiple_of(10) {
                     subscriber.update_connections_periodic();
                 }
 
@@ -522,7 +522,7 @@ impl crate::MutableNode for Iceoryx2SliceReceiverStream {
                     return Ok(false);
                 };
 
-                if self.cycles % 10 == 0 {
+                if self.cycles.is_multiple_of(10) {
                     subscriber.update_connections_periodic();
                 }
 

--- a/wingfoil/src/adapters/iceoryx2/write.rs
+++ b/wingfoil/src/adapters/iceoryx2/write.rs
@@ -336,7 +336,7 @@ where
         };
 
         self.cycles += 1;
-        if self.cycles % 10 == 0 {
+        if self.cycles.is_multiple_of(10) {
             match publisher {
                 Iceoryx2PublisherPort::Ipc(p) => p.update_connections()?,
                 Iceoryx2PublisherPort::Local(p) => p.update_connections()?,
@@ -369,10 +369,8 @@ where
             sent_any = true;
         }
 
-        if sent_any {
-            if let Some(ref n) = self.notifier {
-                n.notify()?;
-            }
+        if sent_any && let Some(ref n) = self.notifier {
+            n.notify()?;
         }
 
         Ok(sent_any)
@@ -460,7 +458,7 @@ impl MutableNode for Iceoryx2SlicePublisher {
         };
 
         self.cycles += 1;
-        if self.cycles % 10 == 0 {
+        if self.cycles.is_multiple_of(10) {
             match publisher {
                 Iceoryx2SlicePublisherPort::Ipc(p) => p.update_connections()?,
                 Iceoryx2SlicePublisherPort::Local(p) => p.update_connections()?,
@@ -493,10 +491,8 @@ impl MutableNode for Iceoryx2SlicePublisher {
             sent_any = true;
         }
 
-        if sent_any {
-            if let Some(ref n) = self.notifier {
-                n.notify()?;
-            }
+        if sent_any && let Some(ref n) = self.notifier {
+            n.notify()?;
         }
 
         Ok(sent_any)


### PR DESCRIPTION
## Summary

- Fix 8 clippy errors in the iceoryx2 adapter introduced by #176 and #194 that break the `cargo clippy --all-features -D warnings` CI check
- Replace manual `% N == 0` checks with `.is_multiple_of(N)` (`manual_is_multiple_of` lint) in `read.rs`, `write.rs`, and `mod.rs`
- Collapse nested `if` statements in `write.rs` (`collapsible_if` lint)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (222 tests)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes