### PR TITLE
Remove RouDi availability check from iceoryx2 adapter

### DIFF
--- a/wingfoil/src/adapters/iceoryx2/mod.rs
+++ b/wingfoil/src/adapters/iceoryx2/mod.rs
@@ -271,39 +271,6 @@ impl From<iceoryx2::waitset::WaitSetRunError> for Iceoryx2Error {
     }
 }
 
-/// Check if RouDi daemon is available for IPC services.
-/// Returns an error with helpful message if RouDi is not running.
-/// (Skipped in tests, which run in controlled environments)
-pub fn check_roudi_availability() -> Iceoryx2Result<()> {
-    #[cfg(not(test))]
-    {
-        use std::process::Command;
-
-        // Check if iox-roudi process is running using ps + grep filter
-        let ps_output = Command::new("sh")
-            .args(["-c", "ps aux | grep '[i]ox-roudi' | grep -v grep"])
-            .output();
-
-        match ps_output {
-            Ok(output) if output.status.success() && !output.stdout.is_empty() => {
-                // Process found - RouDi is running
-                Ok(())
-            }
-            _ => Err(Iceoryx2Error::Other(anyhow::anyhow!(
-                "ERROR: RouDi daemon is not running!\n\n\
-                     The iceoryx2 IPC adapter requires the RouDi daemon.\n\n\
-                     To start RouDi, run:\n  \
-                     iox-roudi &\n\n\
-                     Alternative: Use Local variant for in-process testing without RouDi:\n  \
-                     iceoryx2_sub_with::<T>(service_name, Iceoryx2ServiceVariant::Local)"
-            ))),
-        }
-    }
-
-    #[cfg(test)]
-    Ok(())
-}
-
 mod read;
 mod write;
 

--- a/wingfoil/src/adapters/iceoryx2/read.rs
+++ b/wingfoil/src/adapters/iceoryx2/read.rs
@@ -380,9 +380,6 @@ where
 
                 match self.opts.variant {
                     Iceoryx2ServiceVariant::Ipc => {
-                        // Check if RouDi is available before creating node in Spin mode
-                        // (Threaded/Signaled modes will catch errors in background thread)
-                        super::check_roudi_availability()?;
                         let (node, subscriber) = create_subscriber!(
                             ipc::Service,
                             &self.service_name,
@@ -570,9 +567,6 @@ impl crate::MutableNode for Iceoryx2SliceReceiverStream {
                 state.always_callback();
                 match self.opts.variant {
                     Iceoryx2ServiceVariant::Ipc => {
-                        // Check if RouDi is available before creating node in Spin mode
-                        // (Threaded/Signaled modes will catch errors in background thread)
-                        super::check_roudi_availability()?;
                         let (node, subscriber) = create_subscriber!(
                             ipc::Service,
                             &self.service_name,

--- a/wingfoil/src/adapters/iceoryx2/write.rs
+++ b/wingfoil/src/adapters/iceoryx2/write.rs
@@ -121,8 +121,6 @@ macro_rules! create_publisher_and_notifier {
 
 /// Like `create_publisher_and_notifier` but for slice publishers which need
 /// `initial_max_slice_len`.
-/// WARNING: For Ipc variant, service opening can block indefinitely if RouDi daemon is not running.
-/// Use Local variant for local testing without RouDi.
 macro_rules! create_slice_publisher_and_notifier {
     ($svc:ty, $service_name:expr, $variant:expr, $history_size:expr,
      $initial_max_slice_len:expr) => {{
@@ -389,7 +387,6 @@ where
     fn start(&mut self, _state: &mut GraphState) -> anyhow::Result<()> {
         match self.opts.variant {
             Iceoryx2ServiceVariant::Ipc => {
-                super::check_roudi_availability()?;
                 let (node, publisher, notifier) = create_publisher_and_notifier!(
                     ipc::Service,
                     &self.service_name,
@@ -513,7 +510,6 @@ impl MutableNode for Iceoryx2SlicePublisher {
     fn start(&mut self, _state: &mut GraphState) -> anyhow::Result<()> {
         match self.opts.variant {
             Iceoryx2ServiceVariant::Ipc => {
-                super::check_roudi_availability()?;
                 let (node, publisher, notifier) = create_slice_publisher_and_notifier!(
                     ipc::Service,
                     &self.service_name,


### PR DESCRIPTION
## Summary
Removes the `check_roudi_availability()` function and all its call sites from the iceoryx2 adapter. This simplifies the codebase by delegating RouDi availability validation to the underlying iceoryx2 library itself.

## Key Changes
- Deleted the `check_roudi_availability()` function from `mod.rs` that performed process-level checks for the RouDi daemon
- Removed all calls to `check_roudi_availability()` from:
  - `read.rs`: Two call sites in subscriber creation paths (Spin and Threaded/Signaled modes)
  - `write.rs`: Two call sites in publisher creation paths
- Removed associated warning comments about potential blocking behavior when RouDi is unavailable

## Implementation Details
The removal of these explicit checks means that RouDi availability errors will now be caught directly by the iceoryx2 library when attempting to create IPC services, rather than being pre-checked via shell command execution. This reduces unnecessary process spawning and simplifies error handling by relying on the library's native error reporting mechanisms.

https://claude.ai/code/session_01M7QRyvLRrTinAYnK4wZMXr