### PR TITLE
Use native JSON.stringify/parse for JSON codec in WASM

### DIFF
--- a/wingfoil-wasm/src/lib.rs
+++ b/wingfoil-wasm/src/lib.rs
@@ -83,16 +83,30 @@ pub fn encode_unsubscribe(codec: &str, topics: Vec<String>) -> Result<Vec<u8>, J
 /// frame (ready to send on the WebSocket). Used for client → server
 /// publishes.
 ///
-/// The JS value is first converted to a `serde_json::Value` so it works
-/// for both bincode and JSON codecs without requiring the Rust payload
-/// schema here. The server's `web_sub::<T>` must be able to deserialize
-/// the result back into `T`.
+/// For the JSON codec we sidestep `serde_wasm_bindgen` and use the JS
+/// engine's own `JSON.stringify` to produce the payload bytes. The
+/// detour through `serde_json::Value` forces JS Numbers outside the
+/// safe-integer range (e.g. nanosecond timestamps ~1.78e18) through
+/// `f64`, which serde_json then writes as JSON floats — and the
+/// server's `u64` fields reject floating-point input. JS's native
+/// `JSON.stringify` writes integer-valued Numbers without a decimal
+/// regardless of magnitude, so the server decodes cleanly.
+///
+/// For bincode we still need the serde round-trip because there is no
+/// JS-native bincode encoder.
 #[wasm_bindgen(js_name = encodePayload)]
 pub fn encode_payload(codec: &str, topic: &str, value: JsValue) -> Result<Vec<u8>, JsError> {
     let codec = parse_codec(codec)?;
-    let json: serde_json::Value = serde_wasm_bindgen::from_value(value)
-        .map_err(|e| JsError::new(&format!("encode_payload: from JS: {e}")))?;
-    let payload = codec.encode(&json).map_err(to_js_error)?;
+    let payload: Vec<u8> = match codec {
+        CodecKind::Json => js_sys::JSON::stringify(&value)
+            .map(|s| String::from(s).into_bytes())
+            .map_err(|e| JsError::new(&format!("encode_payload: JSON.stringify: {e:?}")))?,
+        CodecKind::Bincode => {
+            let json: serde_json::Value = serde_wasm_bindgen::from_value(value)
+                .map_err(|e| JsError::new(&format!("encode_payload: from JS: {e}")))?;
+            codec.encode(&json).map_err(to_js_error)?
+        }
+    };
     let env = Envelope {
         topic: topic.to_string(),
         time_ns: 0,
@@ -102,11 +116,28 @@ pub fn encode_payload(codec: &str, topic: &str, value: JsValue) -> Result<Vec<u8
 }
 
 /// Decode the payload bytes of an envelope into a JS value.
+///
+/// JSON: parse with `JSON.parse` rather than the serde_json →
+/// `serde_wasm_bindgen` round-trip. The latter rejects u64 values past
+/// `Number.MAX_SAFE_INTEGER` outright; `JSON.parse` accepts them with
+/// the standard JS Number precision loss (still integer-valued, just
+/// approximated).
 #[wasm_bindgen(js_name = decodePayload)]
 pub fn decode_payload(codec: &str, bytes: &[u8]) -> Result<JsValue, JsError> {
-    let json: serde_json::Value = parse_codec(codec)?.decode(bytes).map_err(to_js_error)?;
-    serde_wasm_bindgen::to_value(&json)
-        .map_err(|e| JsError::new(&format!("decode_payload: to JS: {e}")))
+    let codec = parse_codec(codec)?;
+    match codec {
+        CodecKind::Json => {
+            let s = std::str::from_utf8(bytes)
+                .map_err(|e| JsError::new(&format!("decode_payload: utf8: {e}")))?;
+            js_sys::JSON::parse(s)
+                .map_err(|e| JsError::new(&format!("decode_payload: JSON.parse: {e:?}")))
+        }
+        CodecKind::Bincode => {
+            let json: serde_json::Value = codec.decode(bytes).map_err(to_js_error)?;
+            serde_wasm_bindgen::to_value(&json)
+                .map_err(|e| JsError::new(&format!("decode_payload: to JS: {e}")))
+        }
+    }
 }
 
 /// Decode a control-topic payload into a JS object.


### PR DESCRIPTION
## Summary
This change optimizes JSON payload encoding and decoding in the WASM bridge by using the JavaScript engine's native `JSON.stringify` and `JSON.parse` methods instead of routing through Rust's `serde_json` and `serde_wasm_bindgen`.

## Key Changes
- **encode_payload**: For JSON codec, directly call `js_sys::JSON::stringify` on the JS value instead of converting to `serde_json::Value` first. Bincode codec continues to use the serde round-trip since there's no native JS bincode encoder.
- **decode_payload**: For JSON codec, use `js_sys::JSON::parse` to deserialize directly to a JS value. Bincode codec continues to use the existing serde deserialization path.

## Rationale
The serde round-trip through `serde_json::Value` causes large integers (e.g., nanosecond timestamps ~1.78e18) to be converted to `f64`, which are then serialized as JSON floats. This causes the server to reject `u64` fields that receive floating-point input.

JavaScript's native `JSON.stringify` preserves integer-valued Numbers without decimal points regardless of magnitude, allowing the server to deserialize cleanly. Similarly, `JSON.parse` handles large integers with standard JS Number precision loss while maintaining integer representation.

## Implementation Details
- Added codec-specific branching in both `encode_payload` and `decode_payload` functions
- JSON codec path uses `js_sys::JSON` methods for direct JS interop
- Bincode codec path preserves existing serde-based implementation
- Updated documentation to explain the rationale for the different approaches

https://claude.ai/code/session_01CBkbARBAaZi4P2zmsQiSgG