### PR TITLE
Prevent SecurityGroup replacement by ignoring description drift

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -102,11 +102,22 @@ aws.ec2.RouteTableAssociation(
 # triggers an ASG instance refresh — a 10-minute round-trip. Defining each
 # rule as its own aws.vpc.SecurityGroup{Ingress,Egress}Rule resource keeps
 # the SG itself stable, so rule changes update in place.
+#
+# `description` is immutable in the AWS API — any change forces the SG to
+# be replaced. Replacement here is *catastrophic*: pulumi creates a new SG,
+# updates the launch template to reference it, then tries to delete the
+# old SG while the live spot instance's ENI is still attached to it. AWS
+# returns DependencyViolation until the ASG instance refresh completes,
+# which pulumi doesn't wait for, so the deploy hangs for ~15 minutes and
+# then fails (see CI run 25286033743). Ignore description drift so the SG
+# is never replaced over a cosmetic field; the value below is the "as-of"
+# description AWS will hold forever.
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
     description="wingfoil ec2-spot demo",
     tags={**tags, "Name": f"{prefix}-sg"},
+    opts=pulumi.ResourceOptions(ignore_changes=["description"]),
 )
 
 # 8080: ws_server HTTPS/WSS (terminated in-process via the `web-tls`


### PR DESCRIPTION
## Summary
Added `ignore_changes=["description"]` to the SecurityGroup resource to prevent catastrophic replacement when the description field drifts in AWS.

## Key Changes
- Added `pulumi.ResourceOptions(ignore_changes=["description"])` to the SecurityGroup resource definition
- Added detailed comments explaining why description changes must be ignored:
  - The `description` field is immutable in the AWS API, forcing SG replacement on any change
  - SG replacement triggers a cascade of failures: new SG creation → launch template update → old SG deletion attempt while still attached to live spot instance ENI
  - AWS returns DependencyViolation, causing the deploy to hang for ~15 minutes before failing
  - Ignoring description drift prevents unnecessary replacements over cosmetic changes

## Implementation Details
The fix ensures the SecurityGroup resource remains stable across deployments by preventing Pulumi from attempting to replace it due to description field changes. This is critical in this architecture where SG replacement would block ASG instance refresh operations and cause deployment failures.

https://claude.ai/code/session_01BxK4PH6BhJh95vVPBtm8od