### PR TITLE
ci: install protoc in crates.io publish workflow

### DIFF
--- a/.github/workflows/crate-pub.yml
+++ b/.github/workflows/crate-pub.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
       # Build to generate Cargo.lock
       - name: Build wingfoil
         working-directory: wingfoil


### PR DESCRIPTION
The etcd-client dependency requires protoc to build. Without it, both
the build and verification steps in cargo publish fail.

https://claude.ai/code/session_01ALVoTqNwVF3s5isqo2rcn9