### PR TITLE
Make graph cycle() lock-free; document invariant

### DIFF
--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -1,5 +1,39 @@
 Implement a new I/O adapter for wingfoil named `$ARGUMENTS`. Follow these steps in order. Work test-driven: write each test before its implementation.
 
+## Invariants
+
+These rules apply to every step below.
+
+### No locks on the graph execution path
+
+`Mutex` / `RwLock` must not be locked inside `cycle()`, `setup()`, or any other
+method the graph engine calls per-tick. Graph execution is single-threaded on
+the graph thread; taking a lock there adds uncontended-lock overhead on every
+tick and risks blocking the hot path behind a background thread (HTTP scraper,
+async task, reconnect loop, etc.).
+
+Locks *are* acceptable in, and only in:
+
+- **Wiring / factory functions** — e.g. `$ARGUMENTS_pub(...)`, `$ARGUMENTS_sub(...)`,
+  `WebServer::bind(...)`, `PrometheusExporter::register(...)`. Runs once before
+  the graph starts.
+- **`start()` / `stop()` / `teardown()`** — once-per-run lifecycle hooks.
+- **Background threads** — the OS thread spawned by `ReceiverStream`, the dedicated
+  HTTP/tokio thread behind `WebServer` / `PrometheusExporter`, a FIX session thread,
+  etc. These are *not* the graph thread.
+- **Cross-thread handles handed to user code** — e.g. `FixInjector::inject()` called
+  from outside the graph.
+
+To communicate between a background thread and graph `cycle()`, use the existing
+channel primitives (`ChannelSender` / `ChannelReceiver`, `ReceiverStream`,
+`produce_async` / `consume_async`) rather than a shared `Mutex<...>`. Channels
+give single-producer / single-consumer lock-free hand-off and preserve the
+"cycle never blocks" invariant.
+
+The Prometheus exporter currently locks inside `cycle()` to publish metric
+values to the HTTP scrape thread — this is a known exception, not a pattern to
+copy.
+
 ## 1. Branch
 
 ```bash

--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -30,9 +30,10 @@ channel primitives (`ChannelSender` / `ChannelReceiver`, `ReceiverStream`,
 give single-producer / single-consumer lock-free hand-off and preserve the
 "cycle never blocks" invariant.
 
-The Prometheus exporter currently locks inside `cycle()` to publish metric
-values to the HTTP scrape thread — this is a known exception, not a pattern to
-copy.
+When the payload is a whole value that a background thread reads ad-hoc (not a
+stream of deltas), `arc_swap::ArcSwap<T>` gives a lock-free atomic pointer swap
+in `cycle()` that the reader can `.load()` off-thread — see
+`wingfoil/src/adapters/prometheus/exporter.rs` for the per-slot pattern.
 
 ## 1. Branch
 

--- a/.github/workflows/bulk-rebase.yml
+++ b/.github/workflows/bulk-rebase.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WF_REBASE_PAT }}
       - name: Configure Git
         run: |
           git config user.name "github-actions"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.WF_REBASE_PAT }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.WF_REBASE_PAT }}
 
       - name: Install Rust Toolchains
         uses: actions-rs/toolchain@v1
@@ -44,5 +46,5 @@ jobs:
         uses: ad-m/github-push-action@v0.6.0
         if: success()
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.WF_REBASE_PAT }}
           branch: ${{ github.ref_name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,9 +317,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -318,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1455,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fefix"
@@ -1497,7 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31463d4f7708a7b04d5997eadaa96e4d99680e0b096936386250aa7635a75bcb"
 dependencies = [
  "darling 0.12.4",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3464,7 +3473,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3933,15 +3942,6 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -5637,15 +5637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5668,18 +5659,6 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
-dependencies = [
- "indexmap 2.13.1",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.1",
 ]
 
 [[package]]
@@ -6336,14 +6315,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6619,6 +6598,7 @@ name = "wingfoil"
 version = "4.0.1"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "arrayvec",
  "async-stream",
  "axum",
@@ -6743,9 +6723,6 @@ name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -27,7 +27,7 @@ fluvio = ["dep:fluvio", "async"]
 fluvio-integration-test = ["fluvio", "dep:testcontainers", "dep:fluvio-controlplane-metadata"]
 iceoryx2-integration-test = ["iceoryx2-beta", "dep:testcontainers"]
 iceoryx2-beta = ["dep:iceoryx2"]
-prometheus = []
+prometheus = ["dep:arc-swap"]
 prometheus-integration-test = ["prometheus", "dep:reqwest"]
 otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "async"]
 otlp-integration-test = ["otlp", "dep:testcontainers"]
@@ -112,6 +112,7 @@ fluvio = { version = "0.50.1", optional = true }
 fluvio-controlplane-metadata = { version = "0.50.1", optional = true }
 iceoryx2 = { version = "0.8", optional = true }
 reqwest = { version = "0.12", features = ["json", "blocking"], optional = true }
+arc-swap = { version = "1.7", optional = true }
 opentelemetry = { version = "0.28", optional = true }
 opentelemetry_sdk = { version = "0.28", features = ["metrics"], optional = true }
 opentelemetry-otlp = { version = "0.28", features = ["http-proto", "reqwest-blocking-client", "metrics"], optional = true }

--- a/wingfoil/src/adapters/prometheus/CLAUDE.md
+++ b/wingfoil/src/adapters/prometheus/CLAUDE.md
@@ -18,8 +18,12 @@ prometheus/
 - Prometheus text format is hand-rolled (no `prometheus` crate) — format is simple, avoids a heavy dep.
 - `PrometheusExporter` spawns its own OS thread (same pattern as the ZMQ publisher).
   `serve()` binds synchronously so bind errors surface before the graph starts.
-- Metric nodes are regular `MutableNode` sinks; they read `peek_value()` each tick and write to a
-  shared `Arc<Mutex<HashMap>>` that the HTTP thread reads on each scrape.
+- Metric nodes are regular `MutableNode` sinks; they read `peek_value()` each tick and publish the
+  stringified value into a per-metric `Arc<ArcSwap<String>>` slot with a lock-free atomic pointer
+  swap. The exporter holds a `Mutex<Vec<(name, slot)>>` registry that is locked only at
+  `register()` time and once per HTTP scrape (off the graph thread) — never from `cycle()`. On
+  scrape the HTTP thread snapshots the registry, drops the lock, then `.load()`s each slot to
+  render the response.
 - **Historical / backtesting mode**: `setup()` detects `RunMode::HistoricalFrom` and sets an internal
   flag so `cycle()` becomes a no-op. No metrics are written and no connections are made. The HTTP
   server is still started if `serve()` was called, but it just serves an empty body.

--- a/wingfoil/src/adapters/prometheus/exporter.rs
+++ b/wingfoil/src/adapters/prometheus/exporter.rs
@@ -1,15 +1,26 @@
-use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use arc_swap::ArcSwapOption;
+
 use crate::{Element, GraphState, IntoNode, MutableNode, Node, RunMode, Stream, UpStreams};
 
 const READ_TIMEOUT: Duration = Duration::from_secs(5);
 
-type MetricStore = Arc<Mutex<HashMap<String, String>>>;
+/// Latest stringified value for a single metric. `ArcSwapOption` lets `cycle()`
+/// publish a new value with a lock-free atomic pointer swap, and the HTTP
+/// scrape thread read it without coordinating with the graph thread. `None`
+/// means "never ticked" — such slots are omitted from the scrape response so
+/// historical-mode graphs produce an empty body.
+type MetricSlot = Arc<ArcSwapOption<String>>;
+
+/// Registry of all metrics the HTTP thread should render. Only locked when a
+/// new metric is registered (wiring time) and once per HTTP scrape (off the
+/// graph thread) — never from `cycle()`.
+type Registry = Arc<Mutex<Vec<(String, MetricSlot)>>>;
 
 /// Serves a Prometheus-compatible `GET /metrics` endpoint.
 ///
@@ -18,14 +29,14 @@ type MetricStore = Arc<Mutex<HashMap<String, String>>>;
 /// the returned sink nodes as part of your graph.
 pub struct PrometheusExporter {
     addr: String,
-    metrics: MetricStore,
+    registry: Registry,
 }
 
 impl PrometheusExporter {
     pub fn new(addr: impl Into<String>) -> Self {
         Self {
             addr: addr.into(),
-            metrics: Arc::new(Mutex::new(HashMap::new())),
+            registry: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -37,8 +48,8 @@ impl PrometheusExporter {
     pub fn serve(&self) -> Result<u16, std::io::Error> {
         let listener = TcpListener::bind(&self.addr)?;
         let port = listener.local_addr()?.port();
-        let metrics = self.metrics.clone();
-        std::thread::spawn(move || run_server(listener, metrics));
+        let registry = self.registry.clone();
+        std::thread::spawn(move || run_server(listener, registry));
         Ok(port)
     }
 
@@ -54,26 +65,31 @@ impl PrometheusExporter {
     where
         T: Element + std::fmt::Display,
     {
+        let name = name.into();
+        let slot: MetricSlot = Arc::new(ArcSwapOption::empty());
+        self.registry
+            .lock()
+            .expect("PrometheusExporter: registry lock poisoned")
+            .push((name, slot.clone()));
         PrometheusMetricNode {
-            name: name.into(),
             stream,
-            metrics: self.metrics.clone(),
+            slot,
             historical: false,
         }
         .into_node()
     }
 }
 
-fn run_server(listener: TcpListener, metrics: MetricStore) {
+fn run_server(listener: TcpListener, registry: Registry) {
     for stream in listener.incoming() {
         match stream {
-            Ok(conn) => handle_connection(conn, &metrics),
+            Ok(conn) => handle_connection(conn, &registry),
             Err(_) => break,
         }
     }
 }
 
-fn handle_connection(mut conn: TcpStream, metrics: &MetricStore) {
+fn handle_connection(mut conn: TcpStream, registry: &Registry) {
     if let Err(e) = conn.set_read_timeout(Some(READ_TIMEOUT)) {
         log::warn!("PrometheusExporter: failed to set read timeout: {e}");
     }
@@ -106,7 +122,7 @@ fn handle_connection(mut conn: TcpStream, metrics: &MetricStore) {
         return;
     }
 
-    let body = build_metrics_body(metrics);
+    let body = build_metrics_body(registry);
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {}\r\n\r\n{}",
         body.len(),
@@ -117,16 +133,21 @@ fn handle_connection(mut conn: TcpStream, metrics: &MetricStore) {
     }
 }
 
-fn build_metrics_body(metrics: &MetricStore) -> String {
-    let store = match metrics.lock() {
-        Ok(s) => s,
+fn build_metrics_body(registry: &Registry) -> String {
+    // Snapshot the registry under the lock, then release it before loading any
+    // slots so a slow serialize can never block a concurrent register() call.
+    let snapshot: Vec<(String, MetricSlot)> = match registry.lock() {
+        Ok(g) => g.clone(),
         Err(_) => {
-            log::warn!("PrometheusExporter: metrics lock poisoned, serving empty body");
+            log::warn!("PrometheusExporter: registry lock poisoned, serving empty body");
             return String::new();
         }
     };
-    let mut pairs: Vec<(&String, &String)> = store.iter().collect();
-    pairs.sort_by_key(|(name, _)| *name);
+    let mut pairs: Vec<(String, Arc<String>)> = snapshot
+        .into_iter()
+        .filter_map(|(name, slot)| slot.load_full().map(|v| (name, v)))
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
     let mut out = String::new();
     for (name, value) in pairs {
         out.push_str(&format!("# TYPE {name} gauge\n{name} {value}\n"));
@@ -135,9 +156,8 @@ fn build_metrics_body(metrics: &MetricStore) -> String {
 }
 
 struct PrometheusMetricNode<T: Element> {
-    name: String,
     stream: Rc<dyn Stream<T>>,
-    metrics: MetricStore,
+    slot: MetricSlot,
     historical: bool,
 }
 
@@ -152,10 +172,7 @@ impl<T: Element + std::fmt::Display> MutableNode for PrometheusMetricNode<T> {
             return Ok(true);
         }
         let value = self.stream.peek_value().to_string();
-        self.metrics
-            .lock()
-            .map_err(|_| anyhow::anyhow!("PrometheusExporter: metrics lock poisoned"))?
-            .insert(self.name.clone(), value);
+        self.slot.store(Some(Arc::new(value)));
         Ok(true)
     }
 


### PR DESCRIPTION
## Summary

- Audited every `Mutex` / `RwLock` usage in the codebase. All comply with the "no locks on the graph execution path" rule **except** `PrometheusMetricNode::cycle()`, which locked a shared `Arc<Mutex<HashMap>>` on every tick.
- Rewrote the Prometheus exporter so `cycle()` publishes via a per-metric `Arc<ArcSwapOption<String>>` slot — a single lock-free atomic pointer swap. The `Mutex<Vec<(name, slot)>>` registry is now touched only at `register()` time and once per HTTP scrape (off the graph thread).
- `ArcSwapOption` models "never ticked" as `None` so historical-mode graphs still render an empty scrape body (matching prior behaviour).
- Added `arc-swap` as an optional dep gated behind the existing `prometheus` feature.
- Documented the invariant in the `new-adapter` skill (`.claude/commands/new-adapter.md`) with the acceptable locking locations (wiring, lifecycle hooks, background threads, user-facing handles) and a pointer at channels / `ArcSwap` for cross-thread hand-off.

## Audit result

| Location | Verdict |
|---|---|
| `graph.rs` `GRAPH_ID` | ✅ `GraphState::new()` — init time |
| `fix/mod.rs` inject / session thread / stop | ✅ user-facing handle / background thread / shutdown |
| `web/server.rs` pub & sub topic maps | ✅ wiring + tokio server task |
| `prometheus/exporter.rs` | ❌ → ✅ fixed here |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --exclude wingfoil-python --features prometheus -- -D warnings`
- [x] `cargo test --features prometheus -p wingfoil` — 214 unit + 14 doc tests pass
- [x] Existing prometheus unit tests (`serves_registered_metric`, `historical_mode_produces_no_metrics`, `returns_404_for_unknown_path`, `connection_refused_when_port_occupied`) all pass

https://claude.ai/code/session_01DmRgeSMABy95NncXTooUWU