### PR TITLE
Add end-to-end latency demo with multi-process pipeline

### DIFF
--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -306,3 +306,13 @@ required-features = ["fluvio"]
 name = "kafka"
 path = "examples/kafka/main.rs"
 required-features = ["kafka"]
+
+[[example]]
+name = "latency_e2e_ws_server"
+path = "examples/latency_e2e/ws_server.rs"
+required-features = ["web", "iceoryx2-beta", "prometheus", "otlp"]
+
+[[example]]
+name = "latency_e2e_fix_gw"
+path = "examples/latency_e2e/fix_gw.rs"
+required-features = ["fix", "iceoryx2-beta"]

--- a/wingfoil/examples/latency_e2e/README.md
+++ b/wingfoil/examples/latency_e2e/README.md
@@ -1,0 +1,181 @@
+# latency_e2e — end-to-end latency demo
+
+A multi-process wingfoil pipeline that stamps wall-clock timestamps at every
+hop on the way out and back, accumulates per-hop histograms, and renders a
+live per-session dashboard in the browser.
+
+```
+browser ── WebSocket ──► ws_server ── iceoryx2 ──► fix_gw ── FIX/TLS ──► LMAX
+   ▲                          ▲                       │                      │
+   │                          │                       ▼                      │
+   │                          └──── iceoryx2 ◄──── fix_gw ◄──── FIX/TLS ◄───┘
+   └────────── WebSocket ─────┘
+```
+
+Nine stamp stages, in order: `ws_recv → ws_publish → gw_recv → gw_price →
+fix_send → fix_recv → gw_publish → ws_sub_recv → ws_send`.
+
+## Layout
+
+```
+examples/latency_e2e/
+  shared.rs          payload + latency schema, env-var helpers
+  ws_server.rs       binary — WS edge, iceoryx2 pub/sub, session cap, prometheus
+  fix_gw.rs          binary — iceoryx2 pub/sub, LMAX MD subscribe, pricing, fill
+  static/            browser client (single index.html + app.js, uPlot via CDN)
+  prometheus/        prometheus scrape config
+  grafana/           provisioned datasource + dashboard
+  docker-compose.yml grafana + prometheus stack
+```
+
+## Run it
+
+Two binaries, one browser tab. The order doesn't matter — the iceoryx2
+service auto-discovers.
+
+```bash
+# Required — fix_gw opens two TLS FIX sessions to LMAX London Demo
+# (market data + order routing). The binary refuses to start without these.
+export LMAX_USERNAME=...
+export LMAX_PASSWORD=...
+
+# Terminal 1
+cargo run --release --example latency_e2e_fix_gw \
+  --features "fix,iceoryx2-beta" -- --precise
+
+# Terminal 2
+cargo run --release --example latency_e2e_ws_server \
+  --features "web,iceoryx2-beta,prometheus,otlp" -- --addr 0.0.0.0:8080 --precise
+
+# Terminal 3 (operator stack — Prometheus + Tempo + Grafana, auto-provisioned)
+docker compose -f wingfoil/examples/latency_e2e/docker-compose.yml up -d
+```
+
+Then open `http://localhost:8080` and click **start**. The page shows
+three panels simultaneously: a live in-page chart (this session's
+per-hop latency in real time), an embedded Grafana iframe showing
+aggregate p50/p99 across all sessions (Prometheus), and below that
+the per-session trace waterfall (Tempo), pre-filtered to this
+browser's UUID via `?var-session=…`.
+
+## Intra-cycle vs cycle-start stamps
+
+`stamp::<S>` reads `GraphState::wall_time()` (one load, snapped at cycle
+start). `stamp_precise::<S>` reads `GraphState::wall_time_precise()` (a
+fresh TSC, ~5–10 ns extra cost). Either way, stages that share an engine
+cycle would otherwise collide on identical timestamps; precise mode gives
+each stamp a distinct value.
+
+Toggle either way:
+
+```bash
+# CLI
+cargo run --example latency_e2e_ws_server -- --precise
+# or env
+WINGFOIL_PRECISE_STAMPS=1 cargo run --example latency_e2e_ws_server
+```
+
+The `.stamp_if::<S>(enabled)` / `.stamp_precise_if::<S>(enabled)`
+operators compile to a no-op when disabled — zero runtime cost when off.
+
+## Session cap and auto-expiry
+
+`ws_server` admits up to `WINGFOIL_SESSION_CAP` (default 8) concurrent
+sessions, each living `WINGFOIL_SESSION_SECS` (default 60). Orders past
+the cap are dropped server-side and a warning is logged. This caps load
+on the LMAX session and bounds Prometheus cardinality.
+
+## Three observability views, one browser tab
+
+Per-session metric labels would explode Prometheus cardinality (one
+unique label per UUID) — so we route the signal to the right tool:
+
+| View | Where | Storage | Filtered to my session? |
+|------|-------|---------|-------------------------|
+| Live per-hop chart | in-page uPlot | in-memory only | Yes — browser renders fills carrying its own UUID |
+| Aggregate per-hop p50/p99 | Grafana | Prometheus (low cardinality) | No — aggregated across all sessions |
+| Per-session trace waterfall | Grafana (embedded iframe on the page) | Tempo (high cardinality OK) | Yes — `$session` template var pre-filled from page |
+
+Every completed fill is exported as an OTLP trace by `ws_server`:
+one parent span `roundtrip` covering the full `stamps[0..N-1]` window
+plus one child span per hop. `session.id`, `client_seq`, `side`, and
+`filled_qty` are attached as span attributes so TraceQL can search by
+any of them. Tempo handles the cardinality natively (object-store
+backend, trace-ID-keyed) — the storage economics of traces are built
+for this, whereas Prometheus would OOM.
+
+The `otlp_spans` stream operator that drives this is part of the
+wingfoil `otlp` adapter (see `wingfoil/src/adapters/otlp/traces.rs`).
+It's generic over any `Stream<P>` where `P: HasLatency` and takes a
+closure for attribute extraction — reusable for any wingfoil pipeline,
+not just this demo.
+
+## How `fix_gw` matches orders to fills
+
+Two FIX sessions, one HashMap, no custom node — the matcher is composed
+from stock wingfoil primitives:
+
+```
+orders ──► price ──► stamp(fix_send) ──┬──► for_each: inject NewOrderSingle
+                                        │
+                                        └──► map(MatcherEvent::Order) ─┐
+                                                                       ├─► combine ─► fold ─► map_filter ─► stamp(fix_recv) ─► stamp(gw_publish) ─► iceoryx2_pub
+order_session.data ─► map_filter(Exec) ────────────────────────────────┘
+```
+
+`combine(vec![order_events, exec_events])` emits a
+`Burst<MatcherEvent>` per cycle containing whichever of the two
+upstreams ticked — zero, one, or both. `fold` carries a
+`RefCell<HashMap<ClOrdID, Traced<…>>>` in its captured state and walks
+the burst in order: Order events `park(t)`; ExecReport events
+`remove(id)`, merge fill data from tags 31/32 (or 0/0 on
+reject/cancel so the round-trip still closes), and set `*last = Some`.
+The downstream `MapFilterStream` drops the Nones.
+
+ClOrdID is `"<sessionHex>-<seq>"` — unique by construction. Orders go
+out as IOC limits (TimeInForce=3, OrdType=2) priced at the opposite
+touch, so every order produces a terminal ExecutionReport (Fill,
+partial-fill-then-cancel, or reject) within milliseconds. No timeouts
+needed.
+
+## Cross-clock RTT — single-clock arithmetic, no NTP
+
+`performance.now()` (browser) and `NanoTime::now()` (server) use
+different epochs, but we never compare across them. Every delta we
+care about is a subtraction within *one* clock frame:
+
+```
+rtt_total   = T4 - T1                    (client clock)
+resident    = stamps[8] - stamps[0]      (server clock)
+wire_rtt    = rtt_total - resident       (same units; just minus)
+```
+
+The browser records `T1 = nowNs()` at order submit and `T4 = nowNs()`
+at fill receipt; the server stamps `stamps[0] = ws_recv` and
+`stamps[8] = ws_send`. The browser posts all four back on
+`TOPIC_ECHO`; the server aggregates `rtt_total` and `wire_rtt` into
+two `StageStats` histograms exposed via Prometheus
+(`latency_e2e_rtt_total_{p50,p99,count}_ns` and
+`latency_e2e_wire_rtt_…`). No offset estimation, no convergence
+heuristic, no symmetric-path assumption. The only thing we don't
+split is inbound vs outbound wire legs — they're lumped into
+`wire_rtt` together.
+
+## Ports
+
+| Service | Port |
+|---------|------|
+| `ws_server` HTTP + WebSocket | 8080 |
+| `ws_server` Prometheus exporter | 9091 |
+| Prometheus | 9090 |
+| Tempo (HTTP API + OTLP ingest) | 3200, 4318 |
+| Grafana | 3000 |
+
+All overridable via the env vars documented at the top of each binary.
+
+## Pre-commit
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings
+```

--- a/wingfoil/examples/latency_e2e/docker-compose.yml
+++ b/wingfoil/examples/latency_e2e/docker-compose.yml
@@ -1,0 +1,52 @@
+# Operator-side dashboard stack for the wingfoil end-to-end latency demo.
+#
+# Brings up Prometheus (metric scrape), Tempo (traces), and Grafana
+# (provisioned with both datasources and the latency dashboard). Expects
+# ws_server / fix_gw to be running on the host; ws_server's Prometheus
+# exporter is reached via host.docker.internal:9091 and its OTLP trace
+# push targets host.docker.internal:4318 → Tempo.
+#
+# Usage:
+#   docker compose -f examples/latency_e2e/docker-compose.yml up -d
+#   open http://localhost:3000  (admin/admin; dashboard is auto-loaded)
+#
+# ws_server:
+#   WINGFOIL_OTLP_ENDPOINT=http://localhost:4318 \
+#     cargo run --release --example latency_e2e_ws_server ...
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  tempo:
+    image: grafana/tempo:2.6.1
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    ports:
+      - "3200:3200"    # Tempo HTTP API (Grafana datasource talks here)
+      - "4318:4318"    # OTLP / HTTP (ws_server push target)
+    volumes:
+      - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      GF_SECURITY_ALLOW_EMBEDDING: "true"
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/latency.json
+      GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+      - tempo

--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -1,0 +1,384 @@
+// End-to-end latency demo — FIX gateway.
+//
+// Two FIX sessions, both TLS to the LMAX London Demo:
+//   * MD session    — fix-marketdata.london-demo.lmax.com:443  (LMXBDM)
+//                     subscribes to EUR/USD; folded into a top-of-book.
+//   * Order session — fix-order.london-demo.lmax.com:443       (LMXBD)
+//                     receives NewOrderSingle injections and surfaces
+//                     ExecutionReports.
+//
+// Pipeline (this binary):
+//   ws_server ── iceoryx2 ──► fix_gw ──── FIX/TLS ──► LMAX                (orders)
+//   ws_server ◄── iceoryx2 ── fix_gw ◄─── FIX/TLS ─── LMAX                (fills)
+//
+// Stamps `gw_recv` and `gw_price` on the way out, `fix_send` just before
+// FIX injection, then on the inbound side `fix_recv` (when the
+// ExecutionReport surfaces) and `gw_publish` (just before iceoryx2
+// publish). The four stages on the WS edge live in ws_server.
+//
+// Run:
+//   LMAX_USERNAME=xxx LMAX_PASSWORD=yyy \
+//     cargo run --release --example latency_e2e_fix_gw \
+//     --features "fix,iceoryx2-beta" -- [--precise]
+//
+// Without LMAX_USERNAME / LMAX_PASSWORD the binary refuses to start —
+// real order routing requires real creds. (We deliberately removed the
+// "simulated fill" fallback so the latency report only ever shows
+// honest end-to-end numbers.)
+
+#[path = "shared.rs"]
+mod shared;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use wingfoil::adapters::fix::{FixMessage, FixSender, FixSessionStatus, fix_connect_tls};
+use wingfoil::adapters::iceoryx2::{iceoryx2_pub, iceoryx2_sub};
+use wingfoil::*;
+
+use shared::{
+    RoundTrip, RoundTripLatency, SIDE_BUY, SVC_FILLS, SVC_ORDERS, env_u64, precise_stamps_enabled,
+    round_trip_latency, session_hex,
+};
+
+const LMAX_HOST_MD: &str = "fix-marketdata.london-demo.lmax.com";
+const LMAX_HOST_ORD: &str = "fix-order.london-demo.lmax.com";
+const LMAX_PORT: u16 = 443;
+const LMAX_TARGET_MD: &str = "LMXBDM";
+const LMAX_TARGET_ORD: &str = "LMXBD";
+const EUR_USD_ID: &str = "4001";
+
+// ── FIX tag constants we actually touch ──────────────────────────────────
+//
+// MarketData group (snapshot / incremental refresh):
+const TAG_MD_ENTRY_TYPE: u32 = 269;
+const TAG_MD_ENTRY_PX: u32 = 270;
+//
+// NewOrderSingle (MsgType "D") / ExecutionReport (MsgType "8"):
+const TAG_CL_ORD_ID: u32 = 11;
+const TAG_EXEC_TYPE: u32 = 150;
+const TAG_LAST_PX: u32 = 31;
+const TAG_LAST_QTY: u32 = 32;
+const TAG_TEXT: u32 = 58;
+
+/// Top-of-book in basis-points (price × 10 000) so we stay integer.
+#[derive(Debug, Clone, Copy, Default)]
+struct TopOfBook {
+    bid_bps: i64,
+    ask_bps: i64,
+    last_update_ns: u64,
+}
+
+impl TopOfBook {
+    fn is_ready(&self) -> bool {
+        self.bid_bps > 0 && self.ask_bps > 0
+    }
+}
+
+/// Event carried through the matcher's merged input stream.
+///
+/// `Default = None` lets the merge / fold pipeline use idle ticks (e.g.
+/// non-ExecutionReport messages on the order session) without losing the
+/// real ones — they fold to a no-op.
+#[derive(Debug, Clone, Default)]
+enum MatcherEvent {
+    #[default]
+    None,
+    Order(Traced<RoundTrip, RoundTripLatency>),
+    Exec(FixMessage),
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let precise = precise_stamps_enabled();
+    let max_md_age_ms = env_u64("WINGFOIL_MAX_MD_AGE_MS", 500);
+
+    let username = std::env::var("LMAX_USERNAME")
+        .map_err(|_| anyhow::anyhow!("LMAX_USERNAME env var is required"))?;
+    let password = std::env::var("LMAX_PASSWORD")
+        .map_err(|_| anyhow::anyhow!("LMAX_PASSWORD env var is required"))?;
+
+    log::info!("fix_gw starting — precise={precise} max_md_age_ms={max_md_age_ms} as {username}");
+
+    // ── Two FIX sessions ─────────────────────────────────────────────────
+    log::info!("connecting MD    session {LMAX_HOST_MD}:{LMAX_PORT} target={LMAX_TARGET_MD}");
+    let fix_md = fix_connect_tls(
+        LMAX_HOST_MD,
+        LMAX_PORT,
+        &username,
+        LMAX_TARGET_MD,
+        Some(&password),
+    );
+    log::info!("connecting Order session {LMAX_HOST_ORD}:{LMAX_PORT} target={LMAX_TARGET_ORD}");
+    let fix_ord = fix_connect_tls(
+        LMAX_HOST_ORD,
+        LMAX_PORT,
+        &username,
+        LMAX_TARGET_ORD,
+        Some(&password),
+    );
+
+    let book = build_top_of_book(fix_md.data.clone());
+    let md_sub = fix_md.fix_sub(constant(vec![EUR_USD_ID.into()]));
+    let md_status = log_status("md-session", fix_md.status.clone());
+    let ord_status = log_status("ord-session", fix_ord.status.clone());
+
+    // ── Outbound: orders → price → stamp fix_send → (fork) ───────────────
+    let orders = iceoryx2_sub::<Traced<RoundTrip, RoundTripLatency>>(SVC_ORDERS)
+        .collapse::<Traced<RoundTrip, RoundTripLatency>>()
+        .stamp_if::<round_trip_latency::gw_recv>(!precise)
+        .stamp_precise_if::<round_trip_latency::gw_recv>(precise);
+
+    let priced = bimap(
+        Dep::Active(orders),
+        Dep::Passive(book),
+        move |mut order: Traced<RoundTrip, RoundTripLatency>, book: TopOfBook| {
+            let now: u64 = NanoTime::now().into();
+            if !book.is_ready()
+                || now.saturating_sub(book.last_update_ns) > max_md_age_ms * 1_000_000
+            {
+                log::warn!(
+                    "skipping order seq={} — book stale or empty (last_update {} ns ago)",
+                    order.payload.client_seq,
+                    now.saturating_sub(book.last_update_ns),
+                );
+                return order;
+            }
+            order.payload.fill_price_bps = if order.payload.side == SIDE_BUY {
+                book.ask_bps
+            } else {
+                book.bid_bps
+            };
+            order
+        },
+    )
+    .stamp_if::<round_trip_latency::gw_price>(!precise)
+    .stamp_precise_if::<round_trip_latency::gw_price>(precise)
+    .stamp_if::<round_trip_latency::fix_send>(!precise)
+    .stamp_precise_if::<round_trip_latency::fix_send>(precise);
+
+    // Side branch: send NewOrderSingle to the FIX order session via the
+    // lock-free kanal channel (see wingfoil FIX adapter PR #225).
+    let sender = fix_ord.sender();
+    let inject_sink = priced.clone().for_each(move |t, _time| {
+        if t.payload.fill_price_bps == 0 {
+            return; // book was stale at pricing time — already logged
+        }
+        send_new_order_single(&sender, &t.payload);
+    });
+
+    // Main branch: into the matcher as Order events.
+    let order_events: Rc<dyn Stream<MatcherEvent>> = priced.map(MatcherEvent::Order);
+
+    // Inbound: ExecutionReports from the order session. Filter here so
+    // only MsgType=8 frames propagate — admin / heartbeat frames never
+    // show up in the matcher's burst.
+    let exec_events: Rc<dyn Stream<MatcherEvent>> = MapFilterStream::new(
+        fix_ord.data.clone().collapse::<FixMessage>(),
+        Box::new(|m: FixMessage| {
+            let is_exec = m.msg_type == "8";
+            (MatcherEvent::Exec(m), is_exec)
+        }),
+    )
+    .into_stream();
+
+    // ── Matcher: combine + fold + map_filter ─────────────────────────────
+    //
+    // `combine` collects the ticked values from both upstreams into a
+    // single `Burst<MatcherEvent>` per cycle — if an Order and an
+    // ExecReport land in the same graph cycle both show up, whereas
+    // `merge` would have kept only the first. `fold` carries the
+    // `RefCell<HashMap<ClOrdID, Traced>>` of parked orders in its
+    // captured state. Each cycle, we walk the burst in order, parking
+    // orders or matching ExecReports. The output value is the last
+    // matched fill this cycle (or None); downstream `MapFilterStream`
+    // drops the Nones.
+
+    let matched = {
+        let park: RefCell<HashMap<String, Traced<RoundTrip, RoundTripLatency>>> =
+            RefCell::new(HashMap::new());
+        combine(vec![order_events, exec_events]).fold(
+            move |last: &mut Option<Traced<RoundTrip, RoundTripLatency>>,
+                  burst: Burst<MatcherEvent>| {
+                *last = None;
+                for ev in burst {
+                    match ev {
+                        MatcherEvent::Order(t) => {
+                            let id = cl_ord_id(&t.payload);
+                            park.borrow_mut().insert(id, t);
+                        }
+                        MatcherEvent::Exec(msg) => {
+                            let cl_ord = msg.field(TAG_CL_ORD_ID).unwrap_or("").to_string();
+                            let exec_type = msg.field(TAG_EXEC_TYPE).unwrap_or("");
+                            let Some(mut parked) = park.borrow_mut().remove(&cl_ord) else {
+                                log::debug!(
+                                    "unmatched exec report cl_ord_id={cl_ord} type={exec_type}"
+                                );
+                                continue;
+                            };
+                            match exec_type {
+                                "F" | "1" | "2" => {
+                                    // Fill (F) or partial-fill (1) or fully-filled (2).
+                                    let last_qty: u64 = msg
+                                        .field(TAG_LAST_QTY)
+                                        .and_then(|s| s.parse().ok())
+                                        .unwrap_or(0);
+                                    let last_px: f64 = msg
+                                        .field(TAG_LAST_PX)
+                                        .and_then(|s| s.parse().ok())
+                                        .unwrap_or(0.0);
+                                    parked.payload.filled_qty = last_qty;
+                                    parked.payload.fill_price_bps =
+                                        (last_px * 10_000.0).round() as i64;
+                                }
+                                _ => {
+                                    // Cancelled / Rejected — emit zero-fill so the
+                                    // browser's round-trip counter still closes.
+                                    let text = msg.field(TAG_TEXT).unwrap_or("");
+                                    log::info!(
+                                        "order cl_ord={cl_ord} terminal exec_type={exec_type} text={text}"
+                                    );
+                                    parked.payload.filled_qty = 0;
+                                    parked.payload.fill_price_bps = 0;
+                                }
+                            }
+                            *last = Some(parked);
+                        }
+                        MatcherEvent::None => {}
+                    }
+                }
+            },
+        )
+    };
+
+    // Drop Nones, stamp the inbound stages, publish back via iceoryx2.
+    let fills = MapFilterStream::new(
+        matched,
+        Box::new(|v: Option<Traced<RoundTrip, RoundTripLatency>>| {
+            let ticked = v.is_some();
+            (v.unwrap_or_default(), ticked)
+        }),
+    )
+    .into_stream()
+    .stamp_if::<round_trip_latency::fix_recv>(!precise)
+    .stamp_precise_if::<round_trip_latency::fix_recv>(precise)
+    .stamp_if::<round_trip_latency::gw_publish>(!precise)
+    .stamp_precise_if::<round_trip_latency::gw_publish>(precise);
+
+    let pub_fills = iceoryx2_pub(fills.map(|t| burst![t]), SVC_FILLS);
+
+    let nodes: Vec<Rc<dyn Node>> = vec![
+        pub_fills,
+        inject_sink,
+        md_sub,
+        md_status,
+        ord_status,
+        fix_md.data.as_node(),
+        fix_ord.data.as_node(),
+    ];
+
+    Graph::new(nodes, RunMode::RealTime, RunFor::Forever).run()?;
+    Ok(())
+}
+
+// ── ClOrdID and NewOrderSingle ───────────────────────────────────────────
+
+/// `<sessionHex>-<seq>` is unique by construction (session UUID is
+/// random per browser tab, seq is monotonic per session).
+fn cl_ord_id(p: &RoundTrip) -> String {
+    format!("{}-{}", session_hex(&p.session), p.client_seq)
+}
+
+/// Build and send a `NewOrderSingle` (MsgType `D`) to the LMAX order
+/// session. Always IOC limit (TimeInForce=3, OrdType=2) at the price the
+/// caller computed against the top-of-book — guarantees an immediate
+/// terminal ExecutionReport (Fill, partial-fill-then-cancel, or reject)
+/// so the round-trip closes cleanly.
+///
+/// `FixSender::send` is a non-blocking `try_send` on a bounded kanal
+/// channel. On `QueueFull` we log loudly and drop — for the demo that's
+/// the least-bad option; a production gateway would propagate the
+/// rejection back to the browser.
+fn send_new_order_single(sender: &FixSender, p: &RoundTrip) {
+    let cl_ord = cl_ord_id(p);
+    let side = if p.side == SIDE_BUY { "1" } else { "2" };
+    let price = (p.fill_price_bps as f64) / 10_000.0;
+    let transact_time = chrono::Utc::now().format("%Y%m%d-%H:%M:%S%.3f").to_string();
+    let fields = vec![
+        (TAG_CL_ORD_ID, cl_ord.clone()),
+        (22, "8".into()),            // SecurityIDSource = ExchangeSymbol
+        (48, EUR_USD_ID.into()),     // SecurityID
+        (54, side.into()),           // Side
+        (38, p.qty.to_string()),     // OrderQty
+        (40, "2".into()),            // OrdType = Limit
+        (44, format!("{price:.5}")), // Price
+        (59, "3".into()),            // TimeInForce = IOC
+        (60, transact_time),         // TransactTime
+    ];
+    if let Err(e) = sender.send(FixMessage {
+        msg_type: "D".into(),
+        seq_num: 0,
+        sending_time: NanoTime::ZERO,
+        fields,
+    }) {
+        log::error!("FixSender dropped NewOrderSingle cl_ord={cl_ord}: {e}");
+    }
+}
+
+// ── Top-of-book builder from the LMAX MD stream ──────────────────────────
+//
+// LMAX sends MarketDataSnapshotFullRefresh (MsgType W) and
+// MarketDataIncrementalRefresh (X) with repeating groups of
+// (269 MDEntryType, 270 MDEntryPx, 271 MDEntrySize). We don't need the
+// size for this demo so we walk the fields linearly: when we see a 269
+// the next matching 270 in the same group sets bid (269=0) or ask (269=1).
+
+fn build_top_of_book(data: Rc<dyn Stream<Burst<FixMessage>>>) -> Rc<dyn Stream<TopOfBook>> {
+    data.collapse::<FixMessage>()
+        .fold(|book: &mut TopOfBook, msg: FixMessage| {
+            if !matches!(msg.msg_type.as_str(), "W" | "X") {
+                return;
+            }
+            let now: u64 = NanoTime::now().into();
+            let mut current_type: Option<u8> = None;
+            for (tag, val) in &msg.fields {
+                match *tag {
+                    TAG_MD_ENTRY_TYPE => {
+                        current_type = val.parse::<u8>().ok();
+                    }
+                    TAG_MD_ENTRY_PX => {
+                        if let (Some(t), Ok(px)) = (current_type, val.parse::<f64>()) {
+                            let bps = (px * 10_000.0).round() as i64;
+                            match t {
+                                0 => book.bid_bps = bps, // Bid
+                                1 => book.ask_bps = bps, // Offer
+                                _ => {}
+                            }
+                            book.last_update_ns = now;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        })
+}
+
+fn log_status(
+    label: &'static str,
+    status: Rc<dyn Stream<Burst<FixSessionStatus>>>,
+) -> Rc<dyn Node> {
+    let cell: RefCell<FixSessionStatus> = RefCell::new(FixSessionStatus::Disconnected);
+    status.for_each(move |burst, _t| {
+        for st in burst {
+            if st != *cell.borrow() {
+                log::info!("{label}: {st:?}");
+                *cell.borrow_mut() = st;
+            }
+        }
+    })
+}

--- a/wingfoil/examples/latency_e2e/grafana/provisioning/dashboards/dashboards.yml
+++ b/wingfoil/examples/latency_e2e/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: latency_e2e
+    folder: ''
+    type: file
+    disableDeletion: true
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/wingfoil/examples/latency_e2e/grafana/provisioning/dashboards/latency.json
+++ b/wingfoil/examples/latency_e2e/grafana/provisioning/dashboards/latency.json
@@ -1,0 +1,101 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "per-hop p99 latency (ns) — aggregate across all sessions",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ns",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 5, "pointSize": 4 }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] } },
+      "targets": [
+        { "expr": "{__name__=~\"latency_e2e_.*_p99_ns\"}", "legendFormat": "{{__name__}}", "refId": "A" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "per-hop p50 latency (ns)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "ns" } },
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean"] } },
+      "targets": [
+        { "expr": "{__name__=~\"latency_e2e_.*_p50_ns\"}", "legendFormat": "{{__name__}}", "refId": "A" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "active sessions",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 18 },
+      "options": { "colorMode": "value", "graphMode": "area" },
+      "targets": [{ "expr": "latency_e2e_active_sessions", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "orders rate (per s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 18 },
+      "options": { "colorMode": "value", "graphMode": "area" },
+      "targets": [{ "expr": "rate(latency_e2e_admitted_total[1m])", "refId": "A" }]
+    },
+    {
+      "type": "stat",
+      "title": "rejected orders (cap reached)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 18 },
+      "options": { "colorMode": "value", "graphMode": "area" },
+      "targets": [{ "expr": "increase(latency_e2e_rejected_total[5m])", "refId": "A" }]
+    },
+    {
+      "type": "traces",
+      "title": "your session traces — $session",
+      "datasource": { "type": "tempo", "uid": "tempo" },
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 22 },
+      "targets": [
+        {
+          "queryType": "traceql",
+          "query": "{ resource.service.name=\"wingfoil-latency-e2e\" && span.session.id=\"$session\" }",
+          "limit": 50,
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["wingfoil", "latency"],
+  "templating": {
+    "list": [
+      {
+        "name": "session",
+        "label": "session.id",
+        "type": "textbox",
+        "query": "",
+        "current": { "text": "", "value": "" },
+        "hide": 0,
+        "description": "Session UUID (32 hex chars). Pre-filled via URL var when embedded in the client page."
+      }
+    ]
+  },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "wingfoil latency end-to-end",
+  "uid": "wingfoil-latency-e2e",
+  "version": 2,
+  "weekStart": ""
+}

--- a/wingfoil/examples/latency_e2e/grafana/provisioning/datasources/datasource.yml
+++ b/wingfoil/examples/latency_e2e/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,19 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    jsonData:
+      # Link traces to metrics: exemplars and service-graph integration.
+      tracesToMetrics:
+        datasourceUid: prometheus
+    editable: false

--- a/wingfoil/examples/latency_e2e/prometheus/prometheus.yml
+++ b/wingfoil/examples/latency_e2e/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+  scrape_timeout: 4s
+
+scrape_configs:
+  - job_name: latency_e2e_ws_server
+    static_configs:
+      - targets: ['host.docker.internal:9091']
+        labels:
+          service: ws_server

--- a/wingfoil/examples/latency_e2e/shared.rs
+++ b/wingfoil/examples/latency_e2e/shared.rs
@@ -1,0 +1,153 @@
+// End-to-end latency demo — shared payload, latency schema, and wire types.
+//
+// Two binaries (ws_server, fix_gw) are linked against this module via
+// `#[path = "shared.rs"] mod shared;`. Both processes must agree on the
+// layout — the `latency_stages!` macro guarantees this when both sides
+// declare the same stages in the same order.
+
+// Each binary only uses a subset of the symbols here; the other half
+// looks "dead" to the compiler. Silence at module scope.
+#![allow(dead_code)]
+
+use iceoryx2::prelude::ZeroCopySend;
+use serde::{Deserialize, Serialize};
+use wingfoil::*;
+
+// ── iceoryx2 services (shared memory pipes between ws_server and fix_gw) ──
+pub const SVC_ORDERS: &str = "wingfoil/latency_e2e/orders";
+pub const SVC_FILLS: &str = "wingfoil/latency_e2e/fills";
+
+// ── WebSocket topics (ws_server ↔ browser) ────────────────────────────────
+pub const TOPIC_ORDERS: &str = "orders";
+pub const TOPIC_FILLS: &str = "fills";
+pub const TOPIC_ECHO: &str = "latency_echo";
+pub const TOPIC_SESSION: &str = "session";
+
+pub type SessionId = [u8; 16];
+
+pub const SIDE_BUY: u8 = 0;
+pub const SIDE_SELL: u8 = 1;
+
+/// Shared-memory payload that traverses ws_server → iceoryx2 → fix_gw
+/// and then, after fill matching, fix_gw → iceoryx2 → ws_server.
+///
+/// `#[repr(C)]` + `ZeroCopySend` so the whole `Traced<RoundTrip, RoundTripLatency>`
+/// can be transported by iceoryx2 without serialization.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, ZeroCopySend, Serialize, Deserialize)]
+pub struct RoundTrip {
+    pub session: SessionId,
+    pub client_seq: u64,
+    pub qty: u64,
+    pub filled_qty: u64,
+    /// Fill price × 10 000 (four decimal places). Zero until filled.
+    pub fill_price_bps: i64,
+    /// Browser `performance.now()` in nanoseconds at order submit.
+    /// This is in the client clock domain, not the server's.
+    pub t_client_send: u64,
+    pub side: u8,
+    /// Explicit padding to keep the struct layout and `[u64; N]` alignment
+    /// stable across compilers and make the `ZeroCopySend` contract obvious.
+    pub _pad: [u8; 7],
+}
+
+// Stage order = offset order in the on-wire [u64; 9] view of the record.
+// The first five stages are stamped on the outbound leg, the last four on
+// the inbound leg after the fill is matched.
+latency_stages! {
+    pub RoundTripLatency {
+        ws_recv,
+        ws_publish,
+        gw_recv,
+        gw_price,
+        fix_send,
+        fix_recv,
+        gw_publish,
+        ws_sub_recv,
+        ws_send,
+    }
+}
+
+// ── WebSocket wire types (JSON by default for easy browser devtools) ──────
+
+/// Browser → ws_server on TOPIC_ORDERS.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OrderFrame {
+    pub session: SessionId,
+    pub client_seq: u64,
+    pub side: u8,
+    pub qty: u64,
+    pub t_client_send: u64,
+}
+
+/// ws_server → browser on TOPIC_FILLS. Carries the full set of server-side
+/// stamps so the browser can render per-hop latency bars.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FillFrame {
+    pub session: SessionId,
+    pub client_seq: u64,
+    pub side: u8,
+    pub filled_qty: u64,
+    pub fill_price_bps: i64,
+    pub t_client_send: u64,
+    pub stamps: [u64; 9],
+}
+
+/// Browser → ws_server on TOPIC_ECHO, carrying `t_client_recv` stamped in
+/// the browser plus the full server-side stamps vector. Used for
+/// round-trip aggregation (LatencyReport on the server).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EchoFrame {
+    pub session: SessionId,
+    pub client_seq: u64,
+    pub t_client_send: u64,
+    pub t_client_recv: u64,
+    pub stamps: [u64; 9],
+}
+
+/// ws_server → browser on TOPIC_SESSION. Lets the browser render queue
+/// position / remaining time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionStatus {
+    pub session: SessionId,
+    pub state: String,
+    pub remaining_secs: u32,
+    pub queue_pos: u32,
+}
+
+// ── Env var helpers ───────────────────────────────────────────────────────
+
+pub fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+pub fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+pub fn env_string(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+/// Are intra-cycle precise TSC reads enabled? Flip via `--precise` CLI
+/// flag or `WINGFOIL_PRECISE_STAMPS=1`. The `.stamp_precise_if` /
+/// `.stamp_if` ops compile to zero cost when disabled.
+pub fn precise_stamps_enabled() -> bool {
+    env_flag("WINGFOIL_PRECISE_STAMPS") || std::env::args().any(|a| a == "--precise")
+}
+
+/// Format a session UUID as 32 hex chars (e.g. for log lines / metric keys).
+pub fn session_hex(id: &SessionId) -> String {
+    let mut s = String::with_capacity(32);
+    for b in id {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}

--- a/wingfoil/examples/latency_e2e/static/app.js
+++ b/wingfoil/examples/latency_e2e/static/app.js
@@ -1,0 +1,248 @@
+// wingfoil latency end-to-end — browser client.
+//
+// Emits OrderFrames at the configured rate, listens for FillFrames,
+// stamps a t_client_recv and posts the round-trip back as an EchoFrame.
+// Renders a uPlot chart of the per-hop latency for THIS session.
+
+// Each entry is either a server-clock delta (indices into stamps[]) or
+// the derived `wire_rtt` computed from the client-clock RTT minus the
+// server residence time. Every number lives inside a single clock
+// domain — no NTP-style sync needed.
+const STAGES = [
+  ["ws_recv→ws_publish",    "server", 0, 1],
+  ["ws_publish→gw_recv",    "server", 1, 2],
+  ["gw_recv→gw_price",      "server", 2, 3],
+  ["gw_price→fix_send",     "server", 3, 4],
+  ["fix_send→fix_recv",     "server", 4, 5],
+  ["fix_recv→gw_publish",   "server", 5, 6],
+  ["gw_publish→ws_sub_recv", "server", 6, 7],
+  ["ws_sub_recv→ws_send",   "server", 7, 8],
+  ["wire RTT (out+in)",     "wire"],
+];
+const COLOURS = [
+  "#58a6ff","#3fb950","#f0883e","#f85149",
+  "#bc8cff","#79c0ff","#ff7b72","#a371f7",
+  "#e3b341",
+];
+const MAX_POINTS = 200; // ~100 s at 2 Hz
+
+// ── session UUID as 16 raw bytes (sent verbatim as JSON array) ───────────
+function newSessionId() {
+  const u = (crypto.randomUUID ? crypto.randomUUID() : fallbackUuid()).replaceAll('-', '');
+  const out = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) out[i] = parseInt(u.slice(i*2, i*2+2), 16);
+  return out;
+}
+function fallbackUuid() {
+  const r = new Uint8Array(16); crypto.getRandomValues(r);
+  r[6] = (r[6] & 0x0f) | 0x40; r[8] = (r[8] & 0x3f) | 0x80;
+  const h = [...r].map(b => b.toString(16).padStart(2, '0')).join('');
+  return `${h.slice(0,8)}-${h.slice(8,12)}-${h.slice(12,16)}-${h.slice(16,20)}-${h.slice(20)}`;
+}
+function hex(bytes) { return [...bytes].map(b => b.toString(16).padStart(2,'0')).join(''); }
+function nowNs() { return Math.round(performance.timeOrigin * 1e6 + performance.now() * 1e6); }
+
+// ── WebSocket envelope plumbing ──────────────────────────────────────────
+//
+// CodecKind::Json on the server: each WS frame is JSON-encoded
+// `Envelope { topic, time_ns, payload: Vec<u8> }`. The payload is itself
+// the JSON-encoded user type as a byte array. We unwrap one level here
+// so handlers see the actual object.
+
+let ws = null;
+function connect(onMsg) {
+  const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
+  ws = new WebSocket(url);
+  ws.binaryType = 'arraybuffer';
+  ws.onopen = () => {
+    setStatus('live');
+    // Subscribe to the topics we care about.
+    sendCtrl({ Subscribe: { topics: ['fills', 'session'] } });
+  };
+  ws.onclose = () => { setStatus('disconnected'); ws = null; };
+  ws.onerror = (e) => console.warn('ws error', e);
+  ws.onmessage = async (ev) => {
+    const buf = typeof ev.data === 'string'
+      ? new TextEncoder().encode(ev.data)
+      : new Uint8Array(ev.data);
+    let env;
+    try { env = JSON.parse(new TextDecoder().decode(buf)); }
+    catch (e) { console.warn('bad envelope', e); return; }
+    if (env.topic === '$ctrl') return;
+    let payload;
+    try { payload = JSON.parse(new TextDecoder().decode(new Uint8Array(env.payload))); }
+    catch (e) { console.warn('bad payload', env.topic, e); return; }
+    onMsg(env.topic, payload);
+  };
+}
+
+function sendFrame(topic, payloadObj) {
+  if (!ws || ws.readyState !== 1) return;
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(payloadObj));
+  const env = { topic, time_ns: 0, payload: Array.from(payloadBytes) };
+  ws.send(JSON.stringify(env));
+}
+function sendCtrl(ctrl) {
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(ctrl));
+  const env = { topic: '$ctrl', time_ns: 0, payload: Array.from(payloadBytes) };
+  ws.send(JSON.stringify(env));
+}
+
+// ── UI state ──────────────────────────────────────────────────────────────
+const session = newSessionId();
+const sessionArr = Array.from(session);
+let seq = 0, sent = 0, filled = 0, sumPx = 0, lastRttNs = 0;
+let nextSide = 0;
+let chart, chartData, ticker = null;
+
+document.getElementById('session').textContent = hex(session).slice(0, 8) + '…';
+
+// Point the embedded Grafana iframe at the operator dashboard, pre-filtered
+// to this session via the `$session` template variable. Assumes Grafana is
+// on the same host on port 3000 (docker-compose default). `kiosk=tv` hides
+// Grafana chrome; `theme=dark` matches the page.
+(function initGrafana() {
+  const origin = `${location.protocol}//${location.hostname}:3000`;
+  const url = `${origin}/d/wingfoil-latency-e2e/wingfoil-latency-end-to-end` +
+              `?var-session=${hex(session)}` +
+              `&kiosk=tv&theme=dark&refresh=5s&from=now-15m&to=now`;
+  document.getElementById('grafana').src = url;
+})();
+
+function setStatus(s) {
+  const el = document.getElementById('status');
+  el.textContent = s;
+  el.className = 'pill ' + (s === 'live' ? 'live' : 'idle');
+}
+
+// Resolve one STAGES entry to a delta in ns. Server stages read from
+// stamps[]; the wire stage reads rtt_total and server residence, both
+// derived from same-domain subtractions.
+function stageNs(entry, stamps, rttTotal) {
+  const [, kind, a, b] = entry;
+  if (kind === 'server') return stamps[b] - stamps[a];
+  if (kind === 'wire')   return Math.max(0, rttTotal - (stamps[8] - stamps[0]));
+  return 0;
+}
+
+function renderStages(stamps, rttTotal) {
+  const values = STAGES.map(s => stageNs(s, stamps, rttTotal));
+  const max = Math.max(...values);
+  const root = document.getElementById('stages');
+  root.innerHTML = '';
+  for (let i = 0; i < STAGES.length; i++) {
+    const ns = values[i];
+    const pct = max > 0 ? (ns / max) * 100 : 0;
+    const row = document.createElement('div');
+    row.className = 'stage-bar';
+    row.innerHTML = `<span class="name">${STAGES[i][0]}</span>
+      <div class="bar"><div style="width:${pct}%;background:${COLOURS[i]}"></div></div>
+      <span class="v">${ns.toLocaleString()}</span>`;
+    root.appendChild(row);
+  }
+}
+
+function pushChartPoint(stamps, rttTotal) {
+  const t = chartData[0].length;
+  chartData[0].push(t);
+  for (let i = 0; i < STAGES.length; i++) {
+    chartData[i + 1].push(stageNs(STAGES[i], stamps, rttTotal));
+  }
+  while (chartData[0].length > MAX_POINTS) {
+    chartData.forEach(s => s.shift());
+  }
+  chart.setData(chartData);
+}
+
+function initChart() {
+  chartData = [[], ...STAGES.map(() => [])];
+  const opts = {
+    width: document.getElementById('chart').clientWidth - 16,
+    height: 480,
+    title: 'per-hop latency (ns) — this session',
+    cursor: { drag: { x: true, y: false } },
+    scales: { x: { time: false }, y: { distr: 3, log: 10 } },
+    series: [
+      { label: 'sample' },
+      ...STAGES.map(([name], i) => ({
+        label: name,
+        stroke: COLOURS[i],
+        width: 1.5,
+      })),
+    ],
+    axes: [{ stroke: '#8b949e' }, { stroke: '#8b949e', values: (_, vs) => vs.map(v => v.toLocaleString()) }],
+  };
+  chart = new uPlot(opts, chartData, document.getElementById('chart'));
+}
+
+function startStream() {
+  const rate = parseInt(document.getElementById('rate').value, 10);
+  const qty = parseInt(document.getElementById('qty').value, 10);
+  const sideSel = document.getElementById('side').value;
+  if (ticker) clearInterval(ticker);
+  ticker = setInterval(() => {
+    if (!ws || ws.readyState !== 1) return;
+    let side;
+    if (sideSel === 'alt') { side = nextSide; nextSide ^= 1; }
+    else side = parseInt(sideSel, 10);
+    seq += 1; sent += 1;
+    document.getElementById('sent').textContent = sent.toLocaleString();
+    sendFrame('orders', {
+      session: sessionArr,
+      client_seq: seq,
+      side, qty,
+      t_client_send: nowNs(),
+    });
+  }, Math.max(50, Math.floor(1000 / rate)));
+  const btn = document.getElementById('start');
+  btn.textContent = 'stop'; btn.classList.add('stop');
+  btn.onclick = stopStream;
+}
+
+function stopStream() {
+  if (ticker) { clearInterval(ticker); ticker = null; }
+  const btn = document.getElementById('start');
+  btn.textContent = 'start'; btn.classList.remove('stop');
+  btn.onclick = startStream;
+}
+
+// ── Bootstrap ─────────────────────────────────────────────────────────────
+window.addEventListener('DOMContentLoaded', () => {
+  initChart();
+  document.getElementById('start').onclick = startStream;
+  connect((topic, msg) => {
+    if (topic === 'fills') {
+      // Filter: only this session's fills.
+      if (!sameId(msg.session, sessionArr)) return;
+      const tRecv = nowNs();
+      const rttTotal = Math.max(0, tRecv - msg.t_client_send);
+      filled += 1;
+      sumPx += msg.fill_price_bps;
+      lastRttNs = rttTotal;
+      document.getElementById('filled').textContent = filled.toLocaleString();
+      document.getElementById('px').textContent = (sumPx / filled / 10000).toFixed(5);
+      document.getElementById('rtt').textContent = (rttTotal / 1_000_000).toFixed(2) + ' ms';
+      renderStages(msg.stamps, rttTotal);
+      pushChartPoint(msg.stamps, rttTotal);
+      // Echo to the server with t_client_recv stamped. The server
+      // derives rtt_total and wire_rtt from the four stamps, all
+      // arithmetic within a single clock domain per delta.
+      sendFrame('latency_echo', {
+        session: sessionArr,
+        client_seq: msg.client_seq,
+        t_client_send: msg.t_client_send,
+        t_client_recv: tRecv,
+        stamps: msg.stamps,
+      });
+    } else if (topic === 'session') {
+      // Reserved — server can broadcast queue state here.
+      console.log('session', msg);
+    }
+  });
+});
+
+function sameId(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}

--- a/wingfoil/examples/latency_e2e/static/index.html
+++ b/wingfoil/examples/latency_e2e/static/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>wingfoil latency end-to-end</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.31/dist/uPlot.min.css" />
+  <style>
+    :root {
+      --bg: #0d1117; --panel: #161b22; --fg: #e6edf3; --muted: #8b949e;
+      --green: #3fb950; --red: #f85149; --accent: #58a6ff;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font: 14px/1.45 system-ui, sans-serif; background: var(--bg); color: var(--fg); }
+    header { padding: 12px 20px; border-bottom: 1px solid #21262d; display: flex; gap: 16px; align-items: center; }
+    header h1 { margin: 0; font-size: 16px; font-weight: 600; }
+    main { padding: 20px; display: grid; grid-template-columns: 360px 1fr; gap: 20px; }
+    .panel { background: var(--panel); border: 1px solid #21262d; border-radius: 6px; padding: 14px; }
+    .panel h2 { margin: 0 0 10px; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); }
+    .row { display: flex; align-items: center; justify-content: space-between; padding: 4px 0; }
+    .row .k { color: var(--muted); }
+    .row .v { font-variant-numeric: tabular-nums; }
+    button { background: var(--accent); color: white; border: 0; padding: 8px 16px; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 14px; }
+    button:disabled { background: #30363d; color: var(--muted); cursor: not-allowed; }
+    button.stop { background: var(--red); }
+    select, input[type=number] { background: #0d1117; color: var(--fg); border: 1px solid #30363d; border-radius: 6px; padding: 6px 8px; }
+    .controls { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin-bottom: 12px; }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; }
+    .pill.live { background: rgba(63, 185, 80, 0.15); color: var(--green); }
+    .pill.idle { background: rgba(139, 148, 158, 0.15); color: var(--muted); }
+    .stage-bar { display: grid; grid-template-columns: 110px 1fr 90px; align-items: center; gap: 8px; margin: 4px 0; font-size: 12px; }
+    .stage-bar .name { color: var(--muted); }
+    .stage-bar .bar { background: #0d1117; height: 14px; border-radius: 3px; overflow: hidden; }
+    .stage-bar .bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), #1f6feb); transition: width 0.15s; }
+    .stage-bar .v { text-align: right; font-variant-numeric: tabular-nums; }
+    #chart { background: var(--panel); border-radius: 6px; padding: 8px; }
+    a { color: var(--accent); }
+    code { background: #0d1117; padding: 1px 5px; border-radius: 3px; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>wingfoil latency end-to-end</h1>
+    <span id="status" class="pill idle">disconnected</span>
+    <span style="color:var(--muted)">session <code id="session">—</code></span>
+    <span style="margin-left:auto"><a href="/metrics">prometheus</a> · operator dashboard typically lives in Grafana</span>
+  </header>
+  <main>
+    <section class="panel">
+      <h2>controls</h2>
+      <div class="controls">
+        <label>side
+          <select id="side">
+            <option value="alt">alternate</option>
+            <option value="0">buy</option>
+            <option value="1">sell</option>
+          </select>
+        </label>
+        <label>qty <input id="qty" type="number" min="1" value="1" style="width:70px"/></label>
+        <label>rate Hz <input id="rate" type="number" min="1" max="20" value="2" style="width:60px"/></label>
+        <button id="start">start</button>
+      </div>
+      <h2>session stats</h2>
+      <div class="row"><span class="k">orders sent</span><span class="v" id="sent">0</span></div>
+      <div class="row"><span class="k">fills received</span><span class="v" id="filled">0</span></div>
+      <div class="row"><span class="k">avg fill price</span><span class="v" id="px">—</span></div>
+      <div class="row"><span class="k">total round-trip (click → fill)</span><span class="v" id="rtt">—</span></div>
+      <h2 style="margin-top:14px">last fill — per-hop ns</h2>
+      <div id="stages"></div>
+    </section>
+    <section>
+      <div id="chart"></div>
+      <p style="color:var(--muted);font-size:12px">
+        Each line is one hop's latency for orders submitted by <em>this
+        browser session</em> only. Aggregate per-hop p50/p99 across all
+        sessions are in Prometheus at <a href="/metrics" target="_blank"><code>:9091/metrics</code></a>.
+        Per-session traces — indexed by high-cardinality <code>session.id</code>,
+        which Prometheus can't handle — are pushed to Tempo via OTLP and
+        surfaced in the Grafana dashboard below, pre-filtered to this session.
+      </p>
+      <iframe id="grafana" title="Grafana — session traces" style="width:100%;height:640px;border:1px solid #21262d;border-radius:6px;background:#0d1117"></iframe>
+      <p style="color:var(--muted);font-size:12px">
+        Grafana not loading? Start the operator stack:
+        <code>docker compose -f wingfoil/examples/latency_e2e/docker-compose.yml up -d</code>
+      </p>
+    </section>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/uplot@1.6.31/dist/uPlot.iife.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/wingfoil/examples/latency_e2e/tempo/tempo.yaml
+++ b/wingfoil/examples/latency_e2e/tempo/tempo.yaml
@@ -1,0 +1,30 @@
+# Minimal Tempo config for the latency_e2e demo — all-in-one,
+# local filesystem backend, no auth. For production see
+# https://grafana.com/docs/tempo/latest/configuration/.
+
+server:
+  http_listen_port: 3200
+  grpc_listen_port: 9095
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 24h
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /tmp/tempo/wal
+    local:
+      path: /tmp/tempo/blocks

--- a/wingfoil/examples/latency_e2e/ws_server.rs
+++ b/wingfoil/examples/latency_e2e/ws_server.rs
@@ -1,0 +1,370 @@
+// End-to-end latency demo — WebSocket server edge.
+//
+// Pipeline (this binary):
+//   browser ── WS ──► ws_server ── iceoryx2 ──► fix_gw            (outbound)
+//   browser ◄── WS ── ws_server ◄── iceoryx2 ── fix_gw            (inbound)
+//   browser ── WS ──► ws_server                                    (echo)
+//
+// Stamps `ws_recv` and `ws_publish` on the way out, `ws_sub_recv` and
+// `ws_send` on the way back. Enforces a global cap on concurrent sessions
+// and auto-expires each session after 60 s — protects the single LMAX
+// session living in fix_gw and keeps a public deployment bounded.
+//
+// Run (after starting fix_gw):
+//   cargo run --example latency_e2e_ws_server \
+//     --features "web,iceoryx2-beta,prometheus" -- \
+//     --addr 0.0.0.0:8080 [--precise]
+
+#[path = "shared.rs"]
+mod shared;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use iceoryx2::prelude::ZeroCopySend;
+use wingfoil::adapters::iceoryx2::{iceoryx2_pub, iceoryx2_sub};
+use wingfoil::adapters::otlp::{OtlpAttributeBuffer, OtlpConfig, OtlpSpans};
+use wingfoil::adapters::prometheus::PrometheusExporter;
+use wingfoil::adapters::web::{CodecKind, WebPubOperators, WebServer, web_sub};
+use wingfoil::*;
+
+use shared::{
+    EchoFrame, FillFrame, OrderFrame, RoundTrip, RoundTripLatency, SVC_FILLS, SVC_ORDERS,
+    SessionId, TOPIC_ECHO, TOPIC_FILLS, TOPIC_ORDERS, env_string, env_u64, precise_stamps_enabled,
+    round_trip_latency, session_hex,
+};
+
+// ── Session registry ──────────────────────────────────────────────────────
+//
+// Lives in an `Arc<Mutex<…>>` because the Prometheus gauges read it from
+// the graph thread while the order pipeline writes to it from the web_sub
+// async consumer thread. Every order frame touches this once; contention
+// is negligible.
+
+#[derive(Debug, Clone, Copy)]
+struct SessionEntry {
+    admitted_at_ns: u64,
+    orders: u64,
+}
+
+#[derive(Default)]
+struct Sessions {
+    active: HashMap<SessionId, SessionEntry>,
+    cap: usize,
+    ttl_ns: u64,
+    admitted_total: u64,
+    rejected_total: u64,
+}
+
+impl Sessions {
+    fn new(cap: usize, ttl_secs: u64) -> Self {
+        Self {
+            cap,
+            ttl_ns: ttl_secs * 1_000_000_000,
+            ..Default::default()
+        }
+    }
+
+    /// Returns `true` if the order should be forwarded.
+    fn admit(&mut self, id: &SessionId, now_ns: u64) -> bool {
+        self.active
+            .retain(|_, e| now_ns.saturating_sub(e.admitted_at_ns) < self.ttl_ns);
+        if let Some(e) = self.active.get_mut(id) {
+            e.orders += 1;
+            return true;
+        }
+        if self.active.len() >= self.cap {
+            self.rejected_total += 1;
+            return false;
+        }
+        self.active.insert(
+            *id,
+            SessionEntry {
+                admitted_at_ns: now_ns,
+                orders: 1,
+            },
+        );
+        self.admitted_total += 1;
+        true
+    }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let args: Vec<String> = std::env::args().collect();
+    let addr = args
+        .iter()
+        .position(|a| a == "--addr")
+        .and_then(|i| args.get(i + 1).cloned())
+        .unwrap_or_else(|| env_string("WINGFOIL_WEB_ADDR", "0.0.0.0:8080"));
+    let metrics_addr = env_string("WINGFOIL_METRICS_ADDR", "0.0.0.0:9091");
+    let session_cap = env_u64("WINGFOIL_SESSION_CAP", 8) as usize;
+    let session_ttl = env_u64("WINGFOIL_SESSION_SECS", 60);
+    let precise = precise_stamps_enabled();
+
+    let static_dir: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "examples",
+        "latency_e2e",
+        "static",
+    ]
+    .iter()
+    .collect();
+
+    let server = WebServer::bind(&addr)
+        .codec(CodecKind::Json)
+        .serve_static(&static_dir)
+        .start()?;
+    log::info!(
+        "ws_server listening on http://{} (port {}) — static dir {}",
+        addr,
+        server.port(),
+        static_dir.display(),
+    );
+    log::info!("session_cap={session_cap} ttl={session_ttl}s precise={precise}");
+
+    let sessions = Arc::new(Mutex::new(Sessions::new(session_cap, session_ttl)));
+
+    // ── Outbound leg ─────────────────────────────────────────────────────
+    let orders_in = web_sub::<OrderFrame>(&server, TOPIC_ORDERS).collapse::<OrderFrame>();
+    let admitted = {
+        let s = sessions.clone();
+        MapFilterStream::new(
+            orders_in,
+            Box::new(move |frame: OrderFrame| {
+                let now_ns: u64 = NanoTime::now().into();
+                let admit = s.lock().unwrap().admit(&frame.session, now_ns);
+                if !admit {
+                    log::warn!(
+                        "rejected order session={} seq={} (cap reached)",
+                        session_hex(&frame.session),
+                        frame.client_seq,
+                    );
+                }
+                (frame, admit)
+            }),
+        )
+        .into_stream()
+    };
+
+    let traced_orders = admitted
+        .map(|o: OrderFrame| {
+            Traced::<RoundTrip, RoundTripLatency>::new(RoundTrip {
+                session: o.session,
+                client_seq: o.client_seq,
+                qty: o.qty,
+                side: o.side,
+                t_client_send: o.t_client_send,
+                ..Default::default()
+            })
+        })
+        .stamp_if::<round_trip_latency::ws_recv>(!precise)
+        .stamp_precise_if::<round_trip_latency::ws_recv>(precise)
+        .stamp_if::<round_trip_latency::ws_publish>(!precise)
+        .stamp_precise_if::<round_trip_latency::ws_publish>(precise);
+
+    let pub_orders = iceoryx2_pub(traced_orders.map(|t| burst![t]), SVC_ORDERS);
+
+    // ── Inbound leg ──────────────────────────────────────────────────────
+    let fills_in = iceoryx2_sub::<Traced<RoundTrip, RoundTripLatency>>(SVC_FILLS)
+        .collapse::<Traced<RoundTrip, RoundTripLatency>>()
+        .stamp_if::<round_trip_latency::ws_sub_recv>(!precise)
+        .stamp_precise_if::<round_trip_latency::ws_sub_recv>(precise)
+        .stamp_if::<round_trip_latency::ws_send>(!precise)
+        .stamp_precise_if::<round_trip_latency::ws_send>(precise);
+
+    let (inbound_report, inbound_stats) = fills_in.latency_report(true);
+
+    // OTLP trace export — one parent span + one child per hop, per fill.
+    // The attribute extractor pushes session.id and client_seq onto the
+    // parent span so the Grafana dashboard can filter by session (which
+    // Prometheus can't do without blowing up cardinality).
+    let otlp_endpoint = env_string("WINGFOIL_OTLP_ENDPOINT", "http://localhost:4318");
+    log::info!("otlp trace export → {otlp_endpoint}");
+    let span_sink = fills_in.clone().otlp_spans(
+        OtlpConfig {
+            endpoint: otlp_endpoint,
+            service_name: "wingfoil-latency-e2e".into(),
+        },
+        "roundtrip",
+        |t: &Traced<RoundTrip, RoundTripLatency>, attrs: &mut OtlpAttributeBuffer| {
+            attrs.add("session.id", session_hex(&t.payload.session));
+            attrs.add("client_seq", t.payload.client_seq as i64);
+            attrs.add("side", if t.payload.side == 0 { "buy" } else { "sell" });
+            attrs.add("filled_qty", t.payload.filled_qty as i64);
+        },
+    );
+
+    let fill_frames = fills_in.map(|t: Traced<RoundTrip, RoundTripLatency>| {
+        let l = t.latency;
+        FillFrame {
+            session: t.payload.session,
+            client_seq: t.payload.client_seq,
+            side: t.payload.side,
+            filled_qty: t.payload.filled_qty,
+            fill_price_bps: t.payload.fill_price_bps,
+            t_client_send: t.payload.t_client_send,
+            stamps: [
+                l.ws_recv,
+                l.ws_publish,
+                l.gw_recv,
+                l.gw_price,
+                l.fix_send,
+                l.fix_recv,
+                l.gw_publish,
+                l.ws_sub_recv,
+                l.ws_send,
+            ],
+        }
+    });
+    let pub_fills = fill_frames.web_pub(&server, TOPIC_FILLS);
+
+    // ── Echo leg (round-trip from browser) ───────────────────────────────
+    //
+    // The echo carries four stamps: T1 (client send), T2/T3 (server
+    // ws_recv / ws_send), T4 (client recv). Every delta we care about
+    // lives inside a single clock domain:
+    //     rtt_total         = T4 - T1            (client clock)
+    //     server_resident   = T3 - T2            (server clock)
+    //     wire_rtt          = rtt_total - server_resident
+    // All three are subtractions within one clock — no NTP-style offset
+    // estimation needed.
+
+    let echoes = web_sub::<EchoFrame>(&server, TOPIC_ECHO).collapse::<EchoFrame>();
+
+    let rtt_stats: Rc<std::cell::RefCell<StageStats>> =
+        Rc::new(std::cell::RefCell::new(StageStats::default()));
+    let wire_stats: Rc<std::cell::RefCell<StageStats>> =
+        Rc::new(std::cell::RefCell::new(StageStats::default()));
+
+    let rtt_sink = {
+        let rtt = rtt_stats.clone();
+        let wire = wire_stats.clone();
+        echoes.clone().for_each(move |e, _t| {
+            let Some(rtt_total) = e.t_client_recv.checked_sub(e.t_client_send) else {
+                return;
+            };
+            let resident = e.stamps[8].saturating_sub(e.stamps[0]);
+            rtt.borrow_mut().record(rtt_total);
+            wire.borrow_mut().record(rtt_total.saturating_sub(resident));
+            log::debug!(
+                "echo session={} seq={} rtt={} resident={} wire={}",
+                session_hex(&e.session),
+                e.client_seq,
+                rtt_total,
+                resident,
+                rtt_total.saturating_sub(resident),
+            );
+        })
+    };
+    let echo_counter = echoes.count();
+
+    // ── Prometheus metrics ───────────────────────────────────────────────
+    let exporter = PrometheusExporter::new(&metrics_addr);
+    let metrics_port = exporter.serve()?;
+    log::info!("prometheus on http://{metrics_addr}/metrics (bound :{metrics_port})");
+
+    let tick_1s = ticker(Duration::from_secs(1));
+    let active_gauge = {
+        let s = sessions.clone();
+        tick_1s.produce(move || s.lock().unwrap().active.len() as u64)
+    };
+    let admitted_gauge = {
+        let s = sessions.clone();
+        tick_1s.produce(move || s.lock().unwrap().admitted_total)
+    };
+    let rejected_gauge = {
+        let s = sessions.clone();
+        tick_1s.produce(move || s.lock().unwrap().rejected_total)
+    };
+
+    let mut nodes: Vec<Rc<dyn Node>> = vec![
+        pub_orders,
+        pub_fills,
+        inbound_report,
+        span_sink,
+        rtt_sink,
+        exporter.register("latency_e2e_active_sessions", active_gauge),
+        exporter.register("latency_e2e_admitted_total", admitted_gauge),
+        exporter.register("latency_e2e_rejected_total", rejected_gauge),
+        exporter.register("latency_e2e_echoes_total", echo_counter),
+    ];
+    nodes.extend(register_stage_metrics(&exporter, &inbound_stats));
+    nodes.extend(register_stage_stats(&exporter, "rtt_total", &rtt_stats));
+    nodes.extend(register_stage_stats(&exporter, "wire_rtt", &wire_stats));
+
+    Graph::new(nodes, RunMode::RealTime, RunFor::Forever).run()?;
+    Ok(())
+}
+
+// ── Per-stage Prometheus gauges ──────────────────────────────────────────
+//
+// The Prometheus adapter has no native label support, so we register one
+// gauge per (stage × statistic) tuple. The Grafana dashboard groups them
+// back together via metric-name regex.
+
+fn register_stage_metrics<L: Latency>(
+    exporter: &PrometheusExporter,
+    stats: &Rc<std::cell::RefCell<LatencyStats<L>>>,
+) -> Vec<Rc<dyn Node>> {
+    let mut out: Vec<Rc<dyn Node>> = Vec::new();
+    let names = L::stage_names();
+    for i in 1..L::N {
+        let stage = format!("{}__{}", names[i - 1], names[i]);
+        let tick = ticker(Duration::from_secs(1));
+        let p50 = {
+            let st = stats.clone();
+            tick.produce(move || st.borrow().stages[i].quantile_ns(0.5))
+        };
+        let p99 = {
+            let st = stats.clone();
+            tick.produce(move || st.borrow().stages[i].quantile_ns(0.99))
+        };
+        let count = {
+            let st = stats.clone();
+            tick.produce(move || st.borrow().stages[i].count)
+        };
+        out.push(exporter.register(format!("latency_e2e_{stage}_p50_ns"), p50));
+        out.push(exporter.register(format!("latency_e2e_{stage}_p99_ns"), p99));
+        out.push(exporter.register(format!("latency_e2e_{stage}_count_total"), count));
+    }
+    out
+}
+
+/// Register p50 / p99 / count gauges for a single `StageStats` handle
+/// (used for the cross-domain `rtt_total` and `wire_rtt` histograms).
+fn register_stage_stats(
+    exporter: &PrometheusExporter,
+    prefix: &str,
+    stats: &Rc<std::cell::RefCell<StageStats>>,
+) -> Vec<Rc<dyn Node>> {
+    let tick = ticker(Duration::from_secs(1));
+    let p50 = {
+        let s = stats.clone();
+        tick.produce(move || s.borrow().quantile_ns(0.5))
+    };
+    let p99 = {
+        let s = stats.clone();
+        tick.produce(move || s.borrow().quantile_ns(0.99))
+    };
+    let count = {
+        let s = stats.clone();
+        tick.produce(move || s.borrow().count)
+    };
+    vec![
+        exporter.register(format!("latency_e2e_{prefix}_p50_ns"), p50),
+        exporter.register(format!("latency_e2e_{prefix}_p99_ns"), p99),
+        exporter.register(format!("latency_e2e_{prefix}_count_total"), count),
+    ]
+}
+
+// Compile-time sanity: the iceoryx2 payload type is zero-copy sendable.
+const _: fn() = || {
+    fn assert_zc<T: ZeroCopySend>() {}
+    assert_zc::<Traced<RoundTrip, RoundTripLatency>>();
+};


### PR DESCRIPTION
## Summary

This PR adds a comprehensive end-to-end latency demonstration that showcases wingfoil's ability to instrument a multi-process pipeline with precise wall-clock timestamps at every hop. The demo routes orders through a WebSocket server, shared-memory IPC (iceoryx2), a FIX gateway, and real LMAX trading infrastructure, then stamps the return path and visualizes per-hop latencies in a live browser dashboard.

## Key Changes

- **New example binaries**:
  - `ws_server.rs`: WebSocket edge that admits orders, enforces session caps, publishes fills, and exports OTLP traces
  - `fix_gw.rs`: FIX gateway that subscribes to market data, prices orders, routes to LMAX, and matches ExecutionReports
  - `shared.rs`: Shared payload schema, latency stage definitions, and wire types (OrderFrame, FillFrame, EchoFrame)

- **Browser client** (`static/app.js`, `static/index.html`):
  - Real-time per-hop latency visualization using uPlot
  - Session UUID tracking and echo-based round-trip measurement
  - Configurable order rate and side alternation

- **Observability stack**:
  - Prometheus metrics export (per-hop p50/p99 histograms, session gauges)
  - OTLP trace export with parent span + child spans per hop
  - Pre-provisioned Grafana dashboard + Tempo datasource via docker-compose
  - Three complementary views: in-page chart (per-session), Prometheus (aggregate), Tempo (trace waterfall)

- **New OTLP adapter feature** (`src/adapters/otlp/traces.rs`):
  - `OtlpSpans` trait for streaming `Traced<T, L>` values as OpenTelemetry spans
  - Parent span covering full journey + child spans per adjacent stage pair
  - User-provided attribute extractor for high-cardinality fields (session ID, client_seq, etc.)
  - Graceful handling of partial/invalid stamp records

- **Configuration**:
  - Environment variables for LMAX credentials, session caps, TTLs, precise stamping mode
  - `--precise` CLI flag to enable per-stamp TSC reads (vs. cycle-start wall time)
  - Configurable max market-data age to prevent stale pricing

## Notable Implementation Details

- **Latency schema**: Nine stages defined via `latency_stages!` macro, shared between binaries via `#[path = "shared.rs"]` module inclusion
- **Session management**: Arc<Mutex<HashMap>> for thread-safe session registry (graph thread reads for Prometheus, web_sub async thread writes)
- **Matcher pattern**: `combine` + `fold` to park orders and match ExecutionReports in the same cycle, handling out-of-order fills gracefully
- **Precise stamping**: `stamp_if` / `stamp_precise_if` operators compile to no-op when disabled, zero runtime cost
- **Cardinality strategy**: Prometheus for low-cardinality aggregates (per-hop p50/p99), Tempo for high-cardinality traces (per-session, per-request)
- **iceoryx2 integration**: Zero-copy shared-memory transport via `#[repr(C)]` + `ZeroCopySend` for `Traced<RoundTrip, RoundTripLatency>`

https://claude.ai/code/session_01R6F6cyP2jfSFQLEza6z6aL