### PR TITLE
Fix flamegraph canvas height flickering on re-render

### DIFF
--- a/wingfoil/examples/latency_e2e/static/app.js
+++ b/wingfoil/examples/latency_e2e/static/app.js
@@ -29,6 +29,7 @@ const COLOURS = [
 ];
 const MAX_POINTS = 200;       // chart history (~100 s at 2 Hz)
 const FLAME_WINDOW = 32;      // rolling-mean window for the flamegraph
+const FLAME_CSS_HEIGHT = 200; // design CSS height (px); bitmap is dpr-scaled
 
 // Flamegraph layers, bottom (widest, outermost) to top (narrowest, deepest).
 // Each layer is a strict sub-interval of the layer below it — that nesting
@@ -218,7 +219,11 @@ function flamegraphCanvas() {
   const c = document.getElementById('flamegraph');
   const dpr = window.devicePixelRatio || 1;
   const cssW = c.clientWidth;
-  const cssH = parseInt(c.getAttribute('height'), 10) || 200;
+  // Don't read the `height` attribute back: setting `c.height` reflects into
+  // it, so on the second render cssH would be the previous bitmap height
+  // (e.g. 400 at dpr=2), then 800, then 1600 — the canvas grows every frame
+  // and the panel flickers. Keep the CSS height as a constant.
+  const cssH = FLAME_CSS_HEIGHT;
   if (c.width !== cssW * dpr || c.height !== cssH * dpr) {
     c.width = cssW * dpr; c.height = cssH * dpr;
     c.style.height = cssH + 'px';
@@ -301,7 +306,7 @@ function flamegraphHitTest(ev) {
   const rect = c.getBoundingClientRect();
   const x = ev.clientX - rect.left;
   const y = ev.clientY - rect.top;
-  const h = parseInt(c.getAttribute('height'), 10) || 200;
+  const h = FLAME_CSS_HEIGHT;
   const pad = 4;
   const rowH = Math.floor((h - pad * 2) / FLAME_LAYERS.length);
   const { boxes, root } = flamegraphBoxes();


### PR DESCRIPTION
## Summary
Fixed a bug where the flamegraph canvas would grow exponentially on each render, causing the panel to flicker. The issue was caused by reading back the `height` attribute after setting it, which reflects the scaled bitmap height rather than the CSS height.

## Changes
- Added `FLAME_CSS_HEIGHT` constant (200px) to define the flamegraph's design height
- Updated `flamegraphCanvas()` to use the constant instead of reading the `height` attribute, preventing the exponential growth bug where the canvas would double in size each frame (200 → 400 → 800 → 1600px)
- Updated `flamegraphHitTest()` to use the same constant for consistency in hit detection calculations
- Added explanatory comment documenting why the attribute should not be read back

## Implementation Details
The root cause was that setting `c.height` (the bitmap height) automatically reflects into the `height` attribute. On subsequent renders, reading this attribute would return the previous frame's scaled bitmap height (e.g., 400 at dpr=2) instead of the intended CSS height (200), causing the canvas to grow exponentially and creating visual flickering.

https://claude.ai/code/session_01488GHhTsoMjD7gijZroyHq