### PR TITLE
ci(latency_e2e/ami): forward ECR token from runner; align region default

### DIFF
--- a/.github/workflows/build-latency-e2e-ami.yml
+++ b/.github/workflows/build-latency-e2e-ami.yml
@@ -22,7 +22,7 @@
 #       - Build AMIs (ec2:* on AMI/snapshot/instance lifecycle)
 #       - Pull from ECR (ecr:GetAuthorizationToken, ecr:BatchGetImage etc.)
 #       - Write SSM parameter /wingfoil/latency-e2e/ec2-spot/ami_id
-#   - AWS_REGION          (optional, defaults to eu-west-2)
+#   - AWS_REGION          (optional, defaults to us-east-1)
 
 name: Build latency_e2e AMI (ec2-spot)
 
@@ -42,7 +42,10 @@ on:
       - '.github/workflows/build-latency-e2e-ami.yml'
 
 env:
-  AWS_REGION: ${{ secrets.AWS_REGION || 'eu-west-2' }}
+  AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+  # Push-triggered runs don't get workflow_dispatch inputs, so fall back to
+  # `latest` (matches the tag pushed by build-latency-e2e-images.yml).
+  IMAGE_TAG: ${{ inputs.image_tag || 'latest' }}
   SSM_AMI_PARAM: /wingfoil/latency-e2e/ec2-spot/ami_id
 
 jobs:
@@ -71,11 +74,11 @@ jobs:
           REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
           {
             echo "registry=${REGISTRY}"
-            echo "ws_server=${REGISTRY}/wingfoil/ws-server:${{ inputs.image_tag }}"
-            echo "fix_gw=${REGISTRY}/wingfoil/fix-gw:${{ inputs.image_tag }}"
-            echo "prometheus=${REGISTRY}/wingfoil/prometheus:${{ inputs.image_tag }}"
-            echo "tempo=${REGISTRY}/wingfoil/tempo:${{ inputs.image_tag }}"
-            echo "grafana=${REGISTRY}/wingfoil/grafana:${{ inputs.image_tag }}"
+            echo "ws_server=${REGISTRY}/wingfoil/ws-server:${IMAGE_TAG}"
+            echo "fix_gw=${REGISTRY}/wingfoil/fix-gw:${IMAGE_TAG}"
+            echo "prometheus=${REGISTRY}/wingfoil/prometheus:${IMAGE_TAG}"
+            echo "tempo=${REGISTRY}/wingfoil/tempo:${IMAGE_TAG}"
+            echo "grafana=${REGISTRY}/wingfoil/grafana:${IMAGE_TAG}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Packer
@@ -86,18 +89,25 @@ jobs:
       - name: Packer init
         run: packer init wingfoil-latency.pkr.hcl
 
+      # Fetch the ECR auth token on the runner (which has AWS creds via OIDC)
+      # and forward it to Packer. The provisioner uses this to `docker login`
+      # on the build instance — the instance has no IAM role, so calling
+      # `aws ecr get-login-password` from inside install.sh would fail with
+      # "Unable to locate credentials".
       - name: Packer build
+        env:
+          PKR_VAR_region: ${{ env.AWS_REGION }}
+          PKR_VAR_image_tag: ${{ env.IMAGE_TAG }}
+          PKR_VAR_ecr_registry: ${{ steps.ecr.outputs.registry }}
+          PKR_VAR_ws_server_image: ${{ steps.ecr.outputs.ws_server }}
+          PKR_VAR_fix_gw_image: ${{ steps.ecr.outputs.fix_gw }}
+          PKR_VAR_prometheus_image: ${{ steps.ecr.outputs.prometheus }}
+          PKR_VAR_tempo_image: ${{ steps.ecr.outputs.tempo }}
+          PKR_VAR_grafana_image: ${{ steps.ecr.outputs.grafana }}
         run: |
-          packer build \
-            -var "region=${AWS_REGION}" \
-            -var "image_tag=${{ inputs.image_tag }}" \
-            -var "ecr_registry=${{ steps.ecr.outputs.registry }}" \
-            -var "ws_server_image=${{ steps.ecr.outputs.ws_server }}" \
-            -var "fix_gw_image=${{ steps.ecr.outputs.fix_gw }}" \
-            -var "prometheus_image=${{ steps.ecr.outputs.prometheus }}" \
-            -var "tempo_image=${{ steps.ecr.outputs.tempo }}" \
-            -var "grafana_image=${{ steps.ecr.outputs.grafana }}" \
-            wingfoil-latency.pkr.hcl
+          ECR_PASSWORD=$(aws ecr get-login-password --region "$AWS_REGION")
+          echo "::add-mask::$ECR_PASSWORD"
+          PKR_VAR_ecr_password="$ECR_PASSWORD" packer build wingfoil-latency.pkr.hcl
 
       - name: Extract AMI ID
         id: ami
@@ -131,7 +141,7 @@ jobs:
             echo ""
             echo "- **AMI ID**: \`${{ steps.ami.outputs.ami_id }}\`"
             echo "- **Region**: \`${AWS_REGION}\`"
-            echo "- **Image tag**: \`${{ inputs.image_tag }}\`"
+            echo "- **Image tag**: \`${IMAGE_TAG}\`"
             echo "- **SSM parameter**: \`${SSM_AMI_PARAM}\`"
             echo ""
             echo "Wire it into the Pulumi stack:"

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -32,16 +32,26 @@ sudo /tmp/aws/install
 rm -rf /tmp/aws /tmp/awscliv2.zip
 
 # Authenticate to ECR if we're pulling private images. ECR_REGISTRY is the
-# host portion only (e.g. 123456789012.dkr.ecr.eu-west-2.amazonaws.com).
+# host portion only (e.g. 123456789012.dkr.ecr.us-east-1.amazonaws.com).
+# ECR_PASSWORD is the auth token CI fetched via `aws ecr get-login-password`
+# — the build instance has no IAM role, so it can't fetch the token itself.
 if [ -n "${ECR_REGISTRY:-}" ]; then
-  aws ecr get-login-password --region "${AWS_REGION}" \
-    | sudo docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+  if [ -z "${ECR_PASSWORD:-}" ]; then
+    echo "ERROR: ECR_REGISTRY is set but ECR_PASSWORD is empty; CI must forward PKR_VAR_ecr_password." >&2
+    exit 1
+  fi
+  echo "${ECR_PASSWORD}" | sudo docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 fi
 
 # Pre-pull every image so reclaim recovery doesn't wait on the registry.
 for img in "${WS_SERVER_IMAGE}" "${FIX_GW_IMAGE}" "${PROMETHEUS_IMAGE}" "${TEMPO_IMAGE}" "${GRAFANA_IMAGE}"; do
   sudo docker pull "${img}"
 done
+
+# Drop the docker login state so the AMI doesn't ship with an ECR token
+# baked into /root/.docker/config.json. The token expires in ~12h anyway,
+# but cleaning up keeps the AMI free of credential artifacts.
+sudo rm -rf /root/.docker /home/ec2-user/.docker
 
 # Stage the runtime files in /opt/wingfoil. user_data writes the .env file
 # alongside compose.yml on first boot, then runs `docker compose up -d`.

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
@@ -55,6 +55,16 @@ variable "ecr_registry" {
   default = ""
 }
 
+# Pre-fetched ECR auth token, forwarded from CI via PKR_VAR_ecr_password.
+# The build instance has no IAM role attached, so it can't run
+# `aws ecr get-login-password` itself — CI fetches the token (which is valid
+# for ~12h) and we use it directly in `docker login`.
+variable "ecr_password" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 locals {
   ami_name = "wingfoil-latency-ec2-spot-${var.image_tag}-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
 }
@@ -115,6 +125,7 @@ build {
       "TEMPO_IMAGE=${var.tempo_image}",
       "GRAFANA_IMAGE=${var.grafana_image}",
       "ECR_REGISTRY=${var.ecr_registry}",
+      "ECR_PASSWORD=${var.ecr_password}",
       "AWS_REGION=${var.region}",
     ]
     script = "${path.root}/install.sh"


### PR DESCRIPTION
Three issues were stopping the AMI build from completing:

1. install.sh ran `aws ecr get-login-password` on the Packer build
   instance, but the source has no `iam_instance_profile`, so the
   instance has no AWS credentials and the call fails with "Unable to
   locate credentials". Now CI fetches the token (it already has OIDC
   creds), forwards it through Packer as a sensitive variable, and the
   provisioner pipes it directly into `docker login`. The login state
   is deleted before the AMI snapshot so no credential artifacts ship
   in the image.

2. The push trigger never sets `inputs.image_tag`, so image refs
   resolved to `<registry>/wingfoil/<name>:` (trailing colon, invalid
   reference). Default to "latest" via an `IMAGE_TAG` env var that
   covers both push and dispatch.

3. Region default was `eu-west-2` while the sister images and deploy
   workflows default to `us-east-1`. If `AWS_REGION` isn't set as a
   secret, the AMI build was looking for ECR images in the wrong
   region. Aligned to `us-east-1`.

https://claude.ai/code/session_01V2KZ4W4SJXDqqpxGSLk3dP