### PR TITLE
contributing: add cargo lint/lint-all aliases mirroring CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Cargo aliases that mirror what CI runs in `.github/workflows/rust.yml`.
+# Run these before pushing to catch failures locally.
+#
+# Note: `lint-all` (and `cargo build --features full` / `cargo test --features
+# full`) pull in dependencies that need `protoc` on the build machine. Install
+# with `apt-get install -y protobuf-compiler` on Debian/Ubuntu, `brew install
+# protobuf` on macOS.
+[alias]
+lint     = "clippy --workspace --all-targets -- -D warnings"
+lint-all = "clippy --workspace --all-targets --all-features -- -D warnings"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,15 @@ cd wingfoil-python && maturin develop && pytest
 # Benchmarks
 cargo bench
 
-# Lint
-cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings
+# Lint (these aliases live in .cargo/config.toml and mirror CI exactly)
+cargo lint        # default features
+cargo lint-all    # all features — catches code behind `fix`, `csv`, `iceoryx2-beta`, etc.
 cargo fmt --all -- --check
 ```
+
+`cargo lint-all` requires `protoc` on the build machine (one of its
+transitive dependencies builds proto files). On Debian/Ubuntu:
+`sudo apt-get install -y protobuf-compiler`.
 
 ## Development Workflow Rules
 
@@ -67,10 +72,11 @@ cargo fmt --all -- --check
 Before committing any changes, ALWAYS run:
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings
+cargo lint        # default features
+cargo lint-all    # all features — CI runs this and feature-gated code is easy to miss
 ```
 
-These commands must pass without errors before creating a commit.
+All three must pass without errors before creating a commit.
 
 ## Key Architecture Concepts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,31 @@ These tools are required for building, testing, and packaging the core **wingfoi
 
 * **The Rust toolchain:** `rustup`, `cargo`, `rustc`, etc. We aim for compatibility with the latest stable version.
 * **`rustfmt` and `clippy`:** We use `rustfmt` for consistent code style and `clippy` for linting across the whole code base.
+* **`protoc` (Protocol Buffers compiler):** required when building with `--all-features` (used transitively by `etcd-client` and a few other adapters).
+  * Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`
+  * macOS: `brew install protobuf`
 
 For prerequisites specific to the **wingfoil-python** crate and the full build process, please see the [**BUILD.md**](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil-python/build.md) documentation.
 
 ### Building
 
 ```bash
-cargo build
+cargo build                    # default features
+cargo build --features full    # everything CI builds (needs protoc)
 ```
+
+### Pre-PR check (matches CI)
+
+CI is configured in [`.github/workflows/rust.yml`](.github/workflows/rust.yml). The same checks are wrapped as cargo aliases in `.cargo/config.toml` so you can run them locally with one command each:
+
+```bash
+cargo fmt --all -- --check     # formatting
+cargo lint                     # clippy, default features
+cargo lint-all                 # clippy, all features  ← most-missed step
+cargo test -p wingfoil --features full
+```
+
+`cargo lint-all` is the step that most often surfaces issues that pass locally but fail in CI — it exercises code behind feature flags (`fix`, `csv`, `iceoryx2-beta`, `kdb`, etc.) that the default build skips. Please run it before pushing.
 
 
 


### PR DESCRIPTION
Contributors who run only `cargo build` and the documented
`cargo clippy --workspace --all-targets -- -D warnings` miss code
behind feature flags (fix, csv, iceoryx2-beta, kdb, etc.) that CI
exercises via `--all-features`. Surface that as a one-line alias and
document the protoc prerequisite so the gap is visible without having
to read the workflow YAML.

- .cargo/config.toml: `cargo lint` and `cargo lint-all` aliases
- CLAUDE.md: pre-commit checklist now includes lint-all
- CONTRIBUTING.md: pre-PR check section + protoc prerequisite