### PR TITLE
Refactor security group rules to prevent ASG instance refresh

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -97,23 +97,48 @@ aws.ec2.RouteTableAssociation(
     route_table_id=rt.id,
 )
 
+# Inline ingress/egress on aws.ec2.SecurityGroup would force the SG to be
+# replaced on every rule edit, which in turn bumps the launch template and
+# triggers an ASG instance refresh — a 10-minute round-trip. Defining each
+# rule as its own aws.vpc.SecurityGroup{Ingress,Egress}Rule resource keeps
+# the SG itself stable, so rule changes update in place.
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
-    description="wingfoil ec2-spot demo - WSS (ws_server), HTTPS (grafana)",
-    ingress=[
-        # 8080: ws_server HTTPS/WSS (terminated in-process via the
-        # `web-tls` feature); 3000: Grafana HTTPS.
-        # 9090 (Prometheus UI) and 9091 (ws_server /metrics) stay
-        # plain-HTTP and are no longer exposed publicly — Prometheus
-        # scrapes via localhost on the host network. Operators who
-        # want the Prometheus UI can still reach it via an SSM
-        # session manager port-forward.
-        aws.ec2.SecurityGroupIngressArgs(from_port=8080, to_port=8080, protocol="tcp", cidr_blocks=[ingress_cidr]),
-        aws.ec2.SecurityGroupIngressArgs(from_port=3000, to_port=3000, protocol="tcp", cidr_blocks=[ingress_cidr]),
-    ],
-    egress=[aws.ec2.SecurityGroupEgressArgs(from_port=0, to_port=0, protocol="-1", cidr_blocks=["0.0.0.0/0"])],
+    description="wingfoil ec2-spot demo",
     tags={**tags, "Name": f"{prefix}-sg"},
+)
+
+# 8080: ws_server HTTPS/WSS (terminated in-process via the `web-tls`
+# feature); 3000: Grafana HTTPS. 9090 (Prometheus UI) and 9091
+# (ws_server /metrics) stay plain-HTTP and are no longer exposed publicly —
+# Prometheus scrapes via localhost on the host network. Operators who want
+# the Prometheus UI can still reach it via an SSM session manager
+# port-forward.
+aws.vpc.SecurityGroupIngressRule(
+    f"{prefix}-sg-wss",
+    security_group_id=sg.id,
+    from_port=8080,
+    to_port=8080,
+    ip_protocol="tcp",
+    cidr_ipv4=ingress_cidr,
+    tags=tags,
+)
+aws.vpc.SecurityGroupIngressRule(
+    f"{prefix}-sg-grafana",
+    security_group_id=sg.id,
+    from_port=3000,
+    to_port=3000,
+    ip_protocol="tcp",
+    cidr_ipv4=ingress_cidr,
+    tags=tags,
+)
+aws.vpc.SecurityGroupEgressRule(
+    f"{prefix}-sg-egress-all",
+    security_group_id=sg.id,
+    ip_protocol="-1",
+    cidr_ipv4="0.0.0.0/0",
+    tags=tags,
 )
 
 # ── Elastic IP ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Refactored the security group configuration to define ingress and egress rules as separate `aws.vpc.SecurityGroupRule` resources instead of inline rules on the security group itself. This prevents unnecessary security group replacement and subsequent ASG instance refresh cycles when rules are modified.

## Key Changes
- Moved ingress/egress rules from inline `SecurityGroup` definition to standalone `SecurityGroupIngressRule` and `SecurityGroupEgressRule` resources
- Simplified security group description from detailed rule documentation to a brief identifier
- Created three separate rule resources:
  - WSS rule for port 8080 (ws_server HTTPS/WSS)
  - Grafana rule for port 3000 (Grafana HTTPS)
  - Egress rule allowing all outbound traffic (0.0.0.0/0)
- Added tags to individual rule resources for better resource tracking

## Implementation Details
This change addresses a critical operational issue: inline rule modifications would force the security group to be replaced, which in turn bumps the launch template and triggers an ASG instance refresh—a 10-minute round-trip. By defining rules as separate resources, the security group itself remains stable, allowing rule changes to update in place without triggering instance refreshes.

The rule documentation previously embedded in the security group description has been moved to a code comment above the rule definitions for clarity.

https://claude.ai/code/session_01FpZUBKHqwo36Gdsn8VMTfp