### PR TITLE
Fix wasm package inclusion in npm publish tarball

### DIFF
--- a/.github/workflows/npm-pub.yml
+++ b/.github/workflows/npm-pub.yml
@@ -44,13 +44,13 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: wingfoil-js/pnpm-lock.yaml
 
-      - name: Build wasm bundle
-        working-directory: wingfoil-wasm
-        run: wasm-pack build --target web --release --out-dir ../wingfoil-js/wasm-pkg
-
       - name: Install JS deps
         working-directory: wingfoil-js
         run: pnpm install --frozen-lockfile
+
+      - name: Build wasm bundle
+        working-directory: wingfoil-js
+        run: pnpm run build:wasm
 
       - name: Build TypeScript
         working-directory: wingfoil-js
@@ -59,6 +59,22 @@ jobs:
       - name: Lint
         working-directory: wingfoil-js
         run: pnpm run lint
+
+      # Sanity check: pnpm/npm-packlist honors any .gitignore inside wasm-pkg/
+      # (wasm-pack writes one with `*`), which silently strips the entire
+      # directory from the publish tarball even though it's listed in `files`.
+      # `build:wasm` removes the offending file; verify the dry-run tarball
+      # actually contains the wasm before we ship it.
+      - name: Verify wasm files are packaged
+        working-directory: wingfoil-js
+        run: |
+          set -euo pipefail
+          tarball=$(pnpm pack --pack-destination /tmp 2>&1 | tail -n1)
+          if ! tar tzf "$tarball" | grep -q 'wasm-pkg/wingfoil_wasm_bg\.wasm$'; then
+            echo "::error::publish tarball is missing wasm-pkg/ — refusing to publish"
+            tar tzf "$tarball"
+            exit 1
+          fi
 
       - name: Publish to npm
         working-directory: wingfoil-js

--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -41,7 +41,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:wasm": "cd ../wingfoil-wasm && wasm-pack build --target web --release --out-dir ../wingfoil-js/wasm-pkg",
+    "build:wasm": "cd ../wingfoil-wasm && wasm-pack build --target web --release --out-dir ../wingfoil-js/wasm-pkg && rm -f ../wingfoil-js/wasm-pkg/.gitignore",
     "build:ts": "tsc",
     "build": "npm run build:wasm && npm run build:ts",
     "dev": "vite examples/solid-dashboard",


### PR DESCRIPTION
## Summary
This PR fixes an issue where the wasm bundle was being silently excluded from the npm publish tarball due to a `.gitignore` file generated by wasm-pack.

## Key Changes
- **Reordered CI steps**: Moved the wasm build to occur after `pnpm install` so it can use the `build:wasm` npm script instead of running wasm-pack directly
- **Updated build script**: Modified `build:wasm` script to remove the `.gitignore` file that wasm-pack generates in the `wasm-pkg/` directory, which was causing npm-packlist to exclude the entire directory from the tarball
- **Added verification step**: Introduced a sanity check in the CI pipeline that verifies the wasm files are actually present in the publish tarball before publishing to npm

## Implementation Details
The root cause was that wasm-pack generates a `.gitignore` file with `*` in the `wasm-pkg/` directory. Even though `wasm-pkg/` is listed in the `files` array of `package.json`, npm-packlist honors `.gitignore` files and silently strips the entire directory from the publish tarball. By removing this `.gitignore` file after the wasm build completes, the wasm files are now properly included in the published package.

The verification step provides a safety net to catch this issue in the future if the build process changes.

https://claude.ai/code/session_017uNgBJLNKLcjRoHde7rpde