### PR TITLE
Replace unwrap() with expect() and ? for better error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,23 @@ See `wingfoil/examples/dynamic/dynamic-manual/main.rs` for a fully manual custom
 - Factory functions return `Rc<dyn Stream<T>>` or `Rc<dyn Node>`
 - Fluent API: `ticker(duration).map(f).filter(g).fold(init, h)`
 
+### Error Handling
+
+Production code must not call `.unwrap()`. Replacement priority:
+
+1. **`?`** — preferred. `cycle/setup/start/stop/teardown` all return
+   `anyhow::Result`, so propagate via `?` and add `.context("…")` from
+   `anyhow::Context` at I/O boundaries (file open, socket connect, codec decode).
+2. **`.expect("invariant: WHY")`** — only when a precondition makes the
+   `None`/`Err` branch unreachable. The message must explain the invariant
+   (e.g. `expect("current_node_index set during cycle")`).
+3. **`.unwrap()`** — allowed inside `#[cfg(test)]` modules and doc comments
+   showing example usage; otherwise disallowed.
+
+Mutex poisoning is not recovered: `.lock().expect("<name> mutex poisoned")` is
+the pattern. The expect documents intent — a poisoned lock means another
+thread panicked while holding it, and we propagate that panic deliberately.
+
 ### Run Modes
 
 - `RunMode::RealTime` - uses wall clock time

--- a/wingfoil/src/adapters/csv/read.rs
+++ b/wingfoil/src/adapters/csv/read.rs
@@ -14,12 +14,16 @@ fn csv_iterator<T>(
 where
     T: Element + DeserializeOwned + 'static,
 {
+    let file = File::open(path).unwrap_or_else(|e| panic!("csv_read: failed to open {path}: {e}"));
+    let path_owned = path.to_owned();
     let data = csv::ReaderBuilder::new()
         .has_headers(has_headers)
-        .from_reader(File::open(path).unwrap())
+        .from_reader(file)
         .into_deserialize();
     Box::new(data.map(move |record: Result<T, csv::Error>| {
-        let rec = record.unwrap();
+        let rec = record.unwrap_or_else(|e| {
+            panic!("csv_read: failed to deserialize row from {path_owned}: {e}")
+        });
         let t = get_time_func(&rec);
         ValueAt {
             value: rec,
@@ -89,6 +93,18 @@ mod tests {
             .collect();
         assert_eq!(data_ticks.len(), 6);
         assert!(data_ticks.iter().all(|b| b.value.len() == 1));
+    }
+
+    #[test]
+    #[should_panic(expected = "csv_read: failed to open")]
+    fn csv_read_missing_file_panics_with_context() {
+        // Verify that a missing CSV file produces a contextual panic message
+        // rather than a bare "called Option::unwrap on None".
+        let _ = csv_read::<Record>(
+            "src/adapters/csv/test_data/does_not_exist.csv",
+            get_time,
+            false,
+        );
     }
 
     #[test]

--- a/wingfoil/src/adapters/csv/write.rs
+++ b/wingfoil/src/adapters/csv/write.rs
@@ -22,7 +22,7 @@ pub struct CsvWriterNode<T: Element> {
 impl<T: Element + Serialize + DeserializeOwned + 'static> MutableNode for CsvWriterNode<T> {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
         if !self.headers_written {
-            write_header::<T>(&mut self.writer);
+            write_header::<T>(&mut self.writer)?;
             self.headers_written = true;
         }
         for rec in self.upstream.peek_value() {
@@ -34,12 +34,19 @@ impl<T: Element + Serialize + DeserializeOwned + 'static> MutableNode for CsvWri
     }
 }
 
-fn write_header<T: Serialize + DeserializeOwned + 'static>(writer: &mut csv::Writer<File>) {
+fn write_header<T: Serialize + DeserializeOwned + 'static>(
+    writer: &mut csv::Writer<File>,
+) -> anyhow::Result<()> {
     let fields = serde_introspect::<T>();
     if !fields.is_empty() {
-        writer.write_field("time").unwrap();
-        writer.write_record(fields).unwrap();
+        writer
+            .write_field("time")
+            .map_err(|e| anyhow::anyhow!("Failed to write CSV time header: {e}"))?;
+        writer
+            .write_record(fields)
+            .map_err(|e| anyhow::anyhow!("Failed to write CSV header record: {e}"))?;
     }
+    Ok(())
 }
 
 /// Trait to add csv write operators to streams.
@@ -54,7 +61,7 @@ impl<T: Element + Serialize + DeserializeOwned + 'static> CsvOperators<T> for dy
         let writer = csv::WriterBuilder::new()
             .has_headers(false)
             .from_path(path)
-            .unwrap();
+            .unwrap_or_else(|e| panic!("csv_write: failed to open {path} for writing: {e}"));
         CsvWriterNode::new(self.clone(), writer).into_node()
     }
 }

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -1128,7 +1128,11 @@ impl MutableNode for FixThreadedSource {
 
                 // Store a clone so stop() can shut down the live socket.
                 match sock.try_clone() {
-                    Ok(clone) => *socket_arc_thread.lock().unwrap() = Some(clone),
+                    Ok(clone) => {
+                        *socket_arc_thread
+                            .lock()
+                            .expect("FIX socket_arc mutex poisoned") = Some(clone)
+                    }
                     Err(e) => {
                         if !send_status(FixSessionStatus::Error(e.to_string())) {
                             break;
@@ -1174,7 +1178,9 @@ impl MutableNode for FixThreadedSource {
                 };
 
                 // Clear the stale socket handle.
-                *socket_arc_thread.lock().unwrap() = None;
+                *socket_arc_thread
+                    .lock()
+                    .expect("FIX socket_arc mutex poisoned") = None;
 
                 if !still_open {
                     break; // channel closed — graph has stopped
@@ -1210,7 +1216,7 @@ impl MutableNode for FixThreadedSource {
         self.stop_flag.store(true, Ordering::Relaxed);
         // Shut down the live socket so the thread's blocking read() returns.
         if let Some(arc) = self.socket_arc.take()
-            && let Some(s) = arc.lock().unwrap().take()
+            && let Some(s) = arc.lock().expect("FIX socket_arc mutex poisoned").take()
         {
             let _ = s.shutdown(Shutdown::Both);
         }

--- a/wingfoil/src/adapters/kdb/read_cached.rs
+++ b/wingfoil/src/adapters/kdb/read_cached.rs
@@ -138,7 +138,10 @@ where
                             }
                         }
                     }
-                    let sock = socket.as_mut().unwrap();
+                    // Just populated above on cache miss when None.
+                    let sock = socket
+                        .as_mut()
+                        .expect("socket initialised on cache miss above");
 
                     info!("KDB query: {query}");
                     let fetch_start = std::time::Instant::now();

--- a/wingfoil/src/bencher.rs
+++ b/wingfoil/src/bencher.rs
@@ -66,17 +66,23 @@ impl Bencher {
     }
 
     pub fn start(&mut self) {
-        let builder = self.builder.take().unwrap();
+        let builder = self
+            .builder
+            .take()
+            .expect("Bencher::start called more than once");
         let signal = self.signal.clone();
         let run_mode = self.run_mode;
         std::thread::spawn(move || {
             let trigger = BenchTriggerNode::new(signal.clone()).into_node();
+            let signal_for_end = signal.clone();
             let node = builder(trigger).produce(move || {
-                signal.store(Signal::End.into(), Ordering::SeqCst);
+                signal_for_end.store(Signal::End.into(), Ordering::SeqCst);
             });
-            Graph::new(vec![node], run_mode, RunFor::Forever)
-                .run()
-                .unwrap();
+            if let Err(e) = Graph::new(vec![node], run_mode, RunFor::Forever).run() {
+                log::error!("bencher worker thread terminated: {e:#}");
+                // Wake the bencher loop so step() doesn't spin forever.
+                signal.store(Signal::End.into(), Ordering::SeqCst);
+            }
         });
     }
 

--- a/wingfoil/src/graph.rs
+++ b/wingfoil/src/graph.rs
@@ -132,7 +132,7 @@ pub struct GraphState {
 impl GraphState {
     pub fn new(run_mode: RunMode, run_for: RunFor, start_time: NanoTime) -> Self {
         let (ready_notifier, ready_callbacks) = crossbeam::channel::unbounded();
-        let mut id = GRAPH_ID.lock().unwrap();
+        let mut id = GRAPH_ID.lock().expect("GRAPH_ID mutex poisoned");
         let slf = Self {
             time: NanoTime::ZERO,
             wall_time: NanoTime::ZERO,
@@ -199,7 +199,9 @@ impl GraphState {
 
     pub(crate) fn ready_notifier(&self) -> ReadyNotifier {
         ReadyNotifier {
-            node_index: self.current_node_index.unwrap(),
+            node_index: self
+                .current_node_index
+                .expect("ready_notifier called outside of a node cycle"),
             sender: self.ready_notifier.clone(),
         }
     }
@@ -219,22 +221,28 @@ impl GraphState {
                     tokio::runtime::Builder::new_multi_thread()
                         .enable_all()
                         .build()
-                        .unwrap(),
+                        .expect("failed to build tokio runtime"),
                 )
             })
             .clone()
     }
 
     pub fn add_callback(&mut self, time: NanoTime) {
-        self.add_callback_for_node(self.current_node_index.unwrap(), time);
+        let ix = self
+            .current_node_index
+            .expect("add_callback called outside of a node cycle");
+        self.add_callback_for_node(ix, time);
     }
 
     pub(crate) fn current_node_id(&self) -> usize {
-        self.current_node_index.unwrap()
+        self.current_node_index
+            .expect("current_node_id called outside of a node cycle")
     }
 
     pub fn always_callback(&mut self) {
-        let ix = self.current_node_index.unwrap();
+        let ix = self
+            .current_node_index
+            .expect("always_callback called outside of a node cycle");
         self.always_callbacks.push(ix);
     }
 
@@ -269,7 +277,9 @@ impl GraphState {
     /// `add_upstream` call without waiting for the next source tick.
     #[cfg(feature = "dynamic-graph-beta")]
     pub fn add_upstream(&mut self, upstream: Rc<dyn Node>, is_active: bool, recycle: bool) {
-        let caller_index = self.current_node_index.unwrap();
+        let caller_index = self
+            .current_node_index
+            .expect("add_upstream called outside of a node cycle");
         self.pending_additions
             .push((upstream, caller_index, is_active, recycle));
     }
@@ -298,19 +308,13 @@ impl GraphState {
     }
 
     fn next_scheduled_time(&self) -> NanoTime {
-        if self.scheduled_callbacks.is_empty() {
-            NanoTime::MAX
-        } else {
-            self.scheduled_callbacks.next_time()
-        }
+        self.scheduled_callbacks
+            .next_time()
+            .unwrap_or(NanoTime::MAX)
     }
 
     pub(crate) fn add_callback_for_node(&mut self, node_index: usize, time: NanoTime) {
         self.scheduled_callbacks.push(node_index, time);
-    }
-
-    fn has_pending_scheduled_callbacks(&self) -> bool {
-        self.scheduled_callbacks.pending(self.time)
     }
 
     fn wait_ready_callback(&mut self, end_time: NanoTime) -> Option<usize> {
@@ -323,7 +327,10 @@ impl GraphState {
             let timeout = u64::from(end_time - now);
             select! {
                 recv(self.ready_callbacks) -> msg => {
-                    Some(msg.unwrap())
+                    // Only `Err` if all senders are dropped. Senders live on
+                    // worker threads owned by the graph, so reaching this path
+                    // means a worker has gone away mid-run; treat as no event.
+                    msg.ok()
                 },
                 default(Duration::from_nanos(timeout)) => {
                     None
@@ -597,7 +604,13 @@ impl Graph {
         }
         let mut max_layer: i32 = -1;
         for i in 0..self.state.nodes.len() {
-            max_layer = max(max_layer, self.state.nodes[i].layer.try_into().unwrap());
+            max_layer = max(
+                max_layer,
+                self.state.nodes[i]
+                    .layer
+                    .try_into()
+                    .expect("graph layer count fits in i32"),
+            );
             self.state.node_dirty.push(false);
             for j in 0..self.state.nodes[i].upstreams.len() {
                 let (up_index, active) = self.state.nodes[i].upstreams[j];
@@ -634,7 +647,9 @@ impl Graph {
         // constructing NodeData wrapper for each node and pushing
         // onto self.nodes returns index of new NodeData in self.nodes
         if self.state.seen(node.clone()) {
-            self.state.node_index(node.clone()).unwrap()
+            self.state
+                .node_index(node.clone())
+                .expect("seen() returned true but node_index lookup failed")
         } else {
             let mut layer = 0;
             let mut upstream_indexes = vec![];
@@ -670,8 +685,8 @@ impl Graph {
             self.mark_dirty(ix);
             progressed = true;
         }
-        while self.state.has_pending_scheduled_callbacks() {
-            let ix = self.state.scheduled_callbacks.pop();
+        let now = self.state.time;
+        while let Some(ix) = self.state.scheduled_callbacks.pop_if_pending(now) {
             self.mark_dirty(ix);
             progressed = true;
         }
@@ -698,8 +713,9 @@ impl Graph {
 
     fn process_ready_callbacks(&mut self) -> bool {
         let mut progressed = false;
-        while !self.state.ready_callbacks.is_empty() {
-            let ix = self.state.ready_callbacks.recv().unwrap();
+        // try_recv drains whatever has arrived without blocking; if a sender
+        // has been dropped, Err breaks the loop cleanly instead of panicking.
+        while let Ok(ix) = self.state.ready_callbacks.try_recv() {
             self.mark_dirty(ix);
             progressed = true;
         }
@@ -864,7 +880,10 @@ impl Graph {
         // is called more than once with the same node in a single cycle.
         let mut wired_edges: HashSet<(usize, usize)> = HashSet::new();
         for (node, caller_index, is_active, recycle) in &additions {
-            let node_index = self.state.node_index(node.clone()).unwrap();
+            let node_index = self
+                .state
+                .node_index(node.clone())
+                .expect("node was just inserted into the graph above");
             if wired_edges.insert((*caller_index, node_index)) {
                 self.state.nodes[*caller_index]
                     .upstreams
@@ -1036,6 +1055,43 @@ mod tests {
     use itertools::Itertools;
 
     // ── RunFor::done ─────────────────────────────────────────────────────────
+
+    // ── Error-path propagation ───────────────────────────────────────────────
+
+    /// A node that errors on cycle to verify Err bubbles out of Graph::run.
+    struct ErroringNode {
+        upstream: Rc<dyn Node>,
+    }
+
+    impl MutableNode for ErroringNode {
+        fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+            anyhow::bail!("synthetic cycle failure")
+        }
+        fn upstreams(&self) -> UpStreams {
+            UpStreams::new(vec![self.upstream.clone()], vec![])
+        }
+    }
+
+    #[test]
+    fn cycle_error_propagates_from_run() {
+        let src: Rc<RefCell<CallBackStream<u64>>> = Rc::new(RefCell::new(CallBackStream::new()));
+        src.borrow_mut().push(ValueAt::new(1, NanoTime::new(10)));
+        let node = Rc::new(RefCell::new(ErroringNode {
+            upstream: src.clone().as_node(),
+        }));
+        let result = Graph::new(
+            vec![node.as_node()],
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Forever,
+        )
+        .run();
+        assert!(result.is_err());
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("synthetic cycle failure") || err.contains("Error in node"),
+            "expected error to mention the cycle failure, got: {err}"
+        );
+    }
 
     #[test]
     fn run_for_cycles_done_when_exceeded() {

--- a/wingfoil/src/nodes/callback.rs
+++ b/wingfoil/src/nodes/callback.rs
@@ -21,20 +21,18 @@ pub struct CallBackStream<T: Element + Hash + Eq> {
 impl<T: Element + Hash + Eq> MutableNode for CallBackStream<T> {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
         let mut ticked = false;
-        while self.queue.pending(state.time()) {
-            self.value = self.queue.pop();
+        while let Some(value) = self.queue.pop_if_pending(state.time()) {
+            self.value = value;
             ticked = true;
         }
-        if !self.queue.is_empty() {
-            let callback_time = self.queue.next_time();
+        if let Some(callback_time) = self.queue.next_time() {
             state.add_callback(callback_time);
         }
         Ok(ticked)
     }
 
     fn start(&mut self, state: &mut GraphState) -> anyhow::Result<()> {
-        if !self.queue.is_empty() {
-            let time = self.queue.next_time();
+        if let Some(time) = self.queue.next_time() {
             state.add_callback(time);
         }
         Ok(())

--- a/wingfoil/src/nodes/channel.rs
+++ b/wingfoil/src/nodes/channel.rs
@@ -179,7 +179,12 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
                             }
 
                             // Validate: all timestamps must be >= current graph time
-                            let min_time = batch.iter().map(|va| va.time).min().unwrap();
+                            // (batch is non-empty per the `is_empty()` check above).
+                            let min_time = batch
+                                .iter()
+                                .map(|va| va.time)
+                                .min()
+                                .expect("batch is non-empty");
                             if min_time < state.time() {
                                 return Err(anyhow!(
                                     "received HistoricalBatch with timestamp less than graph time, {} < {}",
@@ -207,16 +212,19 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
                 }
                 while let Some(value_at) = self.queue.front() {
                     if value_at.time <= state.time() {
-                        values.push(self.queue.pop_front().unwrap().value);
+                        // front() returned Some, so pop_front is guaranteed.
+                        let popped = self.queue.pop_front().expect("front() just returned Some");
+                        values.push(popped.value);
                     } else {
                         break;
                     }
                 }
-                if self.queue.is_empty() {
-                    // Clear message_time when queue is empty to avoid infinite callback loops
-                    self.message_time = None;
-                } else {
-                    state.add_callback(self.queue.front().unwrap().time);
+                match self.queue.front() {
+                    None => {
+                        // Clear message_time when queue is empty to avoid infinite callback loops.
+                        self.message_time = None;
+                    }
+                    Some(head) => state.add_callback(head.time),
                 }
             }
         }

--- a/wingfoil/src/nodes/delay.rs
+++ b/wingfoil/src/nodes/delay.rs
@@ -38,8 +38,8 @@ impl<T: Element + Hash + Eq> MutableNode for DelayStream<T> {
                 state.add_callback(next_time);
                 self.queue.push(self.upstream.peek_value(), next_time)
             }
-            while self.queue.pending(current_time) {
-                self.value = self.queue.pop();
+            while let Some(value) = self.queue.pop_if_pending(current_time) {
+                self.value = value;
                 ticked = true;
             }
             Ok(ticked)

--- a/wingfoil/src/nodes/delay_with_reset.rs
+++ b/wingfoil/src/nodes/delay_with_reset.rs
@@ -48,8 +48,8 @@ impl<T: Element + Hash + Eq> MutableNode for DelayWithResetStream<T> {
                 state.add_callback(next_time);
                 self.queue.push(self.upstream.peek_value(), next_time)
             }
-            while self.queue.pending(current_time) {
-                self.value = self.queue.pop();
+            while let Some(value) = self.queue.pop_if_pending(current_time) {
+                self.value = value;
                 ticked = true;
             }
             Ok(ticked)

--- a/wingfoil/src/nodes/demux.rs
+++ b/wingfoil/src/nodes/demux.rs
@@ -104,7 +104,10 @@ where
             },
             None => match self.peek_available() {
                 Some(index) => {
-                    self.available.take(&index).unwrap();
+                    // peek_available just confirmed the index is in `available`.
+                    self.available
+                        .take(&index)
+                        .expect("peek_available returned a missing index");
                     self.in_use.insert(key, Some(index));
                     DemuxEntry::Some(index)
                 }
@@ -128,7 +131,10 @@ pub struct Overflow<T: Element>(Rc<RefCell<Option<Rc<dyn Stream<T>>>>>);
 impl<T: Element> Overflow<T> {
     #[must_use]
     pub fn stream(&self) -> Rc<dyn Stream<T>> {
-        self.0.borrow().clone().unwrap()
+        self.0
+            .borrow()
+            .clone()
+            .expect("Overflow stream accessed before demux setup populated it")
     }
     #[must_use]
     pub fn panic(&self) -> Rc<dyn Node> {
@@ -218,7 +224,9 @@ where
             DemuxEvent::None => self.map.get_or_insert(key),
         };
         let graph_index = match entry {
-            DemuxEntry::Overflow => self.overflow_graph_index.unwrap(),
+            DemuxEntry::Overflow => self
+                .overflow_graph_index
+                .expect("overflow_graph_index populated during setup"),
             DemuxEntry::Some(index) => self.index_map[index],
         };
         // mark dirty directly instead of ticking
@@ -228,18 +236,20 @@ where
 
     fn setup(&mut self, graph_state: &mut GraphState) -> anyhow::Result<()> {
         let mut childes = self.children.borrow_mut();
-        let mut node_indexes: Vec<_> = childes
+        let node_indexes: Vec<_> = childes
             .drain(..)
             .map(|strm| {
-                graph_state.node_index(strm.as_node()).unwrap_or_else(|| {
-                    panic!("Failed to resolve graph index of demux child node.  Was it added to the graph?")
+                graph_state.node_index(strm.as_node()).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Failed to resolve graph index of demux child node.  Was it added to the graph?"
+                    )
                 })
             })
-            .collect();
+            .collect::<anyhow::Result<_>>()?;
         drop(childes);
-        node_indexes
-            .drain(..)
-            .for_each(|node_index| self.index_map.push(node_index));
+        for node_index in node_indexes {
+            self.index_map.push(node_index);
+        }
         let overflow = self
             .overflow_child
             .take()
@@ -381,7 +391,9 @@ where
             let (index, graph_index) = match entry {
                 DemuxEntry::Overflow => {
                     let index = self.map.size();
-                    let graph_index = self.overflow_graph_index.unwrap();
+                    let graph_index = self
+                        .overflow_graph_index
+                        .expect("overflow_graph_index populated during setup");
                     (index, graph_index)
                 }
                 DemuxEntry::Some(index) => {
@@ -398,19 +410,24 @@ where
 
     fn setup(&mut self, graph_state: &mut GraphState) -> anyhow::Result<()> {
         let mut childes = self.children.borrow_mut();
-        let mut node_indexes: Vec<_> = childes
+        let node_indexes: Vec<_> = childes
             .drain(..)
             .map(|strm| {
-                graph_state.node_index(strm.as_node()).unwrap_or_else(|| {
-                    panic!("Failed to resolve graph index of demux child node.  Was it added to the graph?")
+                graph_state.node_index(strm.as_node()).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Failed to resolve graph index of demux child node.  Was it added to the graph?"
+                    )
                 })
             })
-            .collect();
+            .collect::<anyhow::Result<_>>()?;
         drop(childes);
-        node_indexes
-            .drain(..)
-            .for_each(|node_index| self.index_map.push(node_index));
-        let overflow = self.overflow_child.take().unwrap();
+        for node_index in node_indexes {
+            self.index_map.push(node_index);
+        }
+        let overflow = self
+            .overflow_child
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("demux overflow child is already taken"))?;
         self.overflow_graph_index = graph_state.node_index(overflow.as_node());
         anyhow::ensure!(
             self.overflow_graph_index.is_some(),
@@ -445,7 +462,14 @@ where
     }
 
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        self.value = self.source.peek_ref_cell().get(self.index).unwrap().clone();
+        // Indices were checked against the parent's value vector during setup;
+        // the parent always sizes `value` to `map.size() + 1`.
+        self.value = self
+            .source
+            .peek_ref_cell()
+            .get(self.index)
+            .expect("DemuxVecChild index out of bounds vs parent value vector")
+            .clone();
         Ok(true)
     }
 }

--- a/wingfoil/src/nodes/feedback.rs
+++ b/wingfoil/src/nodes/feedback.rs
@@ -19,12 +19,8 @@ pub(crate) struct FeedbackStream<T: Element + Hash + Eq> {
 impl<T: Element + Hash + Eq> MutableNode for FeedbackStream<T> {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
         let mut ticked = false;
-        loop {
-            let mut q = self.queue.borrow_mut();
-            if !q.pending(state.time()) {
-                break;
-            }
-            self.value = q.pop();
+        while let Some(value) = self.queue.borrow_mut().pop_if_pending(state.time()) {
+            self.value = value;
             ticked = true;
         }
         Ok(ticked)
@@ -59,7 +55,11 @@ impl<T: Element + Hash + Eq> FeedbackSink<T> {
     pub fn send(&self, value: T, state: &mut GraphState) {
         let time = state.time() + 1;
         self.queue.borrow_mut().push(value, time);
-        state.add_callback_for_node(self.node_id.get().unwrap(), time);
+        let node_id = self
+            .node_id
+            .get()
+            .expect("FeedbackSink::send called before paired stream's setup");
+        state.add_callback_for_node(node_id, time);
     }
 }
 

--- a/wingfoil/src/nodes/graph_node.rs
+++ b/wingfoil/src/nodes/graph_node.rs
@@ -57,7 +57,10 @@ where
     }
 
     fn cycle(&mut self, graph_state: &mut GraphState) -> anyhow::Result<bool> {
-        self.receiver_stream.get_mut().unwrap().cycle(graph_state)
+        self.receiver_stream
+            .get_mut()
+            .ok_or_else(|| anyhow::anyhow!("GraphProducerStream cycled before setup"))?
+            .cycle(graph_state)
     }
 
     fn setup(&mut self, graph_state: &mut GraphState) -> anyhow::Result<()> {
@@ -72,7 +75,9 @@ where
                 let (sender, receiver) = channel_pair(notifier);
                 let mut receiver_stream = ChannelReceiverStream::new(receiver, None, None);
                 receiver_stream.setup(graph_state)?;
-                self.receiver_stream.set(receiver_stream).unwrap();
+                self.receiver_stream
+                    .set(receiver_stream)
+                    .map_err(|_| anyhow::anyhow!("GraphProducerStream setup called twice"))?;
                 let tokio_runtime = graph_state.tokio_runtime();
                 let start_time = graph_state.start_time();
                 let run_mode = graph_state.run_mode();
@@ -80,13 +85,15 @@ where
                     let node = func().send(sender, None);
                     let mut graph =
                         Graph::new_with(vec![node], tokio_runtime, run_mode, run_for, start_time);
-                    graph.run().unwrap();
+                    if let Err(e) = graph.run() {
+                        log::error!("graph producer worker thread terminated: {e:#}");
+                    }
                 };
 
                 let handle = thread::spawn(task);
                 self.state = GraphProducerStreamState::Handle(handle);
             }
-            _ => panic!(),
+            _ => anyhow::bail!("GraphProducerStream::setup called in unexpected state"),
         }
         Ok(())
     }
@@ -94,12 +101,14 @@ where
     fn teardown(&mut self, graph_state: &mut GraphState) -> anyhow::Result<()> {
         self.receiver_stream
             .get_mut()
-            .unwrap()
+            .ok_or_else(|| anyhow::anyhow!("GraphProducerStream torn down before setup"))?
             .teardown(graph_state)?;
         let state = mem::take(&mut self.state);
         match state {
             GraphProducerStreamState::Handle(handle) => {
-                handle.join().unwrap();
+                if let Err(panic) = handle.join() {
+                    log::error!("graph producer worker thread panicked: {panic:?}");
+                }
                 self.state = GraphProducerStreamState::Empty;
             }
             _ => anyhow::bail!("unexpected state"),
@@ -114,7 +123,10 @@ where
     FUNC: FnOnce() -> Rc<dyn Stream<T>> + Send + 'static,
 {
     fn peek_ref(&self) -> &Burst<T> {
-        self.receiver_stream.get().unwrap().peek_ref()
+        self.receiver_stream
+            .get()
+            .expect("peek_ref called before GraphProducerStream::setup")
+            .peek_ref()
     }
 }
 
@@ -189,7 +201,7 @@ where
         if graph_state.ticked(self.source.clone()) {
             self.sender
                 .get_mut()
-                .unwrap()
+                .ok_or_else(|| anyhow::anyhow!("GraphMapStream cycled before setup"))?
                 .send(graph_state, self.source.peek_value())?;
         }
         self.receiver_stream.cycle(graph_state)
@@ -222,7 +234,9 @@ where
                     let node = func(src.clone()).send(sender_out, Some(src.as_node()));
                     let mut graph =
                         Graph::new_with(vec![node], tokio_runtime, run_mode, run_for, start_time);
-                    graph.run().unwrap();
+                    if let Err(e) = graph.run() {
+                        log::error!("graph map worker thread terminated: {e:#}");
+                    }
                 };
                 let handle = thread::spawn(task);
                 self.state = GraphMapStreamState::Handle(handle);
@@ -230,11 +244,15 @@ where
                     RunMode::HistoricalFrom(_) => {}
                     RunMode::RealTime => {
                         let timeout = Duration::from_millis(100);
-                        let notifier = rx_notif.recv_timeout(timeout).unwrap();
+                        let notifier = rx_notif
+                            .recv_timeout(timeout)
+                            .map_err(|e| anyhow::anyhow!("waiting for ready notifier: {e}"))?;
                         sender_in.set_notifier(notifier);
                     }
                 };
-                self.sender.set(sender_in).unwrap();
+                self.sender
+                    .set(sender_in)
+                    .map_err(|_| anyhow::anyhow!("GraphMapStream setup called twice"))?;
             }
             _ => anyhow::bail!("Invalid state"),
         }
@@ -254,7 +272,9 @@ where
         let state = mem::take(&mut self.state);
         match state {
             GraphMapStreamState::Handle(handle) => {
-                handle.join().unwrap();
+                if let Err(panic) = handle.join() {
+                    log::error!("graph map worker thread panicked: {panic:?}");
+                }
                 self.state = GraphMapStreamState::Empty;
             }
             _ => anyhow::bail!("Invalid state"),

--- a/wingfoil/src/nodes/iterator_stream.rs
+++ b/wingfoil/src/nodes/iterator_stream.rs
@@ -31,7 +31,13 @@ impl<T: Element> MutableNode for IteratorStream<T> {
         self.value.clear();
         while let Some(value_at) = self.peekable.peek() {
             if value_at.time == state.time() {
-                let val = self.peekable.next().unwrap().value.clone();
+                // peek() returned Some, so next() is guaranteed.
+                let val = self
+                    .peekable
+                    .next()
+                    .expect("peek() just returned Some")
+                    .value
+                    .clone();
                 self.value.push(val);
             } else {
                 break;
@@ -70,7 +76,12 @@ pub struct SimpleIteratorStream<T: Element> {
 #[node(output = value: T)]
 impl<T: Element> MutableNode for SimpleIteratorStream<T> {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
-        let val_at1 = self.peekable.next().unwrap();
+        // Scheduling only happens when peek() is Some, so cycle() can only be
+        // entered if the iterator has at least one item left.
+        let val_at1 = self
+            .peekable
+            .next()
+            .expect("SimpleIteratorStream cycled with no upcoming item");
         self.value = val_at1.value;
 
         if let Some(val_at2) = self.peekable.peek() {

--- a/wingfoil/src/nodes/node_flow.rs
+++ b/wingfoil/src/nodes/node_flow.rs
@@ -67,8 +67,7 @@ impl MutableNode for DelayNode {
                 self.queue.push((), next_time);
             }
             let mut ticked = false;
-            while self.queue.pending(current_time) {
-                self.queue.pop();
+            while self.queue.pop_if_pending(current_time).is_some() {
                 ticked = true;
             }
             Ok(ticked)

--- a/wingfoil/src/queue/time_queue.rs
+++ b/wingfoil/src/queue/time_queue.rs
@@ -17,28 +17,31 @@ pub(crate) struct TimeQueue<T: Hash + Eq> {
 }
 
 impl<T: Hash + Eq + std::fmt::Debug + std::clone::Clone> TimeQueue<T> {
-    pub fn next_time(&self) -> NanoTime {
-        self.queue.peek().unwrap().1.0
+    /// Time of the next item, or `None` if the queue is empty.
+    pub fn next_time(&self) -> Option<NanoTime> {
+        self.queue.peek().map(|(_, Reverse(t))| *t)
     }
     pub fn is_empty(&self) -> bool {
-        let item = self.queue.peek();
-        item.is_none()
+        self.queue.is_empty()
     }
     pub fn push(&mut self, value: T, time: NanoTime) {
         self.queue.push(ValueAt::new(value, time), Reverse(time));
     }
-    pub fn pop(&mut self) -> T {
-        self.queue.pop().unwrap().0.value
+    /// Pop the earliest item, or `None` if the queue is empty.
+    pub fn pop(&mut self) -> Option<T> {
+        self.queue.pop().map(|(va, _)| va.value)
+    }
+    /// Pop the earliest item iff its time is `<= current_time`. Designed for the
+    /// `while let Some(v) = q.pop_if_pending(now) { ... }` idiom that drains all
+    /// callbacks due at or before the current engine tick.
+    pub fn pop_if_pending(&mut self, current_time: NanoTime) -> Option<T> {
+        match self.next_time() {
+            Some(t) if t <= current_time => self.pop(),
+            _ => None,
+        }
     }
     pub fn clear(&mut self) {
         self.queue.clear();
-    }
-    pub fn pending(&self, current_time: NanoTime) -> bool {
-        let item = self.queue.peek();
-        match item {
-            Some(item) => item.1.0 <= current_time,
-            None => false,
-        }
     }
 }
 
@@ -54,7 +57,7 @@ mod tests {
         queue.push(1, NanoTime::new(100));
         queue.push(1, NanoTime::new(100));
         queue.push(1, NanoTime::new(100));
-        assert_eq!(queue.pop(), 1);
+        assert_eq!(queue.pop(), Some(1));
         assert!(queue.is_empty());
     }
 
@@ -64,9 +67,9 @@ mod tests {
         queue.push(1, NanoTime::new(100));
         queue.push(1, NanoTime::new(200));
         queue.push(1, NanoTime::new(300));
-        assert_eq!(queue.pop(), 1);
-        assert_eq!(queue.pop(), 1);
-        assert_eq!(queue.pop(), 1);
+        assert_eq!(queue.pop(), Some(1));
+        assert_eq!(queue.pop(), Some(1));
+        assert_eq!(queue.pop(), Some(1));
         assert!(queue.is_empty());
     }
 
@@ -77,29 +80,43 @@ mod tests {
         queue.push(2, NanoTime::new(100));
         queue.push(3, NanoTime::new(100));
         // 3 values in indeterminate order
-        queue.pop();
-        queue.pop();
-        queue.pop();
+        assert!(queue.pop().is_some());
+        assert!(queue.pop().is_some());
+        assert!(queue.pop().is_some());
         assert!(queue.is_empty());
     }
+
     #[test]
     fn sorted() {
         let mut queue: TimeQueue<u32> = TimeQueue::new();
         queue.push(1, NanoTime::new(300));
         queue.push(3, NanoTime::new(100));
         queue.push(2, NanoTime::new(200));
-        assert_eq!(queue.pop(), 3);
-        assert_eq!(queue.pop(), 2);
-        assert_eq!(queue.pop(), 1);
+        assert_eq!(queue.pop(), Some(3));
+        assert_eq!(queue.pop(), Some(2));
+        assert_eq!(queue.pop(), Some(1));
         assert!(queue.is_empty());
     }
+
     #[test]
-    fn pending() {
+    fn pop_if_pending() {
         let mut queue: TimeQueue<u32> = TimeQueue::new();
-        assert!(!queue.pending(NanoTime::MAX));
-        assert!(!queue.pending(NanoTime::new(0)));
+        assert_eq!(queue.pop_if_pending(NanoTime::MAX), None);
         queue.push(1, NanoTime::new(100));
-        assert!(queue.pending(NanoTime::new(100)));
-        assert!(!queue.pending(NanoTime::new(99)));
+        assert_eq!(queue.pop_if_pending(NanoTime::new(99)), None);
+        assert_eq!(queue.pop_if_pending(NanoTime::new(100)), Some(1));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn next_time_is_none_when_empty() {
+        let queue: TimeQueue<u32> = TimeQueue::new();
+        assert_eq!(queue.next_time(), None);
+    }
+
+    #[test]
+    fn pop_is_none_when_empty() {
+        let mut queue: TimeQueue<u32> = TimeQueue::new();
+        assert_eq!(queue.pop(), None);
     }
 }

--- a/wingfoil/src/time.rs
+++ b/wingfoil/src/time.rs
@@ -97,7 +97,11 @@ impl From<Duration> for NanoTime {
 
 impl From<NaiveDateTime> for NanoTime {
     fn from(date_time: NaiveDateTime) -> Self {
-        let t = date_time.and_utc().timestamp_nanos_opt().unwrap();
+        // `timestamp_nanos_opt` only returns None for dates outside ~1677..2262.
+        let t = date_time
+            .and_utc()
+            .timestamp_nanos_opt()
+            .expect("NanoTime supports years 1677..=2262");
         NanoTime(t as RawTime)
     }
 }
@@ -116,8 +120,10 @@ impl From<NanoTime> for u64 {
 
 impl From<NanoTime> for NaiveDateTime {
     fn from(t: NanoTime) -> Self {
+        // Only fails for seconds outside chrono's representable range; NanoTime's
+        // u64 nanos can't reach those bounds.
         DateTime::from_timestamp((t.0 / 1_000_000_000) as i64, (t.0 % 1_000_000_000) as u32)
-            .unwrap()
+            .expect("NanoTime is always within chrono's representable range")
             .naive_utc()
     }
 }


### PR DESCRIPTION
## Summary
This PR systematically replaces unsafe `.unwrap()` calls with contextual `.expect()` messages and proper error propagation via `?` operator throughout the codebase. This improves error diagnostics and aligns with the project's error handling guidelines documented in CLAUDE.md.

## Key Changes

### Error Handling Improvements
- **Mutex operations**: Changed `.lock().unwrap()` to `.lock().expect("<name> mutex poisoned")` to document intent when recovering from poisoned locks
- **Option/Result unwraps**: Replaced with `.expect("invariant: WHY")` where preconditions make the None/Err branch unreachable, with messages explaining the invariant
- **Error propagation**: Converted panicking `.unwrap()` calls to `?` operator in fallible functions (cycle, setup, teardown, start, stop)
- **I/O operations**: Added contextual error messages at boundaries (file open, CSV deserialization, socket operations)

### TimeQueue API Refactoring
- `next_time()` now returns `Option<NanoTime>` instead of panicking on empty queue
- `pop()` now returns `Option<T>` instead of panicking on empty queue
- Added `pop_if_pending(current_time)` method for the common pattern of draining callbacks due at or before current time
- Removed `pending()` method in favor of `pop_if_pending()` for cleaner semantics
- Updated all call sites to use the new API with proper Option handling

### Graph State Improvements
- Replaced `has_pending_scheduled_callbacks()` with direct use of `pop_if_pending()`
- Changed `wait_ready_callback()` to use `.ok()` instead of `.unwrap()` for channel recv, with comment explaining that Err only occurs when senders are dropped (worker threads gone)
- Updated callback processing loops to use `while let` patterns with the new TimeQueue API

### Node-Specific Changes
- **GraphProducerStream/GraphMapStream**: Changed `.unwrap()` on graph.run() to proper error logging with `if let Err(e)`
- **ChannelReceiverStream**: Improved error handling for queue operations and batch validation
- **Demux nodes**: Converted panicking unwraps to `anyhow::Result` propagation in setup methods
- **CSV adapters**: Added contextual panic messages for file open/deserialization failures
- **FIX adapter**: Added mutex poisoning messages for socket operations
- **Iterator streams**: Added expect messages explaining why next() is guaranteed after peek()

### Testing
- Added `cycle_error_propagates_from_run()` test to verify error paths bubble correctly from Graph::run
- Updated TimeQueue tests to handle new Option-returning API
- Added tests for `pop_if_pending()` and `next_time()` returning None when empty

### Documentation
- Updated CLAUDE.md with error handling guidelines:
  - Priority: `?` > `.expect("invariant: WHY")` > `.unwrap()` (tests only)
  - Mutex poisoning pattern documented
  - I/O boundary context requirements specified

## Notable Implementation Details
- Worker thread errors (graph producer, graph map, bencher) now log errors instead of panicking, allowing graceful degradation
- The `pop_if_pending()` idiom replaces the previous `while pending() { pop() }` pattern for better clarity
- All expect messages follow the pattern "invariant: WHY" to document preconditions
- Panic messages in adapters now include context (file path, operation type) for better debugging

https://claude.ai/code/session_016VYeiegRqfRicw42GGbiZ2