### PR TITLE
latency_e2e Dockerfiles: scope cargo build with -p wingfoil

### DIFF
--- a/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
+++ b/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
@@ -9,7 +9,12 @@ RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
 WORKDIR /workspace
 COPY . .
 
+# `-p wingfoil` is essential. Without it, cargo unifies features across
+# the whole workspace, and `wingfoil-python` pulls in `etcd, kafka, zmq,
+# fluvio, kdb` — dragging in system deps (protoc, cmake, libsasl2,
+# libzmq) and ~hundreds of crates we don't ship in this image.
 RUN cargo build --release \
+    -p wingfoil \
     --example latency_e2e_fix_gw \
     --features "fix,iceoryx2-beta"
 

--- a/wingfoil/examples/latency_e2e/Dockerfile.ws_server
+++ b/wingfoil/examples/latency_e2e/Dockerfile.ws_server
@@ -9,7 +9,12 @@ RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
 WORKDIR /workspace
 COPY . .
 
+# `-p wingfoil` is essential. Without it, cargo unifies features across
+# the whole workspace, and `wingfoil-python` pulls in `etcd, kafka, zmq,
+# fluvio, kdb` — dragging in system deps (protoc, cmake, libsasl2,
+# libzmq) and ~hundreds of crates we don't ship in this image.
 RUN cargo build --release \
+    -p wingfoil \
     --example latency_e2e_ws_server \
     --features "web-tls,iceoryx2-beta,prometheus,otlp"
 


### PR DESCRIPTION
Without `-p wingfoil`, cargo unifies features across the whole
workspace and `wingfoil-python` (a workspace member) pulls in
`etcd, kafka, zmq, fluvio, kdb` for wingfoil. That dragged in
`etcd-client`, `rdkafka-sys`, `zmq-sys`, `kdb-plus-fixed`, etc.,
which both require system deps the image doesn't install (cmake,
libsasl2, libzmq) and add hundreds of crates worth of compile time
to a binary that ships none of them.

Restricting the build to the `wingfoil` package alone fixes the CI
failure (exit 101 in `latency-e2e.build.images`) and brings the
release build down from "all features" to "actually-shipped
features", which is what the binary needs.

https://claude.ai/code/session_01HM5KUPqrrgJG9dmebZC1Uj