### PR TITLE
latency_e2e ec2-spot: opt-in Let's Encrypt cert via dns_hostname

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
@@ -115,20 +115,41 @@ pulumi config set --secret lmax_password <YOUR_LMAX_PASSWORD>
 # pulumi config set ingress_cidr      203.0.113.0/24    # lock to your office IP
 # pulumi config set max_spot_price    0.0228            # cap (default = on-demand price)
 
+# ── Optional: Let's Encrypt cert (no browser trust warning) ──────────────
+# Set a hostname you control and the browser will see a real cert chain.
+# Without these, the stack falls back to a self-signed cert and browsers
+# warn on first access.
+# pulumi config set dns_hostname       e2e.example.com
+# pulumi config set letsencrypt_email  ops@example.com    # required when dns_hostname is set
+# pulumi config set route53_zone_id    Z0123456ABCDEF      # optional — Pulumi creates the A record for you
+#                                                          # omit if you'll manage DNS yourself
+
 pulumi up
 ```
 
 After ~3–5 min the outputs print:
 
 ```
-ws_server_url   https://<eip>:8080
-grafana_url     https://<eip>:3000
+ws_server_url   https://<host>:8080      # <host> = dns_hostname if set, else <eip>
+grafana_url     https://<host>:3000
 public_ip       <eip>
+cert_bucket     <bucket>                 # only when dns_hostname is set
 ```
 
 Both endpoints are served over TLS, terminated **in-process** by ws_server
 (via the `web-tls` cargo feature, rustls + ring) and by Grafana
-(`GF_SERVER_PROTOCOL=https`). The cert is a **self-signed** RSA-2048
+(`GF_SERVER_PROTOCOL=https`).
+
+**With `dns_hostname` set** — `user_data.sh` runs certbot in `--standalone`
+mode against your hostname, persists `/etc/letsencrypt` to the
+`cert_bucket` S3 bucket so a Spot reclaim doesn't burn a fresh issuance,
+and a daily systemd timer (`wingfoil-le-renew.timer`) renews the cert and
+bounces the ws_server / grafana containers when it actually rotates. If
+you didn't set `route53_zone_id`, you must create the `A` record yourself
+**before** the instance boots — `pulumi up` shows the EIP in its preview,
+so add the record there, then let `pulumi up` finish creating the ASG.
+
+**Without `dns_hostname`** — the cert is a **self-signed** RSA-2048
 generated on every boot by `user_data.sh`, with `subjectAltName=IP:<eip>`
 so it matches the URL the browser uses. Browsers will show a one-time
 warning until you accept the cert.

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -57,6 +57,28 @@ ingress_cidr = config.get("ingress_cidr") or "0.0.0.0/0"
 # guarantee visible in the Pulumi diff.
 max_spot_price = config.get("max_spot_price") or "0.0228"
 
+# Optional Let's Encrypt support. When `dns_hostname` is set, user_data runs
+# certbot in --standalone mode against the public IP, persists the resulting
+# cert to S3 so a Spot reclaim doesn't burn an LE issuance, and a daily
+# systemd timer handles renewal. When unset, the stack falls back to the
+# self-signed cert path (current default behaviour).
+#
+# `letsencrypt_email` becomes required as soon as `dns_hostname` is set —
+# certbot uses it for expiry notifications and ACME account registration.
+#
+# `route53_zone_id` is optional even when `dns_hostname` is set: if the user
+# manages DNS outside Route53, they create the A record themselves after
+# `pulumi up` outputs the EIP. If set, Pulumi creates the A record so the
+# instance can fetch a cert on first boot without manual intervention.
+dns_hostname = config.get("dns_hostname")
+letsencrypt_email = config.get("letsencrypt_email")
+route53_zone_id = config.get("route53_zone_id")
+if dns_hostname and not letsencrypt_email:
+    raise pulumi.RunError(
+        "letsencrypt_email is required when dns_hostname is set "
+        "(certbot needs an account email)."
+    )
+
 tags = {"Project": project, "Stack": stack, "ManagedBy": "Pulumi"}
 
 # ── Networking ───────────────────────────────────────────────────────────
@@ -140,18 +162,29 @@ aws.ec2.RouteTableAssociation(
 # `d.Timeout(schema.TimeoutDelete)`, so bumping it doesn't help. The deploy
 # workflow handles this by draining the ASG to 0 *before* `pulumi up`, which
 # guarantees no ENI references the old SG when Pulumi deletes it.
+sg_ingress = [
+    aws.ec2.SecurityGroupIngressArgs(
+        from_port=8080, to_port=8080, protocol="tcp", cidr_blocks=[ingress_cidr]
+    ),
+    aws.ec2.SecurityGroupIngressArgs(
+        from_port=3000, to_port=3000, protocol="tcp", cidr_blocks=[ingress_cidr]
+    ),
+]
+if dns_hostname:
+    # certbot --standalone binds :80 for the HTTP-01 challenge. Open it to
+    # the world (not `ingress_cidr`) because Let's Encrypt's validation
+    # servers connect from rotating, undocumented IPs.
+    sg_ingress.append(
+        aws.ec2.SecurityGroupIngressArgs(
+            from_port=80, to_port=80, protocol="tcp", cidr_blocks=["0.0.0.0/0"]
+        )
+    )
+
 sg = aws.ec2.SecurityGroup(
     f"{prefix}-sg",
     vpc_id=vpc.id,
     description="wingfoil ec2-spot demo",
-    ingress=[
-        aws.ec2.SecurityGroupIngressArgs(
-            from_port=8080, to_port=8080, protocol="tcp", cidr_blocks=[ingress_cidr]
-        ),
-        aws.ec2.SecurityGroupIngressArgs(
-            from_port=3000, to_port=3000, protocol="tcp", cidr_blocks=[ingress_cidr]
-        ),
-    ],
+    ingress=sg_ingress,
     tags={**tags, "Name": f"{prefix}-sg"},
     opts=pulumi.ResourceOptions(ignore_changes=["description"]),
 )
@@ -164,6 +197,54 @@ eip = aws.ec2.Eip(
     domain="vpc",
     tags={**tags, "Name": f"{prefix}-eip"},
 )
+
+# ── DNS + Let's Encrypt cert cache (optional) ────────────────────────────
+# When `dns_hostname` is set:
+#  * If `route53_zone_id` is also set, point the hostname's A record at the
+#    EIP automatically. Otherwise the operator creates the record themselves
+#    in whichever DNS provider they use.
+#  * Provision an S3 bucket so cert state survives Spot reclaims. Without
+#    this every reclaim would issue a new cert; LE allows 50/week/domain so
+#    a busy reclaim day could trip the limit.
+cert_bucket = None
+if dns_hostname:
+    if route53_zone_id:
+        aws.route53.Record(
+            f"{prefix}-dns",
+            zone_id=route53_zone_id,
+            name=dns_hostname,
+            type="A",
+            ttl=60,
+            records=[eip.public_ip],
+        )
+
+    # Bucket name must be globally unique; let Pulumi append a random suffix
+    # rather than relying on `prefix` alone.
+    cert_bucket = aws.s3.BucketV2(
+        f"{prefix}-tls-cache",
+        force_destroy=True,
+        tags={**tags, "Name": f"{prefix}-tls-cache"},
+    )
+    aws.s3.BucketServerSideEncryptionConfigurationV2(
+        f"{prefix}-tls-cache-sse",
+        bucket=cert_bucket.id,
+        rules=[
+            aws.s3.BucketServerSideEncryptionConfigurationV2RuleArgs(
+                apply_server_side_encryption_by_default=aws.s3.
+                BucketServerSideEncryptionConfigurationV2RuleApplyServerSideEncryptionByDefaultArgs(
+                    sse_algorithm="AES256",
+                ),
+            )
+        ],
+    )
+    aws.s3.BucketPublicAccessBlock(
+        f"{prefix}-tls-cache-pab",
+        bucket=cert_bucket.id,
+        block_public_acls=True,
+        block_public_policy=True,
+        ignore_public_acls=True,
+        restrict_public_buckets=True,
+    )
 
 # ── Secrets ──────────────────────────────────────────────────────────────
 lmax_username_secret = aws.secretsmanager.Secret(f"{prefix}-lmax-username", tags=tags)
@@ -195,51 +276,74 @@ instance_role = aws.iam.Role(
 
 account_id = aws.get_caller_identity().account_id
 
+def _instance_policy(args):
+    user_arn, pw_arn, eip_alloc, bucket_arn = args
+    statements = [
+        {
+            "Effect": "Allow",
+            "Action": ["secretsmanager:GetSecretValue"],
+            "Resource": [user_arn, pw_arn],
+        },
+        # DescribeAddresses doesn't support resource-level permissions
+        # at all (the previous tag condition was silently a no-op), so
+        # split it out as `Resource: "*"` and accept the breadth — it's
+        # a read-only API.
+        {
+            "Effect": "Allow",
+            "Action": ["ec2:DescribeAddresses"],
+            "Resource": "*",
+        },
+        # AssociateAddress: scope to *this* EIP allocation ARN plus any
+        # instance/network-interface tagged with our Project/Stack. The
+        # resource-tag condition is enforced per-resource — both the
+        # EIP and the instance must satisfy it for the call to succeed.
+        {
+            "Effect": "Allow",
+            "Action": ["ec2:AssociateAddress"],
+            "Resource": [
+                f"arn:aws:ec2:*:{account_id}:elastic-ip/{eip_alloc}",
+                f"arn:aws:ec2:*:{account_id}:instance/*",
+                f"arn:aws:ec2:*:{account_id}:network-interface/*",
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/Project": project,
+                    "aws:ResourceTag/Stack": stack,
+                }
+            },
+        },
+    ]
+    if bucket_arn is not None:
+        # Scoped to this stack's cert cache only. Get/Put on objects, List
+        # on the bucket so user_data can detect a missing cert without
+        # eating an HTTP 403 -> 404 distinction.
+        statements.append(
+            {
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:PutObject"],
+                "Resource": [f"{bucket_arn}/*"],
+            }
+        )
+        statements.append(
+            {
+                "Effect": "Allow",
+                "Action": ["s3:ListBucket"],
+                "Resource": [bucket_arn],
+            }
+        )
+    return json.dumps({"Version": "2012-10-17", "Statement": statements})
+
+
+_policy_inputs = [
+    lmax_username_secret.arn,
+    lmax_password_secret.arn,
+    eip.allocation_id,
+    cert_bucket.arn if cert_bucket is not None else pulumi.Output.from_input(None),
+]
 aws.iam.RolePolicy(
     f"{prefix}-instance-policy",
     role=instance_role.id,
-    policy=pulumi.Output.all(
-        lmax_username_secret.arn,
-        lmax_password_secret.arn,
-        eip.allocation_id,
-    ).apply(lambda a: json.dumps({
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": ["secretsmanager:GetSecretValue"],
-                "Resource": [a[0], a[1]],
-            },
-            # DescribeAddresses doesn't support resource-level permissions
-            # at all (the previous tag condition was silently a no-op), so
-            # split it out as `Resource: "*"` and accept the breadth — it's
-            # a read-only API.
-            {
-                "Effect": "Allow",
-                "Action": ["ec2:DescribeAddresses"],
-                "Resource": "*",
-            },
-            # AssociateAddress: scope to *this* EIP allocation ARN plus any
-            # instance/network-interface tagged with our Project/Stack. The
-            # resource-tag condition is enforced per-resource — both the
-            # EIP and the instance must satisfy it for the call to succeed.
-            {
-                "Effect": "Allow",
-                "Action": ["ec2:AssociateAddress"],
-                "Resource": [
-                    f"arn:aws:ec2:*:{account_id}:elastic-ip/{a[2]}",
-                    f"arn:aws:ec2:*:{account_id}:instance/*",
-                    f"arn:aws:ec2:*:{account_id}:network-interface/*",
-                ],
-                "Condition": {
-                    "StringEquals": {
-                        "aws:ResourceTag/Project": project,
-                        "aws:ResourceTag/Stack": stack,
-                    }
-                },
-            },
-        ],
-    })),
+    policy=pulumi.Output.all(*_policy_inputs).apply(_instance_policy),
 )
 
 instance_profile = aws.iam.InstanceProfile(
@@ -252,13 +356,16 @@ user_data_template = (HERE / "user_data.sh").read_text()
 
 
 def render_user_data(args):
-    eip_alloc, user_arn, pw_arn = args
+    eip_alloc, user_arn, pw_arn, cert_bucket_name = args
     rendered = (
         user_data_template
         .replace("__EIP_ALLOCATION_ID__",     eip_alloc)
         .replace("__LMAX_USERNAME_SECRET__",  user_arn)
         .replace("__LMAX_PASSWORD_SECRET__",  pw_arn)
         .replace("__AWS_REGION__",            aws_region)
+        .replace("__DNS_HOSTNAME__",          dns_hostname or "")
+        .replace("__LETSENCRYPT_EMAIL__",     letsencrypt_email or "")
+        .replace("__CERT_BUCKET__",           cert_bucket_name or "")
     )
     # cloud-init needs base64 user_data when passed via launch templates.
     import base64
@@ -266,7 +373,10 @@ def render_user_data(args):
 
 
 user_data_b64 = pulumi.Output.all(
-    eip.allocation_id, lmax_username_secret.arn, lmax_password_secret.arn
+    eip.allocation_id,
+    lmax_username_secret.arn,
+    lmax_password_secret.arn,
+    cert_bucket.bucket if cert_bucket is not None else pulumi.Output.from_input(None),
 ).apply(render_user_data)
 
 launch_template = aws.ec2.LaunchTemplate(
@@ -340,11 +450,18 @@ asg = aws.autoscaling.Group(
 
 # ── Outputs ──────────────────────────────────────────────────────────────
 pulumi.export("public_ip",      eip.public_ip)
-# Both endpoints terminate TLS with a self-signed cert regenerated on
-# every boot (see user_data.sh). Browsers will show a one-time warning
-# until you accept the cert; the `wingfoil-js` client respects
-# `location.protocol`, so the UI auto-upgrades to `wss://`.
-pulumi.export("ws_server_url",  eip.public_ip.apply(lambda ip: f"https://{ip}:8080"))
-pulumi.export("grafana_url",    eip.public_ip.apply(lambda ip: f"https://{ip}:3000"))
+# When `dns_hostname` is set, both endpoints serve a Let's Encrypt cert
+# (cached in S3 across Spot reclaims). Browsers won't warn. When unset,
+# the stack falls back to a self-signed cert regenerated on every boot,
+# and browsers will show a one-time warning until the cert is accepted.
+# In either case `wingfoil-js` respects `location.protocol` so the UI
+# auto-upgrades to `wss://`.
+endpoint_host = (
+    pulumi.Output.from_input(dns_hostname) if dns_hostname else eip.public_ip
+)
+pulumi.export("ws_server_url",  endpoint_host.apply(lambda h: f"https://{h}:8080"))
+pulumi.export("grafana_url",    endpoint_host.apply(lambda h: f"https://{h}:3000"))
 pulumi.export("asg_name",       asg.name)
 pulumi.export("availability_zone", availability_zone)
+if cert_bucket is not None:
+    pulumi.export("cert_bucket", cert_bucket.bucket)

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -69,6 +69,13 @@ for img in "${WS_SERVER_IMAGE}" "${FIX_GW_IMAGE}" "${PROMETHEUS_IMAGE}" "${TEMPO
   sudo docker pull "${img}"
 done
 
+# certbot is fetched as a Docker image rather than a system package so the
+# AMI doesn't carry an EPEL/snap dependency. Pre-pulling here means
+# user_data's --standalone run on the first post-reclaim boot starts
+# instantly instead of stalling on a registry pull while the public IP
+# is uncertified.
+sudo docker pull certbot/certbot:latest
+
 # Drop the docker login state so the AMI doesn't ship with an ECR token
 # baked into /root/.docker/config.json. The token expires in ~12h anyway,
 # but cleaning up keeps the AMI free of credential artifacts.

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -20,6 +20,11 @@ EIP_ALLOCATION_ID="__EIP_ALLOCATION_ID__"
 LMAX_USERNAME_SECRET="__LMAX_USERNAME_SECRET__"
 LMAX_PASSWORD_SECRET="__LMAX_PASSWORD_SECRET__"
 AWS_REGION="__AWS_REGION__"
+# Let's Encrypt opt-in. Empty when the operator hasn't set `dns_hostname` in
+# Pulumi config, in which case we keep the self-signed-cert path below.
+DNS_HOSTNAME="__DNS_HOSTNAME__"
+LETSENCRYPT_EMAIL="__LETSENCRYPT_EMAIL__"
+CERT_BUCKET="__CERT_BUCKET__"
 
 # IMDSv2 — fetch our instance ID for the EIP association call.
 IMDS_TOKEN=$(curl -fsSL -X PUT \
@@ -71,26 +76,183 @@ set -x
 chmod 0600 /etc/wingfoil/lmax.env
 
 # ── TLS material for ws_server + Grafana ──────────────────────────────────
-# Self-signed cert regenerated on every boot. Browsers will warn (no public
-# CA chain), but the WS / iframe traffic is then encrypted on the wire,
-# which matters whenever the demo is reachable from a public network. The
-# subjectAltName carries the EIP so `https://<eip>:8080` matches the cert
-# enough for `openssl s_client`-style verification — browsers still
-# require a manual click-through for the unknown root.
+# Two modes, selected by whether DNS_HOSTNAME was set in Pulumi config:
+#
+#  1. DNS_HOSTNAME unset → self-signed cert regenerated on every boot.
+#     Browsers warn (no public CA chain), but the WS / iframe traffic is
+#     still encrypted on the wire. The subjectAltName carries the EIP so
+#     `https://<eip>:8080` matches the cert enough for
+#     `openssl s_client`-style verification.
+#
+#  2. DNS_HOSTNAME set → Let's Encrypt cert fetched via certbot in
+#     --standalone mode (HTTP-01 on :80). Cert state is cached in S3 so a
+#     Spot reclaim doesn't burn a fresh issuance against LE's 50/week/domain
+#     limit. A daily systemd timer renews and bounces the containers if the
+#     cert was actually rotated. If the LE flow fails for any reason
+#     (DNS hasn't propagated yet, certbot pull error, etc.) we fall back
+#     to the self-signed path so the demo still comes up.
 PUBLIC_IPV4=$(curl -fsSL \
   -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" \
   http://169.254.169.254/latest/meta-data/public-ipv4)
 
 install -d -m 0755 /etc/wingfoil/tls
-openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
-  -keyout /etc/wingfoil/tls/key.pem \
-  -out    /etc/wingfoil/tls/cert.pem \
-  -subj "/CN=${PUBLIC_IPV4}" \
-  -addext "subjectAltName=IP:${PUBLIC_IPV4}"
-# Both files must be world-readable: the ws_server container runs as
-# UID 10001 and the grafana container as UID 472. The key is regenerated
-# on every boot, so file-system leakage of a stale key buys nothing.
-chmod 0644 /etc/wingfoil/tls/cert.pem /etc/wingfoil/tls/key.pem
+
+write_self_signed_cert() {
+  openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -keyout /etc/wingfoil/tls/key.pem \
+    -out    /etc/wingfoil/tls/cert.pem \
+    -subj "/CN=${PUBLIC_IPV4}" \
+    -addext "subjectAltName=IP:${PUBLIC_IPV4}"
+  # Both files must be world-readable: the ws_server container runs as
+  # UID 10001 and the grafana container as UID 472. The key is regenerated
+  # on every boot, so file-system leakage of a stale key buys nothing.
+  chmod 0644 /etc/wingfoil/tls/cert.pem /etc/wingfoil/tls/key.pem
+}
+
+publish_le_cert() {
+  # Copy the LE-issued material out of /etc/letsencrypt (root-only) into
+  # /etc/wingfoil/tls (world-readable, mounted by ws_server + grafana).
+  cp -L "/etc/letsencrypt/live/${DNS_HOSTNAME}/fullchain.pem" /etc/wingfoil/tls/cert.pem
+  cp -L "/etc/letsencrypt/live/${DNS_HOSTNAME}/privkey.pem"   /etc/wingfoil/tls/key.pem
+  chmod 0644 /etc/wingfoil/tls/cert.pem /etc/wingfoil/tls/key.pem
+}
+
+push_le_cert_to_s3() {
+  # Tar /etc/letsencrypt as the unit of state — certbot's `live/`
+  # symlinks reference `archive/` and `renewal/` config, so all three
+  # need to ride together.
+  tar -C / -czf /tmp/letsencrypt.tar.gz etc/letsencrypt
+  aws s3 cp /tmp/letsencrypt.tar.gz \
+    "s3://${CERT_BUCKET}/${DNS_HOSTNAME}/letsencrypt.tar.gz" \
+    --region "${AWS_REGION}"
+  rm -f /tmp/letsencrypt.tar.gz
+}
+
+restore_le_cert_from_s3() {
+  if aws s3 cp \
+      "s3://${CERT_BUCKET}/${DNS_HOSTNAME}/letsencrypt.tar.gz" \
+      /tmp/letsencrypt.tar.gz \
+      --region "${AWS_REGION}" 2>/dev/null; then
+    tar -C / -xzf /tmp/letsencrypt.tar.gz
+    rm -f /tmp/letsencrypt.tar.gz
+    return 0
+  fi
+  return 1
+}
+
+run_certbot() {
+  # certonly --standalone --keep-until-expiring is a no-op when the cached
+  # cert has >30d left, and a fresh issuance otherwise. --non-interactive +
+  # --agree-tos is required for unattended runs. Bind /etc/letsencrypt for
+  # state, publish :80 for the HTTP-01 challenge.
+  docker run --rm \
+    -v /etc/letsencrypt:/etc/letsencrypt \
+    -v /var/lib/letsencrypt:/var/lib/letsencrypt \
+    -p 80:80 \
+    certbot/certbot:latest \
+    certonly --standalone --non-interactive --agree-tos --keep-until-expiring \
+    --email "${LETSENCRYPT_EMAIL}" \
+    -d "${DNS_HOSTNAME}"
+}
+
+wait_for_dns() {
+  # Up to ~5 min — Route53 propagates in seconds, third-party DNS providers
+  # can take a couple of minutes after `pulumi up`. Uses the system resolver
+  # (Amazon's VPC resolver on AL2023) which doesn't cache negative results
+  # for long, so a freshly created record shows up promptly.
+  local attempt resolved
+  for attempt in $(seq 1 30); do
+    resolved=$(getent hosts "${DNS_HOSTNAME}" 2>/dev/null | awk 'NR==1 {print $1}' || true)
+    if [ "${resolved}" = "${PUBLIC_IPV4}" ]; then
+      return 0
+    fi
+    echo "waiting for ${DNS_HOSTNAME} to resolve to ${PUBLIC_IPV4} (got '${resolved}', attempt ${attempt}/30)"
+    sleep 10
+  done
+  return 1
+}
+
+if [ -n "${DNS_HOSTNAME}" ]; then
+  install -d -m 0700 /etc/letsencrypt
+  install -d -m 0700 /var/lib/letsencrypt
+  # Best-effort restore from S3 — first deploy will 404, that's fine.
+  restore_le_cert_from_s3 || echo "no cached cert in s3://${CERT_BUCKET}, will issue a fresh one"
+
+  if wait_for_dns && run_certbot; then
+    publish_le_cert
+    push_le_cert_to_s3
+    LE_OK=1
+  else
+    echo "WARNING: Let's Encrypt flow failed; falling back to self-signed cert" >&2
+    write_self_signed_cert
+    LE_OK=0
+  fi
+else
+  write_self_signed_cert
+  LE_OK=0
+fi
+
+# Daily renewal timer — only set up when LE is actually live. The renew
+# subcommand is idempotent: it skips certs with >30d remaining, so the
+# common-case run is a no-op. The deploy-hook fires only on actual
+# rotation, where we re-publish to /etc/wingfoil/tls, push the new state
+# to S3, and bounce the two containers that read the cert at startup.
+if [ "${LE_OK}" = "1" ]; then
+  cat > /opt/wingfoil/le-renew.sh <<EOF
+#!/bin/bash
+set -euo pipefail
+docker run --rm \\
+  -v /etc/letsencrypt:/etc/letsencrypt \\
+  -v /var/lib/letsencrypt:/var/lib/letsencrypt \\
+  -p 80:80 \\
+  certbot/certbot:latest \\
+  renew --non-interactive \\
+  --deploy-hook "echo rotated" >/var/log/wingfoil-le-renew.log 2>&1
+
+# certbot --deploy-hook only runs when at least one cert was actually
+# renewed. Detect that by comparing the on-disk fingerprint before/after.
+NEW_FP=\$(openssl x509 -in /etc/letsencrypt/live/${DNS_HOSTNAME}/cert.pem -noout -fingerprint -sha256)
+OLD_FP=\$(openssl x509 -in /etc/wingfoil/tls/cert.pem -noout -fingerprint -sha256 2>/dev/null || echo "")
+if [ "\${NEW_FP}" != "\${OLD_FP}" ]; then
+  cp -L /etc/letsencrypt/live/${DNS_HOSTNAME}/fullchain.pem /etc/wingfoil/tls/cert.pem
+  cp -L /etc/letsencrypt/live/${DNS_HOSTNAME}/privkey.pem   /etc/wingfoil/tls/key.pem
+  chmod 0644 /etc/wingfoil/tls/cert.pem /etc/wingfoil/tls/key.pem
+  tar -C / -czf /tmp/letsencrypt.tar.gz etc/letsencrypt
+  aws s3 cp /tmp/letsencrypt.tar.gz \\
+    s3://${CERT_BUCKET}/${DNS_HOSTNAME}/letsencrypt.tar.gz \\
+    --region ${AWS_REGION}
+  rm -f /tmp/letsencrypt.tar.gz
+  ( cd /opt/wingfoil && docker compose restart ws_server grafana )
+fi
+EOF
+  chmod 0755 /opt/wingfoil/le-renew.sh
+
+  cat > /etc/systemd/system/wingfoil-le-renew.service <<'EOF'
+[Unit]
+Description=wingfoil Let's Encrypt cert renewal
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/wingfoil/le-renew.sh
+EOF
+
+  cat > /etc/systemd/system/wingfoil-le-renew.timer <<'EOF'
+[Unit]
+Description=wingfoil Let's Encrypt cert renewal (daily)
+
+[Timer]
+OnBootSec=1h
+OnUnitActiveSec=24h
+RandomizedDelaySec=30min
+
+[Install]
+WantedBy=timers.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable --now wingfoil-le-renew.timer
+fi
 
 # Spot watcher — polls IMDS for reclaim notice, exposes a Prometheus gauge
 # on :9092 that the Grafana banner panel reads.


### PR DESCRIPTION
Adds a Pulumi config flag (`dns_hostname`) that switches the stack from
self-signed certs to Let's Encrypt, eliminating the browser trust warning.
Cert state persists in S3 across Spot reclaims so renewals don't burn
issuances against LE's per-domain rate limit, and a daily systemd timer
handles renewals + bounces ws_server / grafana when the cert rotates. If
the LE flow fails (DNS not propagated, registry hiccup, etc.) user_data
falls back to the existing self-signed path so the demo still comes up.