### PR TITLE
Replace FixInjector pattern with FixConnection and graph-native fix_sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ let fix = fix_connect_tls(
 );
 
 // Subscribe to EUR/USD — waits for LoggedIn, then sends the request.
-let sub = fix.fix_sub(&["4001"]);
+let sub = fix.fix_sub(constant(vec!["4001".into()]));
 
 let data_node = fix.data.logged("fix-data", Info).as_node();
 let status_node = fix.status.logged("fix-status", Info).as_node();

--- a/README.md
+++ b/README.md
@@ -171,22 +171,22 @@ Service discovery via etcd is also supported — see the [etcd examples](https:/
 Connect to a FIX 4.4 exchange (e.g. LMAX London Demo) over TLS, subscribe to market data, and process incoming messages — all as a streaming graph:
 
 ```rust,ignore
-use wingfoil::adapters::fix::{FixInjector, FixMessage, fix_connect_tls};
+use wingfoil::adapters::fix::fix_connect_tls;
 use wingfoil::*;
 
-let (data, status, injector) = fix_connect_tls(
+let fix = fix_connect_tls(
     "fix-marketdata.london-demo.lmax.com", 443,
     &username, "LMXBDM", Some(&password),
 );
 
-// Subscribe to EUR/USD after logon
-subscribe_after_logon(injector, "4001", Duration::from_secs(3));
+// Subscribe to EUR/USD — waits for LoggedIn, then sends the request.
+let sub = fix.fix_sub(&["4001"]);
 
-let data_node = data.logged("fix-data", Info).as_node();
-let status_node = status.logged("fix-status", Info).as_node();
+let data_node = fix.data.logged("fix-data", Info).as_node();
+let status_node = fix.status.logged("fix-status", Info).as_node();
 
 Graph::new(
-    vec![data_node, status_node],
+    vec![data_node, status_node, sub],
     RunMode::RealTime,
     RunFor::Duration(Duration::from_secs(60)),
 )

--- a/wingfoil-python/src/py_fix.rs
+++ b/wingfoil-python/src/py_fix.rs
@@ -76,7 +76,7 @@ pub fn py_fix_connect_tls(
     target_comp_id: String,
     password: Option<String>,
 ) -> (PyStream, PyStream, Py<PyAny>) {
-    let (data, status, injector) = fix_connect_tls(
+    let fix = fix_connect_tls(
         &host,
         port,
         &sender_comp_id,
@@ -84,14 +84,14 @@ pub fn py_fix_connect_tls(
         password.as_deref(),
     );
 
-    let py_data = data.map(|burst| {
+    let py_data = fix.data.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|msg| msg_to_py(py, &msg)).collect();
             PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
         })
     });
 
-    let py_status = status.map(|burst| {
+    let py_status = fix.status.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|s| status_to_py(py, &s)).collect();
             PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
@@ -99,7 +99,9 @@ pub fn py_fix_connect_tls(
     });
 
     let inject_fn = Python::attach(|py| {
-        let injector_cls = PyFixInjector { injector };
+        let injector_cls = PyFixInjector {
+            injector: fix.injector(),
+        };
         Py::new(py, injector_cls).unwrap().into_any()
     });
 

--- a/wingfoil/examples/fix/lmax_demo.rs
+++ b/wingfoil/examples/fix/lmax_demo.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 
 use log::Level::Info;
 use log::info;
-use wingfoil::adapters::fix::{FixInjector, FixMessage, fix_connect_tls};
+use wingfoil::adapters::fix::fix_connect_tls;
 use wingfoil::*;
 
 // ── LMAX London Demo connection parameters ────────────────────────────────────
@@ -41,29 +41,6 @@ const LMAX_MD_TARGET: &str = "LMXBDM";
 // LMAX instrument IDs (London Demo — verify against the LMAX instrument list at
 // https://docs.lmax.com or your account portal before use).
 const EUR_USD_ID: &str = "4001";
-
-// ── Market data request builder ───────────────────────────────────────────────
-
-/// Build a FIX MarketDataRequest (MsgType V) subscribing to top-of-book EUR/USD.
-fn market_data_request(instrument_id: &str) -> FixMessage {
-    FixMessage {
-        msg_type: "V".to_string(),
-        seq_num: 0, // sequence number is set by the session layer
-        sending_time: NanoTime::ZERO,
-        fields: vec![
-            (262, "req1".to_string()),       // MDReqID — unique request identifier
-            (263, "1".to_string()),          // SubscriptionRequestType = 1 (Subscribe)
-            (264, "1".to_string()),          // MarketDepth = 1 (top of book)
-            (265, "0".to_string()),          // MDUpdateType = 0 (Full Refresh)
-            (267, "2".to_string()),          // NoMDEntryTypes = 2
-            (269, "0".to_string()),          // MDEntryType = 0 (Bid)
-            (269, "1".to_string()),          // MDEntryType = 1 (Ask)
-            (146, "1".to_string()),          // NoRelatedSym = 1
-            (48, instrument_id.to_string()), // SecurityID — LMAX instrument ID (group delimiter)
-            (22, "8".to_string()),           // IDSource = 8 (Exchange Symbol)
-        ],
-    }
-}
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
@@ -78,7 +55,7 @@ fn main() {
     info!("Connecting to LMAX London Demo market data session at {LMAX_MD_HOST}:{LMAX_MD_PORT}");
     info!("  SenderCompID = {username}  TargetCompID = {LMAX_MD_TARGET}");
 
-    let (data, status, injector) = fix_connect_tls(
+    let fix = fix_connect_tls(
         LMAX_MD_HOST,
         LMAX_MD_PORT,
         &username,
@@ -86,15 +63,14 @@ fn main() {
         Some(&password),
     );
 
-    // After a brief delay for the TLS handshake and FIX logon to complete,
-    // send a MarketDataRequest for EUR/USD.
-    subscribe_after_logon(injector, EUR_USD_ID, Duration::from_secs(3));
+    // Subscribe to EUR/USD — the node waits for LoggedIn then sends the request.
+    let sub = fix.fix_sub(&[EUR_USD_ID]);
 
-    let data_node = data.logged("fix-data", Info).as_node();
-    let status_node = status.logged("fix-status", Info).as_node();
+    let data_node = fix.data.logged("fix-data", Info).as_node();
+    let status_node = fix.status.logged("fix-status", Info).as_node();
 
     Graph::new(
-        vec![data_node, status_node],
+        vec![data_node, status_node, sub],
         RunMode::RealTime,
         RunFor::Duration(Duration::from_secs(60)),
     )
@@ -102,15 +78,4 @@ fn main() {
     .unwrap();
 
     info!("Done.");
-}
-
-/// Spawn a background thread that waits `delay` then sends a market data subscription.
-fn subscribe_after_logon(injector: FixInjector, instrument_id: &str, delay: Duration) {
-    let req = market_data_request(instrument_id);
-    let id = instrument_id.to_string();
-    std::thread::spawn(move || {
-        std::thread::sleep(delay);
-        info!("Sending MarketDataRequest (instrument {id})");
-        injector.inject(req);
-    });
 }

--- a/wingfoil/examples/fix/lmax_demo.rs
+++ b/wingfoil/examples/fix/lmax_demo.rs
@@ -64,7 +64,7 @@ fn main() {
     );
 
     // Subscribe to EUR/USD — the node waits for LoggedIn then sends the request.
-    let sub = fix.fix_sub(&[EUR_USD_ID]);
+    let sub = fix.fix_sub(constant(vec![EUR_USD_ID.into()]));
 
     let data_node = fix.data.logged("fix-data", Info).as_node();
     let status_node = fix.status.logged("fix-status", Info).as_node();

--- a/wingfoil/examples/fix/lmax_instruments.rs
+++ b/wingfoil/examples/fix/lmax_instruments.rs
@@ -44,7 +44,7 @@ fn main() {
     let password =
         std::env::var("LMAX_PASSWORD").expect("LMAX_PASSWORD environment variable not set");
 
-    let (data, status, injector) = fix_connect_tls(
+    let fix = fix_connect_tls(
         LMAX_MD_HOST,
         LMAX_MD_PORT,
         &username,
@@ -52,6 +52,9 @@ fn main() {
         Some(&password),
     );
 
+    // Sweep instrument IDs with a delay between each request.
+    // This needs raw injection because of the per-request throttling.
+    let injector = fix.injector();
     std::thread::spawn(move || {
         std::thread::sleep(Duration::from_secs(2));
         for id in candidates() {
@@ -60,15 +63,10 @@ fn main() {
         }
     });
 
-    let data_node = data
+    let data_node = fix
+        .data
         .map(|burst| {
             for msg in &burst {
-                let _req_id = msg
-                    .fields
-                    .iter()
-                    .find(|f| f.0 == 262)
-                    .map(|f| f.1.as_str())
-                    .unwrap_or("-");
                 match msg.msg_type.as_str() {
                     "W" | "X" => {
                         let sec_id = msg
@@ -99,7 +97,8 @@ fn main() {
         })
         .as_node();
 
-    let status_node = status
+    let status_node = fix
+        .status
         .map(|burst| {
             for s in &burst {
                 eprintln!("status: {s:?}");

--- a/wingfoil/src/adapters/fix/CLAUDE.md
+++ b/wingfoil/src/adapters/fix/CLAUDE.md
@@ -25,12 +25,14 @@ uses custom `MutableNode` implementations polled by the graph engine. Two poll m
 
 This avoids the overhead of an async runtime for a protocol where microsecond latency matters.
 
-### FixInjector instead of graph-integrated pub node
+### FixConnection and fix_sub
 
-FIX sessions are bidirectional: the same TCP connection carries both inbound market data and
-outbound requests (MarketDataRequest, NewOrderSingle). `FixInjector` queues outbound messages
-on the session thread, avoiding a separate connection. A `FixSenderNode` sink is available for
-cases where a separate outbound connection is needed (e.g. dedicated order routing).
+`fix_connect_tls` returns a `FixConnection` bundling the data/status streams and session handle.
+`FixConnection::fix_sub(&["4001"])` creates a graph node that watches the status stream and
+automatically sends `MarketDataRequest` messages once the session reaches `LoggedIn`.
+`FixConnection::inject(msg)` and `FixConnection::injector()` provide raw access for advanced
+use cases (e.g. throttled sweeps, custom message types). `FixSenderNode` is a separate sink for
+cases where a dedicated outbound connection is needed (e.g. order routing).
 
 ### No testcontainers
 

--- a/wingfoil/src/adapters/fix/integration_tests.rs
+++ b/wingfoil/src/adapters/fix/integration_tests.rs
@@ -8,7 +8,7 @@
 //       -- lmax --nocapture --test-threads=1
 
 use super::*;
-use crate::{Graph, RunFor, RunMode, StreamOperators};
+use crate::{Graph, RunFor, RunMode, StreamOperators, constant};
 use std::time::Duration;
 
 const LMAX_MD_HOST: &str = "fix-marketdata.london-demo.lmax.com";
@@ -72,7 +72,7 @@ fn lmax_market_data() -> anyhow::Result<()> {
     );
 
     // Subscribe via graph node — waits for LoggedIn automatically
-    let sub = fix.fix_sub(&[AVAX_USD_ID]);
+    let sub = fix.fix_sub(constant(vec![AVAX_USD_ID.into()]));
 
     let data_node = fix.data.collect().finally(|items, _| {
         let msgs: Vec<FixMessage> = items

--- a/wingfoil/src/adapters/fix/integration_tests.rs
+++ b/wingfoil/src/adapters/fix/integration_tests.rs
@@ -23,26 +23,6 @@ fn lmax_credentials() -> Option<(String, String)> {
     Some((user, pass))
 }
 
-fn market_data_request() -> FixMessage {
-    FixMessage {
-        msg_type: "V".to_string(),
-        seq_num: 0,
-        sending_time: NanoTime::ZERO,
-        fields: vec![
-            (262, "req1".to_string()),
-            (263, "1".to_string()),
-            (264, "1".to_string()),
-            (265, "0".to_string()),
-            (267, "2".to_string()),        // NoMDEntryTypes = 2
-            (269, "0".to_string()),        // MDEntryType = Bid
-            (269, "1".to_string()),        // MDEntryType = Ask
-            (146, "1".to_string()),        // NoRelatedSym = 1
-            (48, AVAX_USD_ID.to_string()), // SecurityID = instrument ID (LMAX group delimiter)
-            (22, "8".to_string()),         // IDSource = 8 (Exchange Symbol)
-        ],
-    }
-}
-
 /// Verify the FIX session reaches LoggedIn within 10 seconds.
 #[test]
 fn lmax_logon() -> anyhow::Result<()> {
@@ -52,7 +32,7 @@ fn lmax_logon() -> anyhow::Result<()> {
         return Ok(());
     };
 
-    let (_data, status, _injector) = fix_connect_tls(
+    let fix = fix_connect_tls(
         LMAX_MD_HOST,
         LMAX_MD_PORT,
         &username,
@@ -60,7 +40,7 @@ fn lmax_logon() -> anyhow::Result<()> {
         Some(&password),
     );
 
-    let status_node = status.collect().finally(|items, _| {
+    let status_node = fix.status.collect().finally(|items, _| {
         let vs: Vec<FixSessionStatus> = items.into_iter().flat_map(|i| i.value).collect();
         assert!(
             vs.contains(&FixSessionStatus::LoggedIn),
@@ -87,7 +67,7 @@ fn lmax_market_data() -> anyhow::Result<()> {
         return Ok(());
     };
 
-    let (data, status, injector) = fix_connect_tls(
+    let fix = fix_connect_tls(
         LMAX_MD_HOST,
         LMAX_MD_PORT,
         &username,
@@ -95,13 +75,10 @@ fn lmax_market_data() -> anyhow::Result<()> {
         Some(&password),
     );
 
-    // Wait for logon then inject a MarketDataRequest
-    std::thread::spawn(move || {
-        std::thread::sleep(Duration::from_secs(3));
-        injector.inject(market_data_request());
-    });
+    // Subscribe via graph node — waits for LoggedIn automatically
+    let sub = fix.fix_sub(&[AVAX_USD_ID]);
 
-    let data_node = data.collect().finally(|items, _| {
+    let data_node = fix.data.collect().finally(|items, _| {
         let msgs: Vec<FixMessage> = items
             .into_iter()
             .flat_map(|i| i.value.into_iter())
@@ -117,7 +94,7 @@ fn lmax_market_data() -> anyhow::Result<()> {
         Ok(())
     });
 
-    let status_node = status.collect().finally(|items, _| {
+    let status_node = fix.status.collect().finally(|items, _| {
         let vs: Vec<FixSessionStatus> = items.into_iter().flat_map(|i| i.value).collect();
         assert!(
             vs.contains(&FixSessionStatus::LoggedIn),
@@ -127,7 +104,7 @@ fn lmax_market_data() -> anyhow::Result<()> {
     });
 
     Graph::new(
-        vec![data_node, status_node],
+        vec![data_node, status_node, sub],
         RunMode::RealTime,
         RunFor::Duration(Duration::from_secs(20)),
     )

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -159,27 +159,33 @@ pub struct FixConnection {
 }
 
 impl FixConnection {
-    /// Create a graph node that subscribes to market data for the given symbols.
+    /// Create a graph node that subscribes to market data for symbols arriving
+    /// on `symbols`.
     ///
-    /// The node watches the session status stream and automatically sends a
-    /// `MarketDataRequest` (MsgType V) for each symbol once the session reaches
-    /// [`FixSessionStatus::LoggedIn`]. No manual thread spawning or sleeping
-    /// required.
+    /// The node watches both the symbol stream (active) and the session status
+    /// stream (active). When a new batch of symbol IDs arrives and the session
+    /// is [`FixSessionStatus::LoggedIn`], a `MarketDataRequest` (MsgType V) is
+    /// sent for each unseen symbol. Symbols that arrive before logon are queued
+    /// and subscribed automatically once the session is ready.
+    ///
+    /// For a fixed set of symbols, use [`constant`](crate::constant):
     ///
     /// ```ignore
     /// let fix = fix_connect_tls(host, port, sender, target, Some(&pw));
-    /// let sub = fix.fix_sub(&["4001", "4002"]);
+    /// let sub = fix.fix_sub(constant(vec!["4001".into(), "4002".into()]));
     /// Graph::new(
     ///     vec![fix.data.as_node(), fix.status.as_node(), sub],
     ///     RunMode::RealTime, RunFor::Duration(Duration::from_secs(60)),
     /// ).run().unwrap();
     /// ```
-    pub fn fix_sub(&self, symbols: &[&str]) -> Rc<dyn Node> {
+    pub fn fix_sub(&self, symbols: Rc<dyn Stream<Vec<String>>>) -> Rc<dyn Node> {
         FixSubNode {
             injector: self.injector.clone(),
             status: self.status.clone(),
-            symbols: symbols.iter().map(|s| s.to_string()).collect(),
-            subscribed: false,
+            symbols,
+            pending: Vec::new(),
+            sent: Vec::new(),
+            logged_in: false,
         }
         .into_node()
     }
@@ -1176,31 +1182,62 @@ fn market_data_request(symbol: &str, req_id: &str) -> FixMessage {
 struct FixSubNode {
     injector: FixInjector,
     status: Rc<dyn Stream<Burst<FixSessionStatus>>>,
-    symbols: Vec<String>,
-    subscribed: bool,
+    symbols: Rc<dyn Stream<Vec<String>>>,
+    pending: Vec<String>,
+    sent: Vec<String>,
+    logged_in: bool,
+}
+
+impl FixSubNode {
+    fn subscribe(&mut self, sym: &str) {
+        let req_id = format!("sub_{}_{sym}", self.sent.len());
+        self.injector.inject(market_data_request(sym, &req_id));
+        self.sent.push(sym.to_string());
+    }
 }
 
 impl MutableNode for FixSubNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        if self.subscribed {
-            return Ok(false);
-        }
+        // Detect LoggedIn
         let burst = self.status.peek_value();
-        let logged_in = burst
+        if burst
             .iter()
-            .any(|s| matches!(s, FixSessionStatus::LoggedIn));
-        if logged_in {
-            for (i, sym) in self.symbols.iter().enumerate() {
-                let req_id = format!("sub_{i}_{sym}");
-                self.injector.inject(market_data_request(sym, &req_id));
-            }
-            self.subscribed = true;
+            .any(|s| matches!(s, FixSessionStatus::LoggedIn))
+        {
+            self.logged_in = true;
         }
+
+        // Collect new symbols from the stream
+        for sym in self.symbols.peek_value() {
+            if !self.sent.contains(&sym) && !self.pending.contains(&sym) {
+                if self.logged_in {
+                    self.subscribe(&sym);
+                } else {
+                    self.pending.push(sym);
+                }
+            }
+        }
+
+        // Drain anything that was pending before logon
+        if self.logged_in && !self.pending.is_empty() {
+            for sym in std::mem::take(&mut self.pending) {
+                if !self.sent.contains(&sym) {
+                    self.subscribe(&sym);
+                }
+            }
+        }
+
         Ok(false) // sink — never ticks downstream
     }
 
     fn upstreams(&self) -> UpStreams {
-        UpStreams::new(vec![self.status.clone().as_node()], vec![])
+        UpStreams::new(
+            vec![
+                self.status.clone().as_node(),
+                self.symbols.clone().as_node(),
+            ],
+            vec![],
+        )
     }
 }
 

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -10,7 +10,8 @@
 //! `(Stream<Burst<FixMessage>>, Stream<Burst<FixSessionStatus>>)` pair.
 //!
 //! Use [`fix_connect_tls`] to connect to TLS-secured endpoints (e.g. LMAX London Demo).
-//! It additionally returns a [`FixInjector`] for sending outbound messages on the session.
+//! It returns a [`FixConnection`] with data/status streams and
+//! [`fix_sub`](FixConnection::fix_sub) for declarative market data subscription.
 
 use std::collections::VecDeque;
 use std::io::{self, Read, Write};
@@ -131,7 +132,7 @@ pub enum FixPollMode {
 
 /// Handle for injecting outbound [`FixMessage`]s into an established FIX session.
 ///
-/// Obtained from [`fix_connect_tls`]. Thread-safe and cheaply cloneable.
+/// Obtained from [`FixConnection::injector`]. Thread-safe and cheaply cloneable.
 /// Messages are sent on the next background-thread loop iteration.
 #[derive(Clone)]
 pub struct FixInjector {
@@ -142,6 +143,55 @@ impl FixInjector {
     /// Queue `msg` for sending on the next session loop iteration.
     pub fn inject(&self, msg: FixMessage) {
         self.queue.lock().unwrap().push_back(msg);
+    }
+}
+
+/// Bundles the streams and session handle returned by [`fix_connect_tls`].
+///
+/// Use [`fix_sub`](FixConnection::fix_sub) to subscribe to market data as a
+/// graph node, or [`inject`](FixConnection::inject) for raw outbound messages.
+pub struct FixConnection {
+    /// Inbound application messages (MarketDataSnapshot, execution reports, etc.).
+    pub data: Rc<dyn Stream<Burst<FixMessage>>>,
+    /// Session lifecycle events (LoggedIn, LoggedOut, …).
+    pub status: Rc<dyn Stream<Burst<FixSessionStatus>>>,
+    injector: FixInjector,
+}
+
+impl FixConnection {
+    /// Create a graph node that subscribes to market data for the given symbols.
+    ///
+    /// The node watches the session status stream and automatically sends a
+    /// `MarketDataRequest` (MsgType V) for each symbol once the session reaches
+    /// [`FixSessionStatus::LoggedIn`]. No manual thread spawning or sleeping
+    /// required.
+    ///
+    /// ```ignore
+    /// let fix = fix_connect_tls(host, port, sender, target, Some(&pw));
+    /// let sub = fix.fix_sub(&["4001", "4002"]);
+    /// Graph::new(
+    ///     vec![fix.data.as_node(), fix.status.as_node(), sub],
+    ///     RunMode::RealTime, RunFor::Duration(Duration::from_secs(60)),
+    /// ).run().unwrap();
+    /// ```
+    pub fn fix_sub(&self, symbols: &[&str]) -> Rc<dyn Node> {
+        FixSubNode {
+            injector: self.injector.clone(),
+            status: self.status.clone(),
+            symbols: symbols.iter().map(|s| s.to_string()).collect(),
+            subscribed: false,
+        }
+        .into_node()
+    }
+
+    /// Queue a raw outbound [`FixMessage`] for sending on the session thread.
+    pub fn inject(&self, msg: FixMessage) {
+        self.injector.inject(msg);
+    }
+
+    /// Get a clone of the underlying [`FixInjector`] for manual use.
+    pub fn injector(&self) -> FixInjector {
+        self.injector.clone()
     }
 }
 
@@ -1077,6 +1127,60 @@ impl StreamPeekRef<Burst<FixEvent>> for FixThreadedSource {
     }
 }
 
+// ── FixSubNode (market data subscription sink) ──────────────────────────────
+
+/// Build a FIX MarketDataRequest (MsgType V) subscribing to top-of-book for `symbol`.
+fn market_data_request(symbol: &str, req_id: &str) -> FixMessage {
+    FixMessage {
+        msg_type: "V".to_string(),
+        seq_num: 0,
+        sending_time: NanoTime::ZERO,
+        fields: vec![
+            (262, req_id.to_string()), // MDReqID
+            (263, "1".to_string()),    // SubscriptionRequestType = Subscribe
+            (264, "1".to_string()),    // MarketDepth = top of book
+            (265, "0".to_string()),    // MDUpdateType = Full Refresh
+            (267, "2".to_string()),    // NoMDEntryTypes = 2
+            (269, "0".to_string()),    // MDEntryType = Bid
+            (269, "1".to_string()),    // MDEntryType = Ask
+            (146, "1".to_string()),    // NoRelatedSym = 1
+            (48, symbol.to_string()),  // SecurityID
+            (22, "8".to_string()),     // IDSource = Exchange Symbol
+        ],
+    }
+}
+
+struct FixSubNode {
+    injector: FixInjector,
+    status: Rc<dyn Stream<Burst<FixSessionStatus>>>,
+    symbols: Vec<String>,
+    subscribed: bool,
+}
+
+impl MutableNode for FixSubNode {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        if self.subscribed {
+            return Ok(false);
+        }
+        let burst = self.status.peek_value();
+        let logged_in = burst
+            .iter()
+            .any(|s| matches!(s, FixSessionStatus::LoggedIn));
+        if logged_in {
+            for (i, sym) in self.symbols.iter().enumerate() {
+                let req_id = format!("sub_{i}_{sym}");
+                self.injector.inject(market_data_request(sym, &req_id));
+            }
+            self.subscribed = true;
+        }
+        Ok(false) // sink — never ticks downstream
+    }
+
+    fn upstreams(&self) -> UpStreams {
+        UpStreams::new(vec![self.status.clone().as_node()], vec![])
+    }
+}
+
 // ── FixSenderNode (sink) ──────────────────────────────────────────────────────
 
 struct FixSenderNode {
@@ -1190,20 +1294,16 @@ pub fn fix_connect(
 /// `sender_comp_id` should be your registered username; `password` is sent as
 /// tag 554 in the Logon message (with tag 553 = `sender_comp_id`).
 ///
-/// Returns `(data_stream, status_stream, injector)`. The [`FixInjector`] lets you
-/// send outbound messages (e.g. `MarketDataRequest`, `NewOrderSingle`) on the session
-/// from any thread.
+/// Returns a [`FixConnection`] with `data` and `status` streams, plus
+/// [`fix_sub`](FixConnection::fix_sub) for declarative market data subscription
+/// and [`inject`](FixConnection::inject) for raw outbound messages.
 pub fn fix_connect_tls(
     host: &str,
     port: u16,
     sender_comp_id: &str,
     target_comp_id: &str,
     password: Option<&str>,
-) -> (
-    Rc<dyn Stream<Burst<FixMessage>>>,
-    Rc<dyn Stream<Burst<FixSessionStatus>>>,
-    FixInjector,
-) {
+) -> FixConnection {
     let src =
         FixThreadedSource::new_initiator_tls(host, port, sender_comp_id, target_comp_id, password);
     let injector = FixInjector {
@@ -1211,7 +1311,11 @@ pub fn fix_connect_tls(
     };
     let events: Rc<dyn Stream<Burst<FixEvent>>> = src.into_stream();
     let (data, status) = split_events(events);
-    (data, status, injector)
+    FixConnection {
+        data,
+        status,
+        injector,
+    }
 }
 
 /// Bind a FIX acceptor on `port`, accepting one initiator connection.


### PR DESCRIPTION
## Summary

- `fix_connect_tls` now returns a `FixConnection` struct (bundles `data`, `status` streams + session handle) instead of a raw `(data, status, injector)` tuple
- `FixConnection::fix_sub(symbols_stream)` creates a proper graph node that watches the status stream and automatically sends `MarketDataRequest` messages once the session reaches `LoggedIn` — no manual thread spawning, sleeping, or raw FIX message construction
- `fix_sub` accepts `Rc<dyn Stream<Vec<String>>>` so symbols can arrive dynamically from any upstream; for static symbols use `constant(vec!["4001".into()])`
- Symbols arriving before `LoggedIn` are queued and subscribed automatically once the session is ready; duplicates are skipped
- `FixConnection::inject()` and `FixConnection::injector()` remain as escape hatches for advanced use cases (e.g. throttled sweeps, custom message types)

### Before
```rust
let (data, status, injector) = fix_connect_tls(host, port, sender, target, Some(&pw));

// Spawn a thread, sleep 3s, manually build FIX message...
std::thread::spawn(move || {
    std::thread::sleep(Duration::from_secs(3));
    injector.inject(FixMessage { msg_type: "V".into(), fields: vec![...] });
});
```

### After
```rust
let fix = fix_connect_tls(host, port, sender, target, Some(&pw));
let sub = fix.fix_sub(constant(vec!["4001".into()]));

Graph::new(
    vec![fix.data.as_node(), fix.status.as_node(), sub],
    RunMode::RealTime, RunFor::Duration(Duration::from_secs(60)),
).run().unwrap();
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings` passes
- [x] `cargo test -p wingfoil` — 189 tests pass
- [x] `cargo test -p wingfoil --features fix -- fix::tests` — 5 FIX unit tests pass
- [ ] Integration tests (`lmax_logon`, `lmax_market_data`) require LMAX credentials

https://claude.ai/code/session_015BYkhzoxFBUkNZn5mHXHBz