### PR TITLE
Fix latency_e2e Pulumi.yaml: use `value` for aws:region, not `default`

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/Pulumi.yaml
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/Pulumi.yaml
@@ -8,7 +8,7 @@ config:
   aws:region:
     description: AWS region. Default eu-west-2 — LMAX London Demo lives in London,
       so this minimises FIX RTT (~5 ms vs. ~75 ms transatlantic).
-    default: eu-west-2
+    value: eu-west-2
   instance_type:
     description: EC2 bare-metal instance type. c7i.metal-24xl is the cheapest
       current-gen bare metal in eu-west-2 (~$4.28/hr on-demand, 96 vCPU). Smaller

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/Pulumi.yaml
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/Pulumi.yaml
@@ -7,4 +7,4 @@ description: Always-on EC2 Spot deployment of the wingfoil latency_e2e demo. Use
 config:
   aws:region:
     description: AWS region
-    default: eu-west-2
+    value: eu-west-2

--- a/wingfoil/examples/latency_e2e/pulumi/fargate/Pulumi.yaml
+++ b/wingfoil/examples/latency_e2e/pulumi/fargate/Pulumi.yaml
@@ -6,4 +6,4 @@ description: Always-on Fargate deployment of the wingfoil latency_e2e demo. Use 
 config:
   aws:region:
     description: AWS region
-    default: eu-west-2
+    value: eu-west-2


### PR DESCRIPTION
`pulumi stack select --create demo` failed in the deploy workflow with:

  error: could not unmarshal '.../Pulumi.yaml': Configuration key
  'aws:region' is not namespaced by the project and should not define a
  default value. Did you mean to use the 'value' attribute instead of
  'default'?

Pulumi distinguishes between project-namespaced config keys (which take
`default:`, the value the user falls back to if they set nothing) and
keys in another namespace such as `aws:` (which take `value:`, the
literal value handed to that other component). `aws:region` belongs to
the AWS provider, not this project, so it must use `value`.

Apply the same fix to all three latency_e2e stacks (ec2-spot, fargate,
baremetal). Other config keys in baremetal (instance_type,
isolated_cores, etc.) are correctly project-namespaced and keep
`default:`.

https://claude.ai/code/session_01HpAKrYi44TBX7wReYpKv7z