### PR TITLE
Fix: configure etcd example with required feature

### DIFF
--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -231,3 +231,8 @@ required-features = ["zmq-beta", "etcd"]
 name = "zmq_etcd_sub"
 path = "examples/zmq/etcd/zmq_sub.rs"
 required-features = ["zmq-beta", "etcd"]
+
+[[example]]
+name = "etcd"
+path = "examples/etcd/main.rs"
+required-features = ["etcd"]


### PR DESCRIPTION
The etcd example was being auto-discovered but compiled without the etcd feature enabled, causing import errors. Added [[example]] block to Cargo.toml with required-features = ["etcd"].