### PR TITLE
Enable npm provenance for package publishing

### DIFF
--- a/.github/workflows/npm-pub.yml
+++ b/.github/workflows/npm-pub.yml
@@ -11,6 +11,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -58,6 +62,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: wingfoil-js
-        run: pnpm publish --access public --no-git-checks
+        run: pnpm publish --access public --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -4,6 +4,11 @@
   "description": "Browser client for the wingfoil web adapter. Thin TypeScript wrapper around the wingfoil-wasm decoder with reactive framework bindings.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/wingfoil-io/wingfoil",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wingfoil-io/wingfoil.git",
+    "directory": "wingfoil-js"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
This PR enables npm package provenance for the wingfoil-js package, improving supply chain security by allowing npm to verify the authenticity and origin of published packages.

## Key Changes
- **GitHub Actions Workflow**: Added required permissions (`contents: read` and `id-token: write`) to the npm publish job to support provenance generation
- **Publish Command**: Added `--provenance` flag to the `pnpm publish` command to generate provenance attestations
- **Environment Configuration**: Added `NPM_CONFIG_PROVENANCE: "true"` environment variable to ensure provenance is enabled
- **Package Metadata**: Added repository information to `package.json` with git URL and directory path, which is required for npm provenance

## Implementation Details
The changes follow npm's provenance requirements by:
1. Granting the necessary OIDC token permissions at the workflow level
2. Explicitly enabling provenance in both the pnpm command and npm configuration
3. Providing complete repository metadata in the package manifest

This enables npm to generate cryptographically signed provenance attestations that consumers can verify to ensure packages come from the expected source.

https://claude.ai/code/session_01LVHFotCd2nEUUAm9etkhr7