### PR TITLE
Add LatencyTracker for wingfoil latency-tracing pattern

### DIFF
--- a/wingfoil-js/README.md
+++ b/wingfoil-js/README.md
@@ -69,9 +69,14 @@ tracker.send({ side: 0, qty: 1 });
 
 The default field names match the wingfoil convention (`session`,
 `client_seq`, `t_client_send`, `t_client_recv`, `stamps`) and can be
-overridden via `LatencyTrackerOptions.fields` if your wire schema
-diverges. The end-to-end latency demo at
-`wingfoil/examples/latency_e2e/static/app.js` is the canonical example.
+overridden via `LatencyTrackerOptions.fields` (the same map applies to
+both outbound publishes and inbound parsing). The end-to-end latency
+demo at `wingfoil/examples/latency_e2e/static/app.js` is the canonical
+example.
+
+Requires the server to use `CodecKind::Json`: the tracker sends
+`session` as a JS `number[]`, which the JSON codec round-trips as
+`[u8; 16]` but the bincode codec encodes as a length-prefixed `Vec<u8>`.
 
 The main package also re-exports the small browser helpers the tracker
 relies on, in case you need them directly: `newSessionId`,

--- a/wingfoil-js/README.md
+++ b/wingfoil-js/README.md
@@ -37,6 +37,46 @@ client.subscribe("price", (value, timeNs) => {
 client.publish("ui", { kind: "click", note: "hi" });
 ```
 
+## Latency tracing
+
+For UIs that drive a wingfoil server using the `Traced<T, L>` /
+`latency_stages!` pattern, `@wingfoil/client/tracing` provides a
+`LatencyTracker` that owns the per-tab session UUID, stamps outbound
+requests with `client_seq` + `t_client_send`, filters inbound responses
+to the current session, and (optionally) echoes the round-trip back so
+the server can compute `rtt_total` / `wire_rtt` within a single clock
+domain. The listener receives the four deltas pre-computed.
+
+```ts
+import { WingfoilClient } from "@wingfoil/client";
+import { LatencyTracker } from "@wingfoil/client/tracing";
+
+const client = new WingfoilClient({ url: "ws://localhost:8080/ws", codec: "json" });
+const tracker = new LatencyTracker({
+  client,
+  outbound: "orders",
+  inbound:  "fills",
+  echo:     "latency_echo",   // omit to disable the echo leg
+});
+
+tracker.onResponse<FillFrame>(({ payload, rttNs, serverResidentNs, wireRttNs, stamps }) => {
+  console.log(payload.client_seq, rttNs, serverResidentNs, wireRttNs);
+});
+
+// session, client_seq, and t_client_send are stamped by the tracker.
+tracker.send({ side: 0, qty: 1 });
+```
+
+The default field names match the wingfoil convention (`session`,
+`client_seq`, `t_client_send`, `t_client_recv`, `stamps`) and can be
+overridden via `LatencyTrackerOptions.fields` if your wire schema
+diverges. The end-to-end latency demo at
+`wingfoil/examples/latency_e2e/static/app.js` is the canonical example.
+
+The main package also re-exports the small browser helpers the tracker
+relies on, in case you need them directly: `newSessionId`,
+`sessionHex`, `nowNs`.
+
 ## Reactive-framework bindings
 
 ### Solid.js

--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingfoil/client",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Browser client for the wingfoil web adapter. Thin TypeScript wrapper around the wingfoil-wasm decoder with reactive framework bindings.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/wingfoil-io/wingfoil",
@@ -17,6 +17,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./tracing": {
+      "types": "./dist/tracing.d.ts",
+      "import": "./dist/tracing.js"
     },
     "./solid": {
       "types": "./dist/solid.d.ts",

--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -45,7 +45,8 @@
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "dev": "vite examples/solid-dashboard",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "solid-js": "^1.8.0",
@@ -53,15 +54,22 @@
     "vue": "^3.4.0"
   },
   "peerDependenciesMeta": {
-    "solid-js": { "optional": true },
-    "svelte": { "optional": true },
-    "vue": { "optional": true }
+    "solid-js": {
+      "optional": true
+    },
+    "svelte": {
+      "optional": true
+    },
+    "vue": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "solid-js": "^1.8.0",
     "typescript": "^5.5.0",
     "vite": "^5.4.0",
-    "vite-plugin-solid": "^2.10.0"
+    "vite-plugin-solid": "^2.10.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/wingfoil-js/pnpm-lock.yaml
+++ b/wingfoil-js/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       vite-plugin-solid:
         specifier: ^2.10.0
         version: 2.11.12(solid-js@1.9.12)(vite@5.4.21(@types/node@22.19.17))
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.17)
 
 packages:
 
@@ -423,6 +426,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -431,6 +440,35 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vue/compiler-core@3.5.33':
     resolution: {integrity: sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==}
@@ -470,6 +508,10 @@ packages:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -498,8 +540,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -520,6 +574,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
@@ -533,6 +591,9 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -557,6 +618,22 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -579,6 +656,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -591,6 +671,9 @@ packages:
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -616,8 +699,19 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -642,6 +736,9 @@ packages:
     resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
     engines: {node: '>=10'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
@@ -654,9 +751,40 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   svelte@5.55.5:
     resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
     engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -671,6 +799,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
 
   vite-plugin-solid@2.11.12:
     resolution: {integrity: sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==}
@@ -721,6 +854,34 @@ packages:
       vite:
         optional: true
 
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.5.33:
     resolution: {integrity: sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==}
     peerDependencies:
@@ -728,6 +889,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1036,6 +1202,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.17':
@@ -1043,6 +1216,48 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/trusted-types@2.0.7': {}
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.5.33':
     dependencies:
@@ -1102,6 +1317,8 @@ snapshots:
 
   aria-query@5.3.1: {}
 
+  assertion-error@2.0.1: {}
+
   axobject-query@4.1.0: {}
 
   babel-plugin-jsx-dom-expressions@0.40.6(@babel/core@7.29.0):
@@ -1130,7 +1347,19 @@ snapshots:
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   caniuse-lite@1.0.30001791: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
 
   clsx@2.1.1: {}
 
@@ -1142,6 +1371,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   devalue@5.7.1: {}
 
   electron-to-chromium@1.5.344: {}
@@ -1149,6 +1380,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1186,6 +1419,16 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fsevents@2.3.3:
     optional: true
 
@@ -1201,11 +1444,15 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
 
   locate-character@3.0.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -1229,7 +1476,13 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
 
   postcss@8.5.10:
     dependencies:
@@ -1276,6 +1529,8 @@ snapshots:
 
   seroval@1.5.2: {}
 
+  siginfo@2.0.0: {}
+
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
@@ -1292,6 +1547,14 @@ snapshots:
       - supports-color
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   svelte@5.55.5:
     dependencies:
@@ -1314,6 +1577,21 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
@@ -1323,6 +1601,24 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  vite-node@3.2.4(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@5.4.21(@types/node@22.19.17)):
     dependencies:
@@ -1350,6 +1646,44 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.17)
 
+  vitest@3.2.4(@types/node@22.19.17):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 3.2.4(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vue@3.5.33(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.33
@@ -1359,6 +1693,11 @@ snapshots:
       '@vue/shared': 3.5.33
     optionalDependencies:
       typescript: 5.9.3
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}
 

--- a/wingfoil-js/src/index.ts
+++ b/wingfoil-js/src/index.ts
@@ -258,3 +258,48 @@ export class WingfoilClient {
 }
 
 export { wireVersion };
+
+// ── Utilities ─────────────────────────────────────────────────────────────
+//
+// Small browser helpers used by the tracing module and frequently needed
+// by consumers building latency-aware UIs against a wingfoil server.
+
+/**
+ * Generate a fresh 16-byte UUID v4 as a `Uint8Array`. Suitable for use as
+ * the `session: [u8; 16]` field on outbound frames; sent verbatim through
+ * the JSON codec as an array of integers.
+ */
+export function newSessionId(): Uint8Array {
+  const u = (typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : fallbackUuid()
+  ).replaceAll("-", "");
+  const out = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) out[i] = parseInt(u.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+/** Format a 16-byte session ID (or any byte array) as a lowercase hex string. */
+export function sessionHex(bytes: Uint8Array | ArrayLike<number>): string {
+  const arr = bytes instanceof Uint8Array ? bytes : Array.from(bytes);
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * High-resolution wall-clock timestamp in nanoseconds, derived from
+ * `performance.timeOrigin + performance.now()`. Precision is bounded by
+ * the browser's `performance.now()` resolution (typically µs); the value
+ * is truncated to a safe integer for JS Number arithmetic.
+ */
+export function nowNs(): number {
+  return Math.round(performance.timeOrigin * 1e6 + performance.now() * 1e6);
+}
+
+function fallbackUuid(): string {
+  const r = new Uint8Array(16);
+  crypto.getRandomValues(r);
+  r[6] = (r[6] & 0x0f) | 0x40;
+  r[8] = (r[8] & 0x3f) | 0x80;
+  const h = Array.from(r, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}

--- a/wingfoil-js/src/index.ts
+++ b/wingfoil-js/src/index.ts
@@ -259,47 +259,8 @@ export class WingfoilClient {
 
 export { wireVersion };
 
-// ── Utilities ─────────────────────────────────────────────────────────────
-//
-// Small browser helpers used by the tracing module and frequently needed
-// by consumers building latency-aware UIs against a wingfoil server.
-
-/**
- * Generate a fresh 16-byte UUID v4 as a `Uint8Array`. Suitable for use as
- * the `session: [u8; 16]` field on outbound frames; sent verbatim through
- * the JSON codec as an array of integers.
- */
-export function newSessionId(): Uint8Array {
-  const u = (typeof crypto.randomUUID === "function"
-    ? crypto.randomUUID()
-    : fallbackUuid()
-  ).replaceAll("-", "");
-  const out = new Uint8Array(16);
-  for (let i = 0; i < 16; i++) out[i] = parseInt(u.slice(i * 2, i * 2 + 2), 16);
-  return out;
-}
-
-/** Format a 16-byte session ID (or any byte array) as a lowercase hex string. */
-export function sessionHex(bytes: Uint8Array | ArrayLike<number>): string {
-  const arr = bytes instanceof Uint8Array ? bytes : Array.from(bytes);
-  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
-}
-
-/**
- * High-resolution wall-clock timestamp in nanoseconds, derived from
- * `performance.timeOrigin + performance.now()`. Precision is bounded by
- * the browser's `performance.now()` resolution (typically µs); the value
- * is truncated to a safe integer for JS Number arithmetic.
- */
-export function nowNs(): number {
-  return Math.round(performance.timeOrigin * 1e6 + performance.now() * 1e6);
-}
-
-function fallbackUuid(): string {
-  const r = new Uint8Array(16);
-  crypto.getRandomValues(r);
-  r[6] = (r[6] & 0x0f) | 0x40;
-  r[8] = (r[8] & 0x3f) | 0x80;
-  const h = Array.from(r, (b) => b.toString(16).padStart(2, "0")).join("");
-  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
-}
+// Re-export the small browser helpers from `./utils.js` so existing
+// consumers don't have to know about the split. The helpers live in
+// their own file so the tracing module — and tests — don't drag in the
+// wasm decoder.
+export { newSessionId, sessionHex, nowNs } from "./utils.js";

--- a/wingfoil-js/src/tracing.ts
+++ b/wingfoil-js/src/tracing.ts
@@ -13,11 +13,20 @@
 // All four deltas surface on the listener as numbers — no NTP-style
 // clock-sync required, because every subtraction lives in one domain.
 //
-// Field names default to the wingfoil convention (`session`, `client_seq`,
-// `t_client_send`, `t_client_recv`, `stamps`) but can be overridden if
-// your wire schema diverges.
+// Codec assumption: requires the server's web adapter to use
+// `CodecKind::Json`. The bincode codec serialises a JS `number[]` as a
+// length-prefixed `Vec<u8>`, which doesn't match a Rust `[u8; 16]` field.
+//
+// Field-name overrides (`LatencyTrackerOptions.fields`) apply
+// symmetrically to outbound publishes *and* inbound parsing.
+//
+// Numeric assumption: timestamps and stamps are JS Numbers (not BigInt)
+// in the safe-integer range. The wasm JSON decoder produces Numbers
+// today; if the wire ever moves to BigInt for u64 fields, this module
+// needs a coercion layer.
 
-import { nowNs, sessionHex, newSessionId, type WingfoilClient } from "./index.js";
+import type { WingfoilClient } from "./index.js";
+import { newSessionId, nowNs, sessionHex } from "./utils.js";
 
 export interface TracingFields {
   session: string;
@@ -35,6 +44,8 @@ const DEFAULT_FIELDS: TracingFields = {
   stamps: "stamps",
 };
 
+const SESSION_BYTES = 16;
+
 export interface LatencyTrackerOptions {
   /** The wingfoil client carrying the WebSocket connection. */
   client: WingfoilClient;
@@ -48,11 +59,16 @@ export interface LatencyTrackerOptions {
    */
   echo?: string;
   /**
-   * Existing session ID to use; defaults to a fresh random UUID. Useful
-   * if the host page already minted one for cross-tab correlation.
+   * Existing 16-byte session ID to use; defaults to a fresh random UUID.
+   * Useful if the host page already minted one for cross-tab correlation.
+   * Throws if length is not 16.
    */
   session?: Uint8Array;
-  /** Override individual wire field names. */
+  /**
+   * Override individual wire field names. The same map is applied to both
+   * outbound publishes (which keys are stamped onto the request) and
+   * inbound parsing (which keys the tracker reads off the response).
+   */
   fields?: Partial<TracingFields>;
 }
 
@@ -111,9 +127,15 @@ export class LatencyTracker {
   private readonly fields: TracingFields;
   private readonly sessionArr: number[];
   private seq = 0;
+  private closed = false;
   private readonly unsubscribers = new Set<() => void>();
 
   constructor(opts: LatencyTrackerOptions) {
+    if (opts.session && opts.session.length !== SESSION_BYTES) {
+      throw new Error(
+        `LatencyTracker: session must be ${SESSION_BYTES} bytes, got ${opts.session.length}`,
+      );
+    }
     this.client = opts.client;
     this.outbound = opts.outbound;
     this.inbound = opts.inbound;
@@ -126,11 +148,14 @@ export class LatencyTracker {
 
   /**
    * Publish a request on the outbound topic. `session`, `client_seq` and
-   * `t_client_send` are stamped automatically; the caller supplies the
-   * application-specific fields. Returns the `client_seq` that was used.
+   * `t_client_send` are stamped automatically and override any same-named
+   * keys in `payload`. Returns the `client_seq` that was used.
+   *
+   * No-op after `close()`; returns the seq that *would* have been used.
    */
   send(payload: Record<string, unknown> = {}): number {
     this.seq += 1;
+    if (this.closed) return this.seq;
     const f = this.fields;
     this.client.publish(this.outbound, {
       ...payload,
@@ -142,14 +167,20 @@ export class LatencyTracker {
   }
 
   /**
-   * Subscribe to inbound responses for this session only. Each match is
-   * stamped with `t_client_recv = nowNs()`, the four latency deltas are
-   * computed, and (if `echo` was configured) the round-trip is echoed
-   * back to the server before the listener fires.
+   * Subscribe to inbound responses for this session only. For each match:
    *
-   * Returns an unsubscribe function.
+   *   1. `t_client_recv = nowNs()` is stamped
+   *   2. the four latency deltas are computed
+   *   3. if `echo` was configured, the round-trip is echoed *before* the
+   *      listener fires — so a throwing listener can't starve the
+   *      latency-report leg
+   *   4. the listener is invoked
+   *
+   * Returns an unsubscribe function. After `close()`, this is a no-op
+   * that returns a no-op unsubscribe.
    */
   onResponse<T = unknown>(listener: RoundTripListener<T>): () => void {
+    if (this.closed) return () => {};
     const f = this.fields;
     const unsub = this.client.subscribe(this.inbound, (raw) => {
       const msg = raw as Record<string, unknown>;
@@ -158,6 +189,7 @@ export class LatencyTracker {
       const tClientRecv = nowNs();
       const tClientSend = numberOr(msg[f.tClientSend], 0);
       const stamps = (msg[f.stamps] as number[] | undefined) ?? [];
+      const clientSeq = numberOr(msg[f.clientSeq], 0);
       const rttNs = Math.max(0, tClientRecv - tClientSend);
       const serverResidentNs =
         stamps.length >= 2 ? stamps[stamps.length - 1] - stamps[0] : 0;
@@ -166,7 +198,7 @@ export class LatencyTracker {
       if (this.echo) {
         this.client.publish(this.echo, {
           [f.session]: this.sessionArr,
-          [f.clientSeq]: msg[f.clientSeq],
+          [f.clientSeq]: clientSeq,
           [f.tClientSend]: tClientSend,
           [f.tClientRecv]: tClientRecv,
           [f.stamps]: stamps,
@@ -175,7 +207,7 @@ export class LatencyTracker {
 
       listener({
         payload: msg as T,
-        clientSeq: numberOr(msg[f.clientSeq], 0),
+        clientSeq,
         tClientSend,
         tClientRecv,
         rttNs,
@@ -191,8 +223,9 @@ export class LatencyTracker {
     };
   }
 
-  /** Tear down all listeners registered through this tracker. */
+  /** Tear down all listeners registered through this tracker. Idempotent. */
   close(): void {
+    this.closed = true;
     for (const u of this.unsubscribers) u();
     this.unsubscribers.clear();
   }

--- a/wingfoil-js/src/tracing.ts
+++ b/wingfoil-js/src/tracing.ts
@@ -1,0 +1,209 @@
+// Latency-tracing helpers for @wingfoil/client.
+//
+// Captures the round-trip pattern that wingfoil's `latency_stages!` /
+// `Traced<T, L>` server pipeline expects from a browser client:
+//
+//   * generate a session UUID per page-load
+//   * stamp each outbound request with `client_seq` and `t_client_send`
+//   * filter inbound responses to this session
+//   * stamp `t_client_recv` on receipt and echo the four timestamps back
+//     so the server can compute `rtt_total` and `wire_rtt` within a
+//     single clock domain
+//
+// All four deltas surface on the listener as numbers — no NTP-style
+// clock-sync required, because every subtraction lives in one domain.
+//
+// Field names default to the wingfoil convention (`session`, `client_seq`,
+// `t_client_send`, `t_client_recv`, `stamps`) but can be overridden if
+// your wire schema diverges.
+
+import { nowNs, sessionHex, newSessionId, type WingfoilClient } from "./index.js";
+
+export interface TracingFields {
+  session: string;
+  clientSeq: string;
+  tClientSend: string;
+  tClientRecv: string;
+  stamps: string;
+}
+
+const DEFAULT_FIELDS: TracingFields = {
+  session: "session",
+  clientSeq: "client_seq",
+  tClientSend: "t_client_send",
+  tClientRecv: "t_client_recv",
+  stamps: "stamps",
+};
+
+export interface LatencyTrackerOptions {
+  /** The wingfoil client carrying the WebSocket connection. */
+  client: WingfoilClient;
+  /** Topic to publish requests on (e.g. `"orders"`). */
+  outbound: string;
+  /** Topic carrying server responses to filter (e.g. `"fills"`). */
+  inbound: string;
+  /**
+   * Optional topic to echo the round-trip back on (e.g. `"latency_echo"`).
+   * Omit to disable the echo leg.
+   */
+  echo?: string;
+  /**
+   * Existing session ID to use; defaults to a fresh random UUID. Useful
+   * if the host page already minted one for cross-tab correlation.
+   */
+  session?: Uint8Array;
+  /** Override individual wire field names. */
+  fields?: Partial<TracingFields>;
+}
+
+/**
+ * One inbound response, paired with the latency deltas computed from its
+ * timestamps. `payload` is the raw decoded message; `stamps` is a copy of
+ * `payload[fields.stamps]` for convenience.
+ */
+export interface RoundTrip<T = unknown> {
+  payload: T;
+  clientSeq: number;
+  tClientSend: number;
+  tClientRecv: number;
+  /** Total RTT in ns (client clock: `t_client_recv − t_client_send`). */
+  rttNs: number;
+  /** Server-side stamps array (length set by the Rust `latency_stages!`). */
+  stamps: number[];
+  /**
+   * `stamps[last] − stamps[0]` (server clock). Zero if `stamps` has fewer
+   * than two entries.
+   */
+  serverResidentNs: number;
+  /** `rttNs − serverResidentNs`, clamped at zero (wire RTT, ns). */
+  wireRttNs: number;
+}
+
+export type RoundTripListener<T> = (rt: RoundTrip<T>) => void;
+
+/**
+ * Owns one browser session's outbound counter and round-trip echo loop.
+ *
+ * @example
+ * ```ts
+ * const tracker = new LatencyTracker({
+ *   client,
+ *   outbound: "orders",
+ *   inbound:  "fills",
+ *   echo:     "latency_echo",
+ * });
+ * tracker.onResponse<FillFrame>((rt) => {
+ *   console.log(rt.rttNs, rt.serverResidentNs, rt.wireRttNs);
+ * });
+ * tracker.send({ side: 0, qty: 1 });   // session/seq/t_client_send auto-stamped
+ * ```
+ */
+export class LatencyTracker {
+  /** Raw 16-byte session UUID used to tag outbound and filter inbound. */
+  readonly session: Uint8Array;
+  /** Hex form of `session` (32 chars), useful for log / metric labels. */
+  readonly sessionHex: string;
+
+  private readonly client: WingfoilClient;
+  private readonly outbound: string;
+  private readonly inbound: string;
+  private readonly echo?: string;
+  private readonly fields: TracingFields;
+  private readonly sessionArr: number[];
+  private seq = 0;
+  private readonly unsubscribers = new Set<() => void>();
+
+  constructor(opts: LatencyTrackerOptions) {
+    this.client = opts.client;
+    this.outbound = opts.outbound;
+    this.inbound = opts.inbound;
+    this.echo = opts.echo;
+    this.fields = { ...DEFAULT_FIELDS, ...opts.fields };
+    this.session = opts.session ?? newSessionId();
+    this.sessionHex = sessionHex(this.session);
+    this.sessionArr = Array.from(this.session);
+  }
+
+  /**
+   * Publish a request on the outbound topic. `session`, `client_seq` and
+   * `t_client_send` are stamped automatically; the caller supplies the
+   * application-specific fields. Returns the `client_seq` that was used.
+   */
+  send(payload: Record<string, unknown> = {}): number {
+    this.seq += 1;
+    const f = this.fields;
+    this.client.publish(this.outbound, {
+      ...payload,
+      [f.session]: this.sessionArr,
+      [f.clientSeq]: this.seq,
+      [f.tClientSend]: nowNs(),
+    });
+    return this.seq;
+  }
+
+  /**
+   * Subscribe to inbound responses for this session only. Each match is
+   * stamped with `t_client_recv = nowNs()`, the four latency deltas are
+   * computed, and (if `echo` was configured) the round-trip is echoed
+   * back to the server before the listener fires.
+   *
+   * Returns an unsubscribe function.
+   */
+  onResponse<T = unknown>(listener: RoundTripListener<T>): () => void {
+    const f = this.fields;
+    const unsub = this.client.subscribe(this.inbound, (raw) => {
+      const msg = raw as Record<string, unknown>;
+      const inSession = msg[f.session] as ArrayLike<number> | undefined;
+      if (!inSession || !sameSession(inSession, this.sessionArr)) return;
+      const tClientRecv = nowNs();
+      const tClientSend = numberOr(msg[f.tClientSend], 0);
+      const stamps = (msg[f.stamps] as number[] | undefined) ?? [];
+      const rttNs = Math.max(0, tClientRecv - tClientSend);
+      const serverResidentNs =
+        stamps.length >= 2 ? stamps[stamps.length - 1] - stamps[0] : 0;
+      const wireRttNs = Math.max(0, rttNs - serverResidentNs);
+
+      if (this.echo) {
+        this.client.publish(this.echo, {
+          [f.session]: this.sessionArr,
+          [f.clientSeq]: msg[f.clientSeq],
+          [f.tClientSend]: tClientSend,
+          [f.tClientRecv]: tClientRecv,
+          [f.stamps]: stamps,
+        });
+      }
+
+      listener({
+        payload: msg as T,
+        clientSeq: numberOr(msg[f.clientSeq], 0),
+        tClientSend,
+        tClientRecv,
+        rttNs,
+        stamps,
+        serverResidentNs,
+        wireRttNs,
+      });
+    });
+    this.unsubscribers.add(unsub);
+    return () => {
+      unsub();
+      this.unsubscribers.delete(unsub);
+    };
+  }
+
+  /** Tear down all listeners registered through this tracker. */
+  close(): void {
+    for (const u of this.unsubscribers) u();
+    this.unsubscribers.clear();
+  }
+}
+
+function sameSession(a: ArrayLike<number>, b: ArrayLike<number>): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function numberOr(v: unknown, fallback: number): number {
+  return typeof v === "number" ? v : fallback;
+}

--- a/wingfoil-js/src/utils.ts
+++ b/wingfoil-js/src/utils.ts
@@ -1,0 +1,46 @@
+// Small browser helpers for @wingfoil/client. Kept in their own module so
+// the tracing helpers — and tests — don't drag in the wasm decoder.
+
+/**
+ * Generate a fresh 16-byte UUID v4 as a `Uint8Array`. Suitable for use as
+ * the `session: [u8; 16]` field on outbound frames; sent verbatim through
+ * the JSON codec as an array of integers.
+ */
+export function newSessionId(): Uint8Array {
+  const u = (typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : fallbackUuid()
+  ).replaceAll("-", "");
+  const out = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) out[i] = parseInt(u.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+/** Format a 16-byte session ID (or any byte array) as a lowercase hex string. */
+export function sessionHex(bytes: Uint8Array | ArrayLike<number>): string {
+  const arr = bytes instanceof Uint8Array ? bytes : Array.from(bytes);
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * High-resolution wall-clock timestamp in nanoseconds, derived from
+ * `performance.timeOrigin + performance.now()`. Precision is bounded by
+ * the browser's `performance.now()` resolution (typically µs); the value
+ * is truncated to a safe integer for JS Number arithmetic.
+ */
+export function nowNs(): number {
+  return Math.round(performance.timeOrigin * 1e6 + performance.now() * 1e6);
+}
+
+// `crypto.randomUUID` shipped in Node 19 / Safari 15.4 / Chrome 92, so this
+// branch is rarely hit in practice. Both `randomUUID` and `getRandomValues`
+// require a secure context; if neither is available, callers will see a
+// `TypeError` at first use rather than silently colliding session IDs.
+function fallbackUuid(): string {
+  const r = new Uint8Array(16);
+  crypto.getRandomValues(r);
+  r[6] = (r[6] & 0x0f) | 0x40;
+  r[8] = (r[8] & 0x3f) | 0x80;
+  const h = Array.from(r, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}

--- a/wingfoil-js/tests/tracing.test.ts
+++ b/wingfoil-js/tests/tracing.test.ts
@@ -1,0 +1,286 @@
+// Unit tests for `LatencyTracker`. We don't import `WingfoilClient` itself
+// — `tracing.ts` only depends on its `subscribe` / `publish` / `onConnection`
+// surface — so a tiny fake stands in. This keeps the wasm decoder out of
+// the test process.
+
+import { describe, expect, it } from "vitest";
+import {
+  LatencyTracker,
+  type RoundTrip,
+  type TracingFields,
+} from "../src/tracing.js";
+import { nowNs } from "../src/utils.js";
+import type { WingfoilClient } from "../src/index.js";
+
+interface PublishedFrame {
+  topic: string;
+  value: unknown;
+}
+
+class FakeClient {
+  readonly published: PublishedFrame[] = [];
+  private readonly listeners = new Map<string, Set<(v: unknown) => void>>();
+
+  subscribe(topic: string, listener: (v: unknown) => void): () => void {
+    const set = this.listeners.get(topic) ?? new Set();
+    set.add(listener);
+    this.listeners.set(topic, set);
+    return () => {
+      set.delete(listener);
+      if (set.size === 0) this.listeners.delete(topic);
+    };
+  }
+
+  publish(topic: string, value: unknown): void {
+    this.published.push({ topic, value });
+  }
+
+  /** Push a fake inbound frame, as if it had arrived over the WebSocket. */
+  deliver(topic: string, value: unknown): void {
+    const set = this.listeners.get(topic);
+    if (!set) return;
+    for (const fn of set) fn(value);
+  }
+
+  hasListener(topic: string): boolean {
+    return (this.listeners.get(topic)?.size ?? 0) > 0;
+  }
+}
+
+function makeTracker(
+  client: FakeClient,
+  opts: Partial<{ session: Uint8Array; echo: string; fields: Partial<TracingFields> }> = {},
+) {
+  return new LatencyTracker({
+    client: client as unknown as WingfoilClient,
+    outbound: "orders",
+    inbound: "fills",
+    echo: opts.echo,
+    session: opts.session,
+    fields: opts.fields,
+  });
+}
+
+const SESSION = new Uint8Array(16).map((_, i) => i + 1);
+const sessionArr = Array.from(SESSION);
+
+describe("LatencyTracker.constructor", () => {
+  it("defaults to a fresh 16-byte session ID", () => {
+    const t = makeTracker(new FakeClient());
+    expect(t.session).toBeInstanceOf(Uint8Array);
+    expect(t.session.length).toBe(16);
+    expect(t.sessionHex).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("accepts a caller-provided session", () => {
+    const t = makeTracker(new FakeClient(), { session: SESSION });
+    expect(Array.from(t.session)).toEqual(sessionArr);
+    expect(t.sessionHex).toBe("0102030405060708090a0b0c0d0e0f10");
+  });
+
+  it("rejects a session of the wrong byte length", () => {
+    expect(() => makeTracker(new FakeClient(), { session: new Uint8Array(8) })).toThrow(
+      /16 bytes/,
+    );
+  });
+});
+
+describe("LatencyTracker.send", () => {
+  it("stamps session, client_seq, and t_client_send onto every publish", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+
+    expect(t.send({ side: 0, qty: 1 })).toBe(1);
+    expect(t.send({ side: 1, qty: 2 })).toBe(2);
+
+    expect(c.published).toHaveLength(2);
+    const [a, b] = c.published as { topic: string; value: Record<string, unknown> }[];
+
+    expect(a.topic).toBe("orders");
+    expect(a.value.session).toEqual(sessionArr);
+    expect(a.value.client_seq).toBe(1);
+    expect(a.value.side).toBe(0);
+    expect(a.value.qty).toBe(1);
+    expect(typeof a.value.t_client_send).toBe("number");
+
+    expect(b.value.client_seq).toBe(2);
+  });
+
+  it("auto-stamped fields override caller fields of the same name", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+    t.send({ session: [0, 0, 0], client_seq: 999, t_client_send: 0, qty: 7 });
+    const v = (c.published[0].value as Record<string, unknown>);
+    expect(v.session).toEqual(sessionArr);
+    expect(v.client_seq).toBe(1);
+    expect(v.t_client_send).not.toBe(0);
+    expect(v.qty).toBe(7);
+  });
+
+  it("respects field-name overrides on publish", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, {
+      session: SESSION,
+      fields: { clientSeq: "cseq", tClientSend: "tsend" },
+    });
+    t.send({ side: 0 });
+    const v = c.published[0].value as Record<string, unknown>;
+    expect(v.cseq).toBe(1);
+    expect(typeof v.tsend).toBe("number");
+    expect(v.client_seq).toBeUndefined();
+  });
+});
+
+describe("LatencyTracker.onResponse", () => {
+  it("filters out responses for other sessions", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+    const seen: RoundTrip[] = [];
+    t.onResponse((rt) => seen.push(rt));
+
+    c.deliver("fills", {
+      session: Array.from(new Uint8Array(16).fill(0xff)),
+      client_seq: 1,
+      t_client_send: 0,
+      stamps: [10, 20],
+    });
+    expect(seen).toHaveLength(0);
+  });
+
+  it("computes RTT, server-resident, and wire deltas", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+    const seen: RoundTrip[] = [];
+    t.onResponse((rt) => seen.push(rt));
+
+    // Pin t_client_send to a value definitely earlier than nowNs() will report.
+    c.deliver("fills", {
+      session: sessionArr,
+      client_seq: 42,
+      t_client_send: 1,
+      stamps: [100, 250],
+    });
+
+    expect(seen).toHaveLength(1);
+    const rt = seen[0];
+    expect(rt.clientSeq).toBe(42);
+    expect(rt.tClientSend).toBe(1);
+    expect(rt.tClientRecv).toBeGreaterThan(rt.tClientSend);
+    expect(rt.rttNs).toBe(rt.tClientRecv - rt.tClientSend);
+    expect(rt.serverResidentNs).toBe(150); // 250 - 100
+    expect(rt.wireRttNs).toBe(Math.max(0, rt.rttNs - 150));
+    expect(rt.stamps).toEqual([100, 250]);
+  });
+
+  it("yields serverResidentNs=0 when stamps has fewer than two entries", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+    const seen: RoundTrip[] = [];
+    t.onResponse((rt) => seen.push(rt));
+
+    c.deliver("fills", { session: sessionArr, client_seq: 1, t_client_send: 0, stamps: [] });
+    c.deliver("fills", { session: sessionArr, client_seq: 2, t_client_send: 0, stamps: [42] });
+
+    expect(seen[0].serverResidentNs).toBe(0);
+    expect(seen[1].serverResidentNs).toBe(0);
+  });
+
+  it("clamps negative RTT/wire deltas at zero", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+    const seen: RoundTrip[] = [];
+    t.onResponse((rt) => seen.push(rt));
+
+    // t_client_send 10s in the future ⇒ raw RTT would be negative.
+    const future = nowNs() + 10_000_000_000;
+    c.deliver("fills", {
+      session: sessionArr,
+      client_seq: 1,
+      t_client_send: future,
+      stamps: [10, 20],
+    });
+    expect(seen[0].rttNs).toBe(0);
+    expect(seen[0].wireRttNs).toBe(0);
+  });
+
+  it("echoes back BEFORE invoking the listener (so a throwing listener can't starve the echo)", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION, echo: "latency_echo" });
+    const order: string[] = [];
+    t.onResponse(() => {
+      order.push("listener");
+      throw new Error("boom");
+    });
+
+    expect(() =>
+      c.deliver("fills", {
+        session: sessionArr,
+        client_seq: 7,
+        t_client_send: 1,
+        stamps: [10, 20],
+      }),
+    ).toThrow(/boom/);
+
+    expect(c.published).toHaveLength(1);
+    const echo = c.published[0];
+    expect(echo.topic).toBe("latency_echo");
+    const v = echo.value as Record<string, unknown>;
+    expect(v.session).toEqual(sessionArr);
+    expect(v.client_seq).toBe(7);
+    expect(v.t_client_send).toBe(1);
+    expect(v.stamps).toEqual([10, 20]);
+    expect(typeof v.t_client_recv).toBe("number");
+    expect(order).toEqual(["listener"]);
+  });
+
+  it("does not echo when no echo topic is configured", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+    t.onResponse(() => {});
+    c.deliver("fills", { session: sessionArr, client_seq: 1, t_client_send: 0, stamps: [1, 2] });
+    expect(c.published).toHaveLength(0);
+  });
+
+  it("returned unsubscribe removes the listener and untracks it", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION });
+    let calls = 0;
+    const unsub = t.onResponse(() => {
+      calls += 1;
+    });
+    c.deliver("fills", { session: sessionArr, client_seq: 1, t_client_send: 0, stamps: [] });
+    unsub();
+    c.deliver("fills", { session: sessionArr, client_seq: 2, t_client_send: 0, stamps: [] });
+    expect(calls).toBe(1);
+    expect(c.hasListener("fills")).toBe(false);
+  });
+});
+
+describe("LatencyTracker.close", () => {
+  it("tears down all listeners and gates further send/onResponse calls", () => {
+    const c = new FakeClient();
+    const t = makeTracker(c, { session: SESSION, echo: "latency_echo" });
+    let calls = 0;
+    t.onResponse(() => {
+      calls += 1;
+    });
+
+    t.close();
+
+    expect(c.hasListener("fills")).toBe(false);
+    expect(t.send({ side: 0 })).toBe(1); // returns the seq, but doesn't publish
+    expect(c.published).toHaveLength(0);
+    // re-subscribing post-close is a no-op
+    const noopUnsub = t.onResponse(() => {
+      calls += 1;
+    });
+    expect(c.hasListener("fills")).toBe(false);
+    noopUnsub(); // still callable
+  });
+
+  it("is idempotent", () => {
+    const t = makeTracker(new FakeClient(), { session: SESSION });
+    t.close();
+    expect(() => t.close()).not.toThrow();
+  });
+});

--- a/wingfoil-js/vitest.config.ts
+++ b/wingfoil-js/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// Dedicated config so vitest doesn't pick up `vite.config.ts`, which is
+// rooted in `examples/solid-dashboard` for the dev playground.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/wingfoil/examples/latency_e2e/static/app.js
+++ b/wingfoil/examples/latency_e2e/static/app.js
@@ -66,7 +66,8 @@ let chart, chartData, ticker = null;
 function setStatus(s) {
   const el = document.getElementById('status');
   el.textContent = s;
-  el.className = 'pill ' + (s === 'live' ? 'live' : 'idle');
+  const cls = s === 'live' ? 'live' : s === 'connecting' ? 'connecting' : 'idle';
+  el.className = 'pill ' + cls;
 }
 
 client.onConnection((s) => {

--- a/wingfoil/examples/latency_e2e/static/app.js
+++ b/wingfoil/examples/latency_e2e/static/app.js
@@ -1,18 +1,15 @@
 // wingfoil latency end-to-end — browser client.
 //
-// Emits OrderFrames at the configured rate, listens for FillFrames,
-// stamps a t_client_recv and posts the round-trip back as an EchoFrame.
-// Renders a uPlot chart of the per-hop latency for THIS session.
-//
-// Wire plumbing (envelopes, control frames, JSON codec) is delegated to
-// `@wingfoil/client`, loaded from the npm package via the import map in
-// index.html.
+// Streams orders, listens for fills, and renders per-hop latency for the
+// current browser session. The session UUID, sequence counter, outbound
+// timestamps, inbound filtering, RTT/wire deltas, and the echo round-trip
+// back to the server are all delegated to `LatencyTracker`.
 
 import { WingfoilClient } from "@wingfoil/client";
+import { LatencyTracker } from "@wingfoil/client/tracing";
 
 // Each entry is either a server-clock delta (indices into stamps[]) or
-// the derived `wire_rtt` computed from the client-clock RTT minus the
-// server residence time. Every number lives inside a single clock
+// the derived `wire_rtt`. Every number lives inside a single clock
 // domain — no NTP-style sync needed.
 const STAGES = [
   ["ws_recv→ws_publish",    "server", 0, 1],
@@ -32,42 +29,39 @@ const COLOURS = [
 ];
 const MAX_POINTS = 200; // ~100 s at 2 Hz
 
-// ── session UUID as 16 raw bytes (sent verbatim as JSON array) ───────────
-function newSessionId() {
-  const u = (crypto.randomUUID ? crypto.randomUUID() : fallbackUuid()).replaceAll('-', '');
-  const out = new Uint8Array(16);
-  for (let i = 0; i < 16; i++) out[i] = parseInt(u.slice(i*2, i*2+2), 16);
-  return out;
-}
-function fallbackUuid() {
-  const r = new Uint8Array(16); crypto.getRandomValues(r);
-  r[6] = (r[6] & 0x0f) | 0x40; r[8] = (r[8] & 0x3f) | 0x80;
-  const h = [...r].map(b => b.toString(16).padStart(2, '0')).join('');
-  return `${h.slice(0,8)}-${h.slice(8,12)}-${h.slice(12,16)}-${h.slice(16,20)}-${h.slice(20)}`;
-}
-function hex(bytes) { return [...bytes].map(b => b.toString(16).padStart(2,'0')).join(''); }
-function nowNs() { return Math.round(performance.timeOrigin * 1e6 + performance.now() * 1e6); }
+// ── wingfoil client + latency tracker ─────────────────────────────────────
+// Server uses CodecKind::Json (see ws_server.rs); the tracker drives the
+// orders → fills → latency_echo loop end-to-end.
 
-// ── UI state ──────────────────────────────────────────────────────────────
-const session = newSessionId();
-const sessionArr = Array.from(session);
-let seq = 0, sent = 0, filled = 0, sumPx = 0, lastRttNs = 0;
-let nextSide = 0;
-let chart, chartData, ticker = null;
+const client = new WingfoilClient({
+  url: `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`,
+  codec: 'json',
+});
 
-document.getElementById('session').textContent = hex(session).slice(0, 8) + '…';
+const tracker = new LatencyTracker({
+  client,
+  outbound: 'orders',
+  inbound:  'fills',
+  echo:     'latency_echo',
+});
+
+document.getElementById('session').textContent = tracker.sessionHex.slice(0, 8) + '…';
 
 // Point the embedded Grafana iframe at the operator dashboard, pre-filtered
 // to this session via the `$session` template variable. Assumes Grafana is
-// on the same host on port 3000 (docker-compose default). `kiosk=tv` hides
-// Grafana chrome; `theme=dark` matches the page.
+// on the same host on port 3000 (docker-compose default).
 (function initGrafana() {
   const origin = `${location.protocol}//${location.hostname}:3000`;
   const url = `${origin}/d/wingfoil-latency-e2e/wingfoil-latency-end-to-end` +
-              `?var-session=${hex(session)}` +
+              `?var-session=${tracker.sessionHex}` +
               `&kiosk=tv&theme=dark&refresh=5s&from=now-15m&to=now`;
   document.getElementById('grafana').src = url;
 })();
+
+// ── UI state ──────────────────────────────────────────────────────────────
+let sent = 0, filled = 0, sumPx = 0;
+let nextSide = 0;
+let chart, chartData, ticker = null;
 
 function setStatus(s) {
   const el = document.getElementById('status');
@@ -75,9 +69,13 @@ function setStatus(s) {
   el.className = 'pill ' + (s === 'live' ? 'live' : 'idle');
 }
 
-// Resolve one STAGES entry to a delta in ns. Server stages read from
-// stamps[]; the wire stage reads rtt_total and server residence, both
-// derived from same-domain subtractions.
+client.onConnection((s) => {
+  if (s.kind === 'open') setStatus('live');
+  else if (s.kind === 'connecting') setStatus('connecting');
+  else setStatus('disconnected');
+});
+
+// ── Per-hop chart and bars ────────────────────────────────────────────────
 function stageNs(entry, stamps, rttTotal) {
   const [, kind, a, b] = entry;
   if (kind === 'server') return stamps[b] - stamps[a];
@@ -135,23 +133,7 @@ function initChart() {
   chart = new uPlot(opts, chartData, document.getElementById('chart'));
 }
 
-// ── wingfoil client ──────────────────────────────────────────────────────
-// The server runs `WebServer::bind(...).codec(CodecKind::Json)`, so the
-// client must be told to speak JSON. The WingfoilClient handles envelope
-// framing, the control-channel handshake (Hello / Subscribe / Unsubscribe),
-// and reconnect.
-
-const client = new WingfoilClient({
-  url: `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`,
-  codec: 'json',
-});
-
-client.onConnection((s) => {
-  if (s.kind === 'open') setStatus('live');
-  else if (s.kind === 'connecting') setStatus('connecting');
-  else setStatus('disconnected');
-});
-
+// ── Order stream control ──────────────────────────────────────────────────
 function startStream() {
   const rate = parseInt(document.getElementById('rate').value, 10);
   const qty = parseInt(document.getElementById('qty').value, 10);
@@ -161,14 +143,9 @@ function startStream() {
     let side;
     if (sideSel === 'alt') { side = nextSide; nextSide ^= 1; }
     else side = parseInt(sideSel, 10);
-    seq += 1; sent += 1;
+    sent += 1;
     document.getElementById('sent').textContent = sent.toLocaleString();
-    client.publish('orders', {
-      session: sessionArr,
-      client_seq: seq,
-      side, qty,
-      t_client_send: nowNs(),
-    });
+    tracker.send({ side, qty });
   }, Math.max(50, Math.floor(1000 / rate)));
   const btn = document.getElementById('start');
   btn.textContent = 'stop'; btn.classList.add('stop');
@@ -187,39 +164,14 @@ window.addEventListener('DOMContentLoaded', () => {
   initChart();
   document.getElementById('start').onclick = startStream;
 
-  client.subscribe('fills', (msg) => {
-    // Filter: only this session's fills.
-    if (!sameId(msg.session, sessionArr)) return;
-    const tRecv = nowNs();
-    const rttTotal = Math.max(0, tRecv - msg.t_client_send);
+  tracker.onResponse((rt) => {
+    const fill = rt.payload;
     filled += 1;
-    sumPx += msg.fill_price_bps;
-    lastRttNs = rttTotal;
+    sumPx += fill.fill_price_bps;
     document.getElementById('filled').textContent = filled.toLocaleString();
     document.getElementById('px').textContent = (sumPx / filled / 10000).toFixed(5);
-    document.getElementById('rtt').textContent = (rttTotal / 1_000_000).toFixed(2) + ' ms';
-    renderStages(msg.stamps, rttTotal);
-    pushChartPoint(msg.stamps, rttTotal);
-    // Echo to the server with t_client_recv stamped. The server
-    // derives rtt_total and wire_rtt from the four stamps, all
-    // arithmetic within a single clock domain per delta.
-    client.publish('latency_echo', {
-      session: sessionArr,
-      client_seq: msg.client_seq,
-      t_client_send: msg.t_client_send,
-      t_client_recv: tRecv,
-      stamps: msg.stamps,
-    });
-  });
-
-  client.subscribe('session', (msg) => {
-    // Reserved — server can broadcast queue state here.
-    console.log('session', msg);
+    document.getElementById('rtt').textContent = (rt.rttNs / 1_000_000).toFixed(2) + ' ms';
+    renderStages(rt.stamps, rt.rttNs);
+    pushChartPoint(rt.stamps, rt.rttNs);
   });
 });
-
-function sameId(a, b) {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-  return true;
-}

--- a/wingfoil/examples/latency_e2e/static/app.js
+++ b/wingfoil/examples/latency_e2e/static/app.js
@@ -3,6 +3,12 @@
 // Emits OrderFrames at the configured rate, listens for FillFrames,
 // stamps a t_client_recv and posts the round-trip back as an EchoFrame.
 // Renders a uPlot chart of the per-hop latency for THIS session.
+//
+// Wire plumbing (envelopes, control frames, JSON codec) is delegated to
+// `@wingfoil/client`, loaded from the npm package via the import map in
+// index.html.
+
+import { WingfoilClient } from "@wingfoil/client";
 
 // Each entry is either a server-clock delta (indices into stamps[]) or
 // the derived `wire_rtt` computed from the client-clock RTT minus the
@@ -41,52 +47,6 @@ function fallbackUuid() {
 }
 function hex(bytes) { return [...bytes].map(b => b.toString(16).padStart(2,'0')).join(''); }
 function nowNs() { return Math.round(performance.timeOrigin * 1e6 + performance.now() * 1e6); }
-
-// ── WebSocket envelope plumbing ──────────────────────────────────────────
-//
-// CodecKind::Json on the server: each WS frame is JSON-encoded
-// `Envelope { topic, time_ns, payload: Vec<u8> }`. The payload is itself
-// the JSON-encoded user type as a byte array. We unwrap one level here
-// so handlers see the actual object.
-
-let ws = null;
-function connect(onMsg) {
-  const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
-  ws = new WebSocket(url);
-  ws.binaryType = 'arraybuffer';
-  ws.onopen = () => {
-    setStatus('live');
-    // Subscribe to the topics we care about.
-    sendCtrl({ Subscribe: { topics: ['fills', 'session'] } });
-  };
-  ws.onclose = () => { setStatus('disconnected'); ws = null; };
-  ws.onerror = (e) => console.warn('ws error', e);
-  ws.onmessage = async (ev) => {
-    const buf = typeof ev.data === 'string'
-      ? new TextEncoder().encode(ev.data)
-      : new Uint8Array(ev.data);
-    let env;
-    try { env = JSON.parse(new TextDecoder().decode(buf)); }
-    catch (e) { console.warn('bad envelope', e); return; }
-    if (env.topic === '$ctrl') return;
-    let payload;
-    try { payload = JSON.parse(new TextDecoder().decode(new Uint8Array(env.payload))); }
-    catch (e) { console.warn('bad payload', env.topic, e); return; }
-    onMsg(env.topic, payload);
-  };
-}
-
-function sendFrame(topic, payloadObj) {
-  if (!ws || ws.readyState !== 1) return;
-  const payloadBytes = new TextEncoder().encode(JSON.stringify(payloadObj));
-  const env = { topic, time_ns: 0, payload: Array.from(payloadBytes) };
-  ws.send(JSON.stringify(env));
-}
-function sendCtrl(ctrl) {
-  const payloadBytes = new TextEncoder().encode(JSON.stringify(ctrl));
-  const env = { topic: '$ctrl', time_ns: 0, payload: Array.from(payloadBytes) };
-  ws.send(JSON.stringify(env));
-}
 
 // ── UI state ──────────────────────────────────────────────────────────────
 const session = newSessionId();
@@ -175,19 +135,35 @@ function initChart() {
   chart = new uPlot(opts, chartData, document.getElementById('chart'));
 }
 
+// ── wingfoil client ──────────────────────────────────────────────────────
+// The server runs `WebServer::bind(...).codec(CodecKind::Json)`, so the
+// client must be told to speak JSON. The WingfoilClient handles envelope
+// framing, the control-channel handshake (Hello / Subscribe / Unsubscribe),
+// and reconnect.
+
+const client = new WingfoilClient({
+  url: `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`,
+  codec: 'json',
+});
+
+client.onConnection((s) => {
+  if (s.kind === 'open') setStatus('live');
+  else if (s.kind === 'connecting') setStatus('connecting');
+  else setStatus('disconnected');
+});
+
 function startStream() {
   const rate = parseInt(document.getElementById('rate').value, 10);
   const qty = parseInt(document.getElementById('qty').value, 10);
   const sideSel = document.getElementById('side').value;
   if (ticker) clearInterval(ticker);
   ticker = setInterval(() => {
-    if (!ws || ws.readyState !== 1) return;
     let side;
     if (sideSel === 'alt') { side = nextSide; nextSide ^= 1; }
     else side = parseInt(sideSel, 10);
     seq += 1; sent += 1;
     document.getElementById('sent').textContent = sent.toLocaleString();
-    sendFrame('orders', {
+    client.publish('orders', {
       session: sessionArr,
       client_seq: seq,
       side, qty,
@@ -210,34 +186,35 @@ function stopStream() {
 window.addEventListener('DOMContentLoaded', () => {
   initChart();
   document.getElementById('start').onclick = startStream;
-  connect((topic, msg) => {
-    if (topic === 'fills') {
-      // Filter: only this session's fills.
-      if (!sameId(msg.session, sessionArr)) return;
-      const tRecv = nowNs();
-      const rttTotal = Math.max(0, tRecv - msg.t_client_send);
-      filled += 1;
-      sumPx += msg.fill_price_bps;
-      lastRttNs = rttTotal;
-      document.getElementById('filled').textContent = filled.toLocaleString();
-      document.getElementById('px').textContent = (sumPx / filled / 10000).toFixed(5);
-      document.getElementById('rtt').textContent = (rttTotal / 1_000_000).toFixed(2) + ' ms';
-      renderStages(msg.stamps, rttTotal);
-      pushChartPoint(msg.stamps, rttTotal);
-      // Echo to the server with t_client_recv stamped. The server
-      // derives rtt_total and wire_rtt from the four stamps, all
-      // arithmetic within a single clock domain per delta.
-      sendFrame('latency_echo', {
-        session: sessionArr,
-        client_seq: msg.client_seq,
-        t_client_send: msg.t_client_send,
-        t_client_recv: tRecv,
-        stamps: msg.stamps,
-      });
-    } else if (topic === 'session') {
-      // Reserved — server can broadcast queue state here.
-      console.log('session', msg);
-    }
+
+  client.subscribe('fills', (msg) => {
+    // Filter: only this session's fills.
+    if (!sameId(msg.session, sessionArr)) return;
+    const tRecv = nowNs();
+    const rttTotal = Math.max(0, tRecv - msg.t_client_send);
+    filled += 1;
+    sumPx += msg.fill_price_bps;
+    lastRttNs = rttTotal;
+    document.getElementById('filled').textContent = filled.toLocaleString();
+    document.getElementById('px').textContent = (sumPx / filled / 10000).toFixed(5);
+    document.getElementById('rtt').textContent = (rttTotal / 1_000_000).toFixed(2) + ' ms';
+    renderStages(msg.stamps, rttTotal);
+    pushChartPoint(msg.stamps, rttTotal);
+    // Echo to the server with t_client_recv stamped. The server
+    // derives rtt_total and wire_rtt from the four stamps, all
+    // arithmetic within a single clock domain per delta.
+    client.publish('latency_echo', {
+      session: sessionArr,
+      client_seq: msg.client_seq,
+      t_client_send: msg.t_client_send,
+      t_client_recv: tRecv,
+      stamps: msg.stamps,
+    });
+  });
+
+  client.subscribe('session', (msg) => {
+    // Reserved — server can broadcast queue state here.
+    console.log('session', msg);
   });
 });
 

--- a/wingfoil/examples/latency_e2e/static/index.html
+++ b/wingfoil/examples/latency_e2e/static/index.html
@@ -27,6 +27,7 @@
     .controls { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin-bottom: 12px; }
     .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; }
     .pill.live { background: rgba(63, 185, 80, 0.15); color: var(--green); }
+    .pill.connecting { background: rgba(240, 136, 62, 0.15); color: #f0883e; }
     .pill.idle { background: rgba(139, 148, 158, 0.15); color: var(--muted); }
     .stage-bar { display: grid; grid-template-columns: 110px 1fr 90px; align-items: center; gap: 8px; margin: 4px 0; font-size: 12px; }
     .stage-bar .name { color: var(--muted); }

--- a/wingfoil/examples/latency_e2e/static/index.html
+++ b/wingfoil/examples/latency_e2e/static/index.html
@@ -86,6 +86,13 @@
     </section>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/uplot@1.6.31/dist/uPlot.iife.min.js"></script>
-  <script src="app.js"></script>
+  <script type="importmap">
+    {
+      "imports": {
+        "@wingfoil/client": "https://esm.sh/@wingfoil/client@4.0.1"
+      }
+    }
+  </script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/wingfoil/examples/latency_e2e/static/index.html
+++ b/wingfoil/examples/latency_e2e/static/index.html
@@ -89,7 +89,8 @@
   <script type="importmap">
     {
       "imports": {
-        "@wingfoil/client": "https://esm.sh/@wingfoil/client@4.0.1"
+        "@wingfoil/client": "https://esm.sh/@wingfoil/client@4.1.0",
+        "@wingfoil/client/tracing": "https://esm.sh/@wingfoil/client@4.1.0/tracing"
       }
     }
   </script>


### PR DESCRIPTION
Introduces a new `LatencyTracker` class in `@wingfoil/client/tracing` that encapsulates the round-trip latency measurement pattern used by wingfoil's `Traced<T, L>` / `latency_stages!` server pipeline.

## Summary

This PR adds first-class support for latency tracing in browser clients, eliminating boilerplate around session management, request stamping, response filtering, and round-trip echo loops. The tracker automatically handles:

- Per-page-load session UUID generation and management
- Outbound request stamping with `client_seq` and `t_client_send`
- Inbound response filtering by session
- Client-side `t_client_recv` capture and latency delta computation
- Optional echo round-trip back to the server

## Key Changes

- **New module `wingfoil-js/src/tracing.ts`**: Exports `LatencyTracker` class and supporting types (`TracingFields`, `LatencyTrackerOptions`, `RoundTrip`, `RoundTripListener`)
- **Utility functions in `wingfoil-js/src/index.ts`**: Extracted and re-exported `newSessionId()`, `sessionHex()`, and `nowNs()` helpers for direct use by consumers
- **Updated example app**: Refactored `wingfoil/examples/latency_e2e/static/app.js` to use `LatencyTracker`, removing ~100 lines of manual session/stamping/echo logic
- **Documentation**: Added latency tracing section to `wingfoil-js/README.md` with usage examples
- **Package exports**: Added `./tracing` subpath export to `package.json`
- **Version bump**: `4.0.1` → `4.1.0`

## Implementation Details

- `LatencyTracker` owns a single browser session's outbound counter and round-trip echo loop
- Field names are configurable via `LatencyTrackerOptions.fields` to support custom wire schemas
- Computed deltas (`rttNs`, `serverResidentNs`, `wireRttNs`) are all same-domain subtractions, requiring no NTP-style clock synchronization
- The listener receives pre-computed `RoundTrip<T>` objects with both raw payload and latency metrics
- Supports cleanup via `close()` method and per-listener unsubscribe functions

https://claude.ai/code/session_01LJUrFh1kJN2jKsw7bEXGRo