### PR TITLE
latency_e2e ec2-spot: drain ASG before deploy to fix SG DependencyViolation

### DIFF
--- a/.github/workflows/deploy-latency-e2e.yml
+++ b/.github/workflows/deploy-latency-e2e.yml
@@ -149,18 +149,55 @@ jobs:
           pulumi config set grafana_image   "${{ secrets.GRAFANA_IMAGE }}"
           pulumi config set environment     "$PULUMI_STACK"
 
+      # Drain the ASG to 0 before `pulumi up` so the old security group has
+      # no dependent ENI when Pulumi tries to delete it. Solves the
+      # DependencyViolation that hung CI runs 25287037911 and 25288417368
+      # for 15 min and then failed: when the SG is replaced (e.g. after a
+      # leftover pending-replace marker from PR #307/#308 churn), Pulumi
+      # creates the new SG, points the launch template at it, and then
+      # races to delete the old SG while the spot instance's ENI is still
+      # attached. The terraform-aws-provider hardcodes a 15-min retry on
+      # DependencyViolation for SG delete, and Pulumi's `custom_timeouts`
+      # is engine-level only — it doesn't propagate to the bridged
+      # provider's `d.Timeout(schema.TimeoutDelete)`. Draining first makes
+      # the SG delete succeed on the first attempt; `pulumi up` then
+      # scales the ASG back to its declared size of 1.
+      #
+      # No-op on the first deploy when the stack has no `asg_name` output
+      # yet, and no-op when the ASG is already at 0.
+      - name: Drain ASG to release ENIs from old security group (ec2-spot only)
+        if: matrix.target == 'ec2-spot'
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          ASG_NAME=$(pulumi stack output asg_name 2>/dev/null || true)
+          if [ -z "$ASG_NAME" ] || [ "$ASG_NAME" = "null" ]; then
+            echo "No asg_name stack output (first deploy?); skipping drain."
+            exit 0
+          fi
+          echo "Draining ASG $ASG_NAME to 0 to free ENIs before pulumi up."
+          aws autoscaling update-auto-scaling-group \
+            --auto-scaling-group-name "$ASG_NAME" \
+            --min-size 0 --desired-capacity 0
+          # Wait up to 5 min for instances to fully terminate (ENI release
+          # follows the EC2 instance shutdown lifecycle).
+          for _ in $(seq 1 60); do
+            count=$(aws autoscaling describe-auto-scaling-groups \
+              --auto-scaling-group-names "$ASG_NAME" \
+              --query 'AutoScalingGroups[0].Instances | length(@)' \
+              --output text)
+            if [ "$count" = "0" ]; then
+              echo "ASG drained."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::warning::ASG $ASG_NAME still has instances after 5 min; proceeding anyway."
+
       # `--refresh` re-reads each managed resource from AWS before computing
-      # the diff. This unwinds two stale-state failure modes from earlier
-      # deploys of the ec2-spot stack:
-      #   1. A pending-replace marker left over from CI run 25286033743 (the
-      #      SG description change that pre-dated the ignore_changes in
-      #      PR #308). Without refresh, every subsequent `pulumi up` keeps
-      #      retrying the OLD SG delete and hangs for 15 min on
-      #      DependencyViolation while the spot instance's ENI is still
-      #      attached (CI run 25287037911).
-      #   2. Resources that were partially created/deleted by a previous
-      #      failed deploy and no longer exist in AWS — refresh purges them
-      #      from state so `up` doesn't try to update phantoms.
+      # the diff so `up` doesn't try to update resources that were
+      # partially created/deleted by a previous failed deploy and no
+      # longer exist in AWS.
       - name: Pulumi up
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -130,14 +130,16 @@ aws.ec2.RouteTableAssociation(
 # Prometheus scrapes via localhost on the host network. Operators who want
 # the Prometheus UI can still reach it via an SSM session manager
 # port-forward.
-# `delete` timeout: 30 min. If the SG is ever replaced (only via fields not
-# already neutralised above — i.e. nothing we'd plausibly edit), the launch
-# template flips to the new SG and the ASG instance refresh has to terminate
-# the running spot instance before its ENI releases the OLD SG. The default
-# 15 min isn't enough headroom when spot capacity is slow to fulfil the
-# replacement instance — CI run 25287037911 hung for 900s on
-# DependencyViolation and gave up. 30 min covers the worst case (spot
-# request → fulfilment → cloud-init → health-check-grace).
+# If the SG is ever replaced (only via fields not already neutralised above —
+# i.e. nothing we'd plausibly edit), the launch template flips to the new SG
+# and the OLD SG can't be deleted until the running spot instance's ENI
+# releases it. The terraform-aws-provider hardcodes a 15-min retry on
+# DependencyViolation for SG delete (CI runs 25287037911 and 25288417368 both
+# hung for 900s and gave up), and Pulumi's `custom_timeouts.delete` is
+# engine-level only — it does not propagate to the bridged provider's
+# `d.Timeout(schema.TimeoutDelete)`, so bumping it doesn't help. The deploy
+# workflow handles this by draining the ASG to 0 *before* `pulumi up`, which
+# guarantees no ENI references the old SG when Pulumi deletes it.
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
@@ -151,10 +153,7 @@ sg = aws.ec2.SecurityGroup(
         ),
     ],
     tags={**tags, "Name": f"{prefix}-sg"},
-    opts=pulumi.ResourceOptions(
-        ignore_changes=["description"],
-        custom_timeouts=pulumi.CustomTimeouts(delete="30m"),
-    ),
+    opts=pulumi.ResourceOptions(ignore_changes=["description"]),
 )
 
 # ── Elastic IP ───────────────────────────────────────────────────────────


### PR DESCRIPTION
`custom_timeouts.delete` in pulumi-aws is engine-level and does not propagate
to the bridged terraform-aws provider's `d.Timeout(schema.TimeoutDelete)`, so
the 30m bump in PR #311 did nothing — CI run 25288417368 still failed at 900s
on `DeleteSecurityGroup` with `DependencyViolation` because the running spot
instance's ENI was still attached to the old SG.

Drain the ASG to 0 in the deploy workflow before `pulumi up` so the old SG
has no dependent ENI when Pulumi tries to delete it. `pulumi up` then scales
the ASG back to its declared size of 1 on the new SG.