### PR TITLE
Increase market data age threshold from 5s to 60s for LMAX demo

### DIFF
--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -97,9 +97,10 @@ fn main() -> anyhow::Result<()> {
 
     let precise = precise_stamps_enabled();
     // LMAX London Demo updates EUR/USD only every few seconds during quiet
-    // periods, so a tight 500 ms gate rejected most orders. 5 s keeps the
+    // periods — observed gaps of 20+ seconds when the book is dormant — so
+    // even 5 s rejects most orders outside of busy windows. 60 s keeps the
     // safety check meaningful while accepting the demo feed's real cadence.
-    let max_md_age_ms = env_u64("WINGFOIL_MAX_MD_AGE_MS", 5_000);
+    let max_md_age_ms = env_u64("WINGFOIL_MAX_MD_AGE_MS", 60_000);
 
     let username = std::env::var("LMAX_USERNAME")
         .map_err(|_| anyhow::anyhow!("LMAX_USERNAME env var is required"))?;


### PR DESCRIPTION
## Summary
Adjusted the maximum market data age threshold to accommodate the real-world behavior of the LMAX London Demo feed, which has longer and more variable update intervals than initially expected.

## Changes
- Increased `WINGFOIL_MAX_MD_AGE_MS` default value from 5,000ms to 60,000ms
- Updated comments to document observed market data gaps of 20+ seconds during dormant periods
- Clarified that even the previous 5s threshold was rejecting most orders outside of busy trading windows

## Details
The LMAX demo feed exhibits longer quiet periods with gaps exceeding 20 seconds when the order book is inactive. The original 5-second gate was too restrictive for this feed's actual cadence, causing legitimate orders to be rejected. The 60-second threshold maintains the safety check's intent while being realistic for the demo feed's behavior patterns.

https://claude.ai/code/session_01UN5XqbWBACUxbGEcJptwSk