### PR TITLE
Replace VecDeque+Mutex with lock-free kanal channel for FIX message injection

### DIFF
--- a/wingfoil-python/README.md
+++ b/wingfoil-python/README.md
@@ -543,7 +543,7 @@ data, status, injector = fix_connect_tls(
 )
 
 # Send a FIX message on the session:
-injector.inject({
+injector.send({
     "msg_type": "V",
     "fields": [(262, "req1"), (263, "1"), (264, "0")],
 })

--- a/wingfoil-python/README.md
+++ b/wingfoil-python/README.md
@@ -504,7 +504,7 @@ Both ends accept `variant` (`Ipc` for cross-process, `Local` for same-process),
 ### FIX protocol
 
 FIX 4.4 initiator, TLS initiator, and acceptor. All return
-`(data_stream, status_stream)`; TLS additionally returns an injector object
+`(data_stream, status_stream)`; TLS additionally returns a sender object
 for sending outbound messages.
 
 ```python
@@ -529,12 +529,12 @@ Each `data` tick yields a `list[dict]` where every dict is
 Status values are `"disconnected" | "logging_in" | "logged_in"` or a dict
 `{"status": "logged_out"|"error", "reason"|"message": str}`.
 
-TLS initiator (e.g. LMAX) with an injector:
+TLS initiator (e.g. LMAX) with a sender:
 
 ```python
 from wingfoil import fix_connect_tls
 
-data, status, injector = fix_connect_tls(
+data, status, sender = fix_connect_tls(
     host="fix-marketdata.london-digital.lmax.com",
     port=443,
     sender_comp_id="USERNAME",
@@ -543,7 +543,7 @@ data, status, injector = fix_connect_tls(
 )
 
 # Send a FIX message on the session:
-injector.send({
+sender.send({
     "msg_type": "V",
     "fields": [(262, "req1"), (263, "1"), (264, "0")],
 })

--- a/wingfoil-python/src/py_fix.rs
+++ b/wingfoil-python/src/py_fix.rs
@@ -54,11 +54,11 @@ pub fn py_fix_connect(
 }
 
 /// Connect to a TLS-secured FIX acceptor (e.g. LMAX) and return
-/// `(data_stream, status_stream, injector_func)`.
+/// `(data_stream, status_stream, sender)`.
 ///
-/// The injector is a callable that sends a FIX message dict on the session:
+/// The sender is a `FixSender` whose `send()` method sends a FIX message dict:
 /// ```python
-/// injector({"msg_type": "V", "fields": [(262, "req1"), (263, "1")]})
+/// sender.send({"msg_type": "V", "fields": [(262, "req1"), (263, "1")]})
 /// ```
 ///
 /// Args:
@@ -98,14 +98,14 @@ pub fn py_fix_connect_tls(
         })
     });
 
-    let inject_fn = Python::attach(|py| {
-        let injector_cls = PyFixInjector {
-            injector: fix.injector(),
+    let sender_obj = Python::attach(|py| {
+        let sender_cls = PyFixSender {
+            sender: fix.sender(),
         };
-        Py::new(py, injector_cls).unwrap().into_any()
+        Py::new(py, sender_cls).unwrap().into_any()
     });
 
-    (PyStream(py_data), PyStream(py_status), inject_fn)
+    (PyStream(py_data), PyStream(py_status), sender_obj)
 }
 
 /// Bind a FIX acceptor and return `(data_stream, status_stream)`.
@@ -144,14 +144,14 @@ pub fn py_fix_accept(
     (PyStream(py_data), PyStream(py_status))
 }
 
-/// Python wrapper around [`FixInjector`] for sending outbound FIX messages.
+/// Python wrapper around [`FixSender`] for sending outbound FIX messages.
 #[pyclass(unsendable)]
-struct PyFixInjector {
-    injector: wingfoil::adapters::fix::FixInjector,
+struct PyFixSender {
+    sender: wingfoil::adapters::fix::FixSender,
 }
 
 #[pymethods]
-impl PyFixInjector {
+impl PyFixSender {
     /// Send a FIX message on the session.
     ///
     /// Args:
@@ -180,7 +180,7 @@ impl PyFixInjector {
             fields.push((tag, value));
         }
 
-        self.injector.send(FixMessage {
+        self.sender.send(FixMessage {
             msg_type,
             seq_num: 0,
             sending_time: wingfoil::NanoTime::ZERO,

--- a/wingfoil-python/src/py_fix.rs
+++ b/wingfoil-python/src/py_fix.rs
@@ -180,13 +180,14 @@ impl PyFixSender {
             fields.push((tag, value));
         }
 
-        self.sender.send(FixMessage {
-            msg_type,
-            seq_num: 0,
-            sending_time: wingfoil::NanoTime::ZERO,
-            fields,
-        });
-        Ok(())
+        self.sender
+            .send(FixMessage {
+                msg_type,
+                seq_num: 0,
+                sending_time: wingfoil::NanoTime::ZERO,
+                fields,
+            })
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
     }
 }
 

--- a/wingfoil-python/src/py_fix.rs
+++ b/wingfoil-python/src/py_fix.rs
@@ -156,7 +156,7 @@ impl PyFixInjector {
     ///
     /// Args:
     ///     msg: A dict with "msg_type" (str) and "fields" (list of [tag, value] pairs).
-    fn inject(&self, msg: &Bound<'_, PyDict>) -> PyResult<()> {
+    fn send(&self, msg: &Bound<'_, PyDict>) -> PyResult<()> {
         let msg_type = msg
             .get_item("msg_type")?
             .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err("missing 'msg_type'"))?
@@ -180,7 +180,7 @@ impl PyFixInjector {
             fields.push((tag, value));
         }
 
-        self.injector.inject(FixMessage {
+        self.injector.send(FixMessage {
             msg_type,
             seq_num: 0,
             sending_time: wingfoil::NanoTime::ZERO,

--- a/wingfoil-python/tests/test_fix.py
+++ b/wingfoil-python/tests/test_fix.py
@@ -69,7 +69,7 @@ class TestFixLoopback(unittest.TestCase):
         self.assertEqual(len(result), 2)
 
     def test_fix_connect_tls_returns_triple(self):
-        """fix_connect_tls returns a (data_stream, status_stream, injector) triple."""
+        """fix_connect_tls returns a (data_stream, status_stream, sender) triple."""
         from wingfoil import fix_connect_tls
 
         result = fix_connect_tls("127.0.0.1", 443, "S", "T")

--- a/wingfoil/examples/fix/lmax_instruments.rs
+++ b/wingfoil/examples/fix/lmax_instruments.rs
@@ -58,7 +58,7 @@ fn main() {
     std::thread::spawn(move || {
         std::thread::sleep(Duration::from_secs(2));
         for id in candidates() {
-            injector.inject(market_data_request(&id, &format!("req_{id}")));
+            injector.send(market_data_request(&id, &format!("req_{id}")));
             std::thread::sleep(Duration::from_millis(100));
         }
     });

--- a/wingfoil/examples/fix/lmax_instruments.rs
+++ b/wingfoil/examples/fix/lmax_instruments.rs
@@ -54,11 +54,11 @@ fn main() {
 
     // Sweep instrument IDs with a delay between each request.
     // This needs raw injection because of the per-request throttling.
-    let injector = fix.injector();
+    let sender = fix.sender();
     std::thread::spawn(move || {
         std::thread::sleep(Duration::from_secs(2));
         for id in candidates() {
-            injector.send(market_data_request(&id, &format!("req_{id}")));
+            sender.send(market_data_request(&id, &format!("req_{id}")));
             std::thread::sleep(Duration::from_millis(100));
         }
     });

--- a/wingfoil/examples/fix/lmax_instruments.rs
+++ b/wingfoil/examples/fix/lmax_instruments.rs
@@ -58,7 +58,7 @@ fn main() {
     std::thread::spawn(move || {
         std::thread::sleep(Duration::from_secs(2));
         for id in candidates() {
-            sender.send(market_data_request(&id, &format!("req_{id}")));
+            sender.send_or_log(market_data_request(&id, &format!("req_{id}")));
             std::thread::sleep(Duration::from_millis(100));
         }
     });

--- a/wingfoil/src/adapters/fix/CLAUDE.md
+++ b/wingfoil/src/adapters/fix/CLAUDE.md
@@ -30,7 +30,7 @@ This avoids the overhead of an async runtime for a protocol where microsecond la
 `fix_connect_tls` returns a `FixConnection` bundling the data/status streams and session handle.
 `FixConnection::fix_sub(&["4001"])` creates a graph node that watches the status stream and
 automatically sends `MarketDataRequest` messages once the session reaches `LoggedIn`.
-`FixConnection::inject(msg)` and `FixConnection::injector()` provide raw access for advanced
+`FixConnection::send(msg)` and `FixConnection::injector()` provide raw access for advanced
 use cases (e.g. throttled sweeps, custom message types). `FixSenderNode` is a separate sink for
 cases where a dedicated outbound connection is needed (e.g. order routing).
 

--- a/wingfoil/src/adapters/fix/CLAUDE.md
+++ b/wingfoil/src/adapters/fix/CLAUDE.md
@@ -30,7 +30,7 @@ This avoids the overhead of an async runtime for a protocol where microsecond la
 `fix_connect_tls` returns a `FixConnection` bundling the data/status streams and session handle.
 `FixConnection::fix_sub(&["4001"])` creates a graph node that watches the status stream and
 automatically sends `MarketDataRequest` messages once the session reaches `LoggedIn`.
-`FixConnection::send(msg)` and `FixConnection::injector()` provide raw access for advanced
+`FixConnection::send(msg)` and `FixConnection::sender()` provide raw access for advanced
 use cases (e.g. throttled sweeps, custom message types). `FixSenderNode` is a separate sink for
 cases where a dedicated outbound connection is needed (e.g. order routing).
 

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -135,18 +135,18 @@ const INJECT_QUEUE_CAPACITY: usize = 1024;
 
 /// Handle for injecting outbound [`FixMessage`]s into an established FIX session.
 ///
-/// Obtained from [`FixConnection::injector`]. Thread-safe and cheaply cloneable.
+/// Obtained from [`FixConnection::sender`]. Thread-safe and cheaply cloneable.
 /// Messages are sent on the next background-thread loop iteration.
 ///
 /// Internally backed by a lock-free bounded [`kanal`] MPSC channel: `send()`
 /// does a single CAS-style `try_send` and never blocks. If the session thread
 /// falls behind and the channel fills, the message is dropped and logged.
 #[derive(Clone)]
-pub struct FixInjector {
+pub struct FixSender {
     sender: kanal::Sender<FixMessage>,
 }
 
-impl FixInjector {
+impl FixSender {
     /// Queue `msg` for sending on the next session loop iteration.
     ///
     /// Non-blocking. If the inject channel is full (session thread stalled or
@@ -156,9 +156,9 @@ impl FixInjector {
         match self.sender.try_send(msg) {
             Ok(true) => {}
             Ok(false) => log::warn!(
-                "FixInjector: send queue full ({INJECT_QUEUE_CAPACITY}) — dropping message"
+                "FixSender: send queue full ({INJECT_QUEUE_CAPACITY}) — dropping message"
             ),
-            Err(_) => log::warn!("FixInjector: send channel closed — dropping message"),
+            Err(_) => log::warn!("FixSender: send channel closed — dropping message"),
         }
     }
 }
@@ -172,7 +172,7 @@ pub struct FixConnection {
     pub data: Rc<dyn Stream<Burst<FixMessage>>>,
     /// Session lifecycle events (LoggedIn, LoggedOut, …).
     pub status: Rc<dyn Stream<Burst<FixSessionStatus>>>,
-    injector: FixInjector,
+    sender: FixSender,
 }
 
 impl FixConnection {
@@ -197,7 +197,7 @@ impl FixConnection {
     /// ```
     pub fn fix_sub(&self, symbols: Rc<dyn Stream<Vec<String>>>) -> Rc<dyn Node> {
         FixSubNode {
-            injector: self.injector.clone(),
+            sender: self.sender.clone(),
             status: self.status.clone(),
             symbols,
             pending: Vec::new(),
@@ -209,12 +209,12 @@ impl FixConnection {
 
     /// Queue a raw outbound [`FixMessage`] for sending on the session thread.
     pub fn send(&self, msg: FixMessage) {
-        self.injector.send(msg);
+        self.sender.send(msg);
     }
 
-    /// Get a clone of the underlying [`FixInjector`] for manual use.
-    pub fn injector(&self) -> FixInjector {
-        self.injector.clone()
+    /// Get a clone of the underlying [`FixSender`] for manual use.
+    pub fn sender(&self) -> FixSender {
+        self.sender.clone()
     }
 }
 
@@ -908,7 +908,7 @@ struct FixThreadedSource {
     // Set by stop() to prevent the thread from re-accepting after socket shutdown.
     stop_flag: Arc<AtomicBool>,
     // Bounded kanal channel for outbound messages injected from outside the graph.
-    // `inject_sender` is cloned into each `FixInjector`; `inject_receiver` is moved
+    // `inject_sender` is cloned into each `FixSender`; `inject_receiver` is moved
     // into the session thread on setup.
     inject_sender: kanal::Sender<FixMessage>,
     inject_receiver: Option<kanal::Receiver<FixMessage>>,
@@ -1212,7 +1212,7 @@ fn market_data_request(symbol: &str, req_id: &str) -> FixMessage {
 }
 
 struct FixSubNode {
-    injector: FixInjector,
+    sender: FixSender,
     status: Rc<dyn Stream<Burst<FixSessionStatus>>>,
     symbols: Rc<dyn Stream<Vec<String>>>,
     pending: Vec<String>,
@@ -1223,7 +1223,7 @@ struct FixSubNode {
 impl FixSubNode {
     fn subscribe(&mut self, sym: &str) {
         let req_id = format!("sub_{}_{sym}", self.sent.len());
-        self.injector.send(market_data_request(sym, &req_id));
+        self.sender.send(market_data_request(sym, &req_id));
         self.sent.push(sym.to_string());
     }
 }
@@ -1407,7 +1407,7 @@ pub fn fix_connect_tls(
 ) -> FixConnection {
     let src =
         FixThreadedSource::new_initiator_tls(host, port, sender_comp_id, target_comp_id, password);
-    let injector = FixInjector {
+    let sender = FixSender {
         sender: src.inject_sender.clone(),
     };
     let events: Rc<dyn Stream<Burst<FixEvent>>> = src.into_stream();
@@ -1415,7 +1415,7 @@ pub fn fix_connect_tls(
     FixConnection {
         data,
         status,
-        injector,
+        sender,
     }
 }
 

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -129,18 +129,50 @@ pub enum FixPollMode {
     Threaded,
 }
 
-/// Bounded capacity of the outbound inject channel. Matches the drop-newest
-/// slow-consumer protection used by other wingfoil adapters.
+/// Bounded capacity of the outbound inject channel. `try_send` returns full
+/// when this many messages are backlogged; callers receive
+/// [`SendError::QueueFull`] and decide the policy (halt, retry, log-and-drop,
+/// etc.).
 const INJECT_QUEUE_CAPACITY: usize = 1024;
 
-/// Handle for injecting outbound [`FixMessage`]s into an established FIX session.
+/// Reasons `FixSender::send` can fail.
+///
+/// Both variants mean the message was not queued. `QueueFull` is transient —
+/// the session thread is stalled but may recover. `Closed` is terminal — the
+/// session has ended and all subsequent sends will also return `Closed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendError {
+    /// The bounded send queue is full ({INJECT_QUEUE_CAPACITY} messages).
+    /// The session thread is not draining fast enough, typically because the
+    /// socket is backpressured.
+    QueueFull,
+    /// The inject channel is closed — the session thread has exited.
+    Closed,
+}
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SendError::QueueFull => {
+                write!(f, "FIX send queue full ({INJECT_QUEUE_CAPACITY} messages)")
+            }
+            SendError::Closed => f.write_str("FIX send channel closed"),
+        }
+    }
+}
+
+impl std::error::Error for SendError {}
+
+/// Handle for sending outbound [`FixMessage`]s on an established FIX session.
 ///
 /// Obtained from [`FixConnection::sender`]. Thread-safe and cheaply cloneable.
 /// Messages are sent on the next background-thread loop iteration.
 ///
 /// Internally backed by a lock-free bounded [`kanal`] MPSC channel: `send()`
-/// does a single CAS-style `try_send` and never blocks. If the session thread
-/// falls behind and the channel fills, the message is dropped and logged.
+/// does a single CAS-style `try_send` and never blocks. Failure (full or
+/// closed) is surfaced via [`SendError`] so callers choose the policy:
+/// halt trading, route to a dead-letter queue, retry, or log-and-drop via
+/// [`FixSender::send_or_log`].
 #[derive(Clone)]
 pub struct FixSender {
     sender: kanal::Sender<FixMessage>,
@@ -149,16 +181,25 @@ pub struct FixSender {
 impl FixSender {
     /// Queue `msg` for sending on the next session loop iteration.
     ///
-    /// Non-blocking. If the inject channel is full (session thread stalled or
-    /// the socket is backpressured) or closed (session has ended), the message
-    /// is dropped and a warning logged.
-    pub fn send(&self, msg: FixMessage) {
+    /// Non-blocking. Returns [`SendError::QueueFull`] if the session thread is
+    /// stalled and the bounded channel is full, or [`SendError::Closed`] if
+    /// the session has ended. The message is not queued in either case.
+    pub fn send(&self, msg: FixMessage) -> Result<(), SendError> {
         match self.sender.try_send(msg) {
-            Ok(true) => {}
-            Ok(false) => log::warn!(
-                "FixSender: send queue full ({INJECT_QUEUE_CAPACITY}) — dropping message"
-            ),
-            Err(_) => log::warn!("FixSender: send channel closed — dropping message"),
+            Ok(true) => Ok(()),
+            Ok(false) => Err(SendError::QueueFull),
+            Err(_) => Err(SendError::Closed),
+        }
+    }
+
+    /// Convenience wrapper around [`send`](Self::send) that logs and drops on
+    /// failure. Appropriate for non-critical paths (e.g. market-data
+    /// subscriptions that are idempotent and resendable). For order routing or
+    /// other paths where silent drops are unacceptable, use [`send`](Self::send)
+    /// directly and handle the [`SendError`].
+    pub fn send_or_log(&self, msg: FixMessage) {
+        if let Err(e) = self.send(msg) {
+            log::warn!("FixSender: {e} — dropping message");
         }
     }
 }
@@ -208,8 +249,10 @@ impl FixConnection {
     }
 
     /// Queue a raw outbound [`FixMessage`] for sending on the session thread.
-    pub fn send(&self, msg: FixMessage) {
-        self.sender.send(msg);
+    ///
+    /// See [`FixSender::send`] for error semantics.
+    pub fn send(&self, msg: FixMessage) -> Result<(), SendError> {
+        self.sender.send(msg)
     }
 
     /// Get a clone of the underlying [`FixSender`] for manual use.
@@ -1223,7 +1266,7 @@ struct FixSubNode {
 impl FixSubNode {
     fn subscribe(&mut self, sym: &str) {
         let req_id = format!("sub_{}_{sym}", self.sent.len());
-        self.sender.send(market_data_request(sym, &req_id));
+        self.sender.send_or_log(market_data_request(sym, &req_id));
         self.sent.push(sym.to_string());
     }
 }

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -138,7 +138,7 @@ const INJECT_QUEUE_CAPACITY: usize = 1024;
 /// Obtained from [`FixConnection::injector`]. Thread-safe and cheaply cloneable.
 /// Messages are sent on the next background-thread loop iteration.
 ///
-/// Internally backed by a lock-free bounded [`kanal`] MPSC channel: `inject()`
+/// Internally backed by a lock-free bounded [`kanal`] MPSC channel: `send()`
 /// does a single CAS-style `try_send` and never blocks. If the session thread
 /// falls behind and the channel fills, the message is dropped and logged.
 #[derive(Clone)]
@@ -152,13 +152,13 @@ impl FixInjector {
     /// Non-blocking. If the inject channel is full (session thread stalled or
     /// the socket is backpressured) or closed (session has ended), the message
     /// is dropped and a warning logged.
-    pub fn inject(&self, msg: FixMessage) {
+    pub fn send(&self, msg: FixMessage) {
         match self.sender.try_send(msg) {
             Ok(true) => {}
             Ok(false) => log::warn!(
-                "FixInjector: inject queue full ({INJECT_QUEUE_CAPACITY}) — dropping message"
+                "FixInjector: send queue full ({INJECT_QUEUE_CAPACITY}) — dropping message"
             ),
-            Err(_) => log::warn!("FixInjector: inject channel closed — dropping message"),
+            Err(_) => log::warn!("FixInjector: send channel closed — dropping message"),
         }
     }
 }
@@ -166,7 +166,7 @@ impl FixInjector {
 /// Bundles the streams and session handle returned by [`fix_connect_tls`].
 ///
 /// Use [`fix_sub`](FixConnection::fix_sub) to subscribe to market data as a
-/// graph node, or [`inject`](FixConnection::inject) for raw outbound messages.
+/// graph node, or [`send`](FixConnection::send) for raw outbound messages.
 pub struct FixConnection {
     /// Inbound application messages (MarketDataSnapshot, execution reports, etc.).
     pub data: Rc<dyn Stream<Burst<FixMessage>>>,
@@ -208,8 +208,8 @@ impl FixConnection {
     }
 
     /// Queue a raw outbound [`FixMessage`] for sending on the session thread.
-    pub fn inject(&self, msg: FixMessage) {
-        self.injector.inject(msg);
+    pub fn send(&self, msg: FixMessage) {
+        self.injector.send(msg);
     }
 
     /// Get a clone of the underlying [`FixInjector`] for manual use.
@@ -1223,7 +1223,7 @@ struct FixSubNode {
 impl FixSubNode {
     fn subscribe(&mut self, sym: &str) {
         let req_id = format!("sub_{}_{sym}", self.sent.len());
-        self.injector.inject(market_data_request(sym, &req_id));
+        self.injector.send(market_data_request(sym, &req_id));
         self.sent.push(sym.to_string());
     }
 }
@@ -1397,7 +1397,7 @@ pub fn fix_connect(
 ///
 /// Returns a [`FixConnection`] with `data` and `status` streams, plus
 /// [`fix_sub`](FixConnection::fix_sub) for declarative market data subscription
-/// and [`inject`](FixConnection::inject) for raw outbound messages.
+/// and [`send`](FixConnection::send) for raw outbound messages.
 pub fn fix_connect_tls(
     host: &str,
     port: u16,

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -1687,6 +1687,35 @@ mod tests {
         .run()
         .unwrap();
     }
+
+    /// Fills the inject channel to capacity with no draining receiver and
+    /// asserts the next `send` returns `SendError::QueueFull`. Also confirms
+    /// that `send_or_log` swallows the error (doesn't panic) on the same
+    /// overflowed channel.
+    #[test]
+    fn fix_sender_queue_full() {
+        let (tx, _rx) = kanal::bounded::<FixMessage>(INJECT_QUEUE_CAPACITY);
+        let sender = FixSender { sender: tx };
+        let msg = FixMessage::default();
+
+        for i in 0..INJECT_QUEUE_CAPACITY {
+            sender
+                .send(msg.clone())
+                .unwrap_or_else(|e| panic!("send {i} of {INJECT_QUEUE_CAPACITY} failed: {e}"));
+        }
+        assert_eq!(sender.send(msg.clone()), Err(SendError::QueueFull));
+        // send_or_log on a full queue must not panic.
+        sender.send_or_log(msg);
+    }
+
+    /// With the receiver dropped, `send` must return `SendError::Closed`.
+    #[test]
+    fn fix_sender_closed() {
+        let (tx, rx) = kanal::bounded::<FixMessage>(INJECT_QUEUE_CAPACITY);
+        let sender = FixSender { sender: tx };
+        drop(rx);
+        assert_eq!(sender.send(FixMessage::default()), Err(SendError::Closed));
+    }
 }
 
 #[cfg(all(test, feature = "fix-integration-test"))]

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -13,7 +13,6 @@
 //! It returns a [`FixConnection`] with data/status streams and
 //! [`fix_sub`](FixConnection::fix_sub) for declarative market data subscription.
 
-use std::collections::VecDeque;
 use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::rc::Rc;
@@ -130,19 +129,37 @@ pub enum FixPollMode {
     Threaded,
 }
 
+/// Bounded capacity of the outbound inject channel. Matches the drop-newest
+/// slow-consumer protection used by other wingfoil adapters.
+const INJECT_QUEUE_CAPACITY: usize = 1024;
+
 /// Handle for injecting outbound [`FixMessage`]s into an established FIX session.
 ///
 /// Obtained from [`FixConnection::injector`]. Thread-safe and cheaply cloneable.
 /// Messages are sent on the next background-thread loop iteration.
+///
+/// Internally backed by a lock-free bounded [`kanal`] MPSC channel: `inject()`
+/// does a single CAS-style `try_send` and never blocks. If the session thread
+/// falls behind and the channel fills, the message is dropped and logged.
 #[derive(Clone)]
 pub struct FixInjector {
-    queue: Arc<Mutex<VecDeque<FixMessage>>>,
+    sender: kanal::Sender<FixMessage>,
 }
 
 impl FixInjector {
     /// Queue `msg` for sending on the next session loop iteration.
+    ///
+    /// Non-blocking. If the inject channel is full (session thread stalled or
+    /// the socket is backpressured) or closed (session has ended), the message
+    /// is dropped and a warning logged.
     pub fn inject(&self, msg: FixMessage) {
-        self.queue.lock().unwrap().push_back(msg);
+        match self.sender.try_send(msg) {
+            Ok(true) => {}
+            Ok(false) => log::warn!(
+                "FixInjector: inject queue full ({INJECT_QUEUE_CAPACITY}) — dropping message"
+            ),
+            Err(_) => log::warn!("FixInjector: inject channel closed — dropping message"),
+        }
     }
 }
 
@@ -774,7 +791,7 @@ impl StreamPeekRef<Burst<FixEvent>> for FixAcceptorSpin {
 // ── Threaded source (initiator or acceptor) ───────────────────────────────────
 
 /// Run a single FIX session on `sock`, forwarding events to `chan`.
-/// Outbound messages queued in `inject_queue` are flushed each loop iteration.
+/// Outbound messages queued on `inject_rx` are flushed each loop iteration.
 ///
 /// Returns `true` if the session ended due to a normal network disconnect
 /// (the caller may reconnect), or `false` if the channel is closed (graph
@@ -783,7 +800,7 @@ fn run_fix_session<S: Read + Write>(
     mut sock: S,
     session: &mut FixSession,
     is_acceptor: bool,
-    inject_queue: &Arc<Mutex<VecDeque<FixMessage>>>,
+    inject_rx: &kanal::Receiver<FixMessage>,
     chan: &ChannelSender<FixEvent>,
 ) -> bool {
     use crate::channel::Message;
@@ -847,12 +864,18 @@ fn run_fix_session<S: Read + Write>(
             }
         }
 
-        // Flush any outbound messages injected from outside the graph
+        // Flush any outbound messages injected from outside the graph.
+        // `try_recv` is lock-free; no lock is held across `session.send()`.
         if let Some(ref mut s) = sock_opt {
-            let mut queue = inject_queue.lock().unwrap();
-            while let Some(msg) = queue.pop_front() {
-                if session.send(s, &msg.msg_type, &msg.fields).is_err() {
-                    return true;
+            loop {
+                match inject_rx.try_recv() {
+                    Ok(Some(msg)) => {
+                        if session.send(s, &msg.msg_type, &msg.fields).is_err() {
+                            return true;
+                        }
+                    }
+                    Ok(None) => break, // queue empty
+                    Err(_) => break,   // all senders dropped — nothing more will arrive
                 }
             }
         }
@@ -884,14 +907,18 @@ struct FixThreadedSource {
     socket_arc: Option<Arc<Mutex<Option<TcpStream>>>>,
     // Set by stop() to prevent the thread from re-accepting after socket shutdown.
     stop_flag: Arc<AtomicBool>,
-    // Queue for outbound messages injected from outside the graph.
-    inject_queue: Arc<Mutex<VecDeque<FixMessage>>>,
+    // Bounded kanal channel for outbound messages injected from outside the graph.
+    // `inject_sender` is cloned into each `FixInjector`; `inject_receiver` is moved
+    // into the session thread on setup.
+    inject_sender: kanal::Sender<FixMessage>,
+    inject_receiver: Option<kanal::Receiver<FixMessage>>,
 }
 
 impl FixThreadedSource {
     fn new_initiator(host: &str, port: u16, sender: &str, target: &str) -> Self {
         let (chan_sender, receiver) = channel_pair(None);
         let inner = ChannelReceiverStream::new(receiver, None, None);
+        let (inject_sender, inject_receiver) = kanal::bounded(INJECT_QUEUE_CAPACITY);
         Self {
             host: host.to_string(),
             port,
@@ -905,7 +932,8 @@ impl FixThreadedSource {
             thread: None,
             socket_arc: None,
             stop_flag: Arc::new(AtomicBool::new(false)),
-            inject_queue: Arc::new(Mutex::new(VecDeque::new())),
+            inject_sender,
+            inject_receiver: Some(inject_receiver),
         }
     }
 
@@ -918,6 +946,7 @@ impl FixThreadedSource {
     ) -> Self {
         let (chan_sender, receiver) = channel_pair(None);
         let inner = ChannelReceiverStream::new(receiver, None, None);
+        let (inject_sender, inject_receiver) = kanal::bounded(INJECT_QUEUE_CAPACITY);
         Self {
             host: host.to_string(),
             port,
@@ -931,13 +960,15 @@ impl FixThreadedSource {
             thread: None,
             socket_arc: None,
             stop_flag: Arc::new(AtomicBool::new(false)),
-            inject_queue: Arc::new(Mutex::new(VecDeque::new())),
+            inject_sender,
+            inject_receiver: Some(inject_receiver),
         }
     }
 
     fn new_acceptor(port: u16, sender: &str, target: &str) -> Self {
         let (chan_sender, receiver) = channel_pair(None);
         let inner = ChannelReceiverStream::new(receiver, None, None);
+        let (inject_sender, inject_receiver) = kanal::bounded(INJECT_QUEUE_CAPACITY);
         Self {
             host: "0.0.0.0".to_string(),
             port,
@@ -951,7 +982,8 @@ impl FixThreadedSource {
             thread: None,
             socket_arc: None,
             stop_flag: Arc::new(AtomicBool::new(false)),
-            inject_queue: Arc::new(Mutex::new(VecDeque::new())),
+            inject_sender,
+            inject_receiver: Some(inject_receiver),
         }
     }
 }
@@ -979,7 +1011,10 @@ impl MutableNode for FixThreadedSource {
         self.socket_arc = Some(socket_arc);
 
         let stop_flag = self.stop_flag.clone();
-        let inject_queue = self.inject_queue.clone();
+        let inject_rx = self
+            .inject_receiver
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("FixThreadedSource: already set up"))?;
         let host = self.host.clone();
         let port = self.port;
         let sender_id = self.sender_comp_id.clone();
@@ -1077,7 +1112,7 @@ impl MutableNode for FixThreadedSource {
                             tls_stream,
                             &mut session,
                             is_acceptor,
-                            &inject_queue,
+                            &inject_rx,
                             &chan_sender,
                         ),
                         Err(e) => {
@@ -1092,7 +1127,7 @@ impl MutableNode for FixThreadedSource {
                     }
                 } else {
                     let _ = sock.set_read_timeout(Some(Duration::from_millis(200)));
-                    run_fix_session(sock, &mut session, is_acceptor, &inject_queue, &chan_sender)
+                    run_fix_session(sock, &mut session, is_acceptor, &inject_rx, &chan_sender)
                 };
 
                 // Clear the stale socket handle.
@@ -1364,7 +1399,7 @@ pub fn fix_connect_tls(
     let src =
         FixThreadedSource::new_initiator_tls(host, port, sender_comp_id, target_comp_id, password);
     let injector = FixInjector {
-        queue: src.inject_queue.clone(),
+        sender: src.inject_sender.clone(),
     };
     let events: Rc<dyn Stream<Burst<FixEvent>>> = src.into_stream();
     let (data, status) = split_events(events);

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -1275,6 +1275,15 @@ impl MutableNode for FixSubNode {
 
 // ── FixSenderNode (sink) ──────────────────────────────────────────────────────
 
+// Writes FIX messages directly from `cycle` — no channel, no background thread.
+// Back-pressure is applied by the kernel TCP send buffer: if the socket
+// blocks, so does the graph cycle.
+//
+// Shape-wise this is the direct-write equivalent of `AsyncConsumerNode` in
+// nodes/async_io.rs, which instead puts a kanal `ChannelSender` between the
+// graph thread and the sink. If `channel_pair` ever grows a bounded+blocking
+// mode (see comment there), the two could be unified behind a generic
+// "sink node" abstraction parameterised by the actual write call.
 struct FixSenderNode {
     src: Rc<dyn Stream<FixMessage>>,
     host: String,

--- a/wingfoil/src/nodes/async_io.rs
+++ b/wingfoil/src/nodes/async_io.rs
@@ -43,6 +43,15 @@ impl<STRM, T> FutStream<T> for STRM where STRM: futures::Stream<Item = (NanoTime
 
 type ConsumerFunc<T, FUT> = Box<dyn FnOnce(RunParams, Pin<Box<dyn FutStream<T>>>) -> FUT + Send>;
 
+// Routes the source stream into a user-supplied async consumer via a kanal
+// `ChannelSender`. The channel is currently unbounded (see `channel_pair`), so
+// a slow consumer grows memory rather than back-pressuring the graph.
+//
+// Shape-wise this is the channel-backed equivalent of `FixSenderNode` in
+// adapters/fix/mod.rs, which writes directly from `cycle` and gets back-
+// pressure for free from the kernel TCP buffer. If `channel_pair` grows a
+// bounded+blocking mode, the two could share a single "sink node"
+// abstraction parameterised by the actual write call.
 pub(crate) struct AsyncConsumerNode<T, FUT>
 where
     T: Element + Send,


### PR DESCRIPTION
Closes #223.

## Summary

Replaces the `Arc<Mutex<VecDeque<FixMessage>>>` inject queue with a lock-free `kanal::bounded(1024)` channel, and surfaces send failures via a typed `Result<(), SendError>` instead of silently logging and dropping.

## Why

1. **Lock held across TLS write.** The old implementation held a `Mutex` across `session.send()` — a TLS socket write that can stall tens of microseconds under backpressure. Any graph-side `inject()` call was blocked for that entire duration. `kanal::try_send` is lock-free (single CAS) and `try_recv` on the session thread drains without ever holding a lock across I/O.

2. **Silent drops are the wrong default for a HFT library.** Dropping a market-data subscription request is recoverable; silently dropping an order is financial loss. The caller should choose.

## API changes

### Rename + method signature

- `FixInjector` → `FixSender` (co-exists fine with the existing `FixSenderNode` graph sink — different shapes, clear names).
- `FixConnection::injector()` → `FixConnection::sender()`.
- `inject()` → `send()`.
- `send()` now returns `Result<(), SendError>` where `SendError` is:
  - `QueueFull` — transient; session thread is stalled (TCP backpressure, etc.). Message consumed and **not** queued.
  - `Closed` — terminal; session has ended. All subsequent sends also fail.
- `FixSender::send_or_log(msg)` — convenience wrapper preserving the old log-and-drop behaviour for paths where silent drops are acceptable (idempotent / resendable messages like market-data subs).

### Existing call sites

- `FixSubNode::subscribe` uses `send_or_log` (mkt-data subs are resendable; a dead session surfaces via the status stream anyway).
- Python `PyFixSender.send` raises `PyRuntimeError` on `SendError`.
- Example `lmax_instruments.rs` uses `send_or_log`.

## Implementation notes

- `FixThreadedSource` holds `inject_sender: kanal::Sender` (cloned into each `FixSender`) and an `Option<kanal::Receiver>` taken into the session thread on `setup`.
- `run_fix_session` drains via `try_recv` inside the existing poll loop at wingfoil/src/adapters/fix/mod.rs:825 — no lock across `session.send()`.
- Added comments on `FixSenderNode` and `AsyncConsumerNode` noting they could be unified behind a generic sink abstraction once `channel_pair` grows a bounded+blocking mode (the latter is currently unbounded, so a slow async consumer grows memory rather than back-pressuring the graph).

## Test plan

- [x] `cargo test -p wingfoil --features fix fix` — all 5 unit tests pass
- [x] `cargo clippy -p wingfoil --all-targets --features fix -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] LMAX integration tests pass unchanged (requires credentials; not run in CI)
- [ ] Microbench of inject latency variance (issue acceptance criterion)

https://claude.ai/code/session_016HyBGCVvKRz2WLgkTQ8fad