### PR TITLE
Add detailed logging to fix_gw order processing pipeline

### DIFF
--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -133,6 +133,14 @@ fn main() -> anyhow::Result<()> {
     // ── Outbound: orders → price → stamp fix_send → (fork) ───────────────
     let orders = iceoryx2_sub::<Traced<RoundTrip, RoundTripLatency>>(SVC_ORDERS)
         .collapse::<Traced<RoundTrip, RoundTripLatency>>()
+        .inspect(|t| {
+            log::info!(
+                "fix_gw: order received via iceoryx2 cl_ord={} qty={} side={}",
+                cl_ord_id(&t.payload),
+                t.payload.qty,
+                t.payload.side,
+            );
+        })
         .stamp_if::<round_trip_latency::gw_recv>(!precise)
         .stamp_precise_if::<round_trip_latency::gw_recv>(precise);
 
@@ -171,6 +179,11 @@ fn main() -> anyhow::Result<()> {
         if t.payload.fill_price_bps == 0 {
             return; // book was stale at pricing time — already logged
         }
+        log::info!(
+            "fix_gw: sending NewOrderSingle cl_ord={} px_bps={}",
+            cl_ord_id(&t.payload),
+            t.payload.fill_price_bps,
+        );
         send_new_order_single(&sender, &t.payload);
     });
 
@@ -184,6 +197,15 @@ fn main() -> anyhow::Result<()> {
         fix_ord.data.clone().collapse::<FixMessage>(),
         Box::new(|m: FixMessage| {
             let is_exec = m.msg_type == "8";
+            if is_exec {
+                log::info!(
+                    "fix_gw: ExecutionReport received cl_ord={} exec_type={}",
+                    m.field(TAG_CL_ORD_ID).unwrap_or(""),
+                    m.field(TAG_EXEC_TYPE).unwrap_or(""),
+                );
+            } else {
+                log::debug!("fix_gw: non-exec msg_type={} dropped at filter", m.msg_type);
+            }
             (MatcherEvent::Exec(m), is_exec)
         }),
     )
@@ -288,7 +310,19 @@ fn main() -> anyhow::Result<()> {
     .stamp_if::<round_trip_latency::gw_publish>(!precise)
     .stamp_precise_if::<round_trip_latency::gw_publish>(precise);
 
-    let pub_fills = iceoryx2_pub(fills.map(|t| burst![t]), SVC_FILLS);
+    let pub_fills = iceoryx2_pub(
+        fills
+            .inspect(|t| {
+                log::info!(
+                    "fix_gw: publishing fill cl_ord={} filled_qty={} px_bps={}",
+                    cl_ord_id(&t.payload),
+                    t.payload.filled_qty,
+                    t.payload.fill_price_bps,
+                );
+            })
+            .map(|t| burst![t]),
+        SVC_FILLS,
+    );
 
     let nodes: Vec<Rc<dyn Node>> = vec![
         pub_fills,


### PR DESCRIPTION
## Summary
This PR adds comprehensive logging throughout the fix_gw order processing pipeline to improve observability and debugging of order flow, pricing, and execution events.

## Key Changes
- **Order receipt logging**: Added `inspect()` call to log incoming orders via iceoryx2 with client order ID, quantity, and side information
- **Order submission logging**: Added info-level log when sending NewOrderSingle messages with client order ID and fill price
- **Execution report logging**: Added conditional logging for ExecutionReport messages (msg_type="8") with execution type details, and debug-level logging for filtered non-exec messages
- **Fill publication logging**: Added `inspect()` call to log published fills with client order ID, filled quantity, and fill price

## Implementation Details
- All logging uses the standard `log` crate with appropriate levels (info for key events, debug for filtered messages)
- Logging is placed at strategic points in the pipeline: order ingress, order egress, execution receipt, and fill publication
- Uses existing helper functions like `cl_ord_id()` and `FixMessage::field()` for consistent field extraction
- Logging is non-intrusive, using `inspect()` operators that don't modify the data flow

https://claude.ai/code/session_01Rc9Q1vWDq2YHa4PE4qvZL1