### PR TITLE
web: add opt-in TLS (HTTPS / WSS) via WebServerBuilder::tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.23.37",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1928,16 @@ name = "formato"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f6f3299260c1f4180ce881f8bb2bfc1195ceeafd54eea899af5859a6f882ad"
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
 
 [[package]]
 name = "fs_extra"
@@ -3741,6 +3773,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,7 +4023,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4251,6 +4293,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring 0.17.14",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -5548,8 +5603,12 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.37",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tungstenite 0.24.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5913,6 +5972,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.23.37",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -6604,6 +6665,7 @@ dependencies = [
  "arrayvec",
  "async-stream",
  "axum",
+ "axum-server",
  "bincode",
  "cargo-husky",
  "chrono",
@@ -6636,9 +6698,11 @@ dependencies = [
  "priority-queue",
  "quanta",
  "rand 0.9.2",
+ "rcgen",
  "rdkafka",
  "reqwest",
  "rustls 0.23.37",
+ "rustls-pemfile",
  "rxrust",
  "scopeguard",
  "serde",
@@ -6858,6 +6922,15 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -33,7 +33,7 @@ otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", 
 otlp-integration-test = ["otlp", "dep:testcontainers"]
 fix = ["dep:fefix", "dep:rustls", "dep:webpki-roots"]
 fix-integration-test = ["fix"]
-web = ["async", "dep:axum", "dep:tower-http", "dep:tokio-tungstenite", "dep:wingfoil-wire-types", "dep:bincode", "tokio/net", "tokio/sync"]
+web = ["async", "dep:axum", "dep:axum-server", "dep:tower-http", "dep:tokio-tungstenite", "dep:wingfoil-wire-types", "dep:bincode", "dep:rustls", "dep:rustls-pemfile", "tokio/net", "tokio/sync"]
 
 [package]
 name = "wingfoil"
@@ -124,10 +124,11 @@ webpki-roots = { version = "0.26", optional = true }
 
 # web adapter
 axum = { version = "0.8", features = ["ws"], optional = true }
+axum-server = { version = "0.7", features = ["tls-rustls"], optional = true }
 tower-http = { version = "0.6", features = ["fs"], optional = true }
-tokio-tungstenite = { version = "0.24", optional = true }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"], optional = true }
+rustls-pemfile = { version = "2", optional = true }
 wingfoil-wire-types = { path = "../wingfoil-wire-types", version = "4.3.3", optional = true }
-
 
 [dev-dependencies]
 rxrust = "1.0.0-rc.3"
@@ -135,6 +136,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 libc = "0.2"
+rcgen = "0.13"
 
 [[example]]
 name = "dynamic-group"

--- a/wingfoil/src/adapters/web/CLAUDE.md
+++ b/wingfoil/src/adapters/web/CLAUDE.md
@@ -46,6 +46,11 @@ web/
   a no-op server. Both `web_pub` and `web_sub` become no-ops so the same
   graph can run in `RunMode::HistoricalFrom(...)` without touching the
   network — mirrors `PrometheusMetricNode`'s `historical` flag.
+- **Optional TLS (HTTPS / WSS)**: `WebServerBuilder::tls(cert_pem, key_pem)`
+  parses a PEM cert chain + key, builds a rustls `ServerConfig` (ring
+  provider), and switches the runtime path from `axum::serve` to
+  `axum_server::from_tcp_rustls`. Plain HTTP path is unchanged when `tls()`
+  is not called. Clients must use `wss://HOST:PORT/ws`.
 
 ## Threading Model
 

--- a/wingfoil/src/adapters/web/integration_tests.rs
+++ b/wingfoil/src/adapters/web/integration_tests.rs
@@ -21,6 +21,59 @@ use crate::{RunFor, RunMode};
 
 type TungsteniteStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
+/// Generate a self-signed cert covering `localhost` + `127.0.0.1` for use
+/// in TLS integration tests. Returns `(cert_pem, key_pem, cert_der)` —
+/// the DER form is convenient for installing into a client trust store.
+fn make_self_signed() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("rcgen self-signed");
+    let cert_pem = cert.cert.pem().into_bytes();
+    let key_pem = cert.key_pair.serialize_pem().into_bytes();
+    let cert_der = cert.cert.der().to_vec();
+    (cert_pem, key_pem, cert_der)
+}
+
+/// Connect to `wss://127.0.0.1:port/ws`, trusting `cert_der` only.
+async fn connect_tls(port: u16, cert_der: Vec<u8>) -> anyhow::Result<TungsteniteStream> {
+    use rustls::pki_types::CertificateDer;
+
+    let mut roots = rustls::RootCertStore::empty();
+    roots
+        .add(CertificateDer::from(cert_der))
+        .map_err(|e| anyhow::anyhow!("trust store add: {e}"))?;
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let client_config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| anyhow::anyhow!("rustls protocol versions: {e}"))?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let connector = tokio_tungstenite::Connector::Rustls(Arc::new(client_config));
+
+    let url = format!("wss://localhost:{port}/ws");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match tokio_tungstenite::connect_async_tls_with_config(
+            &url,
+            None,
+            false,
+            Some(connector.clone()),
+        )
+        .await
+        {
+            Ok((mut socket, _)) => {
+                let _ = socket.next().await;
+                return Ok(socket);
+            }
+            Err(e) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                let _ = e;
+            }
+            Err(e) => return Err(anyhow::anyhow!("wss connect: {e}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct UiClick {
     button: String,
@@ -381,5 +434,72 @@ fn test_bad_envelope_is_ignored_not_fatal() -> anyhow::Result<()> {
     let got = received.lock().unwrap().clone();
     assert!(!got.is_empty(), "expected at least one safe frame");
     assert_eq!(got[0].topic, "safe");
+    Ok(())
+}
+
+#[test]
+fn test_pub_round_trip_tls() -> anyhow::Result<()> {
+    let (cert_pem, key_pem, cert_der) = make_self_signed();
+    let server = WebServer::bind("127.0.0.1:0")
+        .tls(cert_pem, key_pem)
+        .start()?;
+    assert!(server.is_tls());
+    let port = server.port();
+    let codec = server.codec();
+
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let cert_der_clone = cert_der.clone();
+    let topic = "tick";
+    let topic_owned = topic.to_string();
+    let client = std::thread::spawn(move || -> anyhow::Result<Vec<Envelope>> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async move {
+            let mut socket = connect_tls(port, cert_der_clone).await?;
+            send_control(
+                &mut socket,
+                codec,
+                ControlMessage::Subscribe {
+                    topics: vec![topic_owned.clone()],
+                },
+            )
+            .await?;
+            ready_tx.send(()).ok();
+
+            let mut out = Vec::with_capacity(5);
+            let overall_deadline = Instant::now() + Duration::from_secs(10);
+            while out.len() < 5 && Instant::now() < overall_deadline {
+                match tokio::time::timeout(
+                    Duration::from_secs(2),
+                    recv_envelope(&mut socket, codec),
+                )
+                .await
+                {
+                    Ok(Ok(env)) if env.topic == topic_owned => out.push(env),
+                    Ok(Ok(_)) => continue,
+                    Ok(Err(_)) | Err(_) => break,
+                }
+            }
+            Ok(out)
+        })
+    });
+    ready_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("client failed to subscribe over TLS");
+
+    ticker(Duration::from_millis(10))
+        .count()
+        .web_pub(&server, topic)
+        .run(
+            RunMode::RealTime,
+            RunFor::Duration(Duration::from_millis(500)),
+        )?;
+
+    let envs = client.join().expect("client thread panic")?;
+    assert!(!envs.is_empty(), "no envelopes received over TLS");
+    for env in &envs {
+        assert_eq!(env.topic, topic);
+        let value: u64 = codec.decode(&env.payload)?;
+        assert!(value >= 1);
+    }
     Ok(())
 }

--- a/wingfoil/src/adapters/web/mod.rs
+++ b/wingfoil/src/adapters/web/mod.rs
@@ -55,6 +55,21 @@
 //!     .unwrap();
 //! ```
 //!
+//! # HTTPS / WSS
+//!
+//! Pass PEM-encoded cert chain + key bytes to
+//! [`WebServerBuilder::tls`](crate::adapters::web::WebServerBuilder::tls)
+//! to terminate TLS in-process. Browser clients then connect to
+//! `wss://HOST:PORT/ws`.
+//!
+//! ```ignore
+//! let cert_pem = std::fs::read("server.crt")?;
+//! let key_pem  = std::fs::read("server.key")?;
+//! let server = WebServer::bind("0.0.0.0:8443")
+//!     .tls(cert_pem, key_pem)
+//!     .start()?;
+//! ```
+//!
 //! # Historical mode
 //!
 //! The server exposes [`WebServerBuilder::start_historical`] for use in

--- a/wingfoil/src/adapters/web/server.rs
+++ b/wingfoil/src/adapters/web/server.rs
@@ -13,13 +13,14 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
-use anyhow::Context as _;
+use anyhow::{Context as _, anyhow};
 use axum::Router;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use axum::routing::get;
+use axum_server::tls_rustls::RustlsConfig;
 use futures::{SinkExt, StreamExt};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tower_http::services::ServeDir;
@@ -101,6 +102,7 @@ pub struct WebServer {
     shutdown_tx: Option<oneshot::Sender<()>>,
     thread: Option<JoinHandle<()>>,
     historical_noop: bool,
+    tls: bool,
 }
 
 impl WebServer {
@@ -113,6 +115,7 @@ impl WebServer {
             addr: addr.into(),
             codec: CodecKind::Bincode,
             static_dir: None,
+            tls: None,
         }
     }
 
@@ -129,6 +132,11 @@ impl WebServer {
     /// True when the server was created as a historical-mode no-op.
     pub fn is_historical_noop(&self) -> bool {
         self.historical_noop
+    }
+
+    /// True when the server is serving HTTPS / WSS.
+    pub fn is_tls(&self) -> bool {
+        self.tls
     }
 
     /// Stop the HTTP server and join the server thread. Called
@@ -154,6 +162,12 @@ pub struct WebServerBuilder {
     addr: String,
     codec: CodecKind,
     static_dir: Option<PathBuf>,
+    tls: Option<TlsPem>,
+}
+
+struct TlsPem {
+    cert: Vec<u8>,
+    key: Vec<u8>,
 }
 
 impl WebServerBuilder {
@@ -171,10 +185,28 @@ impl WebServerBuilder {
         self
     }
 
+    /// Enable TLS so the server speaks HTTPS / WSS.
+    ///
+    /// `cert_pem` is a PEM-encoded certificate chain (leaf first); `key_pem`
+    /// is the matching PEM-encoded PKCS#8 / PKCS#1 / SEC1 private key. PEM
+    /// parsing is deferred to [`WebServerBuilder::start`] so this method is
+    /// infallible.
+    ///
+    /// When TLS is enabled, clients should connect to `wss://HOST:PORT/ws`.
+    pub fn tls(mut self, cert_pem: impl Into<Vec<u8>>, key_pem: impl Into<Vec<u8>>) -> Self {
+        self.tls = Some(TlsPem {
+            cert: cert_pem.into(),
+            key: key_pem.into(),
+        });
+        self
+    }
+
     /// Bind the TCP listener and spawn the HTTP + WS server.
     ///
     /// Binding is synchronous so a port conflict is reported
-    /// immediately, before the graph starts.
+    /// immediately, before the graph starts. If [`WebServerBuilder::tls`]
+    /// was called, the server speaks HTTPS / WSS; otherwise plain
+    /// HTTP / WS.
     pub fn start(self) -> anyhow::Result<WebServer> {
         let listener =
             TcpListener::bind(&self.addr).with_context(|| format!("web: bind to {}", self.addr))?;
@@ -183,6 +215,12 @@ impl WebServerBuilder {
         let inner_clone = inner.clone();
         let static_dir = self.static_dir.clone();
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let tls_config = match self.tls {
+            Some(pem) => Some(build_rustls_config(&pem.cert, &pem.key)?),
+            None => None,
+        };
+        let is_tls = tls_config.is_some();
 
         let handle = std::thread::Builder::new()
             .name("wingfoil-web".to_string())
@@ -198,19 +236,38 @@ impl WebServerBuilder {
                     }
                 };
                 rt.block_on(async move {
-                    listener
-                        .set_nonblocking(true)
-                        .expect("listener set_nonblocking");
-                    let tokio_listener =
-                        tokio::net::TcpListener::from_std(listener).expect("web: from_std");
                     let app = build_router(inner_clone, static_dir);
-                    if let Err(e) = axum::serve(tokio_listener, app)
-                        .with_graceful_shutdown(async move {
-                            let _ = shutdown_rx.await;
-                        })
-                        .await
-                    {
-                        log::warn!("web: axum serve exited with error: {e}");
+                    match tls_config {
+                        Some(rustls_config) => {
+                            let handle = axum_server::Handle::new();
+                            let handle_clone = handle.clone();
+                            tokio::spawn(async move {
+                                let _ = shutdown_rx.await;
+                                handle_clone.shutdown();
+                            });
+                            if let Err(e) = axum_server::from_tcp_rustls(listener, rustls_config)
+                                .handle(handle)
+                                .serve(app.into_make_service())
+                                .await
+                            {
+                                log::warn!("web: axum-server (tls) exited with error: {e}");
+                            }
+                        }
+                        None => {
+                            listener
+                                .set_nonblocking(true)
+                                .expect("listener set_nonblocking");
+                            let tokio_listener =
+                                tokio::net::TcpListener::from_std(listener).expect("web: from_std");
+                            if let Err(e) = axum::serve(tokio_listener, app)
+                                .with_graceful_shutdown(async move {
+                                    let _ = shutdown_rx.await;
+                                })
+                                .await
+                            {
+                                log::warn!("web: axum serve exited with error: {e}");
+                            }
+                        }
                     }
                 });
             })
@@ -222,6 +279,7 @@ impl WebServerBuilder {
             shutdown_tx: Some(shutdown_tx),
             thread: Some(handle),
             historical_noop: false,
+            tls: is_tls,
         })
     }
 
@@ -234,8 +292,36 @@ impl WebServerBuilder {
             shutdown_tx: None,
             thread: None,
             historical_noop: true,
+            tls: false,
         })
     }
+}
+
+/// Parse PEM cert chain + key and assemble a rustls server config backed by
+/// the `ring` provider. Synchronous so [`WebServerBuilder::start`] can return
+/// configuration errors before spawning the server thread.
+fn build_rustls_config(cert_pem: &[u8], key_pem: &[u8]) -> anyhow::Result<RustlsConfig> {
+    use rustls::pki_types::PrivateKeyDer;
+
+    let certs: Vec<_> = rustls_pemfile::certs(&mut std::io::Cursor::new(cert_pem))
+        .collect::<Result<Vec<_>, _>>()
+        .context("web: parse TLS cert PEM")?;
+    if certs.is_empty() {
+        return Err(anyhow!("web: TLS cert PEM contained no certificates"));
+    }
+    let key: PrivateKeyDer<'static> =
+        rustls_pemfile::private_key(&mut std::io::Cursor::new(key_pem))
+            .context("web: parse TLS key PEM")?
+            .ok_or_else(|| anyhow!("web: TLS key PEM contained no private key"))?;
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let server_config = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .context("web: rustls protocol versions")?
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .context("web: rustls with_single_cert")?;
+    Ok(RustlsConfig::from_config(Arc::new(server_config)))
 }
 
 fn build_router(inner: Arc<WebServerInner>, static_dir: Option<PathBuf>) -> Router {


### PR DESCRIPTION
Adds `WebServerBuilder::tls(cert_pem, key_pem)` so the in-process web
adapter can terminate HTTPS / WSS instead of plain HTTP / WS. Plain
path is unchanged when `tls()` is not called; with TLS configured the
runtime switches from `axum::serve` to `axum_server::from_tcp_rustls`
backed by the rustls `ring` provider. Adds a wss:// integration test
using an in-test self-signed cert (rcgen) trusted only by the test
client.