### PR TITLE
Add latency breakdown visualization and documentation

### DIFF
--- a/wingfoil/examples/latency_e2e/static/app.js
+++ b/wingfoil/examples/latency_e2e/static/app.js
@@ -310,7 +310,31 @@ window.addEventListener('DOMContentLoaded', () => {
     const rttMs = (rt.rttNs / 1_000_000).toFixed(2);
     document.getElementById('rtt').textContent = rttMs + ' ms';
     document.getElementById('rtt-meta').textContent = `last fill ${rttMs} ms · ${filled} fills`;
+    updateBreakdown(rt.stamps, rt.rttNs);
     pushChartPoint(rt.stamps, rt.rttNs);
     pushFlame(rt.stamps, rt.rttNs);
   });
 });
+
+// ── Breakdown (rtt / resident / wire) ─────────────────────────────────────
+// Three rolling means so the headline numbers don't jitter on every fill.
+const BD_WINDOW = 32;
+const bdTotal = [], bdResident = [], bdWire = [];
+function pushAvg(buf, v) {
+  buf.push(v);
+  if (buf.length > BD_WINDOW) buf.shift();
+  let s = 0; for (const x of buf) s += x;
+  return s / buf.length;
+}
+function fmtUs(ns) {
+  if (!isFinite(ns) || ns <= 0) return '—';
+  if (ns >= 1_000_000) return (ns / 1_000_000).toFixed(2) + ' ms';
+  return (ns / 1000).toFixed(1) + ' µs';
+}
+function updateBreakdown(stamps, rttNs) {
+  const resident = (stamps[0] != null && stamps[8] != null) ? (stamps[8] - stamps[0]) : 0;
+  const wire = Math.max(0, rttNs - resident);
+  document.getElementById('bd-total').textContent    = fmtUs(pushAvg(bdTotal, rttNs));
+  document.getElementById('bd-resident').textContent = fmtUs(pushAvg(bdResident, resident));
+  document.getElementById('bd-wire').textContent     = fmtUs(pushAvg(bdWire, wire));
+}

--- a/wingfoil/examples/latency_e2e/static/index.html
+++ b/wingfoil/examples/latency_e2e/static/index.html
@@ -20,12 +20,15 @@
       display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
     }
     header h1 { margin: 0; font-size: 14px; font-weight: 600; white-space: nowrap; }
+    header .byline { font-size: 11px; color: var(--muted); white-space: nowrap; }
+    header .byline code { background: transparent; padding: 0; }
     header .spacer { flex: 1; }
     header .ctl { display: flex; gap: 6px; align-items: center; font-size: 12px; color: var(--muted); }
     header .ctl select, header .ctl input { background: var(--bg); color: var(--fg); border: 1px solid #30363d; border-radius: 4px; padding: 3px 6px; font-size: 12px; }
     header button { background: var(--accent); color: white; border: 0; padding: 5px 14px; border-radius: 4px; font-weight: 600; cursor: pointer; font-size: 12px; }
     header button:disabled { background: #30363d; color: var(--muted); cursor: not-allowed; }
     header button.stop { background: var(--red); }
+    header .links { display: flex; gap: 10px; align-items: center; font-size: 11px; }
 
     .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; }
     .pill.live { background: rgba(63, 185, 80, 0.15); color: var(--green); }
@@ -45,6 +48,24 @@
     .stats .stat { background: var(--bg); border-radius: 4px; padding: 6px 10px; }
     .stats .k { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); }
     .stats .v { font-size: 16px; font-variant-numeric: tabular-nums; margin-top: 2px; }
+
+    .breakdown {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-top: 8px;
+    }
+    .breakdown .seg { background: var(--bg); border-radius: 4px; padding: 6px 10px; border-left: 3px solid var(--accent); }
+    .breakdown .seg.resident { border-left-color: var(--green); }
+    .breakdown .seg.wire { border-left-color: #f0883e; }
+    .breakdown .k { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--muted); }
+    .breakdown .k .hint { text-transform: none; letter-spacing: 0; color: var(--muted); opacity: 0.8; margin-left: 4px; }
+    .breakdown .v { font-size: 14px; font-variant-numeric: tabular-nums; margin-top: 2px; }
+
+    .legend {
+      margin-top: 10px; padding: 8px 10px; background: var(--bg); border-radius: 4px;
+      font-size: 11px; color: var(--muted); line-height: 1.5;
+    }
+    .legend summary { cursor: pointer; color: var(--fg); font-weight: 600; }
+    .legend p { margin: 6px 0 0; }
+    .legend code { background: var(--panel); }
 
     #chart { width: 100%; }
 
@@ -72,6 +93,7 @@
 <body>
   <header>
     <h1>wingfoil latency e2e</h1>
+    <span class="byline">Rust DAG stream processor · live FIX round-trip to LMAX London</span>
     <span id="status" class="pill idle">disconnected</span>
     <span style="color:var(--muted);font-size:11px">session <code id="session">—</code></span>
     <div class="spacer"></div>
@@ -87,7 +109,11 @@
       <label>Hz <input id="rate" type="number" min="1" max="20" value="2" style="width:42px"/></label>
       <button id="start">start</button>
     </div>
-    <a href="/metrics" target="_blank" style="font-size:11px">prometheus</a>
+    <div class="links">
+      <a href="https://github.com/wingfoil-io/wingfoil" target="_blank" rel="noopener">github</a>
+      <a href="https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/latency_e2e" target="_blank" rel="noopener">source</a>
+      <a href="/metrics" target="_blank">prometheus</a>
+    </div>
   </header>
 
   <main>
@@ -102,7 +128,22 @@
         <div class="stat"><div class="k">avg fill px</div><div class="v" id="px">—</div></div>
         <div class="stat"><div class="k">round-trip</div><div class="v" id="rtt">—</div></div>
       </div>
+      <div class="breakdown">
+        <div class="seg total"><div class="k">rtt mean <span class="hint">last 32 fills</span></div><div class="v" id="bd-total">—</div></div>
+        <div class="seg resident"><div class="k">resident <span class="hint">ws_recv → ws_send (in-process)</span></div><div class="v" id="bd-resident">—</div></div>
+        <div class="seg wire"><div class="k">wire <span class="hint">FIX/TLS to LMAX + WS legs</span></div><div class="v" id="bd-wire">—</div></div>
+      </div>
       <div id="chart" style="margin-top:10px"></div>
+      <details class="legend">
+        <summary>how to read this</summary>
+        <p>
+          Each fill traverses nine wingfoil stamp points: <code>ws_recv → ws_publish → gw_recv → gw_price → fix_send → fix_recv → gw_publish → ws_sub_recv → ws_send</code>.
+          The chart plots the per-hop delta on a log Y-axis (nanoseconds). The flame chart below is one bar per fill, segments coloured by hop.
+        </p>
+        <p>
+          <strong>Resident</strong> is everything inside this server (two processes connected by iceoryx2 shared memory). <strong>Wire</strong> is the FIX-over-TLS round-trip to LMAX plus the WebSocket legs to your browser — derived as <code>rtt_total − resident</code>, both measured in a single clock domain so no NTP sync is needed.
+        </p>
+      </details>
     </section>
 
     <section class="panel">


### PR DESCRIPTION
## Summary
Enhanced the latency e2e example dashboard with detailed latency breakdown metrics, improved header navigation, and user documentation explaining how to interpret the latency data.

## Key Changes

**UI & Styling:**
- Added byline subtitle describing the demo ("Rust DAG stream processor · live FIX round-trip to LMAX London")
- Reorganized header links into a dedicated `.links` container with GitHub repository and source code links
- Added new `.breakdown` grid section displaying three key metrics: total RTT, resident time, and wire time
- Added `.legend` collapsible section with detailed explanation of the latency measurement methodology

**Latency Breakdown Metrics:**
- Implemented `updateBreakdown()` function that calculates and displays:
  - **Total RTT**: Mean round-trip time over last 32 fills
  - **Resident**: In-process latency (ws_recv → ws_send, measured via stamp points 0 and 8)
  - **Wire**: Network latency derived as `rtt_total − resident`
- Added rolling window averaging (32-fill window) to smooth jittery per-fill measurements
- Implemented `fmtUs()` formatter for human-readable time display (µs or ms)
- Added `pushAvg()` helper for maintaining rolling averages

**Documentation:**
- Added collapsible legend explaining the nine wingfoil stamp points in the measurement pipeline
- Clarified the distinction between resident (in-process) and wire (network) latency
- Noted that measurements use a single clock domain, eliminating NTP sync requirements

## Implementation Details
- Breakdown metrics are updated on every fill event alongside existing chart and flame graph updates
- Visual hierarchy uses color-coded left borders (green for resident, orange for wire) matching the existing design system
- All time values gracefully handle invalid/zero cases by displaying "—"

https://claude.ai/code/session_01VRB5LQW53Y1qZXfUku68c8