### PR TITLE
Review IO adapters: update skill for flexibility, add missing pieces

### DIFF
--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -59,18 +59,22 @@ pub mod $ARGUMENTS;
 
 ## 4. Docker image / container setup
 
-Choose an official or well-maintained image for the service. Use `SyncRunner` (blocking) so container startup stays in a plain `#[test]` function without a wrapping async runtime:
+Choose the test infrastructure that fits the service:
+
+### Option A — testcontainers (preferred for open-source services)
+
+Use `SyncRunner` (blocking) so container startup stays in a plain `#[test]` function without a wrapping async runtime:
 
 ```rust
 // In integration_tests.rs
 use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::SyncRunner};
 
-// Option A — if testcontainers-modules has a module for this service:
+// If testcontainers-modules has a module for this service:
 use testcontainers_modules::some_service::SomeService;
 let container = SomeService::default().start()?;
 let port = container.get_host_port_ipv4(DEFAULT_PORT)?;
 
-// Option B — GenericImage (most common; use this when no module exists):
+// Otherwise use GenericImage (most common):
 let container = GenericImage::new("vendor/image", "tag")
     .with_wait_for(WaitFor::message_on_stderr("ready to serve"))
     .with_env_var("KEY", "value")
@@ -81,16 +85,57 @@ let endpoint = format!("http://127.0.0.1:{port}");
 
 The container is stopped automatically when dropped. Hold the container in a binding for the duration of the test (`let _container = ...`). No `docker-compose.yml` needed.
 
+### Option B — external service with skip-if-unavailable
+
+When the service requires a commercial license (e.g. KDB+), cannot run in a container,
+or connects to a remote endpoint (e.g. FIX to an exchange), skip tests if the service is
+not reachable. Use a plain Docker command or manual setup documented in the adapter's
+`CLAUDE.md` and example `README.md`:
+
+```rust
+fn service_available() -> bool {
+    std::net::TcpStream::connect("localhost:PORT").is_ok()
+}
+
+#[test]
+fn test_round_trip() -> anyhow::Result<()> {
+    if !service_available() {
+        eprintln!("skipping: service not running on localhost:PORT");
+        return Ok(());
+    }
+    // ...
+}
+```
+
+### Option C — no external service needed
+
+File-based adapters (e.g. CSV) or IPC adapters (e.g. iceoryx2) may not need any
+container or external service. Unit tests with fixture files or in-process communication
+are sufficient. In this case, skip the integration test feature flag and put tests
+directly in the module's `#[cfg(test)]` blocks.
+
 ## 5. File structure
+
+The default layout for bidirectional pub/sub adapters:
 
 ```
 wingfoil/src/adapters/$ARGUMENTS/
   mod.rs               # Connection config, public types, re-exports
-  read.rs              # sub function (producer)
-  write.rs             # pub function (consumer)
+  read.rs              # sub/read function (producer)
+  write.rs             # pub/write function (consumer)
   integration_tests.rs # gated by $ARGUMENTS-integration-test feature
   CLAUDE.md            # documents design decisions and pre-commit requirements
 ```
+
+**Variations for non-standard adapters:** name files after their function when the
+`read.rs`/`write.rs` split doesn't fit:
+
+- **Push-only adapters** (e.g. OTLP): use `push.rs` instead of `write.rs`; omit `read.rs`
+- **Pull-based exporters** (e.g. Prometheus): use `exporter.rs`; omit `read.rs`/`write.rs`
+- **Stateful bidirectional sessions** (e.g. FIX): keep all logic in `mod.rs` when
+  read/write share session state that is hard to split cleanly
+- **File-based adapters** (e.g. CSV): omit `integration_tests.rs` when unit tests with
+  fixture files provide sufficient coverage
 
 ## 6. Types and module doc — `mod.rs`
 
@@ -109,12 +154,29 @@ pub struct <Name>Entry { /* fields appropriate to the service */ }
 pub struct <Name>Event { /* fields */ }
 ```
 
+**Naming conventions:** the default verbs are `_sub` (producer) and `_pub` (consumer), but
+adapters should use the verb that best fits the domain:
+
+| Pattern | Verbs | Examples |
+|---------|-------|----------|
+| Pub/sub or event streaming | `_sub` / `_pub` | etcd, zmq, iceoryx2 |
+| Batch/file I/O | `_read` / `_write` | kdb, csv |
+| Session/connection | `_connect` / `_accept` | fix |
+| Push-only telemetry | `_push` (trait method) | otlp |
+| Pull-based exporter | `.register()` (method) | prometheus |
+
+Choose the verb that reads naturally at the call site. Generic transports (zmq, iceoryx2)
+typically use generic `T` instead of concrete Entry/Event types — this is fine when the
+adapter is protocol-agnostic. Similarly, adapters that use a config struct (e.g. `OtlpConfig`,
+`Iceoryx2SubOpts`) instead of a `<Name>Connection` are fine when the domain doesn't map
+cleanly to "connect to endpoint".
+
 Add `//!` module-level doc at the top of `mod.rs` covering:
 
 - One-line description of what the adapter does
-- Setup: local Docker one-liner to start the service
-- `# Subscribing` section: minimal `ignore` code block showing `$ARGUMENTS_sub`
-- `# Publishing` section: minimal `ignore` code block showing `$ARGUMENTS_pub`
+- Setup: local Docker one-liner to start the service (omit if N/A, e.g. file-based or IPC)
+- Producer section with minimal `ignore` code block
+- Consumer section with minimal `ignore` code block (omit if adapter is single-direction)
 - Any feature-specific sections (leases, conditional writes, etc.)
 
 ```rust

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -22,7 +22,7 @@ iceoryx2-beta = ["wingfoil/iceoryx2-beta"]
 [dependencies]
 
 # parent
-wingfoil = { path = "../wingfoil", features = ["kdb", "zmq", "etcd", "prometheus", "otlp", "fix"] }
+wingfoil = { path = "../wingfoil", features = ["csv", "kdb", "zmq", "etcd", "prometheus", "otlp", "fix"] }
 
 # workspace deps
 anyhow = {workspace = true}

--- a/wingfoil-python/python/wingfoil/__init__.py
+++ b/wingfoil-python/python/wingfoil/__init__.py
@@ -13,6 +13,9 @@ __version__ = getattr(_ext, "__version__", None)
 
 __all__ = list(getattr(_ext, "__all__", [])) + ["to_dataframe", "build_dataframe"]
 
+# User-friendly aliases for CSV functions
+csv_read = _ext.py_csv_read
+
 # User-friendly aliases for etcd functions
 etcd_sub = _ext.py_etcd_sub
 
@@ -35,6 +38,9 @@ if hasattr(_ext, "py_iceoryx2_sub"):
 fix_connect = _ext.py_fix_connect
 fix_connect_tls = _ext.py_fix_connect_tls
 fix_accept = _ext.py_fix_accept
+
+# User-friendly aliases for OTLP
+# (otlp_push is exposed as a stream method, no top-level sub function needed)
 
 # User-friendly aliases for Prometheus
 PrometheusExporter = _ext.PrometheusExporter

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -1,4 +1,5 @@
 mod proxy_stream;
+mod py_csv;
 mod py_element;
 #[cfg(feature = "etcd")]
 mod py_etcd;
@@ -183,6 +184,7 @@ fn _wingfoil(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(ticker, module)?)?;
     module.add_function(wrap_pyfunction!(constant, module)?)?;
     module.add_function(wrap_pyfunction!(bimap, module)?)?;
+    module.add_function(wrap_pyfunction!(py_csv::py_csv_read, module)?)?;
     #[cfg(feature = "etcd")]
     module.add_function(wrap_pyfunction!(py_etcd::py_etcd_sub, module)?)?;
     module.add_function(wrap_pyfunction!(py_kdb::py_kdb_read, module)?)?;

--- a/wingfoil-python/src/py_csv.rs
+++ b/wingfoil-python/src/py_csv.rs
@@ -1,0 +1,131 @@
+//! Python bindings for the CSV adapter.
+
+use crate::py_element::PyElement;
+use crate::py_stream::PyStream;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::Write;
+use std::rc::Rc;
+use wingfoil::adapters::csv::csv_read;
+use wingfoil::{Burst, NanoTime, Node, Stream, StreamOperators};
+
+type CsvRow = HashMap<String, String>;
+
+/// Read a CSV file into a stream of dicts.
+///
+/// Each tick yields a dict where keys are column headers and values are strings.
+/// Rows sharing the same timestamp are collapsed to one-per-tick.
+///
+/// Args:
+///     path: Path to the CSV file (headers required)
+///     time_column: Name of the column containing the timestamp
+///                  (parsed as integer nanoseconds since epoch)
+#[pyfunction]
+pub fn py_csv_read(path: String, time_column: String) -> PyStream {
+    let stream: Rc<dyn Stream<Burst<CsvRow>>> = csv_read(
+        &path,
+        move |row: &CsvRow| {
+            row.get(&time_column)
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(NanoTime::new)
+                .unwrap_or(NanoTime::ZERO)
+        },
+        true,
+    );
+
+    let py_stream = stream.collapse().map(|row: CsvRow| {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            for (key, value) in &row {
+                dict.set_item(key, value).unwrap();
+            }
+            PyElement::new(dict.into_any().unbind())
+        })
+    });
+
+    PyStream(py_stream)
+}
+
+/// State for the CSV writer: column order and a buffered writer.
+struct CsvWriteState {
+    file: std::io::BufWriter<std::fs::File>,
+    headers: Option<Vec<String>>,
+}
+
+impl CsvWriteState {
+    fn new(path: &str) -> Self {
+        let file = std::fs::File::create(path)
+            .unwrap_or_else(|e| panic!("failed to open CSV file for writing: {e}"));
+        Self {
+            file: std::io::BufWriter::new(file),
+            headers: None,
+        }
+    }
+
+    fn write_row(&mut self, header_row: &[String], values: &[String]) {
+        let line = values
+            .iter()
+            .enumerate()
+            .fold(String::new(), |mut acc, (i, v)| {
+                if i > 0 {
+                    acc.push(',');
+                }
+                // Simple CSV escaping: quote if contains comma, quote, or newline
+                if v.contains(',') || v.contains('"') || v.contains('\n') {
+                    acc.push('"');
+                    acc.push_str(&v.replace('"', "\"\""));
+                    acc.push('"');
+                } else {
+                    acc.push_str(v);
+                }
+                acc
+            });
+        let _ = writeln!(self.file, "{line}");
+        let _ = header_row; // used by caller to set headers, not needed here
+    }
+}
+
+/// Inner implementation for the `.csv_write()` stream method.
+///
+/// Writes each dict as a CSV row. Headers are inferred from the first dict's keys.
+/// A `time` column is prepended with the graph time in nanoseconds.
+pub fn py_csv_write_inner(stream: &Rc<dyn Stream<PyElement>>, path: String) -> Rc<dyn Node> {
+    let state: RefCell<CsvWriteState> = RefCell::new(CsvWriteState::new(&path));
+
+    stream.for_each(move |elem, time| {
+        Python::attach(|py| {
+            let obj = elem.as_ref().bind(py);
+            if let Ok(dict) = obj.cast::<PyDict>() {
+                let mut guard = state.borrow_mut();
+
+                if guard.headers.is_none() {
+                    let keys: Vec<String> = dict
+                        .keys()
+                        .iter()
+                        .map(|k| k.extract::<String>().unwrap_or_default())
+                        .collect();
+                    let mut header_row = vec!["time".to_string()];
+                    header_row.extend(keys.clone());
+                    guard.write_row(&[], &header_row);
+                    guard.headers = Some(keys);
+                }
+
+                let h = guard.headers.clone().unwrap();
+                let time_nanos: u64 = time.into();
+                let mut values = vec![time_nanos.to_string()];
+                for key in &h {
+                    let v = dict
+                        .get_item(key)
+                        .ok()
+                        .flatten()
+                        .map(|v| v.str().map(|s| s.to_string()).unwrap_or_default())
+                        .unwrap_or_default();
+                    values.push(v);
+                }
+                guard.write_row(&[], &values);
+            }
+        });
+    })
+}

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -321,6 +321,20 @@ impl PyStream {
         PyStream(strm)
     }
 
+    /// Write this stream of dicts to a CSV file.
+    ///
+    /// Each dict becomes one CSV row. Headers are inferred from the first dict's
+    /// keys, and a `time` column is prepended with the graph time in nanoseconds.
+    ///
+    /// Args:
+    ///     path: Output file path
+    ///
+    /// Returns:
+    ///     A Node that drives the write operation.
+    fn csv_write(&self, path: String) -> PyNode {
+        PyNode::new(crate::py_csv::py_csv_write_inner(&self.0, path))
+    }
+
     /// Write this stream to a KDB+ table.
     ///
     /// Args:

--- a/wingfoil/src/adapters/iceoryx2/CLAUDE.md
+++ b/wingfoil/src/adapters/iceoryx2/CLAUDE.md
@@ -1,0 +1,52 @@
+# iceoryx2 Adapter
+
+Zero-copy inter-process communication (IPC) via shared memory using iceoryx2.
+
+## Module Structure
+
+```
+iceoryx2/
+  mod.rs               # Config types (ServiceContract, SubOpts, PubOpts, Mode, Variant),
+                       #   FixedBytes<N>, Iceoryx2Error, unit tests
+  read.rs              # iceoryx2_sub*, Iceoryx2ReceiverStream — subscriber (producer)
+  write.rs             # iceoryx2_pub* — publisher (consumer)
+  integration_tests.rs # gated by iceoryx2-integration-test (cross-process IPC tests)
+```
+
+## Key Design Decisions
+
+### Three Polling Modes
+
+The subscriber supports three modes via `Iceoryx2Mode`:
+
+- **Spin** (default) — polls directly inside `cycle()` with `always_callback()`. Lowest latency (~1–5 µs), highest CPU.
+- **Threaded** — background thread polls with 10 µs yield, delivers via channel. Lower CPU, ~10–100 µs added latency.
+- **Signaled** — event-driven WaitSet (true blocking). Requires publisher to signal on a matching Event service.
+
+### Service Contracts
+
+All participants on the same service must use compatible `Iceoryx2ServiceContract` settings (history_size, subscriber_max_buffer_size). Mismatches produce `Iceoryx2Error::ServiceConfigMismatch`.
+
+### Typed vs Slice APIs
+
+- **Typed** (`iceoryx2_sub<T>` / `iceoryx2_pub<T>`) — `T` must be `#[repr(C)]`, `ZeroCopySend`, and self-contained (no heap pointers).
+- **Slice** (`iceoryx2_sub_slice` / `iceoryx2_pub_slice`) — transfers `Vec<u8>` via `[u8]` shared memory slices. Used by Python bindings via `FixedBytes<N>`.
+
+### FixedBytes<N>
+
+A `#[repr(C)]` fixed-size byte buffer implementing `ZeroCopySend`. Bridges the gap between variable-length Python bytes and iceoryx2's fixed-layout shared memory.
+
+## Pre-Commit Requirements
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings
+cargo test -p wingfoil --features iceoryx2-beta
+cargo test -p wingfoil --features iceoryx2-integration-test -- --test-threads=1
+```
+
+## Gotchas
+
+- Feature flag is `iceoryx2-beta` (not `iceoryx2`) because the iceoryx2 crate is pre-1.0.
+- Shared memory paths on Linux live under `/dev/shm/`; stale files from crashed processes may need manual cleanup.
+- Service names must be non-empty and follow iceoryx2's naming rules — invalid names fail fast in `start()`.


### PR DESCRIPTION
Skill updates (new-adapter.md):
- Allow alternative naming verbs (read/write, connect/accept, push)
  instead of mandating sub/pub for all adapters
- Document three test infrastructure options: testcontainers, external
  service with skip-if-unavailable, and no-service-needed
- Allow flexible file structure for non-standard adapters (push-only,
  pull-based, stateful sessions, file-based)

Adapter fixes:
- Add missing CLAUDE.md for iceoryx2 adapter
- Add CSV Python bindings (py_csv_read, csv_write stream method)
- Add OTLP comment in Python __init__.py clarifying push is stream-only

https://claude.ai/code/session_012Kka4qGPomHbVkmzHmuXyN