### PR TITLE
latency_e2e ec2-spot: serve ws_server on :443 (drop :8080 from URL)

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
@@ -24,7 +24,7 @@ on cached images).
                                                             │
                                                   ┌─────────┴─────────────┐
                                                   │  Docker Compose        │
-                                                  │  ws_server  :8080 HTTPS│
+                                                  │  ws_server   :443 HTTPS│
                                                   │  fix_gw     ─→ LMAX    │
                                                   │  prometheus :9090 (lo) │
                                                   │  tempo      :4318      │
@@ -128,7 +128,7 @@ pulumi up
 After ~3–5 min the outputs print:
 
 ```
-ws_server_url   https://<host>:8080      # <host> = dns_hostname if set, else <eip>
+ws_server_url   https://<host>            # <host> = dns_hostname if set, else <eip>
 grafana_url     https://<host>:3000
 public_ip       <eip>
 cert_bucket     <bucket>                 # only when dns_hostname is set
@@ -170,7 +170,7 @@ aws ssm start-session --target <instance-id> \
 
 ```bash
 # WS server — `-k` because the cert is self-signed.
-curl -fsSk https://<eip>:8080/
+curl -fsSk https://<eip>/
 
 # Grafana — load the dashboard, the "Spot interruption status" banner should
 # read green ("Stable — no Spot interruption notice"). Click through the

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -12,7 +12,7 @@ What this stack provisions:
 
   * VPC + one public subnet per AZ (a/b/c) so the ASG can launch in
     whichever AZ has t3.small spot capacity
-  * Security group: 8080 (WS server), 9091 (prometheus), 3000 (grafana)
+  * Security group: 443 (WS server), 9091 (prometheus), 3000 (grafana)
   * Pre-allocated Elastic IP — re-attached on every boot via user_data
   * Launch template + ASG (min/max/desired = 1) requesting Spot capacity,
     capped at on-demand price so we never pay more than the on-demand rate
@@ -172,12 +172,13 @@ for i, suffix in enumerate(_az_suffixes):
 # aws.vpc.SecurityGroupEgressRule) fails with InvalidPermission.Duplicate
 # (CI run 25286544998).
 #
-# 8080: ws_server HTTPS/WSS (terminated in-process via the `web-tls`
-# feature); 3000: Grafana HTTPS. 9090 (Prometheus UI) and 9091
-# (ws_server /metrics) stay plain-HTTP and are no longer exposed publicly —
-# Prometheus scrapes via localhost on the host network. Operators who want
-# the Prometheus UI can still reach it via an SSM session manager
-# port-forward.
+# 443: ws_server HTTPS/WSS (terminated in-process via the `web-tls`
+# feature) — using the standard HTTPS port lets users reach the demo at
+# `https://demo.wingfoil.io/` without an explicit port. 3000: Grafana
+# HTTPS. 9090 (Prometheus UI) and 9091 (ws_server /metrics) stay
+# plain-HTTP and are no longer exposed publicly — Prometheus scrapes via
+# localhost on the host network. Operators who want the Prometheus UI
+# can still reach it via an SSM session manager port-forward.
 # If the SG is ever replaced (only via fields not already neutralised above —
 # i.e. nothing we'd plausibly edit), the launch template flips to the new SG
 # and the OLD SG can't be deleted until the running spot instance's ENI
@@ -190,7 +191,7 @@ for i, suffix in enumerate(_az_suffixes):
 # guarantees no ENI references the old SG when Pulumi deletes it.
 sg_ingress = [
     aws.ec2.SecurityGroupIngressArgs(
-        from_port=8080, to_port=8080, protocol="tcp", cidr_blocks=[ingress_cidr]
+        from_port=443, to_port=443, protocol="tcp", cidr_blocks=[ingress_cidr]
     ),
     aws.ec2.SecurityGroupIngressArgs(
         from_port=3000, to_port=3000, protocol="tcp", cidr_blocks=[ingress_cidr]
@@ -512,7 +513,7 @@ pulumi.export("public_ip",      eip.public_ip)
 endpoint_host = (
     pulumi.Output.from_input(dns_hostname) if dns_hostname else eip.public_ip
 )
-pulumi.export("ws_server_url",  endpoint_host.apply(lambda h: f"https://{h}:8080"))
+pulumi.export("ws_server_url",  endpoint_host.apply(lambda h: f"https://{h}"))
 pulumi.export("grafana_url",    endpoint_host.apply(lambda h: f"https://{h}:3000"))
 pulumi.export("asg_name",       asg.name)
 pulumi.export("availability_zones", [s.availability_zone for s in subnets])

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -160,10 +160,19 @@ sudo tee -a /opt/wingfoil/docker-compose.yml > /dev/null <<EOF
     image: ${WS_SERVER_IMAGE}
     network_mode: host
     ipc: host
+    # NET_BIND_SERVICE lets the non-root container user bind :443.
+    # Required because the Dockerfile drops to UID 10001 and a privileged
+    # port would otherwise be denied even with `network_mode: host`.
+    cap_add:
+      - NET_BIND_SERVICE
     volumes:
       - /etc/wingfoil/tls:/etc/wingfoil/tls:ro
+    # Override the Dockerfile CMD (which hardcodes --addr 0.0.0.0:8080
+    # for local dev convenience). --addr beats WINGFOIL_WEB_ADDR in
+    # ws_server's arg parsing, so setting only the env var here would
+    # be silently ignored.
+    command: ["--addr", "0.0.0.0:443"]
     environment:
-      WINGFOIL_WEB_ADDR: "0.0.0.0:8080"
       WINGFOIL_METRICS_ADDR: "0.0.0.0:9091"
       WINGFOIL_OTLP_ENDPOINT: "http://localhost:4318"
       WINGFOIL_TLS_CERT: "/etc/wingfoil/tls/cert.pem"

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -80,7 +80,7 @@ chmod 0600 /etc/wingfoil/lmax.env
 #  1. DNS_HOSTNAME unset → self-signed cert regenerated on every boot.
 #     Browsers warn (no public CA chain), but the WS / iframe traffic is
 #     still encrypted on the wire. The subjectAltName carries the EIP so
-#     `https://<eip>:8080` matches the cert enough for
+#     `https://<eip>` matches the cert enough for
 #     `openssl s_client`-style verification.
 #
 #  2. DNS_HOSTNAME set → Let's Encrypt cert fetched via certbot in


### PR DESCRIPTION
The demo URL was `https://demo.wingfoil.io:8080/`, which forces users
to type or remember the explicit port. Bind ws_server to the standard
HTTPS port instead so the URL collapses to `https://demo.wingfoil.io/`.

Three coupled changes are needed:
- security group ingress: 8080 → 443
- compose service: add cap_add NET_BIND_SERVICE so the non-root
  container user (UID 10001) can bind a privileged port, and override
  the Dockerfile CMD via `command:` because --addr beats
  WINGFOIL_WEB_ADDR in arg parsing — env-only would silently no-op
- pulumi export: drop the :8080 from ws_server_url

Out of scope: baremetal and fargate stacks (different deployments,
not customer-facing demos), and the ws_server.rs / Dockerfile defaults
(local dev should keep an unprivileged port).