### PR TITLE
fix(ci): unblock PyPI wheel builds on macos-latest and modernize actions

### DIFF
--- a/.github/workflows/pypi-pub.yml
+++ b/.github/workflows/pypi-pub.yml
@@ -16,9 +16,15 @@ jobs:
   build-wheels:
     runs-on: ${{ matrix.os }}
     strategy:
+      # Keep building other matrix entries even if one fails so every
+      # platform/Python error is surfaced in a single run rather than
+      # hidden behind the first failure.
+      fail-fast: false
       matrix:
+        # Python 3.8 is EOL (Oct 2024) and has no macOS arm64 binaries,
+        # which breaks setup-python on the current macos-latest runners.
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Debug matrix
@@ -27,27 +33,45 @@ jobs:
           echo "Python version: ${{ matrix.python-version }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          check-latest: true
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
-          override: true
+          workspaces: wingfoil-python
+
+      # wingfoil-python enables the `etcd`, `otlp`, `prometheus`, and `zmq`
+      # features, which transitively require `protoc` and `libzmq` at build
+      # time. Linux already gets these via apt-get in the base image for most
+      # things, but we install explicitly to be safe. macOS runners do not
+      # ship these, so install via Homebrew. Windows is handled by vcpkg via
+      # the zmq crate's build script (libzmq) and choco (protoc).
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libzmq3-dev
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf zeromq
+
+      - name: Install system dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
 
       - name: Install maturin
-        run: pip install maturin
+        run: pip install "maturin>=1.4,<2.0"
 
-      - name: Build wheel and sdist
-        run: |
-          cd wingfoil-python
-          maturin build --verbose --release --strip -o wheelhouse
+      - name: Build wheel
+        working-directory: wingfoil-python
+        run: maturin build --verbose --release --strip -o wheelhouse --interpreter python${{ matrix.python-version }}
 
       - name: Upload wheels as artifact
         uses: actions/upload-artifact@v4
@@ -60,7 +84,7 @@ jobs:
     needs: build-wheels
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set PyPI target
         id: pypi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2697,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5524,6 +5534,7 @@ dependencies = [
  "kdb-plus-fixed",
  "lazy_static",
  "log",
+ "openssl",
  "pyo3",
  "thiserror 2.0.18",
  "wingfoil",

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -38,6 +38,12 @@ pyo3 = { version = "0.27", features = ["extension-module", "serde"] }
 kdb-plus-fixed = { version = "0.5.0", features = ["ipc"] }
 futures = "0.3"
 
+# Windows does not ship OpenSSL, and `fefix` (pulled in by the `fix` feature)
+# requires `openssl-sys`. Build a vendored OpenSSL on Windows so wheels are
+# self-contained and don't require users to install OpenSSL separately.
+[target.'cfg(target_os = "windows")'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 
 [package.metadata.maturin]
 name = "wingfoil"

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -309,10 +309,7 @@ fn drain_parse_buf<W: Write>(
     is_acceptor: bool,
 ) -> anyhow::Result<bool> {
     let before = events.len();
-    loop {
-        let Some((msg_bytes, consumed)) = find_message(parse_buf) else {
-            break;
-        };
+    while let Some((msg_bytes, consumed)) = find_message(parse_buf) {
         parse_buf.drain(..consumed);
         let Some(msg) = build_message(decode_fields(&msg_bytes)) else {
             continue;


### PR DESCRIPTION
The PyPI Publish workflow was failing on macos-latest because:
- Python 3.8 is EOL and has no macOS arm64 binaries, so setup-python
  fails on current macos-latest (arm64) runners.
- macOS runners don't have `protoc` or `libzmq` installed, which are
  required by the `etcd`/`otlp`/`prometheus`/`zmq` features.
- The default `fail-fast: true` was masking sibling-job failures.

Changes:
- Drop Python 3.8 from the matrix; add 3.12 and 3.13.
- Install `protobuf` and `zeromq` via Homebrew on macOS and via apt on
  Linux; install `protoc` via choco on Windows.
- Set `fail-fast: false` so each platform's error is visible.
- Update deprecated actions (checkout v3->v4, setup-python v4->v5) and
  replace archived `actions-rs/toolchain@v1` with
  `dtolnay/rust-toolchain@stable`.
- Add `Swatinem/rust-cache` to speed up subsequent builds.