### PR TITLE
ci: match all branches in rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_call:
   push:
-    branches: [ "*" ]
+    branches: [ "**" ]
     paths-ignore:
       - ".github/workflows/**"
   pull_request:


### PR DESCRIPTION
## Summary

The `push` trigger in `.github/workflows/rust.yml` used `branches: [ "*" ]`. In GitHub Actions branch globs, `*` does **not** match `/`, so CI silently skipped any branch whose name contains a slash (e.g. `feature/foo`, `claude/investigate-missing-actions-ydNuG`, `dependabot/...`). Switching to `**` matches every branch regardless of nesting.

This explains why several recent branches showed no Actions runs at all.

## Test plan
- [ ] After merge, push to a slash-named branch and confirm the `CI` workflow triggers.
- [ ] Confirm `main` and other flat-named branches still trigger as before.
