### PR TITLE
latency_e2e: install libclang-dev in Rust builder images

### DIFF
--- a/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
+++ b/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
@@ -1,7 +1,7 @@
 # Builder stage
 FROM rust:latest as builder
 
-RUN apt-get update && apt-get install -y protobuf-compiler \
+RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace

--- a/wingfoil/examples/latency_e2e/Dockerfile.ws_server
+++ b/wingfoil/examples/latency_e2e/Dockerfile.ws_server
@@ -1,7 +1,7 @@
 # Builder stage
 FROM rust:latest as builder
 
-RUN apt-get update && apt-get install -y protobuf-compiler \
+RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

The `iceoryx2-beta` feature pulls in `iceoryx2-pal-posix`, whose `build.rs` runs bindgen 0.72 against POSIX headers. bindgen requires `libclang` at build time and the `rust:latest` image does not include it, so the cargo build aborts with exit 101 (`Unable to find libclang`).

Mirror the existing `protobuf-compiler` install in `Dockerfile.fix_gw` and `Dockerfile.ws_server` and add `libclang-dev`.

## Test plan

- [ ] `docker build -f wingfoil/examples/latency_e2e/Dockerfile.fix_gw .` succeeds
- [ ] `docker build -f wingfoil/examples/latency_e2e/Dockerfile.ws_server .` succeeds
- [ ] latency_e2e workflow passes in CI

https://claude.ai/code/session_013zAuF4TXgF2WpeWiBeozZU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUvKwhLi3yuVekzxfkdmUM)_