### PR TITLE
latency_e2e ec2-spot: enable SSM Session Manager + boot-time ipc:host override

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -242,6 +242,24 @@ aws.iam.RolePolicy(
     })),
 )
 
+# Attach AWS-managed `AmazonSSMManagedInstanceCore` so the SSM agent (baked
+# into AL2023 AMIs by default) can register with Systems Manager. Without
+# this, `aws ssm start-session` and the EC2 console "Connect → Session
+# Manager" button both fail with AccessDeniedException — visible in the
+# system log as
+#     "SSM Agent unable to acquire credentials: ... AccessDeniedException:
+#      Systems Manager's instance management role is not configured for
+#      account: <id>"
+# That makes runtime debugging impossible (no SSH port open either), so
+# every container-runtime failure has to be diagnosed from boot logs alone.
+# This managed policy is the standard SSM bootstrap and grants only what
+# the agent needs (ssmmessages:*, ec2messages:*, ssm:Update*/Get*/Put*).
+aws.iam.RolePolicyAttachment(
+    f"{prefix}-instance-ssm-attach",
+    role=instance_role.name,
+    policy_arn="arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+)
+
 instance_profile = aws.iam.InstanceProfile(
     f"{prefix}-instance-profile",
     role=instance_role.name,

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -166,6 +166,50 @@ if ! ${layout_ok}; then
   exit 1
 fi
 
+# ── docker-compose override (boot-time, AMI-agnostic) ────────────────────
+# Two things need to be true for the round trip to work:
+#
+#  1. ws_server and fix_gw must share an IPC namespace. iceoryx2 stores its
+#     segments under /dev/shm/iox2_*; Docker's default per-container IPC
+#     namespace gives each container a private /dev/shm tmpfs, so without
+#     `ipc: host` the two containers can't see each other's iceoryx2
+#     segments — orders never reach fix_gw, and no fills come back.
+#     `network_mode: host` is *not* sufficient; that only shares the
+#     network namespace.
+#
+#  2. Stale iox2_* segments from a previous boot (e.g. Spot reclaim killed
+#     the containers before they cleaned up) must be removed first, or the
+#     fresh containers fail with IncompatibleTypes when they try to open
+#     services that already exist with mismatched generation IDs.
+#
+# Doing this in user_data.sh (rather than only in the Packer install.sh)
+# means the fix applies on every boot, including instances launched from an
+# AMI baked before #313 — the fix doesn't depend on which AMI is in use.
+# install.sh also sets `ipc: host` directly in docker-compose.yml on newer
+# AMIs; the override below is idempotent in that case.
+#
+# The override also re-declares Grafana's HTTPS config, which install.sh
+# previously wrote to docker-compose.override.yml. Re-declaring it here
+# keeps a single source of truth — the override on disk after this section
+# is the one written below, regardless of AMI version.
+rm -f /dev/shm/iox2_* || true
+
+cat > /opt/wingfoil/docker-compose.override.yml <<'EOF'
+services:
+  ws_server:
+    ipc: host
+  fix_gw:
+    ipc: host
+  grafana:
+    environment:
+      GF_SERVER_PROTOCOL: "https"
+      GF_SERVER_CERT_FILE: "/etc/wingfoil/tls/cert.pem"
+      GF_SERVER_CERT_KEY: "/etc/wingfoil/tls/key.pem"
+    volumes:
+      - /etc/wingfoil/tls:/etc/wingfoil/tls:ro
+EOF
+chmod 0644 /opt/wingfoil/docker-compose.override.yml
+
 # Bring up the demo stack — images already cached in the AMI, so this is a
 # fast `docker run` per service rather than a registry pull.
 ( cd /opt/wingfoil && docker compose up -d )


### PR DESCRIPTION
## Why

Symptom: WS UI accepts orders on the ec2-spot deployment, but no fills come back.

The original suspicion (#313) was a private IPC namespace blocking iceoryx2 segments between ws_server and fix_gw. The system log on the running instance shows that fix _did_ apply on this boot, all five containers started cleanly, and `user_data complete:` printed — yet the symptom persists. So the actual cause is somewhere inside fix_gw at runtime, not at startup.

We can't see fix_gw's runtime logs because the instance role is missing `AmazonSSMManagedInstanceCore`. The system log is explicit:

```
SSM Agent unable to acquire credentials: ... AccessDeniedException:
Systems Manager's instance management role is not configured for account
```

With no SSH port open either, runtime diagnosis is impossible.

## What

Two commits:

**1. `apply ipc: host fix at boot, not just AMI bake`** — defense-in-depth. Writes `docker-compose.override.yml` at boot setting `ipc: host` on ws_server/fix_gw and re-declaring Grafana's HTTPS config; cleans `/dev/shm/iox2_*` first to recover from a Spot reclaim that killed containers mid-cycle. Idempotent on AMIs that already bake `ipc: host` from #313.

Full disclosure: this commit does **not** fix today's bug (proven by the boot log — it already ran and the symptom persists). It's prophylactic for Spot reclaim recovery and AMI-version drift.

**2. `attach AmazonSSMManagedInstanceCore to instance role`** — the actually-useful change. Adds the standard SSM bootstrap policy via `RolePolicyAttachment`. After `pulumi up` triggers an instance refresh, EC2 console → Connect → Session Manager works, unblocking `docker logs wingfoil-fix_gw-1` from a phone or laptop.

## Test plan

- [ ] Merge → run `latency-e2e.deploy` (`target=ec2-spot`, stack `demo`).
- [ ] Wait for ASG instance refresh (~60-90 s downtime).
- [ ] EC2 console → Instances → wingfoil-host → Connect → Session Manager. Button should connect (was failing before).
- [ ] From the session: `sudo docker ps` shows 5 containers; `sudo docker logs --tail 200 wingfoil-fix_gw-1` exposes the real cause of the missing fills (FIX login failure / stale MD book / ExecutionReport not arriving / etc.).

https://claude.ai/code/session_01YRRQMuTFW4mKSn4QeSDphK

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRzZEE64TZeRrDz3DnwUhv)_