### PR TITLE
Fix AMI build: install prometheus_client into a venv on AL2023

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -6,7 +6,15 @@
 set -euxo pipefail
 
 # Wait for cloud-init to finish so dnf isn't racing against base setup.
-sudo cloud-init status --wait
+# AL2023's cloud-init returns exit 2 for "degraded done" — cloud-init
+# completed but emitted non-fatal warnings (e.g. NetworkManager noise).
+# Treat that as success; only exit 1 (genuine error) should fail the build.
+cloud_init_rc=0
+sudo cloud-init status --wait || cloud_init_rc=$?
+if [ "${cloud_init_rc}" -ne 0 ] && [ "${cloud_init_rc}" -ne 2 ]; then
+  echo "ERROR: cloud-init failed with exit code ${cloud_init_rc}" >&2
+  exit "${cloud_init_rc}"
+fi
 
 sudo dnf update -y
 # unzip — needed for the AWS CLI installer below.

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -11,11 +11,15 @@ sudo cloud-init status --wait
 sudo dnf update -y
 # unzip — needed for the AWS CLI installer below.
 # prometheus_client (used by spot_watcher.py) isn't packaged for AL2023, so
-# install it via pip. AL2023's system python is externally-managed, so pass
-# --break-system-packages to land it in /usr/lib/python3.x/site-packages where
-# /usr/bin/python3 (the interpreter the systemd unit invokes) can import it.
+# install it into a dedicated venv at /opt/wingfoil/venv. A venv side-steps
+# AL2023's externally-managed-environment marker without depending on the
+# system pip being new enough to recognise --break-system-packages (the flag
+# was only added in pip 23.0.1, and AL2023's bundled pip can lag behind).
+# The systemd unit (see user_data.sh) invokes the venv's python3 directly.
 sudo dnf install -y docker unzip python3-pip
-sudo pip3 install --break-system-packages prometheus_client
+sudo install -d -m 0755 /opt/wingfoil
+sudo python3 -m venv /opt/wingfoil/venv
+sudo /opt/wingfoil/venv/bin/pip install --no-cache-dir prometheus_client
 sudo systemctl enable --now docker
 sudo usermod -aG docker ec2-user
 
@@ -64,7 +68,7 @@ sudo rm -rf /root/.docker /home/ec2-user/.docker
 
 # Stage the runtime files in /opt/wingfoil. user_data writes the .env file
 # alongside compose.yml on first boot, then runs `docker compose up -d`.
-sudo install -d -m 0755 /opt/wingfoil
+# (/opt/wingfoil already exists from the venv step above.)
 sudo install -m 0644 /tmp/docker-compose.yml /opt/wingfoil/docker-compose.yml
 sudo install -m 0755 /tmp/spot_watcher.py     /opt/wingfoil/spot_watcher.py
 
@@ -106,10 +110,10 @@ sudo tee -a /opt/wingfoil/docker-compose.yml > /dev/null <<EOF
     restart: unless-stopped
 EOF
 
-# Verify prometheus_client is importable from /usr/bin/python3 — the systemd
-# unit invokes that interpreter, and a silent missing-package would only
-# surface at first boot.
-/usr/bin/python3 -c "import prometheus_client"
+# Verify prometheus_client is importable from the venv interpreter — the
+# systemd unit invokes /opt/wingfoil/venv/bin/python3, and a silent missing
+# package would only surface at first boot.
+/opt/wingfoil/venv/bin/python3 -c "import prometheus_client"
 
 # Sanity check — fail the build if any image is missing locally.
 for img in "${WS_SERVER_IMAGE}" "${FIX_GW_IMAGE}" "${PROMETHEUS_IMAGE}" "${TEMPO_IMAGE}" "${GRAFANA_IMAGE}"; do

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -80,7 +80,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /opt/wingfoil/spot_watcher.py
+ExecStart=/opt/wingfoil/venv/bin/python3 /opt/wingfoil/spot_watcher.py
 Restart=always
 RestartSec=2
 


### PR DESCRIPTION
`sudo pip3 install --break-system-packages prometheus_client` (added in
PR #292) fails on AL2023 build instances whose bundled `python3-pip`
predates 23.0.1 — the flag is unrecognised, and `set -euxo pipefail`
turns that into a build-aborting error. Even when the flag is accepted,
relying on a specific pip version baked into the AL2023 base AMI is
fragile.

Switch to a dedicated venv at /opt/wingfoil/venv and install
prometheus_client there. A venv side-steps PEP 668 entirely without
depending on the system pip's age. Update the wingfoil-spot-watcher
systemd unit (in user_data.sh) to invoke the venv's python3 so the
import resolves at runtime.