### PR TITLE
latency_e2e: harden matcher invariant, empty-env check, average-price filter

### DIFF
--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -102,10 +102,8 @@ fn main() -> anyhow::Result<()> {
     // safety check meaningful while accepting the demo feed's real cadence.
     let max_md_age_ms = env_u64("WINGFOIL_MAX_MD_AGE_MS", 60_000);
 
-    let username = std::env::var("LMAX_USERNAME")
-        .map_err(|_| anyhow::anyhow!("LMAX_USERNAME env var is required"))?;
-    let password = std::env::var("LMAX_PASSWORD")
-        .map_err(|_| anyhow::anyhow!("LMAX_PASSWORD env var is required"))?;
+    let username = required_env("LMAX_USERNAME")?;
+    let password = required_env("LMAX_PASSWORD")?;
 
     log::info!("fix_gw starting — precise={precise} max_md_age_ms={max_md_age_ms} as {username}");
 
@@ -202,6 +200,14 @@ fn main() -> anyhow::Result<()> {
     // orders or matching ExecReports. The output value is the last
     // matched fill this cycle (or None); downstream `MapFilterStream`
     // drops the Nones.
+    //
+    // Invariant: each upstream emits at most one event per cycle
+    // (`order_events` and `exec_events` are both single-tick streams via
+    // `collapse`), so a burst contains at most one Order and at most one
+    // Exec — and thus at most one match. If that invariant is ever broken
+    // by a wiring change upstream, two Execs in the same burst would
+    // silently overwrite each other (only the last reaches downstream).
+    // We log loud in that case so the regression is visible.
 
     let matched = {
         let park: RefCell<HashMap<String, Traced<RoundTrip, RoundTripLatency>>> =
@@ -251,6 +257,14 @@ fn main() -> anyhow::Result<()> {
                                     parked.payload.fill_price_bps = 0;
                                 }
                             }
+                            if let Some(prev) = last.as_ref() {
+                                log::error!(
+                                    "matcher invariant broken: dropping previously matched fill \
+                                     cl_ord={} for newer cl_ord={cl_ord} in same burst — \
+                                     upstream `collapse` should make this unreachable",
+                                    cl_ord_id(&prev.payload),
+                                );
+                            }
                             *last = Some(parked);
                         }
                         MatcherEvent::None => {}
@@ -293,6 +307,16 @@ fn main() -> anyhow::Result<()> {
 
     Graph::new(nodes, RunMode::RealTime, RunFor::Forever).run()?;
     Ok(())
+}
+
+/// Read an env var that must be set to a non-empty value. `std::env::var`
+/// returns `Ok("")` when the var is set but empty, which would otherwise
+/// slip past a plain `?` check and produce confusing FIX login failures.
+fn required_env(name: &str) -> anyhow::Result<String> {
+    match std::env::var(name) {
+        Ok(v) if !v.trim().is_empty() => Ok(v),
+        _ => anyhow::bail!("{name} env var is required (and must be non-empty)"),
+    }
 }
 
 // ── ClOrdID and NewOrderSingle ───────────────────────────────────────────

--- a/wingfoil/examples/latency_e2e/static/app.js
+++ b/wingfoil/examples/latency_e2e/static/app.js
@@ -173,12 +173,19 @@ window.addEventListener('DOMContentLoaded', () => {
   initChart();
   document.getElementById('start').onclick = startStream;
 
+  let pricedFills = 0;
   tracker.onResponse((rt) => {
     const fill = rt.payload;
     filled += 1;
-    sumPx += fill.fill_price_bps;
     document.getElementById('filled').textContent = filled.toLocaleString();
-    document.getElementById('px').textContent = (sumPx / filled / 10000).toFixed(5);
+    // Skip cancels/rejects (fix_gw emits them as zero-priced zero-qty fills
+    // so the round-trip counter still closes) — including them would drag
+    // the displayed average toward zero.
+    if (fill.fill_price_bps > 0 && fill.filled_qty > 0) {
+      sumPx += fill.fill_price_bps;
+      pricedFills += 1;
+      document.getElementById('px').textContent = (sumPx / pricedFills / 10000).toFixed(5);
+    }
     document.getElementById('rtt').textContent = (rt.rttNs / 1_000_000).toFixed(2) + ' ms';
     renderStages(rt.stamps, rt.rttNs);
     pushChartPoint(rt.stamps, rt.rttNs);


### PR DESCRIPTION
Three review fixes on the latency_e2e example:

* fix_gw: reject empty LMAX_USERNAME / LMAX_PASSWORD (std::env::var returns
  Ok("") for set-but-empty, which previously slipped past the existing
  guard and produced confusing FIX login failures). Extracted to
  `required_env`.

* fix_gw: log loud if the matcher's "at most one Exec per burst"
  invariant is ever broken by an upstream wiring change. Today both
  upstreams `collapse` to a single tick per cycle so this is unreachable,
  but the silent overwrite would otherwise be invisible. Comment now
  spells the invariant out.

* static/app.js: skip cancels/rejects (zero-priced zero-qty fills emitted
  by fix_gw so the round-trip counter still closes) when computing the
  displayed average fill price — including them was dragging the average
  toward zero.

https://claude.ai/code/session_01K3eVKf5c3ezVE6ErYY5kiN