### PR TITLE
ci: include web-integration-test in coverage run

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run tests with coverage
-        run: cargo llvm-cov nextest -p wingfoil --features full --no-capture --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest -p wingfoil --features full,web-integration-test --no-capture --lcov --output-path lcov.info
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run tests with coverage
-        run: cargo llvm-cov nextest -p wingfoil --features full,web-integration-test --no-capture --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest -p wingfoil --features full --no-capture --lcov --output-path lcov.info
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -15,28 +15,6 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  web-rust-integration:
-    name: Web Rust Integration Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust Build Artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: integration
-
-      - name: Run web integration tests (in-process, no external services)
-        run: |
-          cargo test --features web -p wingfoil \
-            -- --test-threads=1 --nocapture adapters::web
-        env:
-          RUST_LOG: INFO
-
   wingfoil-wasm-build:
     name: wingfoil-wasm build + unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run web integration tests (in-process, no external services)
         run: |
-          cargo test --features web-integration-test -p wingfoil \
+          cargo test --features web -p wingfoil \
             -- --test-threads=1 --nocapture adapters::web
         env:
           RUST_LOG: INFO

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -30,7 +30,6 @@ otlp-integration-test = ["otlp", "dep:testcontainers"]
 fix = ["dep:fefix", "dep:rustls", "dep:webpki-roots"]
 fix-integration-test = ["fix"]
 web = ["async", "dep:axum", "dep:tower-http", "dep:tokio-tungstenite", "dep:wingfoil-wire-types", "dep:bincode", "tokio/net", "tokio/sync"]
-web-integration-test = ["web"]
 
 [package]
 name = "wingfoil"

--- a/wingfoil/src/adapters/web/CLAUDE.md
+++ b/wingfoil/src/adapters/web/CLAUDE.md
@@ -13,7 +13,7 @@ web/
   server.rs            # WebServer + axum router + per-connection task
   write.rs             # web_pub() sink + WebPubOperators fluent trait
   read.rs              # web_sub() source
-  integration_tests.rs # Gated by `web-integration-test`; in-process server + tungstenite client
+  integration_tests.rs # Ordinary `#[cfg(test)]`; in-process server + tungstenite client
   CLAUDE.md            # This file
 ```
 
@@ -89,7 +89,7 @@ cargo fmt --all
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 # 2. Unit + integration tests (no external service required)
-cargo test --features web-integration-test -p wingfoil \
+cargo test --features web -p wingfoil \
   -- --test-threads=1 adapters::web
 ```
 

--- a/wingfoil/src/adapters/web/integration_tests.rs
+++ b/wingfoil/src/adapters/web/integration_tests.rs
@@ -1,14 +1,8 @@
 //! Integration tests for the `web` adapter.
 //!
 //! These tests spin up an in-process [`WebServer`] and connect a
-//! `tokio-tungstenite` client to it. No external service is required.
-//!
-//! Run with:
-//!
-//! ```sh
-//! cargo test --features web-integration-test -p wingfoil \
-//!   -- --test-threads=1 adapters::web::integration_tests
-//! ```
+//! `tokio-tungstenite` client to it. No external service is required,
+//! so they run as ordinary unit tests under `cargo test --features web`.
 
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};

--- a/wingfoil/src/adapters/web/mod.rs
+++ b/wingfoil/src/adapters/web/mod.rs
@@ -67,7 +67,7 @@ mod read;
 mod server;
 mod write;
 
-#[cfg(all(test, feature = "web-integration-test"))]
+#[cfg(test)]
 mod integration_tests;
 
 pub use codec::{CONTROL_TOPIC, CodecKind, ControlMessage, Envelope, WIRE_PROTOCOL_VERSION};


### PR DESCRIPTION
The web adapter (PR #215) added ~530 lines across server.rs, read.rs,
and write.rs whose tests live in integration_tests.rs, gated by the
web-integration-test feature. The coverage run uses --features full,
which pulls in web but not web-integration-test, so those tests never
compile and the new code landed as uncovered — driving the sudden
codecov drop.

The web integration tests run entirely in-process (no Docker, per
wingfoil/src/adapters/web/CLAUDE.md), so adding the feature to the
coverage command is safe.