### PR TITLE
Support free-tier EC2 instances for latency E2E AMI builds

### DIFF
--- a/.github/workflows/build-latency-e2e-ami.yml
+++ b/.github/workflows/build-latency-e2e-ami.yml
@@ -34,6 +34,13 @@ on:
         description: "Image tag to bake into the AMI (default: latest)"
         required: false
         default: "latest"
+      instance_type:
+        description: >-
+          EC2 instance type for the Packer builder. Must be
+          free-tier-eligible (e.g. t3.micro) on AWS Free-plan accounts;
+          c6in.large is faster but requires a paid account.
+        required: false
+        default: "t3.micro"
 
 env:
   # Single region for AMI build + ECR pulls + ec2-spot stack launch (London,
@@ -41,6 +48,7 @@ env:
   # `pulumi/ec2-spot/Pulumi.yaml`'s aws:region default.
   AWS_REGION: ${{ secrets.AWS_REGION || 'eu-west-2' }}
   IMAGE_TAG: ${{ inputs.image_tag || 'latest' }}
+  INSTANCE_TYPE: ${{ inputs.instance_type || 't3.micro' }}
   SSM_AMI_PARAM: /wingfoil/latency-e2e/ec2-spot/ami_id
 
 jobs:
@@ -93,6 +101,7 @@ jobs:
         env:
           PKR_VAR_region: ${{ env.AWS_REGION }}
           PKR_VAR_image_tag: ${{ env.IMAGE_TAG }}
+          PKR_VAR_instance_type: ${{ env.INSTANCE_TYPE }}
           PKR_VAR_ecr_registry: ${{ steps.ecr.outputs.registry }}
           PKR_VAR_ws_server_image: ${{ steps.ecr.outputs.ws_server }}
           PKR_VAR_fix_gw_image: ${{ steps.ecr.outputs.fix_gw }}

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
@@ -32,10 +32,14 @@ variable "region" {
 }
 
 variable "instance_type" {
-  type    = string
-  # c6in.large gives 25 Gbps networking + 2 vCPU — the build is dominated by
-  # ECR image pulls, and t3.small's burstable network throttles them.
-  default = "c6in.large"
+  type = string
+  # `t3.micro` is free-tier-eligible — required when the AWS account is on the
+  # AWS Free plan, which rejects launches of non-free-tier instance types with
+  # `InvalidParameterCombination: ... not eligible for Free Tier`. Builds take
+  # longer than on a c6in.large (the bottleneck is ECR image pulls, throttled
+  # on t3.micro's burstable network), but they complete. Override via the
+  # workflow input or `PKR_VAR_instance_type` once the account is upgraded.
+  default = "t3.micro"
 }
 
 variable "ws_server_image"  { type = string }


### PR DESCRIPTION
## Summary
Updated the latency E2E AMI build pipeline to support AWS Free-tier accounts by making the EC2 instance type configurable and defaulting to `t3.micro` instead of `c6in.large`.

## Key Changes
- **Packer configuration**: Changed default instance type from `c6in.large` to `t3.micro` to comply with AWS Free-tier eligibility requirements
- **GitHub Actions workflow**: 
  - Added `instance_type` input parameter to allow overriding the instance type at build time
  - Exposed the parameter through the `PKR_VAR_instance_type` environment variable to Packer
  - Defaults to `t3.micro` for free-tier compatibility

## Implementation Details
- The change acknowledges that `t3.micro` builds take longer due to burstable network throttling during ECR image pulls, but are necessary for free-tier accounts
- Users on paid AWS accounts can override the instance type via the workflow input or `PKR_VAR_instance_type` environment variable to use faster instance types like `c6in.large`
- Updated comments explain the trade-off and provide guidance for account upgrades

https://claude.ai/code/session_01Rc9Q1vWDq2YHa4PE4qvZL1