### PR TITLE
latency_e2e: switch runtime images to debian:bookworm-slim

### DIFF
--- a/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
+++ b/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
@@ -13,12 +13,14 @@ RUN cargo build --release \
     --example latency_e2e_fix_gw \
     --features "fix,iceoryx2-beta"
 
-# Runtime stage
-FROM ubuntu:22.04
+# Runtime stage — bookworm-slim matches the builder's glibc (2.36); pairing
+# it with ubuntu:22.04 (glibc 2.35) risks a runtime ABI break.
+FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y \
-    libssl3 \
-    ca-certificates \
+RUN apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        libssl3 \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 10001 wingfoil \
     && useradd --system --uid 10001 --gid wingfoil --no-create-home --home /app wingfoil

--- a/wingfoil/examples/latency_e2e/Dockerfile.ws_server
+++ b/wingfoil/examples/latency_e2e/Dockerfile.ws_server
@@ -13,12 +13,14 @@ RUN cargo build --release \
     --example latency_e2e_ws_server \
     --features "web,iceoryx2-beta,prometheus,otlp"
 
-# Runtime stage
-FROM ubuntu:22.04
+# Runtime stage — bookworm-slim matches the builder's glibc (2.36); pairing
+# it with ubuntu:22.04 (glibc 2.35) risks a runtime ABI break.
+FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y \
-    libssl3 \
-    ca-certificates \
+RUN apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        libssl3 \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 10001 wingfoil \
     && useradd --system --uid 10001 --gid wingfoil --no-create-home --home /app wingfoil


### PR DESCRIPTION
The two failing buildx jobs (ws-server, fix-gw) compile against
rust:1.87-bookworm (glibc 2.36) and then ran the binary on ubuntu:22.04
(glibc 2.35). Beyond the latent ABI mismatch, the apt-get install in
the runtime stage was failing in CI with exit 100. Aligning the runtime
to debian:bookworm-slim removes the glibc skew, matches the builder's
trusted apt repos, and shrinks the image. Also add Acquire::Retries=3
and --no-install-recommends to harden against transient mirror flakes.

https://claude.ai/code/session_012TPmmZzYBwZBajv8FBt9Sx