### PR TITLE
latency_e2e: harden deployment surface

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Keep the build context lean and prevent secrets / dev artefacts from
+# landing in image layers via `COPY . .` in wingfoil/examples/latency_e2e/Dockerfile.*
+
+.git/
+.gitignore
+.github/
+
+# Build outputs — Docker builds from source, no need to ship host artefacts.
+target/
+**/target/
+**/*.rlib
+**/*.rmeta
+
+# Editor / OS noise
+.idea/
+.vscode/
+.DS_Store
+*.swp
+*.swo
+*~
+
+# Python / Pulumi state — Pulumi.*.yaml may contain encrypted secrets, but
+# it's not needed in the image and a misconfigured passphrase backend in CI
+# could expose plaintext.
+**/__pycache__/
+**/venv/
+**/.pulumi/
+**/Pulumi.*.yaml
+
+# Local env files
+**/.env
+**/.env.*
+
+# Maturin / Python wheel build dirs
+wingfoil-python/target/
+wingfoil-python/dist/
+wingfoil-python/build/

--- a/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
+++ b/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
@@ -1,5 +1,7 @@
-# Builder stage
-FROM rust:latest as builder
+# Builder stage — pinned to match the workspace `rust-version` in
+# /Cargo.toml. Bumping the toolchain is an intentional change, not a
+# silent `:latest` drift.
+FROM rust:1.87-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -17,10 +19,14 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y \
     libssl3 \
     ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 wingfoil \
+    && useradd --system --uid 10001 --gid wingfoil --no-create-home --home /app wingfoil
 
 WORKDIR /app
 
-COPY --from=builder /workspace/target/release/examples/latency_e2e_fix_gw /app/fix_gw
+COPY --from=builder --chown=wingfoil:wingfoil /workspace/target/release/examples/latency_e2e_fix_gw /app/fix_gw
+
+USER wingfoil:wingfoil
 
 ENTRYPOINT ["/app/fix_gw"]

--- a/wingfoil/examples/latency_e2e/Dockerfile.ws_server
+++ b/wingfoil/examples/latency_e2e/Dockerfile.ws_server
@@ -1,5 +1,7 @@
-# Builder stage
-FROM rust:latest as builder
+# Builder stage — pinned to match the workspace `rust-version` in
+# /Cargo.toml. Bumping the toolchain is an intentional change, not a
+# silent `:latest` drift.
+FROM rust:1.87-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -17,14 +19,18 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y \
     libssl3 \
     ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 wingfoil \
+    && useradd --system --uid 10001 --gid wingfoil --no-create-home --home /app wingfoil
 
 WORKDIR /app
 
-COPY --from=builder /workspace/target/release/examples/latency_e2e_ws_server /app/ws_server
-COPY wingfoil/examples/latency_e2e/static /app/static
+COPY --from=builder --chown=wingfoil:wingfoil /workspace/target/release/examples/latency_e2e_ws_server /app/ws_server
+COPY --chown=wingfoil:wingfoil wingfoil/examples/latency_e2e/static /app/static
 
 ENV WINGFOIL_STATIC_DIR=/app/static
+
+USER wingfoil:wingfoil
 
 EXPOSE 8080 9091
 

--- a/wingfoil/examples/latency_e2e/docker-compose.yml
+++ b/wingfoil/examples/latency_e2e/docker-compose.yml
@@ -38,7 +38,11 @@ services:
     ports:
       - "3000:3000"
     environment:
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      # Override locally if you want to log in as admin:
+      #   GF_SECURITY_ADMIN_PASSWORD=$(openssl rand -hex 16) docker compose up -d
+      # Default to a long random value so a left-running compose stack
+      # doesn't sit on `admin/admin`.
+      GF_SECURITY_ADMIN_PASSWORD: "${GF_SECURITY_ADMIN_PASSWORD:-changeme-set-via-env}"
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
       GF_AUTH_DISABLE_LOGIN_FORM: "true"

--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/Pulumi.yaml
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/Pulumi.yaml
@@ -29,6 +29,11 @@ config:
     description: Core ID for the fix_gw graph thread (must appear in
       isolated_cores).
     default: "4"
+  ssh_ingress_cidr:
+    description: CIDR allowed to reach :22. Empty (default) means SSH is
+      not exposed at all. The Instance has no `key_name` by default, so
+      enabling this is only useful if you also add one.
+    default: ""
   alert_email:
     description: Email for cost / abuse alarms. If unset, no alarms are
       created — you're flying blind on a public wake URL.
@@ -37,3 +42,9 @@ config:
     description: AWS Budgets threshold. Sends a warning at 80%% and a
       breach notice at 100%% of this number to alert_email.
     default: "50"
+  wake_token:
+    description: Optional shared secret on the wake URL. When set, the page
+      and JSON API require ?token=<value>. Recommended for any public
+      deployment. Set with `pulumi config set --secret wake_token <...>`.
+    secret: true
+    default: ""

--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/README.md
@@ -130,9 +130,16 @@ action when the threshold hits 100%.
 
 **Want zero unauthenticated access instead?**
 
-* Add a `wake_token` query-param check in `wake_lambda.py` (~10 lines).
-  The token becomes the credential — share the URL with the token in
-  it.
+```bash
+pulumi config set --secret wake_token "$(openssl rand -hex 16)"
+pulumi up
+```
+
+When `wake_token` is set, the lambda rejects any request without
+`?token=<value>` (or `X-Wake-Token: <value>` header) — including the GET
+that serves the HTML page. The exported `wake_url` already includes the
+token, so share it as-is. Constant-time compare on the server side keeps
+the secret out of timing side-channels.
 
 ## Stop without destroying
 

--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/__main__.py
@@ -75,6 +75,10 @@ lmax_username = config.require_secret("lmax_username")
 lmax_password = config.require_secret("lmax_password")
 alert_email = config.get("alert_email") or ""
 monthly_budget_usd = config.get("monthly_budget_usd") or "50"
+# Optional shared secret on the wake URL. When set, GET / and the JSON API
+# require ?token=<value>. Recommended for any public deployment — without
+# it, anyone with the URL can wake the $4.28/hr instance.
+wake_token = config.get_secret("wake_token")
 
 tags = {"Project": project, "Stack": stack, "ManagedBy": "Pulumi"}
 
@@ -120,16 +124,28 @@ aws.ec2.RouteTableAssociation(f"{prefix}-rt-assoc", subnet_id=subnet.id, route_t
 # if you don't want it open to the internet.
 ingress_cidr = config.get("ingress_cidr") or "0.0.0.0/0"
 
+# SSH ingress is opt-in. The instance has no `key_name`, so the default
+# (off) means SSH is unreachable — which is what you want for a public
+# perf demo. Enable for break-glass debugging via:
+#   pulumi config set ssh_ingress_cidr 203.0.113.4/32
+# and add `key_name` to the Instance resource below.
+ssh_ingress_cidr = config.get("ssh_ingress_cidr") or ""
+
+ingress_rules = [
+    aws.ec2.SecurityGroupIngressArgs(from_port=8080, to_port=8080, protocol="tcp", cidr_blocks=[ingress_cidr]),
+    aws.ec2.SecurityGroupIngressArgs(from_port=9091, to_port=9091, protocol="tcp", cidr_blocks=[ingress_cidr]),
+    aws.ec2.SecurityGroupIngressArgs(from_port=3000, to_port=3000, protocol="tcp", cidr_blocks=[ingress_cidr]),
+]
+if ssh_ingress_cidr:
+    ingress_rules.append(
+        aws.ec2.SecurityGroupIngressArgs(from_port=22, to_port=22, protocol="tcp", cidr_blocks=[ssh_ingress_cidr]),
+    )
+
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
-    description="wingfoil baremetal demo — WS, prometheus, grafana, SSH",
-    ingress=[
-        aws.ec2.SecurityGroupIngressArgs(from_port=22,   to_port=22,   protocol="tcp", cidr_blocks=[ingress_cidr]),
-        aws.ec2.SecurityGroupIngressArgs(from_port=8080, to_port=8080, protocol="tcp", cidr_blocks=[ingress_cidr]),
-        aws.ec2.SecurityGroupIngressArgs(from_port=9091, to_port=9091, protocol="tcp", cidr_blocks=[ingress_cidr]),
-        aws.ec2.SecurityGroupIngressArgs(from_port=3000, to_port=3000, protocol="tcp", cidr_blocks=[ingress_cidr]),
-    ],
+    description="wingfoil baremetal demo — WS, prometheus, grafana",
+    ingress=ingress_rules,
     egress=[aws.ec2.SecurityGroupEgressArgs(from_port=0, to_port=0, protocol="-1", cidr_blocks=["0.0.0.0/0"])],
     tags={**tags, "Name": f"{prefix}-sg"},
 )
@@ -141,6 +157,27 @@ bucket = aws.s3.BucketV2(
     f"{prefix}-assets",
     force_destroy=True,  # demo stack — let `pulumi destroy` actually destroy
     tags=tags,
+)
+
+# Belt-and-braces: AWS now defaults new buckets to "block public access" on,
+# but we set it explicitly so a future console click can't loosen it.
+aws.s3.BucketPublicAccessBlock(
+    f"{prefix}-assets-pab",
+    bucket=bucket.id,
+    block_public_acls=True,
+    block_public_policy=True,
+    ignore_public_acls=True,
+    restrict_public_buckets=True,
+)
+
+aws.s3.BucketServerSideEncryptionConfigurationV2(
+    f"{prefix}-assets-sse",
+    bucket=bucket.id,
+    rules=[aws.s3.BucketServerSideEncryptionConfigurationV2RuleArgs(
+        apply_server_side_encryption_by_default=aws.s3.BucketServerSideEncryptionConfigurationV2RuleApplyServerSideEncryptionByDefaultArgs(
+            sse_algorithm="AES256",
+        ),
+    )],
 )
 
 aws.s3.BucketObject(
@@ -301,10 +338,18 @@ instance = aws.ec2.Instance(
     # Replace the box if user_data changes — otherwise edits to the script
     # silently never run on the existing instance.
     user_data_replace_on_change=True,
+    # Force IMDSv2 — defends against SSRF on anything that ever runs here
+    # being able to fetch instance credentials via the IMDSv1 GET path.
+    metadata_options=aws.ec2.InstanceMetadataOptionsArgs(
+        http_tokens="required",
+        http_endpoint="enabled",
+        http_put_response_hop_limit=1,
+    ),
     root_block_device=aws.ec2.InstanceRootBlockDeviceArgs(
         volume_size=64,
         volume_type="gp3",
         delete_on_termination=True,
+        encrypted=True,
     ),
     tags={**tags, "Name": f"{prefix}-host"},
 )
@@ -376,7 +421,11 @@ wake_lambda = aws.lambda_.Function(
     timeout=10,
     memory_size=128,
     environment=aws.lambda_.FunctionEnvironmentArgs(
-        variables={"INSTANCE_ID": instance.id, "WS_SERVER_PORT": "8080"},
+        variables={
+            "INSTANCE_ID": instance.id,
+            "WS_SERVER_PORT": "8080",
+            "WAKE_TOKEN": wake_token if wake_token is not None else "",
+        },
     ),
     tags=tags,
 )
@@ -428,4 +477,9 @@ pulumi.export("ws_server_url",   eip.public_ip.apply(lambda ip: f"http://{ip}:80
 pulumi.export("grafana_url",     eip.public_ip.apply(lambda ip: f"http://{ip}:3000"))
 pulumi.export("prometheus_url",  eip.public_ip.apply(lambda ip: f"http://{ip}:9091/metrics"))
 pulumi.export("assets_bucket",   bucket.bucket)
-pulumi.export("wake_url",        wake_url.function_url)
+pulumi.export(
+    "wake_url",
+    pulumi.Output.all(wake_url.function_url, wake_token).apply(
+        lambda a: f"{a[0]}?token={a[1]}" if a[1] else a[0]
+    ),
+)

--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/user_data.sh
@@ -10,7 +10,8 @@
 #
 # Idempotent: gated on /var/lib/wingfoil-bootstrapped so a manual re-run is safe.
 
-set -euxo pipefail
+set -euo pipefail
+set -x
 
 ISOLATED_CORES="__ISOLATED_CORES__"
 WS_SERVER_CORE="__WS_SERVER_CORE__"
@@ -57,16 +58,22 @@ if [ "$stage" = "installed" ]; then
   aws s3 sync "s3://${BINARIES_BUCKET}/observability/"        /opt/wingfoil/observability/        --region "${AWS_REGION}"
   chmod 0755 /opt/wingfoil/latency_e2e_ws_server /opt/wingfoil/latency_e2e_fix_gw
 
+  # Write LMAX creds to a root-only env file rather than embedding in the
+  # systemd unit (which would expose them via `systemctl show`). Disable -x
+  # for the fetch + heredoc — bash xtrace echoes commands after parameter
+  # expansion, so the secret values would otherwise land in
+  # /var/log/cloud-init-output.log and `aws ec2 get-console-output`.
+  install -d -m 0700 /etc/wingfoil
+  set +x
   LMAX_USERNAME=$(aws secretsmanager get-secret-value --secret-id "${LMAX_USERNAME_SECRET}" --region "${AWS_REGION}" --query SecretString --output text)
   LMAX_PASSWORD=$(aws secretsmanager get-secret-value --secret-id "${LMAX_PASSWORD_SECRET}" --region "${AWS_REGION}" --query SecretString --output text)
-
-  # Write LMAX creds to a root-only env file rather than embedding in the
-  # systemd unit (which would expose them via `systemctl show`).
-  install -d -m 0700 /etc/wingfoil
-  cat > /etc/wingfoil/lmax.env <<EOF
+  ( umask 077 && cat > /etc/wingfoil/lmax.env <<EOF
 LMAX_USERNAME=${LMAX_USERNAME}
 LMAX_PASSWORD=${LMAX_PASSWORD}
 EOF
+  )
+  unset LMAX_USERNAME LMAX_PASSWORD
+  set -x
   chmod 0600 /etc/wingfoil/lmax.env
 
   cat > /etc/systemd/system/wingfoil-ws-server.service <<EOF
@@ -120,6 +127,22 @@ EOF
   # Observability stack — kept on housekeeping cores 0-1 via cpuset so it
   # never competes with the hot-path threads. Configs were synced from S3
   # into /opt/wingfoil/observability/{prometheus,grafana,tempo} above.
+  #
+  # Generate a fresh Grafana admin password on every boot. Anonymous Viewer
+  # is on and the login form is disabled, so nobody logs in interactively
+  # — this just prevents the historical `admin/admin` default that the
+  # Grafana API otherwise accepts. Written to a `.env` file alongside the
+  # compose so `docker compose` substitutes `${GF_SECURITY_ADMIN_PASSWORD}`.
+  set +x
+  GRAFANA_ADMIN_PASSWORD=$(openssl rand -hex 16)
+  ( umask 077 && cat > /opt/wingfoil/observability/.env <<EOF
+GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+EOF
+  )
+  unset GRAFANA_ADMIN_PASSWORD
+  set -x
+  chmod 0600 /opt/wingfoil/observability/.env
+
   cat > /opt/wingfoil/observability/docker-compose.yml <<'EOF'
 services:
   prometheus:
@@ -145,6 +168,7 @@ services:
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
     environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
       GF_AUTH_DISABLE_LOGIN_FORM: "true"

--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/wake_lambda.py
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/wake_lambda.py
@@ -14,6 +14,7 @@ has booted; ws_server itself takes another ~30s after that to come up,
 so the link will 502 briefly. The page handles that by retrying.
 """
 
+import hmac
 import json
 import os
 
@@ -22,6 +23,11 @@ import boto3
 ec2 = boto3.client("ec2")
 INSTANCE_ID = os.environ["INSTANCE_ID"]
 WS_SERVER_PORT = int(os.environ.get("WS_SERVER_PORT", "8080"))
+# Optional shared secret. When set, every HTTP request must carry
+# `?token=<value>` (or matching `X-Wake-Token` header) — including the GET
+# that serves the HTML page. Empty disables the check (back-compat with
+# stacks that haven't set it yet).
+WAKE_TOKEN = os.environ.get("WAKE_TOKEN", "")
 
 
 HTML = """<!doctype html>
@@ -53,8 +59,13 @@ HTML = """<!doctype html>
     const out = document.getElementById("status");
     let pollHandle = null;
 
+    // Forward the token (if any) from the page URL onto every API call so
+    // /status and /wake see the same shared secret the user used to load
+    // this page.
+    const pageToken = new URLSearchParams(window.location.search).get("token") || "";
     async function call(path, method = "GET") {
-      const r = await fetch(path, { method });
+      const url = pageToken ? path + "?token=" + encodeURIComponent(pageToken) : path;
+      const r = await fetch(url, { method });
       return await r.json();
     }
 
@@ -123,10 +134,24 @@ def _json(status, body):
     }
 
 
+def _token_ok(event) -> bool:
+    if not WAKE_TOKEN:
+        return True
+    qs = event.get("queryStringParameters") or {}
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+    presented = qs.get("token") or headers.get("x-wake-token") or ""
+    # Constant-time compare so the function URL doesn't leak the secret one
+    # byte at a time via response timing.
+    return hmac.compare_digest(presented, WAKE_TOKEN)
+
+
 def handler(event, _context):
     http = event.get("requestContext", {}).get("http", {})
     method = http.get("method", "GET")
     path = event.get("rawPath", "/")
+
+    if not _token_ok(event):
+        return _json(401, {"error": "missing or invalid token"})
 
     if method == "GET" and path in ("/", "/index.html"):
         return {

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -150,11 +150,15 @@ instance_role = aws.iam.Role(
     tags=tags,
 )
 
+account_id = aws.get_caller_identity().account_id
+
 aws.iam.RolePolicy(
     f"{prefix}-instance-policy",
     role=instance_role.id,
     policy=pulumi.Output.all(
-        lmax_username_secret.arn, lmax_password_secret.arn, eip.allocation_id
+        lmax_username_secret.arn,
+        lmax_password_secret.arn,
+        eip.allocation_id,
     ).apply(lambda a: json.dumps({
         "Version": "2012-10-17",
         "Statement": [
@@ -163,13 +167,27 @@ aws.iam.RolePolicy(
                 "Action": ["secretsmanager:GetSecretValue"],
                 "Resource": [a[0], a[1]],
             },
-            # AssociateAddress doesn't accept resource-level conditions on
-            # the EIP itself; scope by tag on the instance instead so the
-            # role can only re-associate to instances we own.
+            # DescribeAddresses doesn't support resource-level permissions
+            # at all (the previous tag condition was silently a no-op), so
+            # split it out as `Resource: "*"` and accept the breadth — it's
+            # a read-only API.
             {
                 "Effect": "Allow",
-                "Action": ["ec2:AssociateAddress", "ec2:DescribeAddresses"],
+                "Action": ["ec2:DescribeAddresses"],
                 "Resource": "*",
+            },
+            # AssociateAddress: scope to *this* EIP allocation ARN plus any
+            # instance/network-interface tagged with our Project/Stack. The
+            # resource-tag condition is enforced per-resource — both the
+            # EIP and the instance must satisfy it for the call to succeed.
+            {
+                "Effect": "Allow",
+                "Action": ["ec2:AssociateAddress"],
+                "Resource": [
+                    f"arn:aws:ec2:*:{account_id}:elastic-ip/{a[2]}",
+                    f"arn:aws:ec2:*:{account_id}:instance/*",
+                    f"arn:aws:ec2:*:{account_id}:network-interface/*",
+                ],
                 "Condition": {
                     "StringEquals": {
                         "aws:ResourceTag/Project": project,

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -91,6 +91,21 @@ EOF
 systemctl daemon-reload
 systemctl enable --now wingfoil-spot-watcher.service
 
+# Generate a fresh Grafana admin password on every boot. Anonymous Viewer
+# is on and the login form is disabled, so nobody logs in interactively
+# — this just prevents the historical `admin/admin` default that the
+# Grafana API otherwise accepts. Written to `/opt/wingfoil/.env` so
+# `docker compose` substitutes `${GF_SECURITY_ADMIN_PASSWORD}`.
+set +x
+GRAFANA_ADMIN_PASSWORD=$(openssl rand -hex 16)
+( umask 077 && cat > /opt/wingfoil/.env <<EOF
+GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+EOF
+)
+unset GRAFANA_ADMIN_PASSWORD
+set -x
+chmod 0600 /opt/wingfoil/.env
+
 # Bring up the demo stack — images already cached in the AMI, so this is a
 # fast `docker run` per service rather than a registry pull.
 ( cd /opt/wingfoil && docker compose up -d )

--- a/wingfoil/examples/latency_e2e/pulumi/fargate/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/fargate/README.md
@@ -40,9 +40,10 @@ pulumi config set prometheus_image <ECR_URI_or_DOCKER_HUB_IMAGE>
 pulumi config set tempo_image <ECR_URI_or_DOCKER_HUB_IMAGE>
 pulumi config set grafana_image <ECR_URI_or_DOCKER_HUB_IMAGE>
 
-# Set secrets (LMAX credentials)
+# Set secrets (LMAX credentials + Grafana admin password)
 pulumi config set --secret lmax_username <YOUR_LMAX_USERNAME>
 pulumi config set --secret lmax_password <YOUR_LMAX_PASSWORD>
+pulumi config set --secret grafana_admin_password "$(openssl rand -hex 16)"
 ```
 
 **Example with Docker Hub images:**
@@ -115,6 +116,7 @@ Modify `Pulumi.demo.yaml` or use `pulumi config set` to customize:
 | `grafana_image` | — | Grafana image with provisioning baked in (required) |
 | `lmax_username` | — | LMAX FIX username (secret, required) |
 | `lmax_password` | — | LMAX FIX password (secret, required) |
+| `grafana_admin_password` | — | Grafana admin password (secret, required) |
 
 ## Monitoring
 

--- a/wingfoil/examples/latency_e2e/pulumi/fargate/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/fargate/__main__.py
@@ -14,6 +14,10 @@ tempo_image = config.require("tempo_image")
 grafana_image = config.require("grafana_image")
 lmax_username = config.require_secret("lmax_username")
 lmax_password = config.require_secret("lmax_password")
+# Grafana admin password — required so a stack never silently boots with
+# the historical `admin/admin` default. Set with:
+#   pulumi config set --secret grafana_admin_password "$(openssl rand -hex 16)"
+grafana_admin_password = config.require_secret("grafana_admin_password")
 cpu = config.get_int("cpu") or 1024
 memory = config.get_int("memory") or 2048
 
@@ -74,9 +78,10 @@ public_rt_assoc_b = aws.ec2.RouteTableAssociation(f"{project_name}-public-rt-ass
 alb_sg = aws.ec2.SecurityGroup(f"{project_name}-alb-sg",
     vpc_id=vpc.id,
     description="Security group for ALB",
+    # Only the ports the ALB actually listens on. If you front this with
+    # ACM + an HTTPS listener, add 443 back.
     ingress=[
         aws.ec2.SecurityGroupIngressArgs(from_port=80, to_port=80, protocol="tcp", cidr_blocks=["0.0.0.0/0"]),
-        aws.ec2.SecurityGroupIngressArgs(from_port=443, to_port=443, protocol="tcp", cidr_blocks=["0.0.0.0/0"]),
         aws.ec2.SecurityGroupIngressArgs(from_port=3000, to_port=3000, protocol="tcp", cidr_blocks=["0.0.0.0/0"]),
     ],
     egress=[aws.ec2.SecurityGroupEgressArgs(from_port=0, to_port=0, protocol="-1", cidr_blocks=["0.0.0.0/0"])],
@@ -116,6 +121,14 @@ lmax_password_secret = aws.secretsmanager.Secret(f"{project_name}-lmax-password"
 lmax_password_version = aws.secretsmanager.SecretVersion(f"{project_name}-lmax-password-version",
     secret_id=lmax_password_secret.id,
     secret_string=lmax_password)
+
+grafana_admin_secret = aws.secretsmanager.Secret(f"{project_name}-grafana-admin",
+    description="Grafana admin password",
+    tags=tags)
+
+grafana_admin_version = aws.secretsmanager.SecretVersion(f"{project_name}-grafana-admin-version",
+    secret_id=grafana_admin_secret.id,
+    secret_string=grafana_admin_password)
 
 # IAM role for ECS task (granted to the running container; not used by the agent
 # to fetch secrets — that's the execution role's job)
@@ -161,7 +174,11 @@ ecs_task_execution_policy = aws.iam.RolePolicyAttachment(f"{project_name}-ecs-ta
 # `secrets` using this role, not the task role.
 secrets_policy = aws.iam.RolePolicy(f"{project_name}-ecs-secrets-policy",
     role=ecs_task_execution_role.id,
-    policy=pulumi.Output.all(lmax_username_secret.arn, lmax_password_secret.arn).apply(
+    policy=pulumi.Output.all(
+        lmax_username_secret.arn,
+        lmax_password_secret.arn,
+        grafana_admin_secret.arn,
+    ).apply(
         lambda arns: json.dumps({
             "Version": "2012-10-17",
             "Statement": [{
@@ -248,6 +265,7 @@ task_definition = aws.ecs.TaskDefinition(f"{project_name}-task",
         log_group.name,
         lmax_username_secret.arn,
         lmax_password_secret.arn,
+        grafana_admin_secret.arn,
     ).apply(lambda args: json.dumps([
         # ws_server container
         {
@@ -334,13 +352,15 @@ task_definition = aws.ecs.TaskDefinition(f"{project_name}-task",
                 {"containerPort": 3000, "hostPort": 3000, "protocol": "tcp"},
             ],
             "environment": [
-                {"name": "GF_SECURITY_ADMIN_PASSWORD", "value": "admin"},
                 {"name": "GF_AUTH_ANONYMOUS_ENABLED", "value": "true"},
                 {"name": "GF_AUTH_ANONYMOUS_ORG_ROLE", "value": "Viewer"},
                 {"name": "GF_AUTH_DISABLE_LOGIN_FORM", "value": "true"},
                 {"name": "GF_SECURITY_ALLOW_EMBEDDING", "value": "true"},
                 {"name": "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH", "value": "/etc/grafana/provisioning/dashboards/latency.json"},
                 {"name": "GF_FEATURE_TOGGLES_ENABLE", "value": "traceqlEditor"},
+            ],
+            "secrets": [
+                {"name": "GF_SECURITY_ADMIN_PASSWORD", "valueFrom": args[3]},
             ],
             "logConfiguration": {
                 "logDriver": "awslogs",


### PR DESCRIPTION
Findings from a deployment-side security review:

* baremetal/user_data.sh: secret fetch was running under `set -x`, so
  bash xtrace echoed the resolved LMAX username/password into
  /var/log/cloud-init-output.log and `aws ec2 get-console-output`.
  Bracket the fetch + heredoc with `set +x` / `set -x` (matches the
  pattern already used in ec2-spot/user_data.sh).
* wake_lambda: add optional `WAKE_TOKEN` shared-secret check (constant-
  time compare on `?token=` or `X-Wake-Token`). Threaded through Pulumi
  config; the exported wake_url already includes the token. README's
  "implement this in ~10 lines" mitigation is now actually implemented.
* Grafana admin password: stop shipping `admin` as the default. Fargate
  now requires a `grafana_admin_password` Pulumi secret (injected via
  Secrets Manager + ECS task `secrets`). baremetal + ec2-spot user_data
  generate a fresh random password on every boot and write it to a
  per-stack `.env` file that compose substitutes into
  `${GF_SECURITY_ADMIN_PASSWORD}`. docker-compose.yml takes the value
  from the operator's environment with a non-`admin` fallback.
* baremetal SG: drop SSH (:22) from the default ingress rules — the
  Instance has no `key_name` so it was useless anyway. Re-enable via a
  new opt-in `ssh_ingress_cidr` config. Force IMDSv2 on the Instance
  (`http_tokens=required`) and encrypt the EBS root volume.
* baremetal S3 assets bucket: explicit BucketPublicAccessBlock + AES256
  SSE so a future console click can't loosen them.
* ec2-spot IAM: split the previous `Resource: "*"` policy. The tag
  condition on `ec2:DescribeAddresses` was silently a no-op (that API
  has no resource-level perms). `ec2:AssociateAddress` is now scoped to
  the specific EIP allocation ARN plus tagged instance/network-interface
  ARNs, with the Project/Stack tag condition still enforced.
* fargate ALB SG: drop :443 ingress — there's no HTTPS listener bound,
  so the open port was misleading. Add it back if/when ACM is wired up.
* Dockerfiles: pin Rust builder to `1.87-bookworm` instead of `:latest`,
  add a tight `.dockerignore` to keep .git/, target/, Pulumi.*.yaml,
  and .env files out of the build context, and drop privileges to a
  non-root `wingfoil` user in both runtime images.