### PR TITLE
Fix CI badge to display push event status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust.yml/badge.svg)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust.yml)
+[![CI](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust.yml/badge.svg?event=push)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust.yml)
 [![codecov](https://codecov.io/gh/wingfoil-io/wingfoil/graph/badge.svg)](https://codecov.io/gh/wingfoil-io/wingfoil)
 [![Crates.io Version](https://img.shields.io/crates/v/wingfoil.svg)](https://crates.io/crates/wingfoil)
 [![Docs.rs](https://docs.rs/wingfoil/badge.svg)](https://docs.rs/wingfoil/)


### PR DESCRIPTION
## Summary
Updated the CI badge URL in the README to explicitly filter for push events, ensuring the badge displays the status of the most recent push to the repository.

## Changes
- Modified the CI badge URL to include the `?event=push` query parameter, which ensures the badge reflects the status of push events rather than all workflow events

## Details
The GitHub Actions badge now specifically targets push event workflows, providing a more accurate representation of the CI status for the main branch. This prevents the badge from displaying stale or unrelated workflow run statuses.

https://claude.ai/code/session_015EMPNr3VASEPMvr1TJEucq