### PR TITLE
Restart ws_server and grafana to ensure fresh TLS certs on boot

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -409,4 +409,17 @@ chmod 0644 /opt/wingfoil/docker-compose.override.yml
 # fast `docker run` per service rather than a registry pull.
 ( cd /opt/wingfoil && docker compose up -d )
 
+# ws_server and grafana both load /etc/wingfoil/tls/cert.pem at process
+# startup — neither watches the file. `compose up -d` above won't recreate
+# a container whose config hasn't changed, so any earlier boot that
+# started grafana while the cert file held the self-signed fallback (e.g.
+# wait_for_dns / run_certbot transiently failed, or an operator hand-
+# rotated the cert and only restarted ws_server) leaves grafana serving
+# stale TLS material — visible to browsers as :443 with a valid LE cert
+# but :3000 with an EIP-only self-signed cert. Restart both unconditionally
+# so the running processes always reflect the cert that's on disk now.
+# Mirrors what the renewal deploy-hook already does on rotation; ~2s of
+# no-op on a clean fresh-instance boot is cheap insurance.
+( cd /opt/wingfoil && docker compose restart ws_server grafana )
+
 echo "user_data complete: $(date -u +%FT%TZ)"


### PR DESCRIPTION
## Summary
Added an unconditional restart of `ws_server` and `grafana` containers during instance boot to ensure they load the current TLS certificate from disk, preventing stale certificate issues.

## Changes
- Added `docker compose restart ws_server grafana` command at the end of user data initialization
- This ensures both services reload the TLS certificate (`/etc/wingfoil/tls/cert.pem`) that may have been updated during boot
- Prevents scenarios where grafana continues serving a self-signed fallback certificate while the actual certificate on disk has been rotated or updated

## Implementation Details
- The restart is necessary because neither `ws_server` nor `grafana` watch the certificate file for changes—they only load it at process startup
- `docker compose up -d` won't recreate containers if their configuration hasn't changed, so an earlier boot that started these services with a stale/fallback certificate would persist
- This mirrors the behavior of the existing renewal deploy-hook that already restarts these services on certificate rotation
- The ~2 second overhead on a fresh instance boot is negligible compared to the insurance against serving invalid TLS material to clients

https://claude.ai/code/session_01HHQck6XdZa4tHK8utC3uYi