### PR TITLE
latency_e2e: fix fargate deploy blockers (workflow path, secret wiring, IAM)

### DIFF
--- a/.github/workflows/deploy-latency-e2e.yml
+++ b/.github/workflows/deploy-latency-e2e.yml
@@ -17,7 +17,7 @@
 #        "Action": "sts:AssumeRoleWithWebIdentity",
 #        "Condition": {
 #          "StringEquals": {"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"},
-#          "StringLike": {"token.actions.githubusercontent.com:sub": "repo:wingfoil-io/wingfoil:ref:refs/heads/latency-example"}
+#          "StringLike": {"token.actions.githubusercontent.com:sub": "repo:wingfoil-io/wingfoil:ref:refs/heads/claude/fargate-e2e-deployment-7xP2F"}
 #        }
 #      }]
 #    }
@@ -33,6 +33,9 @@
 #    - AWS_ROLE_TO_ASSUME: arn:aws:iam::ACCOUNT_ID:role/github-actions-latency-deploy
 #    - WS_SERVER_IMAGE: ECR or Docker Hub URI (e.g., 123456789012.dkr.ecr.us-east-1.amazonaws.com/wingfoil/ws-server:latest)
 #    - FIX_GW_IMAGE: ECR or Docker Hub URI (e.g., 123456789012.dkr.ecr.us-east-1.amazonaws.com/wingfoil/fix-gw:latest)
+#    - PROMETHEUS_IMAGE: image with prometheus.yml baked in (built from Dockerfile.prometheus)
+#    - TEMPO_IMAGE: image with tempo.yaml baked in (built from Dockerfile.tempo)
+#    - GRAFANA_IMAGE: image with provisioning baked in (built from Dockerfile.grafana)
 #    - LMAX_USERNAME: Your LMAX FIX username
 #    - LMAX_PASSWORD: Your LMAX FIX password
 #
@@ -40,7 +43,6 @@
 #    - AWS_REGION: Default us-east-1
 #    - PULUMI_CPU: Default 1024 (vCPU units)
 #    - PULUMI_MEMORY: Default 2048 (MB)
-#    - PULUMI_SHM_SIZE: Default 256 (MB for iceoryx2)
 #
 # 4. Run the workflow:
 #    - Go to Actions → Deploy Latency E2E to AWS
@@ -98,32 +100,34 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
 
       - name: Install Python dependencies
-        working-directory: wingfoil/examples/latency_e2e/pulumi
+        working-directory: wingfoil/examples/latency_e2e/pulumi/fargate
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
       - name: Pulumi stack select
-        working-directory: wingfoil/examples/latency_e2e/pulumi
-        run: pulumi stack select $PULUMI_STACK
+        working-directory: wingfoil/examples/latency_e2e/pulumi/fargate
+        run: pulumi stack select --create $PULUMI_STACK
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Set Pulumi config
-        working-directory: wingfoil/examples/latency_e2e/pulumi
+        working-directory: wingfoil/examples/latency_e2e/pulumi/fargate
         run: |
           pulumi config set aws:region ${{ secrets.AWS_REGION || 'us-east-1' }}
           pulumi config set ws_server_image "${{ secrets.WS_SERVER_IMAGE }}"
           pulumi config set fix_gw_image "${{ secrets.FIX_GW_IMAGE }}"
+          pulumi config set prometheus_image "${{ secrets.PROMETHEUS_IMAGE }}"
+          pulumi config set tempo_image "${{ secrets.TEMPO_IMAGE }}"
+          pulumi config set grafana_image "${{ secrets.GRAFANA_IMAGE }}"
           pulumi config set environment "$PULUMI_STACK"
           pulumi config set cpu "${{ secrets.PULUMI_CPU || '1024' }}"
           pulumi config set memory "${{ secrets.PULUMI_MEMORY || '2048' }}"
-          pulumi config set shm_size "${{ secrets.PULUMI_SHM_SIZE || '256' }}"
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Set Pulumi secrets
-        working-directory: wingfoil/examples/latency_e2e/pulumi
+        working-directory: wingfoil/examples/latency_e2e/pulumi/fargate
         run: |
           pulumi config set --secret lmax_username "${{ secrets.LMAX_USERNAME }}"
           pulumi config set --secret lmax_password "${{ secrets.LMAX_PASSWORD }}"
@@ -131,20 +135,20 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Pulumi preview
-        working-directory: wingfoil/examples/latency_e2e/pulumi
+        working-directory: wingfoil/examples/latency_e2e/pulumi/fargate
         run: pulumi preview
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Pulumi up
-        working-directory: wingfoil/examples/latency_e2e/pulumi
+        working-directory: wingfoil/examples/latency_e2e/pulumi/fargate
         run: pulumi up --yes --skip-preview
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
       - name: Get outputs
         id: outputs
-        working-directory: wingfoil/examples/latency_e2e/pulumi
+        working-directory: wingfoil/examples/latency_e2e/pulumi/fargate
         run: |
           ALB_DNS=$(pulumi stack output alb_dns_name)
           echo "alb_dns_name=$ALB_DNS" >> $GITHUB_OUTPUT

--- a/wingfoil/examples/latency_e2e/pulumi/fargate/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/fargate/README.md
@@ -9,6 +9,9 @@ Deploy the complete latency_e2e demo (5 containers: fix_gw, ws_server, prometheu
 3. **Docker images** — Built and pushed to ECR or Docker Hub:
    - `wingfoil/ws-server` (from `Dockerfile.ws_server`)
    - `wingfoil/fix-gw` (from `Dockerfile.fix_gw`)
+   - `wingfoil/prometheus` (from `Dockerfile.prometheus` — bakes in `prometheus.yml`)
+   - `wingfoil/tempo` (from `Dockerfile.tempo` — bakes in `tempo.yaml`)
+   - `wingfoil/grafana` (from `Dockerfile.grafana` — bakes in dashboards/datasources)
 4. **LMAX credentials** — FIX username and password for the demo environment
 
 ## Setup
@@ -33,6 +36,9 @@ pulumi config set aws:region us-east-1
 pulumi config set environment demo
 pulumi config set ws_server_image <ECR_URI_or_DOCKER_HUB_IMAGE>
 pulumi config set fix_gw_image <ECR_URI_or_DOCKER_HUB_IMAGE>
+pulumi config set prometheus_image <ECR_URI_or_DOCKER_HUB_IMAGE>
+pulumi config set tempo_image <ECR_URI_or_DOCKER_HUB_IMAGE>
+pulumi config set grafana_image <ECR_URI_or_DOCKER_HUB_IMAGE>
 
 # Set secrets (LMAX credentials)
 pulumi config set --secret lmax_username <YOUR_LMAX_USERNAME>
@@ -43,12 +49,18 @@ pulumi config set --secret lmax_password <YOUR_LMAX_PASSWORD>
 ```bash
 pulumi config set ws_server_image "yourusername/wingfoil-ws-server:latest"
 pulumi config set fix_gw_image "yourusername/wingfoil-fix-gw:latest"
+pulumi config set prometheus_image "yourusername/wingfoil-prometheus:latest"
+pulumi config set tempo_image "yourusername/wingfoil-tempo:latest"
+pulumi config set grafana_image "yourusername/wingfoil-grafana:latest"
 ```
 
 **Example with ECR images:**
 ```bash
 pulumi config set ws_server_image "123456789012.dkr.ecr.us-east-1.amazonaws.com/wingfoil/ws-server:latest"
 pulumi config set fix_gw_image "123456789012.dkr.ecr.us-east-1.amazonaws.com/wingfoil/fix-gw:latest"
+pulumi config set prometheus_image "123456789012.dkr.ecr.us-east-1.amazonaws.com/wingfoil/prometheus:latest"
+pulumi config set tempo_image "123456789012.dkr.ecr.us-east-1.amazonaws.com/wingfoil/tempo:latest"
+pulumi config set grafana_image "123456789012.dkr.ecr.us-east-1.amazonaws.com/wingfoil/grafana:latest"
 ```
 
 ### 3. Review the deployment plan
@@ -97,9 +109,11 @@ Modify `Pulumi.demo.yaml` or use `pulumi config set` to customize:
 | `environment` | `demo` | Environment tag |
 | `cpu` | `1024` | ECS task CPU units (0.25, 0.5, 1, 2, 4 vCPU equivalent) |
 | `memory` | `2048` | ECS task memory (MB) |
-| `shm_size` | `256` | Shared memory for iceoryx2 (MB) |
 | `ws_server_image` | — | ws_server container image (required) |
 | `fix_gw_image` | — | fix_gw container image (required) |
+| `prometheus_image` | — | Prometheus image with config baked in (required) |
+| `tempo_image` | — | Tempo image with config baked in (required) |
+| `grafana_image` | — | Grafana image with provisioning baked in (required) |
 | `lmax_username` | — | LMAX FIX username (secret, required) |
 | `lmax_password` | — | LMAX FIX password (secret, required) |
 

--- a/wingfoil/examples/latency_e2e/pulumi/fargate/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/fargate/__main__.py
@@ -16,7 +16,6 @@ lmax_username = config.require_secret("lmax_username")
 lmax_password = config.require_secret("lmax_password")
 cpu = config.get_int("cpu") or 1024
 memory = config.get_int("memory") or 2048
-shm_size = config.get_int("shm_size") or 256
 
 tags = {
     "Project": project_name,
@@ -139,7 +138,8 @@ lmax_password_version = aws.secretsmanager.SecretVersion(f"{project_name}-lmax-p
     secret_id=lmax_password_secret.id,
     secret_string=lmax_password)
 
-# IAM role for ECS task
+# IAM role for ECS task (granted to the running container; not used by the agent
+# to fetch secrets — that's the execution role's job)
 ecs_task_role = aws.iam.Role(f"{project_name}-ecs-task-role",
     assume_role_policy=json.dumps({
         "Version": "2012-10-17",
@@ -151,24 +151,11 @@ ecs_task_role = aws.iam.Role(f"{project_name}-ecs-task-role",
     }),
     tags=tags)
 
-# IAM policy for Secrets Manager access
-secrets_policy = aws.iam.RolePolicy(f"{project_name}-ecs-secrets-policy",
-    role=ecs_task_role.id,
-    policy=pulumi.Output.all(lmax_username_secret.arn, lmax_password_secret.arn).apply(
-        lambda arns: json.dumps({
-            "Version": "2012-10-17",
-            "Statement": [{
-                "Effect": "Allow",
-                "Action": ["secretsmanager:GetSecretValue"],
-                "Resource": arns
-            }]
-        })))
-
 # ECS Cluster
 cluster = aws.ecs.Cluster(f"{project_name}-cluster",
     tags=tags)
 
-# ECS Task Execution Role (for logging, pulling images, etc.)
+# ECS Task Execution Role (for logging, pulling images, fetching secrets)
 ecs_task_execution_role = aws.iam.Role(f"{project_name}-ecs-task-execution-role",
     assume_role_policy=json.dumps({
         "Version": "2012-10-17",
@@ -183,6 +170,20 @@ ecs_task_execution_role = aws.iam.Role(f"{project_name}-ecs-task-execution-role"
 ecs_task_execution_policy = aws.iam.RolePolicyAttachment(f"{project_name}-ecs-task-execution-policy",
     role=ecs_task_execution_role.name,
     policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy")
+
+# Secrets Manager access for the execution role — ECS injects task-definition
+# `secrets` using this role, not the task role.
+secrets_policy = aws.iam.RolePolicy(f"{project_name}-ecs-secrets-policy",
+    role=ecs_task_execution_role.id,
+    policy=pulumi.Output.all(lmax_username_secret.arn, lmax_password_secret.arn).apply(
+        lambda arns: json.dumps({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": ["secretsmanager:GetSecretValue"],
+                "Resource": arns
+            }]
+        })))
 
 # ALB
 alb = aws.lb.LoadBalancer(f"{project_name}-alb",
@@ -293,8 +294,8 @@ task_definition = aws.ecs.TaskDefinition(f"{project_name}-task",
                 {"name": "RUST_LOG", "value": "info"},
             ],
             "secrets": [
-                {"name": "LMAX_USERNAME", "valueFrom": f"{args[1]}:LMAX_USERNAME::"},
-                {"name": "LMAX_PASSWORD", "valueFrom": f"{args[2]}:LMAX_PASSWORD::"},
+                {"name": "LMAX_USERNAME", "valueFrom": args[1]},
+                {"name": "LMAX_PASSWORD", "valueFrom": args[2]},
             ],
             "logConfiguration": {
                 "logDriver": "awslogs",


### PR DESCRIPTION
- Point workflow working-directory at pulumi/fargate/ (the Pulumi project
  lives there; pulumi/ has no Pulumi.yaml so every step would error).
- Pass prometheus_image / tempo_image / grafana_image through the workflow
  and document them in the README; __main__.py requires them.
- Drop dead shm_size config (read but never wired into the task definition).
- Fix ECS task-definition secrets: store secrets as raw strings, so
  valueFrom must be the bare ARN — the previous ":LMAX_USERNAME::" suffix
  asks ECS to JSON-decode the secret and would fail at task start.
- Move secretsmanager:GetSecretValue from the task role to the execution
  role; ECS injects task-definition secrets via the execution role.
- Update OIDC trust-policy comment to the current branch name.