### PR TITLE
Emit wasm under dist/ so esm.sh resolves the import correctly

### DIFF
--- a/.github/workflows/npm-pub.yml
+++ b/.github/workflows/npm-pub.yml
@@ -60,18 +60,19 @@ jobs:
         working-directory: wingfoil-js
         run: pnpm run lint
 
-      # Sanity check: pnpm/npm-packlist honors any .gitignore inside wasm-pkg/
-      # (wasm-pack writes one with `*`), which silently strips the entire
-      # directory from the publish tarball even though it's listed in `files`.
-      # `build:wasm` removes the offending file; verify the dry-run tarball
-      # actually contains the wasm before we ship it.
+      # Sanity check: dist/wasm/ is the only path that survives both
+      # npm-packlist's nested-.gitignore quirk *and* esm.sh's relative-import
+      # canonicalisation (a `../` import out of `dist/` gets rewritten to
+      # `https://esm.sh/<dir>/...` as if it were a top-level package). Verify
+      # the packlist tarball actually contains the wasm bindings before we
+      # publish — a missing wasm here means a broken release on npm.
       - name: Verify wasm files are packaged
         working-directory: wingfoil-js
         run: |
           set -euo pipefail
           tarball=$(pnpm pack --pack-destination /tmp 2>&1 | tail -n1)
-          if ! tar tzf "$tarball" | grep -q 'wasm-pkg/wingfoil_wasm_bg\.wasm$'; then
-            echo "::error::publish tarball is missing wasm-pkg/ — refusing to publish"
+          if ! tar tzf "$tarball" | grep -q 'dist/wasm/wingfoil_wasm_bg\.wasm$'; then
+            echo "::error::publish tarball is missing dist/wasm/ — refusing to publish"
             tar tzf "$tarball"
             exit 1
           fi

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -71,13 +71,13 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: wingfoil-js/pnpm-lock.yaml
 
-      - name: Build wasm bundle for JS
-        working-directory: wingfoil-wasm
-        run: wasm-pack build --target web --release --out-dir ../wingfoil-js/wasm-pkg
-
       - name: Install JS deps
         working-directory: wingfoil-js
         run: pnpm install --frozen-lockfile
+
+      - name: Build wasm bundle for JS
+        working-directory: wingfoil-js
+        run: pnpm run build:wasm
 
       - name: Type-check
         working-directory: wingfoil-js

--- a/wingfoil-js/.gitignore
+++ b/wingfoil-js/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 dist/
-wasm-pkg/
+src/wasm/
 .vite/
 *.tsbuildinfo

--- a/wingfoil-js/README.md
+++ b/wingfoil-js/README.md
@@ -137,18 +137,12 @@ need React.
 
 ## Development
 
-Build the wasm bundle first:
-
-```sh
-cd wingfoil-wasm
-wasm-pack build --target web --release --out-dir ../wingfoil-js/wasm-pkg
-```
-
-Then, from `wingfoil-js/`:
+From `wingfoil-js/`:
 
 ```sh
 pnpm install
-pnpm build            # tsc → ./dist
+pnpm run build:wasm   # wasm-pack → ./src/wasm
+pnpm build            # build:wasm + tsc + copy ./src/wasm to ./dist/wasm
 pnpm dev              # Vite dev server for examples/solid-dashboard
 pnpm run lint         # tsc --noEmit
 ```

--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -37,12 +37,11 @@
   },
   "files": [
     "dist",
-    "wasm-pkg",
     "README.md"
   ],
   "scripts": {
-    "build:wasm": "cd ../wingfoil-wasm && wasm-pack build --target web --release --out-dir ../wingfoil-js/wasm-pkg && rm -f ../wingfoil-js/wasm-pkg/.gitignore",
-    "build:ts": "tsc",
+    "build:wasm": "cd ../wingfoil-wasm && wasm-pack build --target web --release --out-dir ../wingfoil-js/src/wasm && rm -f ../wingfoil-js/src/wasm/.gitignore",
+    "build:ts": "tsc && rm -rf dist/wasm && cp -r src/wasm dist/wasm && rm -f dist/wasm/.gitignore",
     "build": "npm run build:wasm && npm run build:ts",
     "dev": "vite examples/solid-dashboard",
     "lint": "tsc --noEmit",

--- a/wingfoil-js/src/index.ts
+++ b/wingfoil-js/src/index.ts
@@ -15,7 +15,7 @@ import init, {
   encodeUnsubscribe,
   init_panic_hook,
   wireVersion,
-} from "../wasm-pkg/wingfoil_wasm.js";
+} from "./wasm/wingfoil_wasm.js";
 
 export type CodecKind = "bincode" | "json";
 

--- a/wingfoil-js/tsconfig.json
+++ b/wingfoil-js/tsconfig.json
@@ -17,5 +17,5 @@
     "jsxImportSource": "solid-js"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "examples", "test", "wasm-pkg"]
+  "exclude": ["node_modules", "dist", "examples", "test"]
 }


### PR DESCRIPTION
## Summary

PR #262 stopped npm from stripping the wasm bundle from the publish tarball, but the latency_e2e demo still 404s on the wasm import. After republishing 4.3.1, the browser fetches:

```
GET https://esm.sh/wasm-pkg/wingfoil_wasm?target=es2022 → 404
```

`dist/index.js` does `import init from "../wasm-pkg/wingfoil_wasm.js"`. esm.sh's relative-import canonicalisation walks the `..` *out* of the `dist/` directory and treats the path as a fresh package-relative URL — dropping the `@wingfoil/client@<ver>` prefix entirely and resolving `wasm-pkg` as a top-level npm package name.

## Fix

Keep every relative import inside `dist/`:

- `wasm-pack` now emits into `wingfoil-js/src/wasm/` (gitignored). `tsc` preserves the `./wasm/wingfoil_wasm.js` import string into `dist/index.js`, and `build:ts` copies `src/wasm/` → `dist/wasm/`. esm.sh resolves the import as `@wingfoil/client@<ver>/dist/wasm/wingfoil_wasm.js` — correctly inside the package.
- `dist/wasm/.gitignore` is removed unconditionally after the copy, so a half-completed `wasm-pack` (e.g. one that fails at `wasm-opt`) can't leak the `*` ignore file and silently strip `dist/wasm/` from the tarball via npm-packlist.
- `package.json` `files` no longer needs `wasm-pkg`; `dist/` covers it.
- npm-pub sanity check now greps for `dist/wasm/wingfoil_wasm_bg.wasm`.
- `web-integration.yml` switched to `pnpm run build:wasm` so the cleanup runs the same way locally and in CI.

Verified locally: `pnpm pack`'s tarball contains all four files under `dist/wasm/`, and `pnpm lint` + `pnpm test` both pass.

## Test plan

- [ ] `npm pub` workflow's "Verify wasm files are packaged" step passes.
- [ ] Bump to 4.3.2 and republish.
- [ ] Reload the latency_e2e demo (hard refresh) and confirm the status pill flips to **live**, orders flow, and per-hop bars render.

https://claude.ai/code/session_017uNgBJLNKLcjRoHde7rpde

---
_Generated by [Claude Code](https://claude.ai/code/session_017uNgBJLNKLcjRoHde7rpde)_