### PR TITLE
ci: enable latency_e2e image build/push workflow

### DIFF
--- a/.github/workflows/build-latency-e2e-images.yml
+++ b/.github/workflows/build-latency-e2e-images.yml
@@ -12,20 +12,20 @@
 
 name: Build & Push latency_e2e Images
 
-# TEMPORARILY DISABLED: AWS OIDC role / secrets not configured yet.
-# The configure-aws-credentials step fails with "Could not load credentials
-# from any providers". Re-enable by restoring the `push` trigger and
-# removing the `if: false` guard on the build job once
-# AWS_ROLE_TO_ASSUME is set and the OIDC trust policy is in place.
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'wingfoil/**'
+      - 'wingfoil/examples/latency_e2e/**'
+      - '.github/workflows/build-latency-e2e-images.yml'
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
 
 jobs:
   build:
-    if: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
AWS OIDC role and AWS_ROLE_TO_ASSUME secret are now configured, so the
guard rails added in cb073ae can come off. Restore the path-scoped push
trigger and drop the if: false on the build job.

https://claude.ai/code/session_016rekTPf4TAp3mnA3aqNVGC