### PR TITLE
Install Rust toolchain for readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+    rust: "1.91"
   apt_packages:
     - protobuf-compiler
 


### PR DESCRIPTION
The wingfoil-python package is a maturin-based PyO3 extension, so
readthedocs needs cargo/rustc to build it via pip. The previous protoc
fix (#222) addressed a tonic-prost-build dependency but did not install
Rust itself, so `pip install wingfoil-python` continues to fail in
the RTD environment.

Add `rust: "1.91"` (latest RTD-supported version) to build.tools so
maturin can compile the extension during the docs build.