### PR TITLE
ci(fmt): install protoc so cargo build succeeds

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Run cargo fmt
         run: cargo fmt --all
 


### PR DESCRIPTION
The fmt workflow's cargo build step fails on adapters that require
protobuf-compiler (e.g. Kafka). Match the rust workflow by installing
protoc before building.