### PR TITLE
Fix iceoryx2 type compatibility across binaries with #[type_name]

### DIFF
--- a/wingfoil-derive/src/lib.rs
+++ b/wingfoil-derive/src/lib.rs
@@ -2,7 +2,8 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
 use syn::{
-    Ident, ImplItem, ImplItemFn, ItemImpl, Token, Type, Visibility, braced, bracketed,
+    Attribute, Ident, ImplItem, ImplItemFn, ItemImpl, LitStr, Token, Type, Visibility, braced,
+    bracketed,
     parse::{Parse, ParseStream},
     parse_macro_input,
     punctuated::Punctuated,
@@ -173,10 +174,36 @@ struct LatencyStagesInput {
     visibility: Visibility,
     name: Ident,
     stages: Vec<Ident>,
+    type_name_override: Option<LitStr>,
 }
 
 impl Parse for LatencyStagesInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let mut type_name_override: Option<LitStr> = None;
+        for attr in &attrs {
+            if attr.path().is_ident("type_name") {
+                if type_name_override.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        attr,
+                        "duplicate #[type_name(...)] attribute",
+                    ));
+                }
+                let lit: LitStr = attr.parse_args().map_err(|_| {
+                    syn::Error::new_spanned(
+                        attr,
+                        "expected #[type_name(\"...\")] with a single string literal",
+                    )
+                })?;
+                type_name_override = Some(lit);
+            } else {
+                return Err(syn::Error::new_spanned(
+                    attr,
+                    "unrecognized attribute on latency_stages!; only #[type_name(\"...\")] is supported",
+                ));
+            }
+        }
+
         let visibility: Visibility = input.parse()?;
         let name: Ident = input.parse()?;
         let content;
@@ -193,6 +220,7 @@ impl Parse for LatencyStagesInput {
             visibility,
             name,
             stages,
+            type_name_override,
         })
     }
 }
@@ -248,6 +276,7 @@ pub fn latency_stages(item: TokenStream) -> TokenStream {
         visibility,
         name,
         stages,
+        type_name_override,
     } = input;
 
     let n = stages.len();
@@ -256,6 +285,12 @@ pub fn latency_stages(item: TokenStream) -> TokenStream {
     let stage_indices: Vec<usize> = (0..n).collect();
     let field_names = &stages;
     let marker_names = &stages;
+    let zero_copy_send_body = match type_name_override {
+        Some(lit) => quote! {
+            unsafe fn type_name() -> &'static str { #lit }
+        },
+        None => quote! {},
+    };
 
     let expanded = quote! {
         #[repr(C)]
@@ -299,7 +334,9 @@ pub fn latency_stages(item: TokenStream) -> TokenStream {
         // invariants. Only emitted when the `iceoryx2-beta` feature is on
         // in the consuming crate.
         #[cfg(feature = "iceoryx2-beta")]
-        unsafe impl ::iceoryx2::prelude::ZeroCopySend for #name {}
+        unsafe impl ::iceoryx2::prelude::ZeroCopySend for #name {
+            #zero_copy_send_body
+        }
 
         #[allow(non_snake_case, non_camel_case_types)]
         #visibility mod #module_name {

--- a/wingfoil/examples/latency_e2e/shared.rs
+++ b/wingfoil/examples/latency_e2e/shared.rs
@@ -33,8 +33,16 @@ pub const SIDE_SELL: u8 = 1;
 ///
 /// `#[repr(C)]` + `ZeroCopySend` so the whole `Traced<RoundTrip, RoundTripLatency>`
 /// can be transported by iceoryx2 without serialization.
+///
+/// `#[type_name(...)]` pins the iceoryx2 type identifier to a string that's
+/// stable across binaries. Without it, the default
+/// `core::any::type_name::<Self>()` embeds the binary-specific module path
+/// (`latency_e2e_fix_gw::shared::RoundTrip` vs
+/// `latency_e2e_ws_server::shared::RoundTrip`), and iceoryx2 reports
+/// `IncompatibleTypes` when the second binary opens the service.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, ZeroCopySend, Serialize, Deserialize)]
+#[type_name("wingfoil::latency_e2e::RoundTrip")]
 pub struct RoundTrip {
     pub session: SessionId,
     pub client_seq: u64,
@@ -54,7 +62,11 @@ pub struct RoundTrip {
 // Stage order = offset order in the on-wire [u64; 9] view of the record.
 // The first five stages are stamped on the outbound leg, the last four on
 // the inbound leg after the fill is matched.
+//
+// `#[type_name(...)]` pins the iceoryx2 type identifier to a binary-stable
+// string (see the matching note on `RoundTrip`).
 latency_stages! {
+    #[type_name("wingfoil::latency_e2e::RoundTripLatency")]
     pub RoundTripLatency {
         ws_recv,
         ws_publish,

--- a/wingfoil/src/latency.rs
+++ b/wingfoil/src/latency.rs
@@ -177,12 +177,39 @@ impl<T, L: Latency> HasLatency for Traced<T, L> {
 // SAFETY: `Traced<T, L>` is `#[repr(C)]` with two fields. When both `T` and
 // `L` are themselves `ZeroCopySend`, the composite is self-contained and has
 // a uniform memory representation, satisfying the trait's invariants.
+//
+// The default `ZeroCopySend::type_name()` returns `core::any::type_name::<Self>()`,
+// which embeds the absolute Rust paths of `T` and `L`. When the same struct is
+// declared via `#[path = "..."] mod ...;` from two different binary crates (a
+// common pattern for sharing an iceoryx2 payload between two example binaries),
+// the paths differ and iceoryx2 reports `IncompatibleTypes` even though the
+// memory layouts are identical. We compose the name from `T::type_name()` and
+// `L::type_name()` so leaf overrides via `#[type_name(...)]` propagate up.
 #[cfg(feature = "iceoryx2-beta")]
 unsafe impl<T, L> iceoryx2::prelude::ZeroCopySend for Traced<T, L>
 where
     T: iceoryx2::prelude::ZeroCopySend,
     L: iceoryx2::prelude::ZeroCopySend,
 {
+    unsafe fn type_name() -> &'static str {
+        traced_type_name(unsafe { T::type_name() }, unsafe { L::type_name() })
+    }
+}
+
+#[cfg(feature = "iceoryx2-beta")]
+fn traced_type_name(t: &'static str, l: &'static str) -> &'static str {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<HashMap<(&'static str, &'static str), &'static str>>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = cache.lock().unwrap();
+    if let Some(s) = guard.get(&(t, l)) {
+        return s;
+    }
+    let composed: &'static str = Box::leak(format!("wingfoil::Traced<{t}, {l}>").into_boxed_str());
+    guard.insert((t, l), composed);
+    composed
 }
 
 // ---------------------------------------------------------------------------
@@ -1009,5 +1036,41 @@ mod tests {
         assert_eq!(l.strategy, l.ingest);
         assert_eq!(l.publish, l.ingest);
         assert_eq!(l.decode, 0);
+    }
+
+    // The Traced<T, L>::type_name() override propagates leaf overrides up so
+    // that two binaries declaring the same payload via `#[path]`-included
+    // modules can still match an iceoryx2 service. This test pins the
+    // composed-name format and confirms the macro's `#[type_name(...)]`
+    // attribute is honoured.
+    #[cfg(feature = "iceoryx2-beta")]
+    mod type_name_propagation {
+        use super::*;
+        use iceoryx2::prelude::ZeroCopySend;
+
+        #[repr(C)]
+        #[derive(Debug, Clone, Copy, Default, ZeroCopySend)]
+        #[type_name("test::Payload")]
+        struct Payload {
+            v: u64,
+        }
+
+        latency_stages! {
+            #[type_name("test::PinnedLatency")]
+            pub PinnedLatency {
+                a,
+                b,
+            }
+        }
+
+        #[test]
+        fn leaf_overrides_propagate_through_traced() {
+            assert_eq!(unsafe { Payload::type_name() }, "test::Payload");
+            assert_eq!(unsafe { PinnedLatency::type_name() }, "test::PinnedLatency");
+            assert_eq!(
+                unsafe { Traced::<Payload, PinnedLatency>::type_name() },
+                "wingfoil::Traced<test::Payload, test::PinnedLatency>",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Adds support for custom type name overrides via `#[type_name(...)]` attributes to ensure iceoryx2 type compatibility when the same payload struct is declared in multiple binaries via `#[path]`-included modules. This prevents `IncompatibleTypes` errors that occur when the default `core::any::type_name()` embeds binary-specific module paths.

## Key Changes

- **wingfoil/src/latency.rs**:
  - Implemented custom `ZeroCopySend::type_name()` for `Traced<T, L>` that composes type names from its generic parameters
  - Added `traced_type_name()` helper function with a static cache to generate stable composed names in the format `"wingfoil::Traced<T, L>"`
  - Added comprehensive test module `type_name_propagation` to verify that leaf-level `#[type_name(...)]` overrides propagate through `Traced` wrappers

- **wingfoil-derive/src/lib.rs**:
  - Extended `latency_stages!` macro to accept optional `#[type_name("...")]` attribute
  - Added parsing logic to extract and validate the type name override from macro attributes
  - Modified code generation to emit custom `type_name()` implementation when override is provided
  - Added error handling for duplicate or malformed `#[type_name(...)]` attributes

- **wingfoil/examples/latency_e2e/shared.rs**:
  - Applied `#[type_name("wingfoil::latency_e2e::RoundTrip")]` to `RoundTrip` struct
  - Applied `#[type_name("wingfoil::latency_e2e::RoundTripLatency")]` to `RoundTripLatency` latency stages
  - Added documentation explaining why type name pinning is necessary for multi-binary iceoryx2 services

## Implementation Details

The solution uses a static `HashMap` cache to ensure that composed type names are interned as `&'static str`, meeting iceoryx2's requirements. The cache is initialized lazily via `OnceLock` to avoid runtime overhead. Type name overrides at the leaf level (on `T` and `L`) automatically propagate through `Traced<T, L>` via the custom implementation, allowing users to pin identifiers at the struct level without needing to override `Traced` itself.

https://claude.ai/code/session_01Vid8msHYqwYTSukZwtVLaM