### PR TITLE
latency_e2e ec2-spot: hardcode demo.wingfoil.io, drop letsencrypt_email

### DIFF
--- a/.github/workflows/deploy-latency-e2e.yml
+++ b/.github/workflows/deploy-latency-e2e.yml
@@ -136,6 +136,10 @@ jobs:
             exit 1
           fi
           pulumi config set ami_id "$AMI_ID"
+          # Pin the demo to a real hostname so user_data fetches a Let's
+          # Encrypt cert (no browser trust warning). DNS for this name lives
+          # in GoDaddy and points at the EIP — see ec2-spot/README.md.
+          pulumi config set dns_hostname demo.wingfoil.io
 
       - name: fargate config (image URIs from secrets)
         if: matrix.target == 'fargate'

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
@@ -118,10 +118,9 @@ pulumi config set --secret lmax_password <YOUR_LMAX_PASSWORD>
 # Set a hostname you control and the browser will see a real cert chain.
 # Without these, the stack falls back to a self-signed cert and browsers
 # warn on first access.
-# pulumi config set dns_hostname       e2e.example.com
-# pulumi config set letsencrypt_email  ops@example.com    # required when dns_hostname is set
-# pulumi config set route53_zone_id    Z0123456ABCDEF      # optional — Pulumi creates the A record for you
-#                                                          # omit if you'll manage DNS yourself
+# pulumi config set dns_hostname    e2e.example.com
+# pulumi config set route53_zone_id Z0123456ABCDEF      # optional — Pulumi creates the A record for you
+#                                                       # omit if you'll manage DNS yourself
 
 pulumi up
 ```
@@ -140,13 +139,16 @@ Both endpoints are served over TLS, terminated **in-process** by ws_server
 (`GF_SERVER_PROTOCOL=https`).
 
 **With `dns_hostname` set** — `user_data.sh` runs certbot in `--standalone`
-mode against your hostname, persists `/etc/letsencrypt` to the
-`cert_bucket` S3 bucket so a Spot reclaim doesn't burn a fresh issuance,
-and a daily systemd timer (`wingfoil-le-renew.timer`) renews the cert and
-bounces the ws_server / grafana containers when it actually rotates. If
-you didn't set `route53_zone_id`, you must create the `A` record yourself
-**before** the instance boots — `pulumi up` shows the EIP in its preview,
-so add the record there, then let `pulumi up` finish creating the ASG.
+mode against your hostname (registered with
+`--register-unsafely-without-email` since this stack's daily renewal
+timer makes LE's expiry-warning email a safety net we don't actually
+use), persists `/etc/letsencrypt` to the `cert_bucket` S3 bucket so a
+Spot reclaim doesn't burn a fresh issuance, and a daily systemd timer
+(`wingfoil-le-renew.timer`) renews the cert and bounces the ws_server /
+grafana containers when it actually rotates. If you didn't set
+`route53_zone_id`, you must create the `A` record yourself **before**
+the instance boots — `pulumi up` shows the EIP in its preview, so add
+the record there, then let `pulumi up` finish creating the ASG.
 
 **Without `dns_hostname`** — the cert is a **self-signed** RSA-2048
 generated on every boot by `user_data.sh`, with `subjectAltName=IP:<eip>`

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -75,21 +75,16 @@ max_spot_price = config.get("max_spot_price") or "0.0228"
 # systemd timer handles renewal. When unset, the stack falls back to the
 # self-signed cert path (current default behaviour).
 #
-# `letsencrypt_email` becomes required as soon as `dns_hostname` is set —
-# certbot uses it for expiry notifications and ACME account registration.
+# certbot is invoked with `--register-unsafely-without-email` so this stack
+# carries no operator email config: renewal is automated by a systemd timer,
+# making the LE expiry-warning email a safety net we don't actually use.
 #
 # `route53_zone_id` is optional even when `dns_hostname` is set: if the user
 # manages DNS outside Route53, they create the A record themselves after
 # `pulumi up` outputs the EIP. If set, Pulumi creates the A record so the
 # instance can fetch a cert on first boot without manual intervention.
 dns_hostname = config.get("dns_hostname")
-letsencrypt_email = config.get("letsencrypt_email")
 route53_zone_id = config.get("route53_zone_id")
-if dns_hostname and not letsencrypt_email:
-    raise pulumi.RunError(
-        "letsencrypt_email is required when dns_hostname is set "
-        "(certbot needs an account email)."
-    )
 
 tags = {"Project": project, "Stack": stack, "ManagedBy": "Pulumi"}
 
@@ -413,7 +408,6 @@ def render_user_data(args):
         .replace("__LMAX_PASSWORD_SECRET__",  pw_arn)
         .replace("__AWS_REGION__",            aws_region)
         .replace("__DNS_HOSTNAME__",          dns_hostname or "")
-        .replace("__LETSENCRYPT_EMAIL__",     letsencrypt_email or "")
         .replace("__CERT_BUCKET__",           cert_bucket_name or "")
     )
     # cloud-init needs base64 user_data when passed via launch templates.

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -23,7 +23,6 @@ AWS_REGION="__AWS_REGION__"
 # Let's Encrypt opt-in. Empty when the operator hasn't set `dns_hostname` in
 # Pulumi config, in which case we keep the self-signed-cert path below.
 DNS_HOSTNAME="__DNS_HOSTNAME__"
-LETSENCRYPT_EMAIL="__LETSENCRYPT_EMAIL__"
 CERT_BUCKET="__CERT_BUCKET__"
 
 # IMDSv2 — fetch our instance ID for the EIP association call.
@@ -143,15 +142,19 @@ restore_le_cert_from_s3() {
 run_certbot() {
   # certonly --standalone --keep-until-expiring is a no-op when the cached
   # cert has >30d left, and a fresh issuance otherwise. --non-interactive +
-  # --agree-tos is required for unattended runs. Bind /etc/letsencrypt for
-  # state, publish :80 for the HTTP-01 challenge.
+  # --agree-tos is required for unattended runs.
+  # --register-unsafely-without-email skips the LE expiry-warning email
+  # prompt: this stack's daily renewal timer (wingfoil-le-renew.timer)
+  # makes that warning a safety net we don't actually use, so we don't
+  # hold an operator email in config for it.
+  # Bind /etc/letsencrypt for state, publish :80 for the HTTP-01 challenge.
   docker run --rm \
     -v /etc/letsencrypt:/etc/letsencrypt \
     -v /var/lib/letsencrypt:/var/lib/letsencrypt \
     -p 80:80 \
     certbot/certbot:latest \
     certonly --standalone --non-interactive --agree-tos --keep-until-expiring \
-    --email "${LETSENCRYPT_EMAIL}" \
+    --register-unsafely-without-email \
     -d "${DNS_HOSTNAME}"
 }
 


### PR DESCRIPTION
Pins `dns_hostname` for the deploy workflow so triggering the action
from a phone is a single click — no need to fill in the hostname or
remember to set it via `pulumi config set` first.

Drops the `letsencrypt_email` Pulumi config (and its required-when-set
validation): certbot is now invoked with `--register-unsafely-without-
email`. The daily wingfoil-le-renew.timer makes LE's expiry-warning
email a safety net we don't actually use, so holding an operator email
in stack config buys nothing.