### PR TITLE
Replace em dashes with hyphens in security group descriptions

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/__main__.py
@@ -144,7 +144,7 @@ if ssh_ingress_cidr:
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
-    description="wingfoil baremetal demo — WS, prometheus, grafana",
+    description="wingfoil baremetal demo - WS, prometheus, grafana",
     ingress=ingress_rules,
     egress=[aws.ec2.SecurityGroupEgressArgs(from_port=0, to_port=0, protocol="-1", cidr_blocks=["0.0.0.0/0"])],
     tags={**tags, "Name": f"{prefix}-sg"},

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -100,7 +100,7 @@ aws.ec2.RouteTableAssociation(
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
-    description="wingfoil ec2-spot demo — WS, prometheus, grafana",
+    description="wingfoil ec2-spot demo - WS, prometheus, grafana",
     ingress=[
         # 8080: ws_server HTTP/WS;  9090: Prometheus UI;
         # 9091: ws_server's /metrics (raw scrape target);  3000: Grafana.


### PR DESCRIPTION
## Summary
Updated security group descriptions in the Pulumi infrastructure code to use standard hyphens instead of em dashes for improved consistency and compatibility.

## Changes
- Replaced em dashes (—) with hyphens (-) in the baremetal demo security group description
- Replaced em dashes (—) with hyphens (-) in the ec2-spot demo security group description

## Details
These changes standardize the formatting of security group descriptions across the example infrastructure code. Using hyphens instead of em dashes ensures better compatibility with systems that may have character encoding restrictions or parsing requirements.

https://claude.ai/code/session_01FF5JSZiLrYNfrwuBWVK1xF