### PR TITLE
Disable Codecov comments on pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+comment: false
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary
Disables automatic Codecov comments on pull requests by setting the `comment` configuration option to `false` in the codecov.yml configuration file.

## Changes
- Added `comment: false` configuration to codecov.yml to prevent Codecov from posting coverage reports as comments on pull requests

## Details
This change reduces noise on pull requests by preventing Codecov from automatically commenting with coverage analysis on each PR. Coverage reports will still be generated and tracked, but they won't be posted as comments in the PR discussion.

https://claude.ai/code/session_01PNsyNHuLCToxx6rYrLxhTR