### PR TITLE
Add prometheus, tempo, and grafana config bind-mounts to packer

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -80,6 +80,16 @@ sudo rm -rf /root/.docker /home/ec2-user/.docker
 sudo install -m 0644 /tmp/docker-compose.yml /opt/wingfoil/docker-compose.yml
 sudo install -m 0755 /tmp/spot_watcher.py     /opt/wingfoil/spot_watcher.py
 
+# Bind-mount sources for the three containers. compose.yml uses paths relative
+# to its own directory (./prometheus/prometheus.yml etc.), so these must live
+# directly under /opt/wingfoil/. Without them docker silently creates each
+# missing path as an empty directory and the container fails to start with
+# "not a directory: ... Are you trying to mount a directory onto a file".
+sudo cp -r /tmp/prometheus /opt/wingfoil/prometheus
+sudo cp -r /tmp/tempo      /opt/wingfoil/tempo
+sudo cp -r /tmp/grafana    /opt/wingfoil/grafana
+sudo chown -R root:root /opt/wingfoil/prometheus /opt/wingfoil/tempo /opt/wingfoil/grafana
+
 # Bake the image references into compose.yml so `compose up` doesn't pull a
 # floating tag on every boot. Fail the build if the upstream compose ever
 # bumps a tag — a silent no-op here would mean booting on stale images.

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
@@ -117,6 +117,24 @@ build {
     destination = "/tmp/docker-compose.yml"
   }
 
+  # Bind-mount sources for prometheus, tempo, and grafana. Compose paths are
+  # relative to /opt/wingfoil/docker-compose.yml, so install.sh moves these
+  # under /opt/wingfoil/{prometheus,tempo,grafana}.
+  provisioner "file" {
+    source      = "${path.root}/../../../prometheus"
+    destination = "/tmp/prometheus"
+  }
+
+  provisioner "file" {
+    source      = "${path.root}/../../../tempo"
+    destination = "/tmp/tempo"
+  }
+
+  provisioner "file" {
+    source      = "${path.root}/../../../grafana"
+    destination = "/tmp/grafana"
+  }
+
   provisioner "shell" {
     environment_vars = [
       "WS_SERVER_IMAGE=${var.ws_server_image}",


### PR DESCRIPTION
## Summary
This change adds the necessary configuration directories for prometheus, tempo, and grafana to the EC2 instance image built by packer. These directories are bind-mounted by the docker-compose configuration and must be present on the host filesystem.

## Key Changes
- **packer/wingfoil-latency.pkr.hcl**: Added three new file provisioners to copy prometheus, tempo, and grafana configuration directories from the source tree into `/tmp/` during the image build
- **packer/install.sh**: Added installation logic to copy the configuration directories from `/tmp/` to `/opt/wingfoil/` with proper ownership, ensuring they exist before docker-compose attempts to bind-mount them

## Implementation Details
The docker-compose configuration uses relative paths (e.g., `./prometheus/prometheus.yml`) that are resolved relative to the compose file location at `/opt/wingfoil/docker-compose.yml`. Without these directories pre-existing on the host, docker silently creates them as empty directories, causing container startup failures with "not a directory" errors. This change ensures the configuration directories are properly staged during AMI creation.

https://claude.ai/code/session_0194EuMH5QxDoQkEr6DDtfLi