### PR TITLE
ci(latency-e2e ami): pass GITHUB_TOKEN to packer init

### DIFF
--- a/.github/workflows/build-latency-e2e-ami.yml
+++ b/.github/workflows/build-latency-e2e-ami.yml
@@ -90,6 +90,12 @@ jobs:
           version: 1.11.2
 
       - name: Packer init
+        env:
+          # Authenticate plugin downloads against the GitHub API. Anonymous
+          # requests share a low IP-pool quota and intermittently hit 403
+          # ("API rate limit exceeded"); the workflow's GITHUB_TOKEN bumps
+          # the limit to 5000 req/h and is available on every run.
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: packer init wingfoil-latency.pkr.hcl
 
       # Fetch the ECR auth token on the runner (which has AWS creds via OIDC)


### PR DESCRIPTION
## Summary

- `packer init` was hitting GitHub's anonymous API rate limit (`403 API rate limit exceeded`) when downloading the `hashicorp/amazon` plugin on Actions runners.
- Set `PACKER_GITHUB_API_TOKEN` to the workflow's built-in `GITHUB_TOKEN` so plugin downloads are authenticated. Authenticated requests get 5000 req/h instead of the shared per-IP anonymous quota.

## Test plan

- [ ] Re-run `latency-e2e.build.ami` from main after merge — `Packer init` step should pass without hitting the rate limit.

https://claude.ai/code/session_01QHELpZcpQX7XGLX7jDZvgd

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHELpZcpQX7XGLX7jDZvgd)_