### PR TITLE
Standardize integration test workflows for consistent per-adapter triggering

### DIFF
--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -1,6 +1,7 @@
 name: Aeron Integration Tests
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     paths:
@@ -19,10 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
@@ -33,6 +31,6 @@ jobs:
       - name: Run Aeron integration tests
         run: |
           cargo test --features aeron-integration-test -p wingfoil \
-            -- --test-threads=1 aeron::integration_tests
+            -- --test-threads=1 --nocapture aeron::integration_tests
         env:
           RUST_LOG: INFO

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -20,10 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
@@ -34,6 +31,6 @@ jobs:
       - name: Run etcd integration tests
         run: |
           cargo test --features etcd-integration-test -p wingfoil \
-            -- --test-threads=1 etcd::integration_tests
+            -- --test-threads=1 --nocapture etcd::integration_tests
         env:
           RUST_LOG: INFO

--- a/.github/workflows/fix-integration.yml
+++ b/.github/workflows/fix-integration.yml
@@ -6,9 +6,6 @@ on:
   push:
     paths:
       - 'wingfoil/src/adapters/fix/**'
-  pull_request:
-    paths:
-      - 'wingfoil/src/adapters/fix/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,10 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -18,9 +18,6 @@ on:
   push:
     paths:
       - 'wingfoil/src/adapters/iceoryx2/**'
-  pull_request:
-    paths:
-      - 'wingfoil/src/adapters/iceoryx2/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,10 +32,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
@@ -49,7 +43,7 @@ jobs:
       - name: Run iceoryx2 integration tests
         run: |
           cargo test --features iceoryx2-integration-test -p wingfoil \
-            -- --test-threads=1 iceoryx2::integration_tests
+            -- --test-threads=1 --nocapture iceoryx2::integration_tests
         env:
           RUST_LOG: INFO
 
@@ -62,10 +56,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
@@ -76,6 +67,6 @@ jobs:
       - name: Run ignored IPC tests
         run: |
           cargo test --features iceoryx2-integration-test -p wingfoil \
-            -- --ignored --test-threads=1 iceoryx2::integration_tests
+            -- --ignored --test-threads=1 --nocapture iceoryx2::integration_tests
         env:
           RUST_LOG: INFO

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,9 +15,9 @@ jobs:
     uses: ./.github/workflows/etcd-integration.yml
     secrets: inherit
 
-  telemetry-integration:
-    name: Telemetry Integration Tests
-    uses: ./.github/workflows/telemetry-integration.yml
+  prometheus-integration:
+    name: Prometheus Integration Tests
+    uses: ./.github/workflows/prometheus-integration.yml
     secrets: inherit
 
   otlp-integration:
@@ -38,4 +38,14 @@ jobs:
   fix-integration:
     name: FIX Integration Tests
     uses: ./.github/workflows/fix-integration.yml
+    secrets: inherit
+
+  iceoryx2-integration:
+    name: iceoryx2 Integration Tests
+    uses: ./.github/workflows/iceoryx2-integration.yml
+    secrets: inherit
+
+  aeron-integration:
+    name: Aeron Integration Tests
+    uses: ./.github/workflows/aeron-integration.yml
     secrets: inherit

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -22,10 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
@@ -59,7 +56,7 @@ jobs:
           RUST_LOG: INFO
         run: |
           cargo test --features kdb-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            -- --test-threads=1 --nocapture kdb::integration_tests kdb::cache_integration_tests
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -20,10 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
@@ -31,6 +28,6 @@ jobs:
       - name: Run OTLP integration tests
         run: |
           cargo test --features otlp-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            -- --test-threads=1 --nocapture otlp::integration_tests
         env:
           RUST_LOG: INFO

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -1,4 +1,4 @@
-name: Telemetry Integration Tests
+name: Prometheus Integration Tests
 
 on:
   workflow_dispatch:
@@ -12,18 +12,15 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  telemetry-integration:
-    name: Telemetry Integration Tests
+  prometheus-integration:
+    name: Prometheus Integration Tests
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
@@ -47,7 +44,7 @@ jobs:
       - name: Run Prometheus integration tests
         run: |
           cargo test --features prometheus-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            -- --test-threads=1 --nocapture prometheus::integration_tests
         env:
           RUST_LOG: INFO
           PROMETHEUS_TEST_URL: http://localhost:9090

--- a/.github/workflows/zmq-etcd-integration.yml
+++ b/.github/workflows/zmq-etcd-integration.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Run ZMQ etcd integration tests
         run: |
           cargo test --features zmq-etcd-integration-test -p wingfoil \
-            -- --test-threads=1 zmq::integration_tests::etcd_tests
+            -- --test-threads=1 --nocapture zmq::integration_tests::etcd_tests
         env:
           RUST_LOG: INFO

--- a/.github/workflows/zmq-integration.yml
+++ b/.github/workflows/zmq-integration.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Run ZMQ integration tests
         run: |
           cargo test --features zmq-integration-test -p wingfoil \
-            -- --test-threads=1 zmq::integration_tests
+            -- --test-threads=1 --nocapture zmq::integration_tests
         env:
           RUST_LOG: INFO


### PR DESCRIPTION
- Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchain@stable
- Remove pull_request triggers from FIX and iceoryx2 (prevents double runs on PR pushes)
- Add workflow_call to Aeron so it can be called from the umbrella workflow
- Add iceoryx2 and Aeron to the umbrella integration-tests.yml
- Add test filters to KDB, OTLP, and Prometheus (scope to adapter tests only)
- Standardize --nocapture across all workflows for CI debugging
- Rename telemetry-integration.yml to prometheus-integration.yml (match adapter name)

https://claude.ai/code/session_01LE56siodGENqBX124Hj5Uw