### PR TITLE
ci: share Rust build cache across integration tests

### DIFF
--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake clang libclang-dev uuid-dev libbsd-dev

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/fix-integration.yml
+++ b/.github/workflows/fix-integration.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Run FIX integration tests
         run: |

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -60,6 +62,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Build KDB image
         run: docker build -t wingfoil-kdb docker/kdb/
@@ -62,6 +64,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: wingfoil-python/pyproject.toml
 
       - name: Install system dependencies
         run: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Run OTLP integration tests
         run: |

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Start Grafana + Prometheus stack
         run: docker compose up -d

--- a/.github/workflows/py-test.yml
+++ b/.github/workflows/py-test.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: wingfoil-python/pyproject.toml
 
       - name: Create virtualenv and install dependencies
         run: |

--- a/.github/workflows/zmq-etcd-integration.yml
+++ b/.github/workflows/zmq-etcd-integration.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/zmq-integration.yml
+++ b/.github/workflows/zmq-integration.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
 
       - name: Run ZMQ integration tests
         run: |


### PR DESCRIPTION
The 9 integration workflows (kdb, etcd, prometheus, otlp, zmq,
zmq-etcd, fix, iceoryx2, aeron) each maintained their own
Swatinem/rust-cache entry keyed by job name, so shared third-party
dependencies (testcontainers, tokio, reqwest, serde, opentelemetry,
etc.) were compiled from scratch in every workflow.

Set shared-key: integration on all of them so they reuse one cache
entry keyed by Cargo.lock. The first workflow to run populates the
cache with compiled dep artifacts and every subsequent integration
workflow restores them, leaving only the feature-specific deps to
build.

Also enable pip caching in py-test.yml and kdb-integration.yml so
Python wheels (pandas, pyzmq, maturin, pytest, pytest-cov) are
restored from cache instead of re-downloaded each run.