### PR TITLE
Bump minimum Rust version to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "3"
 
 [workspace.package]
-rust-version = "1.87"
+rust-version = "1.88"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"

--- a/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
+++ b/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
@@ -1,7 +1,7 @@
 # Builder stage — pinned to match the workspace `rust-version` in
 # /Cargo.toml. Bumping the toolchain is an intentional change, not a
 # silent `:latest` drift.
-FROM rust:1.87-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/wingfoil/examples/latency_e2e/Dockerfile.ws_server
+++ b/wingfoil/examples/latency_e2e/Dockerfile.ws_server
@@ -1,7 +1,7 @@
 # Builder stage — pinned to match the workspace `rust-version` in
 # /Cargo.toml. Bumping the toolchain is an intentional change, not a
 # silent `:latest` drift.
-FROM rust:1.87-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
Updates the workspace minimum Rust version from 1.87 to 1.88 across all configuration files and Dockerfiles.

## Changes
- Updated `rust-version` in `Cargo.toml` workspace configuration from `1.87` to `1.88`
- Updated Dockerfile base images in both `wingfoil/examples/latency_e2e/Dockerfile.fix_gw` and `wingfoil/examples/latency_e2e/Dockerfile.ws_server` from `rust:1.87-bookworm` to `rust:1.88-bookworm`

## Details
This change ensures consistency between the workspace's declared minimum Rust version and the Docker build environments used for the example applications. The Dockerfiles are intentionally pinned to match the workspace configuration to avoid silent toolchain drift.

https://claude.ai/code/session_01W4XH2awd4DdwJkQvVmNQh4