### PR TITLE
Temporarily disable latency E2E workflows pending AWS OIDC setup

### DIFF
--- a/.github/workflows/build-latency-e2e-images.yml
+++ b/.github/workflows/build-latency-e2e-images.yml
@@ -12,16 +12,12 @@
 
 name: Build & Push latency_e2e Images
 
+# TEMPORARILY DISABLED: AWS OIDC role / secrets not configured yet.
+# The configure-aws-credentials step fails with "Could not load credentials
+# from any providers". Re-enable by restoring the `push` trigger and
+# removing the `if: false` guard on the build job once
+# AWS_ROLE_TO_ASSUME is set and the OIDC trust policy is in place.
 on:
-  push:
-    branches: [main]
-    paths:
-      - "wingfoil/Cargo.toml"
-      - "wingfoil/src/**"
-      - "wingfoil/examples/latency_e2e/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/build-latency-e2e-images.yml"
   workflow_dispatch:
 
 env:
@@ -29,6 +25,7 @@ env:
 
 jobs:
   build:
+    if: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/deploy-latency-e2e.yml
+++ b/.github/workflows/deploy-latency-e2e.yml
@@ -57,6 +57,11 @@
 
 name: Deploy Latency E2E to AWS
 
+# TEMPORARILY DISABLED: AWS OIDC role / secrets not configured yet.
+# The configure-aws-credentials step fails with "Could not load credentials
+# from any providers". Re-enable by removing the `if: false` guard on the
+# deploy job once AWS_ROLE_TO_ASSUME is set and the OIDC trust policy is
+# in place.
 on:
   workflow_dispatch:
     inputs:
@@ -76,6 +81,7 @@ env:
 
 jobs:
   deploy:
+    if: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
Temporarily disables two GitHub Actions workflows that depend on AWS OIDC authentication until the required AWS role and OIDC trust policy are properly configured.

## Changes
- **build-latency-e2e-images.yml**: 
  - Removed the `push` trigger that automatically runs on changes to wingfoil source files
  - Added `if: false` guard to the build job to prevent execution
  - Added explanatory comment documenting the temporary disable reason

- **deploy-latency-e2e.yml**:
  - Added `if: false` guard to the deploy job to prevent execution
  - Added explanatory comment documenting the temporary disable reason

## Details
Both workflows currently fail at the `configure-aws-credentials` step with "Could not load credentials from any providers" because the AWS OIDC role and trust policy have not yet been configured. The workflows are disabled to prevent CI failures while setup is completed.

Once `AWS_ROLE_TO_ASSUME` is set and the OIDC trust policy is in place, these changes can be reverted by:
1. Removing the `if: false` guards from both jobs
2. Restoring the `push` trigger in build-latency-e2e-images.yml

https://claude.ai/code/session_0154sGifLeWGrCCY5YRECgSL