### PR TITLE
Increase market data age threshold to 5s for LMAX demo feed

### DIFF
--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -96,7 +96,10 @@ fn main() -> anyhow::Result<()> {
         .ok();
 
     let precise = precise_stamps_enabled();
-    let max_md_age_ms = env_u64("WINGFOIL_MAX_MD_AGE_MS", 500);
+    // LMAX London Demo updates EUR/USD only every few seconds during quiet
+    // periods, so a tight 500 ms gate rejected most orders. 5 s keeps the
+    // safety check meaningful while accepting the demo feed's real cadence.
+    let max_md_age_ms = env_u64("WINGFOIL_MAX_MD_AGE_MS", 5_000);
 
     let username = std::env::var("LMAX_USERNAME")
         .map_err(|_| anyhow::anyhow!("LMAX_USERNAME env var is required"))?;


### PR DESCRIPTION
## Summary
Adjusted the maximum market data age threshold from 500ms to 5 seconds to accommodate the real-world cadence of the LMAX London Demo feed, which updates EUR/USD infrequently during quiet market periods.

## Changes
- Increased `WINGFOIL_MAX_MD_AGE_MS` default value from 500ms to 5,000ms
- Added explanatory comments documenting why the original tight 500ms threshold was too restrictive for the demo feed while still maintaining meaningful safety checks

## Details
The LMAX London Demo feed does not update EUR/USD quotes every 500ms during low-volatility periods. The previous threshold was rejecting most orders unnecessarily. The new 5-second threshold balances safety validation with acceptance of the demo feed's actual update frequency.

https://claude.ai/code/session_01SvAMRxPN86PoRpby8DjQhN