### PR TITLE
contributing: add scripts/setup-dev.sh for protoc install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,13 @@ These tools are required for building, testing, and packaging the core **wingfoi
 
 * **The Rust toolchain:** `rustup`, `cargo`, `rustc`, etc. We aim for compatibility with the latest stable version.
 * **`rustfmt` and `clippy`:** We use `rustfmt` for consistent code style and `clippy` for linting across the whole code base.
-* **`protoc` (Protocol Buffers compiler):** required when building with `--all-features` (used transitively by `etcd-client` and a few other adapters).
-  * Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`
-  * macOS: `brew install protobuf`
+* **`protoc` (Protocol Buffers compiler):** required when building with `--all-features` (used transitively by `etcd-client` and a few other adapters). The easiest way to get it (Linux/macOS) is:
+
+  ```bash
+  ./scripts/setup-dev.sh
+  ```
+
+  Or install manually — Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`; macOS: `brew install protobuf`.
 
 For prerequisites specific to the **wingfoil-python** crate and the full build process, please see the [**BUILD.md**](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil-python/build.md) documentation.
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Install non-cargo build prerequisites (currently just protoc, needed when
+# building with `--features full` or any of: etcd, otlp, fluvio).
+#
+# Idempotent: skips anything already installed.
+
+set -euo pipefail
+
+if command -v protoc >/dev/null 2>&1; then
+    echo "protoc already installed: $(protoc --version)"
+    exit 0
+fi
+
+echo "protoc not found, installing..."
+
+case "$(uname -s)" in
+    Linux*)
+        if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y protobuf-compiler
+        elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y protobuf-compiler
+        elif command -v pacman >/dev/null 2>&1; then
+            sudo pacman -S --noconfirm protobuf
+        else
+            echo "Unsupported Linux distribution. Install protoc manually:"
+            echo "  https://github.com/protocolbuffers/protobuf/releases"
+            exit 1
+        fi
+        ;;
+    Darwin*)
+        if command -v brew >/dev/null 2>&1; then
+            brew install protobuf
+        else
+            echo "Homebrew not found. Install it from https://brew.sh, or install protoc manually:"
+            echo "  https://github.com/protocolbuffers/protobuf/releases"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Unsupported OS: $(uname -s). Install protoc manually:"
+        echo "  https://github.com/protocolbuffers/protobuf/releases"
+        exit 1
+        ;;
+esac
+
+echo "Installed: $(protoc --version)"


### PR DESCRIPTION
## Summary

Follow-up to #270. Adds `scripts/setup-dev.sh` so contributors don't have to read CONTRIBUTING.md to know which package-manager command to run for `protoc`.

- Detects `apt-get` / `dnf` / `pacman` / `brew`; falls back to a clear pointer at the upstream releases page on anything else
- Idempotent — exits early if `protoc` is already on PATH, so it's safe to run unconditionally (e.g. from a future devcontainer `postCreateCommand`)
- CONTRIBUTING.md prerequisites section now leads with `./scripts/setup-dev.sh`, with the manual one-liners kept as backup

## Test plan

- [x] `./scripts/setup-dev.sh` on a host with protoc → reports already-installed and exits 0
- [x] `bash -n scripts/setup-dev.sh` — syntax clean
- [ ] Manual: rerun on a fresh container without protoc to confirm install path works (CI will exercise this implicitly via `apt-get install` step staying in `rust.yml`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAYnetaEMRPczpVUD8BPu4)_