### PR TITLE
ci: stop duplicating integration tests inside release.yml

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -8,10 +8,12 @@ jobs:
   rust-ci:
     name: Rust CI
     uses: ./.github/workflows/rust.yml
+    secrets: inherit
 
   python-tests:
     name: Python Tests
     uses: ./.github/workflows/py-test.yml
+    secrets: inherit
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,81 +38,9 @@ jobs:
     uses: ./.github/workflows/all-tests.yml
     secrets: inherit
 
-  integration-tests:
-    name: Integration Tests
-    needs: preflight
-    uses: ./.github/workflows/integration-tests.yml
-    secrets: inherit
-
-  zmq-integration:
-    name: ZMQ Integration Tests
-    needs: preflight
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust Build Artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Run ZMQ integration tests
-        run: |
-          cargo test --features zmq-integration-test -p wingfoil \
-            -- --test-threads=1 zmq::integration_tests
-        env:
-          RUST_LOG: INFO
-
-  etcd-integration:
-    name: etcd Integration Tests
-    needs: preflight
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust Build Artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
-      - name: Run etcd integration tests
-        run: |
-          cargo test --features etcd-integration-test -p wingfoil \
-            -- --test-threads=1 etcd::integration_tests
-        env:
-          RUST_LOG: INFO
-
-  zmq-etcd-integration:
-    name: ZMQ etcd Integration Tests
-    needs: preflight
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust Build Artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
-      - name: Run ZMQ etcd integration tests
-        run: |
-          cargo test --features zmq-etcd-integration-test -p wingfoil \
-            -- --test-threads=1 zmq::integration_tests::etcd_tests
-        env:
-          RUST_LOG: INFO
-
   tag:
     name: Cut release tag
-    needs: [preflight, all-tests, integration-tests, zmq-integration, etcd-integration, zmq-etcd-integration]
+    needs: [preflight, all-tests]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
release.yml was both calling integration-tests.yml AND inlining its own zmq, etcd, and zmq-etcd jobs. The inline copies omit the per-adapter setup (etcd image pre-pull with retries, etcd container for Python tests, etc.), so they fail intermittently or skip work that the dedicated workflows do. all-tests.yml already calls integration-tests.yml — release just needs to invoke that.

Collapse release.yml down to preflight → all-tests → tag and let the reusable workflow chain do the rest.

Also forward secrets to rust.yml and py-test.yml from all-tests.yml. Without secrets: inherit on those reusable calls, CODECOV_TOKEN is empty, and codecov-action with fail_ci_if_error: true (rust.yml) fails the job whenever it's invoked through the release / all-tests chain.

https://claude.ai/code/session_01PtptXxkC8GLFyXR1JEvZDQ