### PR TITLE
Add ZMQ examples to README and improve Python test coverage

### DIFF
--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -57,8 +57,8 @@ The container is stopped automatically when dropped. Hold the container in a bin
 ```
 wingfoil/src/adapters/$ARGUMENTS/
   mod.rs               # Connection config, public types, re-exports
-  read.rs              # sub function (produce_async)
-  write.rs             # pub function (consume_async)
+  read.rs              # sub function (producer)
+  write.rs             # pub function (consumer)
   integration_tests.rs # gated by $ARGUMENTS-integration-test feature
   CLAUDE.md            # documents design decisions and pre-commit requirements
 ```
@@ -122,7 +122,46 @@ Add `//!` module-level doc at the top of `mod.rs` covering:
 
 ## 7. Sub method — `read.rs` (producer)
 
-Uses `produce_async`. Returns `Rc<dyn Stream<Burst<Event>>>`.
+Choose the threading model based on the I/O library:
+
+- **`produce_async`** — when the I/O library is async (e.g. tokio-based clients like
+  `etcd-client`, `rdkafka`). Returns `Rc<dyn Stream<Burst<Event>>>`.
+- **`ReceiverStream`** — when the I/O library is synchronous and poll-based (e.g. `zmq`,
+  `iceoryx2`). Dedicates a real OS thread per subscriber to marshall incoming messages
+  into the graph via a channel. Use this to avoid wrapping every blocking call in
+  `spawn_blocking`.
+
+### produce_async pattern (async I/O)
+
+```rust
+#[must_use]
+pub fn $ARGUMENTS_sub(conn: impl Into<<Name>Connection>, /* params */) -> Rc<dyn Stream<Burst<<Name>Event>>> {
+    produce_async(move |_ctx: RunParams| async move {
+        Ok(async_stream::stream! {
+            // connect, snapshot, then live stream
+            // yield Ok((NanoTime::now(), event))
+            // yield Err(anyhow::anyhow!("...")) on fatal error
+        })
+    })
+}
+```
+
+### ReceiverStream pattern (synchronous / poll-based I/O)
+
+```rust
+pub fn $ARGUMENTS_sub<T: Element + Send>(address: &str) -> Rc<dyn Stream<Burst<T>>> {
+    let subscriber = Subscriber::new(address.to_string());
+    ReceiverStream::new(
+        move |channel_sender, stop_flag| subscriber.run(channel_sender, stop_flag),
+        true, // real-time only
+    )
+    .into_stream()
+}
+```
+
+The callback runs on a dedicated OS thread. Use `stop_flag: Arc<AtomicBool>` to
+cooperatively shut down, and `channel_sender: ChannelSender<T>` to push
+`Message::RealtimeValue(v)`, `Message::EndOfStream`, or `Message::Error(e)`.
 
 **Flexible arguments via `impl Into<T>`:** for any parameter that callers might supply in
 multiple forms (a URL string, a config struct, a bare value), accept `impl Into<ConfigType>`
@@ -158,19 +197,6 @@ $ARGUMENTS_sub(config)                         // pre-built config
 $ARGUMENTS_sub(("service-name", my_backend))   // mode-switching
 ```
 
-```rust
-#[must_use]
-pub fn $ARGUMENTS_sub(conn: impl Into<<Name>Connection>, /* params */) -> Rc<dyn Stream<Burst<<Name>Event>>> {
-    produce_async(move |_ctx: RunParams| async move {
-        Ok(async_stream::stream! {
-            // connect, snapshot, then live stream
-            // yield Ok((NanoTime::now(), event))
-            // yield Err(anyhow::anyhow!("...")) on fatal error
-        })
-    })
-}
-```
-
 If the service supports a **snapshot + watch** pattern (like etcd), use watch-before-get to avoid races:
 1. Open watch/subscribe first
 2. Read snapshot, capture its revision/cursor
@@ -179,7 +205,53 @@ If the service supports a **snapshot + watch** pattern (like etcd), use watch-be
 
 ## 8. Pub method — `write.rs` (consumer)
 
-Uses `consume_async`. Returns `Rc<dyn Node>`.
+Choose the threading model to match the I/O library (same decision as step 7):
+
+- **`consume_async`** — when the I/O library is async. Returns `Rc<dyn Node>`.
+- **`MutableNode` impl** — when the I/O library is synchronous. Implement `start` / `cycle` /
+  `stop` directly on a struct, giving full control over socket lifecycle and buffering.
+
+### consume_async pattern (async I/O)
+
+```rust
+#[must_use]
+pub fn $ARGUMENTS_pub(conn: <Name>Connection, upstream: &Rc<dyn Stream<Burst<<Name>Entry>>>) -> Rc<dyn Node> {
+    upstream.consume_async(Box::new(move |source: Pin<Box<dyn FutStream<Burst<<Name>Entry>>>>| {
+        async move {
+            // connect once
+            // while let Some((_time, burst)) = source.next().await { write each entry }
+            Ok(())
+        }
+    }))
+}
+```
+
+### MutableNode pattern (synchronous / poll-based I/O)
+
+```rust
+struct SenderNode<T: Element + Send> {
+    src: Rc<dyn Stream<T>>,
+    socket: Option<Socket>,
+    // ... buffering state, config, etc.
+}
+
+impl<T: Element + Send + Serialize> MutableNode for SenderNode<T> {
+    fn start(&mut self, state: &mut GraphState) -> anyhow::Result<()> {
+        // bind socket, register with discovery backend, etc.
+    }
+    fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
+        let value = self.src.peek_value();
+        // serialize and send
+        Ok(true)
+    }
+    fn stop(&mut self, _: &mut GraphState) -> anyhow::Result<()> {
+        // send EndOfStream, revoke registrations, close socket
+    }
+    fn upstreams(&self) -> UpStreams {
+        UpStreams::new(vec![self.src.clone().as_node()], vec![])
+    }
+}
+```
 
 Apply the same `impl Into<T>` and wrapper-type patterns from step 7. A common case is an
 optional registration or side-effect (e.g. register address in a registry, or skip it):
@@ -195,20 +267,9 @@ stream.$ARGUMENTS_pub(port, ())                       // no registration
 stream.$ARGUMENTS_pub(port, ("service-name", backend)) // with registration
 ```
 
-```rust
-#[must_use]
-pub fn $ARGUMENTS_pub(conn: <Name>Connection, upstream: &Rc<dyn Stream<Burst<<Name>Entry>>>) -> Rc<dyn Node> {
-    upstream.consume_async(Box::new(move |source: Pin<Box<dyn FutStream<Burst<<Name>Entry>>>>| {
-        async move {
-            // connect once
-            // while let Some((_time, burst)) = source.next().await { write each entry }
-            Ok(())
-        }
-    }))
-}
+Expose a fluent extension trait so callers can chain `.$ARGUMENTS_pub(...)` on streams:
 
-// Fluent extension trait — implement for both Burst<Entry> and single Entry streams
-// so callers never need to manually wrap items in a Burst.
+```rust
 pub trait <Name>PubOperators {
     #[must_use]
     fn $ARGUMENTS_pub(self: &Rc<Self>, conn: <Name>Connection) -> Rc<dyn Node>;

--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -462,7 +462,7 @@ chains together. Do **not** add directly to `release.yml`.
 Add the adapter's feature to the wingfoil dependency:
 
 ```toml
-wingfoil = { path = "../wingfoil", features = ["kdb", "zmq-beta", "$ARGUMENTS"] }
+wingfoil = { path = "../wingfoil", features = ["kdb", "zmq", "$ARGUMENTS"] }
 ```
 
 ### b. Binding module — `wingfoil-python/src/py_$ARGUMENTS.rs`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run ZMQ integration tests
         run: |
-          cargo test --features zmq-beta-integration-test -p wingfoil \
+          cargo test --features zmq-integration-test -p wingfoil \
             -- --test-threads=1 zmq::integration_tests
         env:
           RUST_LOG: INFO

--- a/.github/workflows/zmq-integration.yml
+++ b/.github/workflows/zmq-integration.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run ZMQ integration tests
         run: |
-          cargo test --features zmq-beta-integration-test -p wingfoil \
+          cargo test --features zmq-integration-test -p wingfoil \
             -- --test-threads=1 zmq::integration_tests
         env:
           RUST_LOG: INFO

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ data.print()
     .run(RunMode::RealTime, RunFor::Forever)?;
 ```
 
+Service discovery via etcd is also supported — see the [etcd examples](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/zmq/etcd/) for details.
+
 [Full example.](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/zmq/)
 
 ## Telemetry Example

--- a/README.md
+++ b/README.md
@@ -135,6 +135,39 @@ round_trip.run(RunMode::RealTime, RunFor::Cycles(3)).unwrap();
 
 [Full example.](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/etcd/)
 
+## ZeroMQ Example
+
+Publish a stream over ZMQ and subscribe from another process — cross-language compatible with the Python bindings:
+
+```rust,ignore
+// publisher
+use wingfoil::adapters::zmq::ZeroMqPub;
+use wingfoil::*;
+
+ticker(Duration::from_millis(100))
+    .count()
+    .map(|n: u64| format!("{n}").into_bytes())
+    .zmq_pub(7779, ())
+    .run(RunMode::RealTime, RunFor::Forever)?;
+```
+
+```rust,ignore
+// subscriber
+use wingfoil::adapters::zmq::zmq_sub;
+use wingfoil::*;
+
+let (data, _status) = zmq_sub::<Vec<u8>>("tcp://127.0.0.1:7779")?;
+data.map(|burst| {
+    burst.into_iter()
+        .map(|b| String::from_utf8_lossy(&b).into_owned())
+        .collect::<Vec<_>>()
+})
+.print()
+.run(RunMode::RealTime, RunFor::Forever)?;
+```
+
+[Full example.](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/zmq/)
+
 ## Telemetry Example
 
 Export stream metrics to Grafana via Prometheus scraping (pull) or OpenTelemetry OTLP push — or both simultaneously:

--- a/README.md
+++ b/README.md
@@ -157,13 +157,9 @@ use wingfoil::adapters::zmq::zmq_sub;
 use wingfoil::*;
 
 let (data, _status) = zmq_sub::<Vec<u8>>("tcp://127.0.0.1:7779")?;
-data.map(|burst| {
-    burst.into_iter()
-        .map(|b| String::from_utf8_lossy(&b).into_owned())
-        .collect::<Vec<_>>()
-})
-.print()
-.run(RunMode::RealTime, RunFor::Forever)?;
+// See wingfoil-python/examples/zmq/ for a Python subscriber
+data.print()
+    .run(RunMode::RealTime, RunFor::Forever)?;
 ```
 
 [Full example.](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/zmq/)

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -22,7 +22,7 @@ iceoryx2-beta = ["wingfoil/iceoryx2-beta"]
 [dependencies]
 
 # parent
-wingfoil = { path = "../wingfoil", features = ["kdb", "zmq-beta", "etcd", "prometheus", "otlp"] }
+wingfoil = { path = "../wingfoil", features = ["kdb", "zmq", "etcd", "prometheus", "otlp"] }
 
 # workspace deps
 anyhow = {workspace = true}

--- a/wingfoil-python/tests/test_zmq.py
+++ b/wingfoil-python/tests/test_zmq.py
@@ -1,43 +1,175 @@
+"""Integration tests for ZMQ pub/sub Python bindings.
+
+ZMQ is peer-to-peer — no broker needed. Direct pub/sub tests run without any
+external infrastructure. etcd discovery tests are skipped unless etcd is
+reachable on localhost:2379.
+
+Setup (etcd tests only):
+    docker run --rm -p 2379:2379 \\
+      -e ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379 \\
+      -e ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379 \\
+      gcr.io/etcd-development/etcd:v3.5.0
+"""
+
+import socket
 import threading
 import time
-
-import pytest
-import zmq
+import unittest
 
 import wingfoil as wf
 
-PORT = 5570
+DIRECT_PORT = 5570
 
 
-def _publish_garbage(port, ready):
-    """Publish raw bytes that cannot be deserialized as Message<Vec<u8>>."""
-    ctx = zmq.Context()
-    sock = ctx.socket(zmq.PUB)
-    sock.bind(f"tcp://127.0.0.1:{port}")
-    ready.set()
-    time.sleep(0.3)  # let subscriber connect (slow-joiner)
-    for _ in range(20):
-        sock.send(b"not valid bincode")
-        time.sleep(0.05)
-    sock.close()
-    ctx.term()
+class TestZmqSub(unittest.TestCase):
+    def test_sub_returns_bytes_list(self):
+        """zmq_sub data stream yields list[bytes] on each tick."""
+        port = DIRECT_PORT
+
+        def _run_publisher():
+            (
+                wf.ticker(0.05)
+                .count()
+                .map(lambda n: str(n).encode())
+                .zmq_pub(port)
+                .run(realtime=True, duration=1.5)
+            )
+
+        pub_thread = threading.Thread(target=_run_publisher, daemon=True)
+        pub_thread.start()
+        time.sleep(0.3)  # let publisher bind
+
+        data, _status = wf.zmq_sub(f"tcp://127.0.0.1:{port}")
+        items = []
+        data.inspect(lambda msgs: items.extend(msgs)).run(
+            realtime=True, duration=0.8
+        )
+
+        self.assertGreater(len(items), 0, "no messages received")
+        for item in items:
+            self.assertIsInstance(item, bytes)
+
+        pub_thread.join(timeout=2.0)
+
+    def test_sub_receives_consecutive_integers(self):
+        """Subscriber receives a consecutive counter sequence from the publisher."""
+        port = DIRECT_PORT + 1
+
+        def _run_publisher():
+            (
+                wf.ticker(0.05)
+                .count()
+                .map(lambda n: str(n).encode())
+                .zmq_pub(port)
+                .run(realtime=True, duration=1.5)
+            )
+
+        pub_thread = threading.Thread(target=_run_publisher, daemon=True)
+        pub_thread.start()
+        time.sleep(0.3)
+
+        data, _status = wf.zmq_sub(f"tcp://127.0.0.1:{port}")
+        items = []
+        data.inspect(lambda msgs: items.extend(msgs)).run(
+            realtime=True, duration=0.8
+        )
+
+        nums = [int(b) for b in items]
+        self.assertGreaterEqual(len(nums), 3, f"expected >= 3 items, got {len(nums)}")
+        for a, b in zip(nums, nums[1:]):
+            self.assertEqual(b, a + 1, f"non-consecutive: {a}, {b}")
+
+        pub_thread.join(timeout=2.0)
+
+    def test_status_stream_yields_strings(self):
+        """zmq_sub status stream yields 'connected' or 'disconnected'."""
+        port = DIRECT_PORT + 2
+
+        def _run_publisher():
+            (
+                wf.ticker(0.05)
+                .count()
+                .map(lambda n: str(n).encode())
+                .zmq_pub(port)
+                .run(realtime=True, duration=1.5)
+            )
+
+        pub_thread = threading.Thread(target=_run_publisher, daemon=True)
+        pub_thread.start()
+        time.sleep(0.3)
+
+        _data, status = wf.zmq_sub(f"tcp://127.0.0.1:{port}")
+        statuses = []
+        status.inspect(lambda s: statuses.append(s)).run(
+            realtime=True, duration=0.8
+        )
+
+        self.assertGreater(len(statuses), 0, "no status events received")
+        for s in statuses:
+            self.assertIn(s, ("connected", "disconnected"))
+
+        pub_thread.join(timeout=2.0)
 
 
-def test_deserialization_error_propagates():
-    ready = threading.Event()
-    t = threading.Thread(target=_publish_garbage, args=(PORT, ready), daemon=True)
-    t.start()
-    ready.wait()
+class TestZmqPub(unittest.TestCase):
+    def test_pub_round_trip(self):
+        """Publisher sends data that subscriber receives correctly."""
+        port = DIRECT_PORT + 3
 
-    data, _status = wf.py_zmq_sub(f"tcp://127.0.0.1:{PORT}")
-    data_node = data.inspect(lambda _: None)
+        def _run_publisher():
+            (
+                wf.ticker(0.05)
+                .count()
+                .map(lambda n: str(n).encode())
+                .zmq_pub(port)
+                .run(realtime=True, duration=1.5)
+            )
 
-    with pytest.raises(Exception):
-        wf.Graph([data_node]).run(duration=3.0)
+        pub_thread = threading.Thread(target=_run_publisher, daemon=True)
+        pub_thread.start()
+        time.sleep(0.3)
+
+        data, _status = wf.zmq_sub(f"tcp://127.0.0.1:{port}")
+        items = []
+        data.inspect(lambda msgs: items.extend(msgs)).run(
+            realtime=True, duration=0.8
+        )
+
+        self.assertGreater(len(items), 0, "no data received in round trip")
+        # Verify all items are valid integer strings
+        for item in items:
+            int(item)  # raises ValueError if not a valid integer
+
+        pub_thread.join(timeout=2.0)
+
+    def test_deserialization_error_propagates(self):
+        """Raw non-bincode bytes from a plain ZMQ socket cause an error."""
+        port = DIRECT_PORT + 4
+
+        def _publish_garbage():
+            import zmq as pyzmq
+
+            ctx = pyzmq.Context()
+            sock = ctx.socket(pyzmq.PUB)
+            sock.bind(f"tcp://127.0.0.1:{port}")
+            time.sleep(0.3)
+            for _ in range(20):
+                sock.send(b"not valid bincode")
+                time.sleep(0.05)
+            sock.close()
+            ctx.term()
+
+        t = threading.Thread(target=_publish_garbage, daemon=True)
+        t.start()
+        time.sleep(0.3)
+
+        data, _status = wf.zmq_sub(f"tcp://127.0.0.1:{port}")
+        with self.assertRaises(Exception):
+            data.inspect(lambda _: None).run(realtime=True, duration=3.0)
 
 
 # --- etcd discovery tests ---
-# Skipped unless etcd is reachable on localhost:2379.
+
 
 ETCD_ENDPOINT = "http://127.0.0.1:2379"
 ETCD_PUB_PORT = 5592
@@ -45,45 +177,46 @@ ETCD_SERVICE = "pytest/etcd-quotes"
 
 
 def _etcd_available():
-    """Return True if etcd is reachable (for test skipping)."""
     try:
-        import socket
-
-        s = socket.create_connection(("127.0.0.1", 2379), timeout=0.5)
-        s.close()
-        return True
+        with socket.create_connection(("127.0.0.1", 2379), timeout=0.5):
+            return True
     except OSError:
         return False
 
 
-@pytest.mark.skipif(
-    not _etcd_available() or wf.zmq_sub_etcd is None,
-    reason="etcd not available on localhost:2379 or etcd feature not compiled",
-)
-class TestZmqEtcdDiscovery:
+ETCD_AVAILABLE = _etcd_available() and wf.zmq_sub_etcd is not None
+
+
+@unittest.skipUnless(ETCD_AVAILABLE, "etcd not available or etcd feature not compiled")
+class TestZmqEtcdDiscovery(unittest.TestCase):
     def test_zmq_sub_etcd_no_etcd_returns_error(self):
-        with pytest.raises(Exception):
+        """Connection refused when etcd is unreachable."""
+        with self.assertRaises(Exception):
             wf.zmq_sub_etcd("anything", "http://127.0.0.1:59999")
 
     def test_zmq_pub_etcd_end_to_end(self):
         """Full round-trip using etcd discovery."""
 
         def _run_publisher():
-            node = (
+            (
                 wf.ticker(0.05)
                 .count()
                 .map(lambda v: str(v).encode())
                 .zmq_pub_etcd(ETCD_SERVICE, ETCD_PUB_PORT, ETCD_ENDPOINT)
+                .run(realtime=True, duration=0.7)
             )
-            node.run(realtime=True, duration=0.7)
 
         pub_thread = threading.Thread(target=_run_publisher, daemon=True)
         pub_thread.start()
-        time.sleep(0.3)  # wait for publisher to register in etcd
+        time.sleep(0.3)
 
         data, _status = wf.zmq_sub_etcd(ETCD_SERVICE, ETCD_ENDPOINT)
         items = []
         data.inspect(lambda v: items.extend(v)).run(realtime=True, duration=0.5)
 
-        assert len(items) > 0, "no data received via etcd discovery"
+        self.assertGreater(len(items), 0, "no data received via etcd discovery")
         pub_thread.join(timeout=2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -1,15 +1,15 @@
 [features]
 default = ["async"]
-full = ["async", "csv", "kdb", "zmq-beta", "etcd", "dynamic-graph-beta", "instrument-default", "iceoryx2-beta", "prometheus", "otlp"]
+full = ["async", "csv", "kdb", "zmq", "etcd", "dynamic-graph-beta", "instrument-default", "iceoryx2-beta", "prometheus", "otlp"]
 dynamic-graph-beta = []
 kdb-integration-test = ["kdb"]
 async = ["dep:tokio", "dep:futures", "dep:async-stream", "dep:futures-util", "tokio/time"]
 csv = ["dep:csv"]
 kdb = ["dep:kdb-plus-fixed", "dep:sha2", "dep:bincode", "async", "tokio/fs"]
-zmq-beta = ["dep:zmq", "dep:bincode"]
-zmq-beta-integration-test = ["zmq-beta"]
-zmq-etcd-integration-test = ["zmq-beta", "etcd", "dep:testcontainers"]
-zmq-cross-lang-test = ["zmq-beta-integration-test"]
+zmq = ["dep:zmq", "dep:bincode"]
+zmq-integration-test = ["zmq"]
+zmq-etcd-integration-test = ["zmq", "etcd", "dep:testcontainers"]
+zmq-cross-lang-test = ["zmq-integration-test"]
 zmq-cross-lang-etcd-test = ["zmq-cross-lang-test", "zmq-etcd-integration-test"]
 etcd = ["dep:etcd-client", "async"]
 etcd-integration-test = ["etcd", "dep:testcontainers"]
@@ -215,22 +215,22 @@ path = "examples/tracing/main.rs"
 [[example]]
 name = "zmq_direct_pub"
 path = "examples/zmq/direct/zmq_pub.rs"
-required-features = ["zmq-beta"]
+required-features = ["zmq"]
 
 [[example]]
 name = "zmq_direct_sub"
 path = "examples/zmq/direct/zmq_sub.rs"
-required-features = ["zmq-beta"]
+required-features = ["zmq"]
 
 [[example]]
 name = "zmq_etcd_pub"
 path = "examples/zmq/etcd/zmq_pub.rs"
-required-features = ["zmq-beta", "etcd"]
+required-features = ["zmq", "etcd"]
 
 [[example]]
 name = "zmq_etcd_sub"
 path = "examples/zmq/etcd/zmq_sub.rs"
-required-features = ["zmq-beta", "etcd"]
+required-features = ["zmq", "etcd"]
 
 [[example]]
 name = "etcd"

--- a/wingfoil/examples/zmq/README.md
+++ b/wingfoil/examples/zmq/README.md
@@ -18,8 +18,8 @@ Two modes are supported:
 Run publisher and subscriber in separate terminals:
 
 ```sh
-RUST_LOG=info cargo run --example zmq_direct_pub --features zmq-beta
-RUST_LOG=info cargo run --example zmq_direct_sub --features zmq-beta
+RUST_LOG=info cargo run --example zmq_direct_pub --features zmq
+RUST_LOG=info cargo run --example zmq_direct_sub --features zmq
 ```
 
 | Example | Description |
@@ -41,8 +41,8 @@ docker run --rm -p 2379:2379 \
 Then run publisher and subscriber in separate terminals:
 
 ```sh
-RUST_LOG=info cargo run --example zmq_etcd_pub --features zmq-beta,etcd
-RUST_LOG=info cargo run --example zmq_etcd_sub --features zmq-beta,etcd
+RUST_LOG=info cargo run --example zmq_etcd_pub --features zmq,etcd
+RUST_LOG=info cargo run --example zmq_etcd_sub --features zmq,etcd
 ```
 
 | Example | Description |

--- a/wingfoil/examples/zmq/direct/zmq_pub.rs
+++ b/wingfoil/examples/zmq/direct/zmq_pub.rs
@@ -5,8 +5,8 @@
 //
 // Run publisher and subscriber in separate terminals:
 //
-//   RUST_LOG=info cargo run --example zmq_direct_pub --features zmq-beta
-//   RUST_LOG=info cargo run --example zmq_direct_sub --features zmq-beta
+//   RUST_LOG=info cargo run --example zmq_direct_pub --features zmq
+//   RUST_LOG=info cargo run --example zmq_direct_sub --features zmq
 
 use log::Level::Info;
 use std::time::Duration;

--- a/wingfoil/examples/zmq/direct/zmq_sub.rs
+++ b/wingfoil/examples/zmq/direct/zmq_sub.rs
@@ -5,8 +5,8 @@
 //
 // Run publisher and subscriber in separate terminals:
 //
-//   RUST_LOG=info cargo run --example zmq_direct_pub --features zmq-beta
-//   RUST_LOG=info cargo run --example zmq_direct_sub --features zmq-beta
+//   RUST_LOG=info cargo run --example zmq_direct_pub --features zmq
+//   RUST_LOG=info cargo run --example zmq_direct_sub --features zmq
 
 use log::Level::Info;
 use wingfoil::adapters::zmq::zmq_sub;

--- a/wingfoil/examples/zmq/etcd/zmq_pub.rs
+++ b/wingfoil/examples/zmq/etcd/zmq_pub.rs
@@ -12,8 +12,8 @@
 //
 // Run publisher and subscriber in separate terminals:
 //
-//   RUST_LOG=info cargo run --example zmq_etcd_pub --features zmq-beta,etcd
-//   RUST_LOG=info cargo run --example zmq_etcd_sub --features zmq-beta,etcd
+//   RUST_LOG=info cargo run --example zmq_etcd_pub --features zmq,etcd
+//   RUST_LOG=info cargo run --example zmq_etcd_sub --features zmq,etcd
 
 use log::Level::Info;
 use std::time::Duration;

--- a/wingfoil/examples/zmq/etcd/zmq_sub.rs
+++ b/wingfoil/examples/zmq/etcd/zmq_sub.rs
@@ -12,8 +12,8 @@
 //
 // Run publisher and subscriber in separate terminals:
 //
-//   RUST_LOG=info cargo run --example zmq_etcd_pub --features zmq-beta,etcd
-//   RUST_LOG=info cargo run --example zmq_etcd_sub --features zmq-beta,etcd
+//   RUST_LOG=info cargo run --example zmq_etcd_pub --features zmq,etcd
+//   RUST_LOG=info cargo run --example zmq_etcd_sub --features zmq,etcd
 
 use log::Level::Info;
 use wingfoil::adapters::zmq::{EtcdRegistry, zmq_sub};

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -15,5 +15,5 @@ pub mod kdb;
 pub mod otlp;
 #[cfg(feature = "prometheus")]
 pub mod prometheus;
-#[cfg(feature = "zmq-beta")]
+#[cfg(feature = "zmq")]
 pub mod zmq;

--- a/wingfoil/src/adapters/zmq/CLAUDE.md
+++ b/wingfoil/src/adapters/zmq/CLAUDE.md
@@ -24,7 +24,7 @@ ZMQ sockets are synchronous and poll-based. The subscriber uses `ReceiverStream`
 which dedicates a real OS thread per subscriber rather than `produce_async` (which
 would require tokio and wrapping every `zmq::poll` call in `spawn_blocking`).
 
-The `zmq-beta` feature deliberately does not depend on `async`; adding a tokio
+The `zmq` feature deliberately does not depend on `async`; adding a tokio
 dependency just to adapt blocking sockets would be unnecessary overhead.
 
 ### Pub/sub via MutableNode (not consume_async)
@@ -95,7 +95,7 @@ cargo fmt --all
 cargo clippy --workspace --all-targets --all-features
 
 # ZMQ tests (no Docker needed)
-cargo test --features zmq-beta-integration-test -p wingfoil \
+cargo test --features zmq-integration-test -p wingfoil \
   -- --test-threads=1 zmq::integration_tests
 
 # etcd discovery tests (requires Docker)

--- a/wingfoil/src/adapters/zmq/mod.rs
+++ b/wingfoil/src/adapters/zmq/mod.rs
@@ -8,13 +8,13 @@
 //!
 //! # Setup
 //!
-//! ZMQ is peer-to-peer — no broker process is required. The `zmq-beta` feature
+//! ZMQ is peer-to-peer — no broker process is required. The `zmq` feature
 //! bundles `libzmq` at build time, so no system installation is needed.
 //!
 //! Enable the feature in `Cargo.toml`:
 //!
 //! ```toml
-//! wingfoil = { version = "...", features = ["zmq-beta"] }
+//! wingfoil = { version = "...", features = ["zmq"] }
 //! ```
 //!
 //! # Direct pub/sub
@@ -69,7 +69,7 @@ mod read;
 pub mod registry;
 mod write;
 
-#[cfg(all(test, feature = "zmq-beta-integration-test"))]
+#[cfg(all(test, feature = "zmq-integration-test"))]
 mod integration_tests;
 
 pub use read::*;

--- a/wingfoil/src/channel/message.rs
+++ b/wingfoil/src/channel/message.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use crate::queue::ValueAt;
 use crate::time::NanoTime;
 use crate::types::Element;
-#[cfg(feature = "zmq-beta")]
+#[cfg(feature = "zmq")]
 use crate::{GraphState, RunMode};
 
 /// Message that can be sent between threads.
@@ -67,10 +67,10 @@ impl<T: Element + Send + PartialEq> PartialEq for Message<T> {
 impl<T: Element + Send + PartialEq> Eq for Message<T> {}
 
 impl<T: Element + Send> Message<T> {
-    // This is used by optional adapters (e.g. `zmq-beta`). When those features are disabled,
+    // This is used by optional adapters (e.g. `zmq`). When those features are disabled,
     // the helper is not compiled. When they are enabled, it can be unused depending on which
     // adapters/tests are built, so keep clippy quiet.
-    #[cfg(feature = "zmq-beta")]
+    #[cfg(feature = "zmq")]
     #[allow(dead_code)]
     pub fn build(value: T, graph_state: &GraphState) -> Message<T> {
         match graph_state.run_mode() {

--- a/wingfoil/src/nodes/mod.rs
+++ b/wingfoil/src/nodes/mod.rs
@@ -37,7 +37,7 @@ mod never;
 mod node_flow;
 mod print;
 mod producer;
-#[cfg(feature = "zmq-beta")]
+#[cfg(feature = "zmq")]
 mod receiver;
 mod sample;
 mod throttle;
@@ -101,7 +101,7 @@ use crate::graph::*;
 use crate::queue::ValueAt;
 use crate::types::*;
 
-#[cfg(feature = "zmq-beta")]
+#[cfg(feature = "zmq")]
 pub(crate) use receiver::*;
 
 use log::Level;


### PR DESCRIPTION
## Summary
- Add ZeroMQ pub/sub example to README with etcd service discovery reference
- Rename `zmq-beta` feature flag to `zmq` across all configs, source, CI, examples, and docs
- Document both async and synchronous threading patterns in the new-adapter command
- Rewrite ZMQ Python tests from pytest to unittest with comprehensive direct pub/sub coverage

## Test plan
- [ ] `cargo build` compiles with renamed `zmq` feature flag
- [ ] `cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings` passes
- [ ] ZMQ Python tests pass: `cd wingfoil-python && maturin develop && pytest tests/test_zmq.py`
- [ ] README renders correctly on GitHub
- [ ] No remaining references to `zmq-beta`