### PR TITLE
ci: restrict push trigger to main to avoid duplicate PR runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   workflow_call:
   push:
-    branches: [ "*" ]
+    branches: [ "main" ]
     paths-ignore:
       - ".github/workflows/**"
   pull_request:


### PR DESCRIPTION
PRs previously ran CI twice — once on push (any branch) and once on
pull_request synchronize. Restricting push to main keeps post-merge
CI while pull_request handles PR validation (including fork PRs).