### PR TITLE
Automate latency_e2e importmap version updates in bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -62,6 +62,12 @@ jobs:
         working-directory: wingfoil-js
         run: npm version --no-git-tag-version ${{ steps.bump_cargo.outputs.new_version }}
 
+      - name: Update latency_e2e importmap pin
+        run: |
+          NEW_VERSION="${{ steps.bump_cargo.outputs.new_version }}"
+          INDEX_HTML="wingfoil/examples/latency_e2e/static/index.html"
+          sed -i -E "s|(esm\.sh/@wingfoil/client@)[0-9]+\.[0-9]+\.[0-9]+|\1${NEW_VERSION}|g" "$INDEX_HTML"
+
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"

--- a/wingfoil/examples/latency_e2e/static/index.html
+++ b/wingfoil/examples/latency_e2e/static/index.html
@@ -90,8 +90,8 @@
   <script type="importmap">
     {
       "imports": {
-        "@wingfoil/client": "https://esm.sh/@wingfoil/client@4.1.0",
-        "@wingfoil/client/tracing": "https://esm.sh/@wingfoil/client@4.1.0/tracing"
+        "@wingfoil/client": "https://esm.sh/@wingfoil/client@4.2.0",
+        "@wingfoil/client/tracing": "https://esm.sh/@wingfoil/client@4.2.0/tracing"
       }
     }
   </script>


### PR DESCRIPTION
## Summary
This PR adds automation to keep the `@wingfoil/client` package version in the latency_e2e example's importmap synchronized with version bumps.

## Key Changes
- Added a new workflow step in the bump CI/CD pipeline that automatically updates the `@wingfoil/client` version pins in `wingfoil/examples/latency_e2e/static/index.html`
- The step uses `sed` to replace version strings matching the pattern `@wingfoil/client@X.Y.Z` with the newly bumped version
- Updated the importmap in index.html to reference version 4.2.0 (from 4.1.0)

## Implementation Details
- The automation step runs after the npm version bump and uses the `new_version` output from the cargo bump step
- Uses a regex pattern to match and update both the main `@wingfoil/client` import and the `@wingfoil/client/tracing` subpath import
- This ensures the example application always uses the latest published version without manual intervention

https://claude.ai/code/session_01Q98tDpnQudjnT2vNYNuzUh