### PR TITLE
Compress user_data with gzip before base64 encoding

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -420,9 +420,14 @@ def render_user_data(args):
         .replace("__DNS_HOSTNAME__",          dns_hostname or "")
         .replace("__CERT_BUCKET__",           cert_bucket_name or "")
     )
-    # cloud-init needs base64 user_data when passed via launch templates.
+    # gzip before base64 — cloud-init auto-detects and decompresses gzip
+    # user_data, and EC2's 16 KiB user_data limit applies to the raw
+    # (pre-base64) bytes, so compressing keeps us comfortably under the cap
+    # as the script grows.
     import base64
-    return base64.b64encode(rendered.encode("utf-8")).decode("ascii")
+    import gzip
+    compressed = gzip.compress(rendered.encode("utf-8"))
+    return base64.b64encode(compressed).decode("ascii")
 
 
 user_data_b64 = pulumi.Output.all(


### PR DESCRIPTION
## Summary
Modified the EC2 user_data encoding to compress the script with gzip before base64 encoding. This reduces the payload size and helps stay within EC2's 16 KiB user_data limit as the initialization script grows.

## Changes
- Added gzip compression step before base64 encoding in `render_user_data()`
- Cloud-init automatically detects and decompresses gzip-compressed user_data, so no changes needed on the instance side
- Updated comments to explain the compression strategy and EC2's size constraints

## Implementation Details
- The EC2 user_data size limit applies to raw (pre-base64) bytes, so gzip compression is applied before base64 encoding to maximize the effective script size
- Cloud-init's built-in gzip detection means the compressed payload is transparently decompressed during instance initialization

https://claude.ai/code/session_01UiSTHx36TYNaR2fT7hunMg