### PR TITLE
Suppress iceoryx2 config file warning by using default config

### DIFF
--- a/config/iceoryx2.toml
+++ b/config/iceoryx2.toml
@@ -1,6 +1,0 @@
-# iceoryx2 configuration
-# See: https://eclipse-iceoryx.github.io/iceoryx2/latest/concepts/configuration/
-
-[global]
-# Default configuration — most settings are sensible defaults
-# Customize as needed per deployment

--- a/wingfoil/src/adapters/iceoryx2/mod.rs
+++ b/wingfoil/src/adapters/iceoryx2/mod.rs
@@ -15,6 +15,7 @@
 //! Payload types must implement [`ZeroCopySend`] and be `#[repr(C)]` and self-contained
 //! (no heap allocations, no pointers to external data).
 
+use iceoryx2::config::Config;
 use iceoryx2::node::Node;
 use iceoryx2::prelude::ZeroCopySend;
 use iceoryx2::service::{ipc, local};
@@ -24,6 +25,18 @@ pub(crate) enum Iceoryx2NodeHandle {
     Ipc(Node<ipc::Service>),
     #[allow(dead_code)]
     Local(Node<local::Service>),
+}
+
+/// Built-in iceoryx2 defaults, cached for the process lifetime.
+///
+/// Passed to every `NodeBuilder::new().config(...)` so iceoryx2's global
+/// singleton is never lazily loaded from disk — that lookup emits a
+/// "No config file was loaded" warning when no `config/iceoryx2.toml`
+/// is found, which we don't want surfaced to users of the adapter.
+pub(crate) fn iceoryx2_default_config() -> &'static Config {
+    use std::sync::OnceLock;
+    static CFG: OnceLock<Config> = OnceLock::new();
+    CFG.get_or_init(Config::default)
 }
 
 pub const ICEORYX2_DEFAULT_HISTORY_SIZE: usize = 5;

--- a/wingfoil/src/adapters/iceoryx2/read.rs
+++ b/wingfoil/src/adapters/iceoryx2/read.rs
@@ -16,7 +16,7 @@ use iceoryx2::prelude::*;
 
 use super::{
     Iceoryx2Error, Iceoryx2Mode, Iceoryx2NodeHandle, Iceoryx2Result, Iceoryx2ServiceContract,
-    Iceoryx2ServiceVariant, Iceoryx2SubOpts,
+    Iceoryx2ServiceVariant, Iceoryx2SubOpts, iceoryx2_default_config,
 };
 
 fn service_open_err_with_context(
@@ -58,6 +58,7 @@ fn service_open_err_with_context(
 macro_rules! create_subscriber {
     ($svc:ty, $service_name:expr, $variant:expr, $history_size:expr, $payload:ty) => {{
         let node = NodeBuilder::new()
+            .config(iceoryx2_default_config())
             .create::<$svc>()
             .map_err(|e| Iceoryx2Error::NodeCreationFailed(e.to_string()))?;
         let contract = Iceoryx2ServiceContract::new($history_size);

--- a/wingfoil/src/adapters/iceoryx2/write.rs
+++ b/wingfoil/src/adapters/iceoryx2/write.rs
@@ -15,7 +15,7 @@ use iceoryx2::service::service_name::ServiceNameError;
 
 use super::{
     Iceoryx2Error, Iceoryx2NodeHandle, Iceoryx2PubOpts, Iceoryx2PubSliceOpts,
-    Iceoryx2ServiceContract, Iceoryx2ServiceVariant,
+    Iceoryx2ServiceContract, Iceoryx2ServiceVariant, iceoryx2_default_config,
 };
 
 fn service_open_err_with_context(
@@ -58,6 +58,7 @@ fn service_open_err_with_context(
 macro_rules! create_publisher_and_notifier {
     ($svc:ty, $service_name:expr, $variant:expr, $history_size:expr, $payload:ty) => {{
         let node = NodeBuilder::new()
+            .config(iceoryx2_default_config())
             .create::<$svc>()
             .map_err(|e| Iceoryx2Error::NodeCreationFailed(e.to_string()))?;
         let contract = Iceoryx2ServiceContract::new($history_size);
@@ -125,6 +126,7 @@ macro_rules! create_slice_publisher_and_notifier {
     ($svc:ty, $service_name:expr, $variant:expr, $history_size:expr,
      $initial_max_slice_len:expr) => {{
         let node = NodeBuilder::new()
+            .config(iceoryx2_default_config())
             .create::<$svc>()
             .map_err(|e| Iceoryx2Error::NodeCreationFailed(e.to_string()))?;
         let contract = Iceoryx2ServiceContract::new($history_size);


### PR DESCRIPTION
## Summary
This PR suppresses the "No config file was loaded" warning from iceoryx2 by explicitly passing a default configuration to all `NodeBuilder` instances, eliminating the need for a config file in the repository.

## Key Changes
- Added `iceoryx2_default_config()` function in `mod.rs` that returns a cached `Config::default()` using `OnceLock` to ensure the default config is initialized once per process lifetime
- Updated `NodeBuilder::new()` calls in both `read.rs` and `write.rs` to explicitly pass the default config via `.config(iceoryx2_default_config())`
- Removed the `config/iceoryx2.toml` file which was only containing placeholder comments and relying on iceoryx2's lazy loading behavior

## Implementation Details
- The `iceoryx2_default_config()` function uses `std::sync::OnceLock` to cache the configuration, avoiding repeated initialization
- This approach prevents iceoryx2's global singleton from being lazily loaded from disk, which was the source of the warning
- All three macro invocations (`create_publisher_and_notifier`, `create_slice_publisher_and_notifier`, and `create_subscriber`) now pass the explicit default config

https://claude.ai/code/session_01QpxpqT7LKpFFrBPevNL12H