### PR TITLE
latency_e2e ec2-spot: deploy with --refresh, bump SG delete timeout to 30m

### DIFF
--- a/.github/workflows/deploy-latency-e2e.yml
+++ b/.github/workflows/deploy-latency-e2e.yml
@@ -149,10 +149,22 @@ jobs:
           pulumi config set grafana_image   "${{ secrets.GRAFANA_IMAGE }}"
           pulumi config set environment     "$PULUMI_STACK"
 
+      # `--refresh` re-reads each managed resource from AWS before computing
+      # the diff. This unwinds two stale-state failure modes from earlier
+      # deploys of the ec2-spot stack:
+      #   1. A pending-replace marker left over from CI run 25286033743 (the
+      #      SG description change that pre-dated the ignore_changes in
+      #      PR #308). Without refresh, every subsequent `pulumi up` keeps
+      #      retrying the OLD SG delete and hangs for 15 min on
+      #      DependencyViolation while the spot instance's ENI is still
+      #      attached (CI run 25287037911).
+      #   2. Resources that were partially created/deleted by a previous
+      #      failed deploy and no longer exist in AWS — refresh purges them
+      #      from state so `up` doesn't try to update phantoms.
       - name: Pulumi up
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-        run: pulumi up --yes --skip-preview
+        run: pulumi up --yes --skip-preview --refresh
 
       - name: Summary
         env:

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -130,6 +130,14 @@ aws.ec2.RouteTableAssociation(
 # Prometheus scrapes via localhost on the host network. Operators who want
 # the Prometheus UI can still reach it via an SSM session manager
 # port-forward.
+# `delete` timeout: 30 min. If the SG is ever replaced (only via fields not
+# already neutralised above — i.e. nothing we'd plausibly edit), the launch
+# template flips to the new SG and the ASG instance refresh has to terminate
+# the running spot instance before its ENI releases the OLD SG. The default
+# 15 min isn't enough headroom when spot capacity is slow to fulfil the
+# replacement instance — CI run 25287037911 hung for 900s on
+# DependencyViolation and gave up. 30 min covers the worst case (spot
+# request → fulfilment → cloud-init → health-check-grace).
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
@@ -143,7 +151,10 @@ sg = aws.ec2.SecurityGroup(
         ),
     ],
     tags={**tags, "Name": f"{prefix}-sg"},
-    opts=pulumi.ResourceOptions(ignore_changes=["description"]),
+    opts=pulumi.ResourceOptions(
+        ignore_changes=["description"],
+        custom_timeouts=pulumi.CustomTimeouts(delete="30m"),
+    ),
 )
 
 # ── Elastic IP ───────────────────────────────────────────────────────────


### PR DESCRIPTION
CI run 25287037911 hung for 900s deleting the original SG with a
DependencyViolation, even though PR #308 added ignore_changes=
["description"] to keep future deploys from triggering a replace.

The replacement was queued back in CI run 25286033743 (the original
non-ASCII description edit, before ignore_changes). Pulumi state still
holds that pending-replace marker, so every subsequent `pulumi up`
retries the OLD SG delete — and the OLD SG can't go because the running
spot instance's ENI is still attached to it. The 15 min default isn't
enough for the ASG instance refresh (spot fulfilment + cloud-init +
health-check-grace) to release the ENI.

Two changes to converge the stack:

  - `pulumi up --refresh` in the deploy workflow re-reads each managed
    resource from AWS before diffing, so a pending-replace marker for a
    resource that no longer exists in AWS gets cleared from state
    instead of being re-attempted on every run.
  - `custom_timeouts.delete=30m` on the SG gives the instance refresh
    enough headroom on the rare future deploy that does end up
    replacing the SG.

https://claude.ai/code/session_01RryA8neVSJhfn9q3MGCwzi