### PR TITLE
latency_e2e ec2-spot: fix Packer file provisioner upload paths

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -85,10 +85,40 @@ sudo install -m 0755 /tmp/spot_watcher.py     /opt/wingfoil/spot_watcher.py
 # directly under /opt/wingfoil/. Without them docker silently creates each
 # missing path as an empty directory and the container fails to start with
 # "not a directory: ... Are you trying to mount a directory onto a file".
+#
+# Verify the bind-mount targets *before* copying — a wrong upload layout (e.g.
+# Packer's file provisioner appending the source basename twice) would silently
+# leave the expected paths missing, which only surfaces at first boot when
+# docker auto-creates them as empty directories and the bind-mount fails.
+for staged in \
+    /tmp/prometheus/prometheus.yml \
+    /tmp/tempo/tempo.yaml \
+    /tmp/grafana/provisioning; do
+  if [ ! -e "${staged}" ]; then
+    echo "ERROR: expected staged path '${staged}' is missing — Packer file" >&2
+    echo "       provisioner produced an unexpected layout. Listing /tmp:" >&2
+    ls -lR /tmp/prometheus /tmp/tempo /tmp/grafana >&2 || true
+    exit 1
+  fi
+done
+
 sudo cp -r /tmp/prometheus /opt/wingfoil/prometheus
 sudo cp -r /tmp/tempo      /opt/wingfoil/tempo
 sudo cp -r /tmp/grafana    /opt/wingfoil/grafana
 sudo chown -R root:root /opt/wingfoil/prometheus /opt/wingfoil/tempo /opt/wingfoil/grafana
+
+# Sanity check the final layout on disk: docker compose mounts these exact
+# paths, and a missing file at boot triggers the silent-empty-directory
+# behaviour that this section exists to prevent.
+for mount_src in \
+    /opt/wingfoil/prometheus/prometheus.yml \
+    /opt/wingfoil/tempo/tempo.yaml \
+    /opt/wingfoil/grafana/provisioning; do
+  if [ ! -e "${mount_src}" ]; then
+    echo "ERROR: bind-mount source '${mount_src}' is missing after copy." >&2
+    exit 1
+  fi
+done
 
 # Bake the image references into compose.yml so `compose up` doesn't pull a
 # floating tag on every boot. Fail the build if the upstream compose ever

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
@@ -120,19 +120,27 @@ build {
   # Bind-mount sources for prometheus, tempo, and grafana. Compose paths are
   # relative to /opt/wingfoil/docker-compose.yml, so install.sh moves these
   # under /opt/wingfoil/{prometheus,tempo,grafana}.
+  #
+  # Destination is `/tmp` (which exists) — Packer's file provisioner appends
+  # the source's basename to the destination when there's no trailing slash on
+  # the source path, so e.g. `.../prometheus` -> `/tmp/prometheus/`. Uploading
+  # to a non-existent `/tmp/prometheus` instead produces `/tmp/prometheus/
+  # prometheus/` (basename appended a second time), and the docs explicitly
+  # warn that "if the destination directory does not exist, the file
+  # provisioner may succeed, but it will have undefined results".
   provisioner "file" {
     source      = "${path.root}/../../../prometheus"
-    destination = "/tmp/prometheus"
+    destination = "/tmp"
   }
 
   provisioner "file" {
     source      = "${path.root}/../../../tempo"
-    destination = "/tmp/tempo"
+    destination = "/tmp"
   }
 
   provisioner "file" {
     source      = "${path.root}/../../../grafana"
-    destination = "/tmp/grafana"
+    destination = "/tmp"
   }
 
   provisioner "shell" {


### PR DESCRIPTION
PR #298 staged the prometheus/tempo/grafana directories in Packer with
`destination = /tmp/{prometheus,tempo,grafana}` — paths that don't exist
on the build instance. Packer's file provisioner appends the source's
basename when there's no trailing slash on the source, so
`source=.../prometheus + destination=/tmp/prometheus` actually uploads
to `/tmp/prometheus/prometheus/prometheus.yml`, not the expected
`/tmp/prometheus/prometheus.yml`. The subsequent
`cp -r /tmp/prometheus /opt/wingfoil/prometheus` then preserved the
extra layer, leaving `/opt/wingfoil/prometheus/prometheus.yml` missing
on the AMI. On boot, docker auto-created the host path as an empty
directory and `docker compose up` failed with "not a directory: Are
you trying to mount a directory onto a file" — the same symptom #298
was meant to fix.

Set destination to `/tmp` (which exists), so Packer creates
`/tmp/prometheus/`, `/tmp/tempo/`, `/tmp/grafana/` directly. Add
explicit existence checks for the bind-mount sources both before and
after the copy in install.sh so any future upload-layout drift fails
the AMI build instead of silently shipping a broken AMI.