### PR TITLE
Update CI badge to use shields.io with main branch filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust.yml/badge.svg?event=push)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/wingfoil-io/wingfoil/rust.yml?branch=main&label=CI)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust.yml)
 [![codecov](https://codecov.io/gh/wingfoil-io/wingfoil/graph/badge.svg)](https://codecov.io/gh/wingfoil-io/wingfoil)
 [![Crates.io Version](https://img.shields.io/crates/v/wingfoil.svg)](https://crates.io/crates/wingfoil)
 [![Docs.rs](https://docs.rs/wingfoil/badge.svg)](https://docs.rs/wingfoil/)


### PR DESCRIPTION
## Summary
Updated the CI badge in the README to use shields.io's GitHub Actions workflow status endpoint instead of the GitHub-hosted badge, with an explicit filter for the main branch.

## Changes
- Replaced the GitHub-native CI badge URL with shields.io's `github/actions/workflow/status` endpoint
- Added `branch=main` parameter to display CI status specifically for the main branch
- Updated the badge label to "CI" for consistency

## Details
This change improves the badge by:
- Using a more reliable third-party badge service (shields.io)
- Explicitly filtering to show only the main branch status, avoiding confusion from other branch builds
- Maintaining the same link target to the GitHub Actions workflow page

https://claude.ai/code/session_01GRQ8TQZvzTEtJ34esKwMwo