### PR TITLE
Optimize Docker image pulls based on EC2 instance type

### DIFF
--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/install.sh
@@ -64,21 +64,29 @@ if [ -n "${ECR_REGISTRY:-}" ]; then
 fi
 
 # Pre-pull every image so reclaim recovery doesn't wait on the registry.
-# Pulls run concurrently — t3.small/c6in.large can saturate the network with
-# parallel layer downloads, and serial pulls were the dominant slice of the
-# AMI build's ~10 min wall time.
-pids=()
-for img in "${WS_SERVER_IMAGE}" "${FIX_GW_IMAGE}" "${PROMETHEUS_IMAGE}" "${TEMPO_IMAGE}" "${GRAFANA_IMAGE}"; do
-  sudo docker pull "${img}" &
-  pids+=("$!")
-done
-pull_failed=0
-for pid in "${pids[@]}"; do
-  wait "${pid}" || pull_failed=1
-done
-if [ "${pull_failed}" -ne 0 ]; then
-  echo "ERROR: one or more docker pulls failed" >&2
-  exit 1
+# Parallelism is gated by the builder size: anything bigger than t*.micro can
+# saturate the network with concurrent layer downloads, but burstable micro
+# instances exhaust their network credits (and 1 GiB RAM) under five parallel
+# pulls and end up slower than serial. The Packer template computes
+# PARALLEL_PULLS from var.instance_type.
+if [ "${PARALLEL_PULLS:-false}" = "true" ]; then
+  pids=()
+  for img in "${WS_SERVER_IMAGE}" "${FIX_GW_IMAGE}" "${PROMETHEUS_IMAGE}" "${TEMPO_IMAGE}" "${GRAFANA_IMAGE}"; do
+    sudo docker pull "${img}" &
+    pids+=("$!")
+  done
+  pull_failed=0
+  for pid in "${pids[@]}"; do
+    wait "${pid}" || pull_failed=1
+  done
+  if [ "${pull_failed}" -ne 0 ]; then
+    echo "ERROR: one or more docker pulls failed" >&2
+    exit 1
+  fi
+else
+  for img in "${WS_SERVER_IMAGE}" "${FIX_GW_IMAGE}" "${PROMETHEUS_IMAGE}" "${TEMPO_IMAGE}" "${GRAFANA_IMAGE}"; do
+    sudo docker pull "${img}"
+  done
 fi
 
 # certbot is fetched as a Docker image rather than a system package so the

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
@@ -73,6 +73,12 @@ variable "ecr_password" {
 
 locals {
   ami_name = "wingfoil-latency-ec2-spot-${var.image_tag}-${formatdate("YYYYMMDD-hhmmss", timestamp())}"
+
+  # Five concurrent docker pulls drain a t*.micro/nano's network burst credits
+  # faster than they save by overlapping, and 1 GiB RAM also makes parallel
+  # layer extraction painful. Anything larger (t3.small upward, m5/c6in/etc.)
+  # has enough headroom to actually win from parallelism.
+  parallel_pulls = !can(regex("^t[0-9]+a?\\.(nano|micro)$", var.instance_type))
 }
 
 source "amazon-ebs" "wingfoil" {
@@ -169,6 +175,7 @@ build {
       "ECR_REGISTRY=${var.ecr_registry}",
       "ECR_PASSWORD=${var.ecr_password}",
       "AWS_REGION=${var.region}",
+      "PARALLEL_PULLS=${local.parallel_pulls}",
     ]
     script = "${path.root}/install.sh"
   }


### PR DESCRIPTION
## Summary
This change optimizes the Packer build process by conditionally parallelizing Docker image pulls based on the EC2 instance type being used. Smaller burstable instances (t*.micro/nano) perform better with serial pulls, while larger instances benefit from parallel downloads.

## Key Changes
- **install.sh**: Wrapped concurrent docker pull logic in a conditional check for `PARALLEL_PULLS` environment variable, with a fallback to serial pulls when parallelism is disabled
- **wingfoil-latency.pkr.hcl**: 
  - Added `parallel_pulls` local variable that detects instance type and disables parallelism for t*.micro and t*.nano instances
  - Passes `PARALLEL_PULLS` to the install script via environment variables

## Implementation Details
The optimization addresses a performance issue where t*.micro/nano instances exhaust their network burst credits and 1 GiB RAM faster than they save time through concurrent layer downloads. The instance type detection uses a regex pattern to identify burstable micro/nano instances, while all other instance types (t3.small, m5, c6in, etc.) benefit from parallel pulls. This reduces AMI build time for larger instances while preventing performance degradation on smaller ones.

https://claude.ai/code/session_01C4BCbVgayngd74icaLg16C