### PR TITLE
Protect Elastic IP from accidental replacement in Spot instance

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -218,10 +218,19 @@ sg = aws.ec2.SecurityGroup(
 # ── Elastic IP ───────────────────────────────────────────────────────────
 # Pre-allocated and *not* attached to a specific instance. user_data on the
 # Spot instance associates it on every boot via the IAM permission below.
+#
+# `protect=True`: the public IP is hand-mirrored into a GoDaddy A record for
+# `dns_hostname` (Pulumi doesn't manage the record because the zone isn't in
+# Route53 — see `route53_zone_id` above). If Pulumi ever replaced the EIP,
+# the record would silently go stale and the demo would be unreachable
+# until the operator noticed and updated GoDaddy. Protecting the resource
+# turns "pulumi destroy" / accidental replacement into a hard error so the
+# IP stays pinned for the lifetime of the stack.
 eip = aws.ec2.Eip(
     f"{prefix}-eip",
     domain="vpc",
     tags={**tags, "Name": f"{prefix}-eip"},
+    opts=pulumi.ResourceOptions(protect=True),
 )
 
 # ── DNS + Let's Encrypt cert cache (optional) ────────────────────────────


### PR DESCRIPTION
## Summary
Added resource protection to the Elastic IP (EIP) in the EC2 Spot instance example to prevent accidental replacement that would break DNS resolution.

## Key Changes
- Added `protect=True` to the EIP resource options to prevent Pulumi from replacing it
- Expanded documentation comments explaining why protection is necessary for this resource

## Implementation Details
The EIP is manually mirrored into a GoDaddy A record for DNS resolution since the zone is not managed in Route53. If Pulumi were to replace the EIP during a stack update, the DNS record would become stale without operator notification, making the demo unreachable. By protecting the resource, any accidental replacement attempt will now fail with a hard error, ensuring the IP address remains pinned for the lifetime of the stack and preventing silent DNS failures.

https://claude.ai/code/session_01X1aM7gwnNbNsArXH9xivEt