### PR TITLE
Enable UI iteration without AMI rebuilds via bind-mounted static files

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
@@ -166,6 +166,35 @@ aws ssm start-session --target <instance-id> \
   --parameters '{"portNumber":["9090"],"localPortNumber":["9090"]}'
 ```
 
+## Iterating on the UI
+
+The `static/` directory is bind-mounted into the ws_server container at
+`/app/static`, so the UI can be updated without rebuilding the image or
+re-baking the AMI. Sync new files to `/opt/wingfoil/static` on the
+instance and bounce ws_server:
+
+```bash
+INSTANCE_ID=$(aws autoscaling describe-auto-scaling-groups \
+  --auto-scaling-group-names $(pulumi stack output asg_name) \
+  --query 'AutoScalingGroups[0].Instances[0].InstanceId' --output text)
+
+# Open an SSH session via SSM (requires the AWS SSM Session Manager
+# plugin and an SSH config that proxies through `aws ssm start-session`).
+rsync -av --delete \
+  wingfoil/examples/latency_e2e/static/ \
+  "${INSTANCE_ID}:/opt/wingfoil/static/"
+
+aws ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["cd /opt/wingfoil && docker compose restart ws_server"]'
+```
+
+Edits survive container restarts and Spot reclaims of the *running*
+instance — but a fresh ASG launch reverts to the AMI's baked copy, so
+once a UI change has stabilised, bake a new AMI to make it the new
+baseline.
+
 ## 3. Verify
 
 ```bash

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -100,11 +100,12 @@ sudo install -m 0755 /tmp/spot_watcher.py     /opt/wingfoil/spot_watcher.py
 for staged in \
     /tmp/prometheus/prometheus.yml \
     /tmp/tempo/tempo.yaml \
-    /tmp/grafana/provisioning; do
+    /tmp/grafana/provisioning \
+    /tmp/static/index.html; do
   if [ ! -e "${staged}" ]; then
     echo "ERROR: expected staged path '${staged}' is missing — Packer file" >&2
     echo "       provisioner produced an unexpected layout. Listing /tmp:" >&2
-    ls -lR /tmp/prometheus /tmp/tempo /tmp/grafana >&2 || true
+    ls -lR /tmp/prometheus /tmp/tempo /tmp/grafana /tmp/static >&2 || true
     exit 1
   fi
 done
@@ -112,7 +113,11 @@ done
 sudo cp -r /tmp/prometheus /opt/wingfoil/prometheus
 sudo cp -r /tmp/tempo      /opt/wingfoil/tempo
 sudo cp -r /tmp/grafana    /opt/wingfoil/grafana
-sudo chown -R root:root /opt/wingfoil/prometheus /opt/wingfoil/tempo /opt/wingfoil/grafana
+# static/ is bind-mounted into ws_server at /app/static (read-only) so the
+# UI can be iterated on without rebuilding the image: rsync new files into
+# /opt/wingfoil/static and `docker compose restart ws_server`.
+sudo cp -r /tmp/static     /opt/wingfoil/static
+sudo chown -R root:root /opt/wingfoil/prometheus /opt/wingfoil/tempo /opt/wingfoil/grafana /opt/wingfoil/static
 
 # Sanity check the final layout on disk: docker compose mounts these exact
 # paths, and a missing file at boot triggers the silent-empty-directory
@@ -120,7 +125,8 @@ sudo chown -R root:root /opt/wingfoil/prometheus /opt/wingfoil/tempo /opt/wingfo
 for mount_src in \
     /opt/wingfoil/prometheus/prometheus.yml \
     /opt/wingfoil/tempo/tempo.yaml \
-    /opt/wingfoil/grafana/provisioning; do
+    /opt/wingfoil/grafana/provisioning \
+    /opt/wingfoil/static/index.html; do
   if [ ! -e "${mount_src}" ]; then
     echo "ERROR: bind-mount source '${mount_src}' is missing after copy." >&2
     exit 1
@@ -170,6 +176,10 @@ sudo tee -a /opt/wingfoil/docker-compose.yml > /dev/null <<EOF
       - NET_BIND_SERVICE
     volumes:
       - /etc/wingfoil/tls:/etc/wingfoil/tls:ro
+      # /app/static is shadowed by the host directory so UI iteration
+      # doesn't require rebuilding the image. Files in /opt/wingfoil/static
+      # are served directly; restart the container after rsync'ing changes.
+      - /opt/wingfoil/static:/app/static:ro
     # Override the Dockerfile CMD (which hardcodes --addr 0.0.0.0:8080
     # for local dev convenience). --addr beats WINGFOIL_WEB_ADDR in
     # ws_server's arg parsing, so setting only the env var here would

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
@@ -143,6 +143,16 @@ build {
     destination = "/tmp"
   }
 
+  # ws_server's static UI assets, bind-mounted into the container at
+  # /app/static (overlaying the in-image copy). Staging them outside the
+  # image is what lets the operator iterate on the UI by syncing files
+  # into /opt/wingfoil/static and bouncing the container — no AMI bake,
+  # no image rebuild.
+  provisioner "file" {
+    source      = "${path.root}/../../../static"
+    destination = "/tmp"
+  }
+
   provisioner "shell" {
     environment_vars = [
       "WS_SERVER_IMAGE=${var.ws_server_image}",

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -332,7 +332,8 @@ done
 layout_ok=true
 for f in \
     /opt/wingfoil/prometheus/prometheus.yml \
-    /opt/wingfoil/tempo/tempo.yaml; do
+    /opt/wingfoil/tempo/tempo.yaml \
+    /opt/wingfoil/static/index.html; do
   if [ ! -f "${f}" ]; then
     echo "ERROR: expected bind-mount source '${f}' is missing or not a regular file." >&2
     layout_ok=false


### PR DESCRIPTION
## Summary
This change enables developers to iterate on the web UI without rebuilding the Docker image or re-baking the AMI. The `static/` directory is now bind-mounted into the ws_server container, allowing UI updates to be synced directly to the running instance.

## Key Changes
- **Packer configuration**: Added file provisioner to stage the `static/` directory into the AMI at `/opt/wingfoil/static`
- **Docker Compose setup**: Added read-only bind mount of `/opt/wingfoil/static` to `/app/static` in the ws_server container, overlaying the in-image copy
- **Installation script**: Updated to copy staged static files to `/opt/wingfoil/static` and validate the mount source exists
- **User data validation**: Added check for `/opt/wingfoil/static/index.html` to ensure the bind-mount source is present at boot
- **Documentation**: Added "Iterating on the UI" section with instructions for syncing changes and restarting the container

## Implementation Details
- The bind mount is read-only (`:ro`) to prevent accidental modifications in the container
- UI changes survive container restarts and Spot instance reclaims, but fresh ASG launches revert to the AMI's baked copy
- Developers can use `rsync` to sync new files to `/opt/wingfoil/static` and restart ws_server via `docker compose restart`
- Once UI changes stabilize, a new AMI should be baked to make the changes the new baseline

https://claude.ai/code/session_01E8hqCvtrWuFdZf4jWECCKR