### PR TITLE
latency_e2e ec2-spot: drop redundant egress rule that duplicates AWS default

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -144,13 +144,11 @@ aws.vpc.SecurityGroupIngressRule(
     cidr_ipv4=ingress_cidr,
     tags=tags,
 )
-aws.vpc.SecurityGroupEgressRule(
-    f"{prefix}-sg-egress-all",
-    security_group_id=sg.id,
-    ip_protocol="-1",
-    cidr_ipv4="0.0.0.0/0",
-    tags=tags,
-)
+# No explicit egress rule: AWS auto-creates a "0.0.0.0/0 allow all" egress
+# rule on every new SG, and the pulumi-aws SecurityGroup resource leaves it
+# alone unless an inline `egress` block is specified. Re-declaring it via
+# aws.vpc.SecurityGroupEgressRule fails with InvalidPermission.Duplicate
+# (CI run 25286544998).
 
 # ── Elastic IP ───────────────────────────────────────────────────────────
 # Pre-allocated and *not* attached to a specific instance. user_data on the


### PR DESCRIPTION
AWS auto-creates a "0.0.0.0/0 allow all" egress rule on every new SG,
and the pulumi-aws SecurityGroup resource leaves that default alone
unless an inline `egress` block is specified. PR #307 added an explicit
aws.vpc.SecurityGroupEgressRule for the same peer/protocol/cidr, which
the EC2 API rejects with InvalidPermission.Duplicate on first apply
(CI run 25286544998).

Drop the explicit rule and document the AWS-default behaviour inline so
the next person editing this file doesn't add it back.

Co-authored-by: Claude <noreply@anthropic.com>