### PR TITLE
Enable non-root ws_server to bind privileged ports via file capabilities

### DIFF
--- a/wingfoil/examples/latency_e2e/Dockerfile.ws_server
+++ b/wingfoil/examples/latency_e2e/Dockerfile.ws_server
@@ -26,6 +26,7 @@ RUN apt-get -o Acquire::Retries=3 update \
     && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
         libssl3 \
         ca-certificates \
+        libcap2-bin \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --system --gid 10001 wingfoil \
     && useradd --system --uid 10001 --gid wingfoil --no-create-home --home /app wingfoil
@@ -34,6 +35,13 @@ WORKDIR /app
 
 COPY --from=builder --chown=wingfoil:wingfoil /workspace/target/release/examples/latency_e2e_ws_server /app/ws_server
 COPY --chown=wingfoil:wingfoil wingfoil/examples/latency_e2e/static /app/static
+
+# File caps so the non-root user (UID 10001) can bind privileged ports
+# like :443 in deployments that pass `--addr 0.0.0.0:443` (ec2-spot).
+# `cap_add: NET_BIND_SERVICE` in compose is also required — it puts the
+# cap in the container's bounding set; this `setcap` is what actually
+# grants it to the non-root process at exec time.
+RUN setcap cap_net_bind_service=+ep /app/ws_server
 
 ENV WINGFOIL_STATIC_DIR=/app/static
 

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -160,9 +160,12 @@ sudo tee -a /opt/wingfoil/docker-compose.yml > /dev/null <<EOF
     image: ${WS_SERVER_IMAGE}
     network_mode: host
     ipc: host
-    # NET_BIND_SERVICE lets the non-root container user bind :443.
-    # Required because the Dockerfile drops to UID 10001 and a privileged
-    # port would otherwise be denied even with `network_mode: host`.
+    # cap_add puts NET_BIND_SERVICE in the container's bounding set so
+    # the file capability baked onto /app/ws_server (`setcap
+    # cap_net_bind_service=+ep` in Dockerfile.ws_server) actually
+    # resolves to an effective cap on exec — without it the bounding
+    # set masks the file cap and the non-root UID 10001 still gets
+    # EACCES on bind(443).
     cap_add:
       - NET_BIND_SERVICE
     volumes:


### PR DESCRIPTION
## Summary
This change enables the non-root `ws_server` process (UID 10001) to bind to privileged ports like :443 by using Linux file capabilities instead of requiring the container to run as root.

## Key Changes
- **Dockerfile.ws_server**: 
  - Added `libcap2-bin` package dependency to support `setcap` command
  - Added `RUN setcap cap_net_bind_service=+ep /app/ws_server` to grant the NET_BIND_SERVICE capability to the binary
  
- **docker-compose.yml** (in install.sh):
  - Updated the comment explaining `cap_add: NET_BIND_SERVICE` to clarify the interaction between file capabilities and container capability bounding sets
  - The comment now explains that `cap_add` puts the capability in the bounding set, while the `setcap` in the Dockerfile grants it to the process at exec time

## Implementation Details
The solution uses a two-part approach:
1. **File capability** (`setcap` in Dockerfile): Bakes the NET_BIND_SERVICE capability directly onto the `/app/ws_server` binary
2. **Container capability** (`cap_add` in compose): Ensures the capability is in the container's bounding set, allowing the file capability to take effect

Without both parts, the bounding set masks the file capability and the non-root process still receives EACCES errors when attempting to bind to port 443. This approach maintains security by avoiding the need to run the container as root while still allowing privileged port binding.

https://claude.ai/code/session_01E8hqCvtrWuFdZf4jWECCKR