### PR TITLE
Install protobuf-compiler for readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - protobuf-compiler
 
 # Python environment setup
 python:


### PR DESCRIPTION
etcd-client 0.18 uses tonic-prost-build which requires protoc at build
time. The wingfoil-python package enables the etcd feature by default,
so readthedocs cannot build it without protoc installed.