### PR TITLE
Redesign Spot interruption status panel for compact display

### DIFF
--- a/wingfoil/examples/latency_e2e/grafana/provisioning/dashboards/latency.json
+++ b/wingfoil/examples/latency_e2e/grafana/provisioning/dashboards/latency.json
@@ -9,34 +9,36 @@
   "panels": [
     {
       "type": "stat",
-      "title": "Spot interruption status",
-      "description": "Shows a red banner with the seconds remaining when the EC2 Spot watcher detects an interruption notice. Stays green ('Stable') when no notice is active and on stacks where the watcher isn't running.",
+      "title": "",
+      "description": "EC2 Spot interruption status. '.' when stable; countdown (s) when AWS has scheduled a reclaim.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "gridPos": { "h": 2, "w": 24, "x": 0, "y": 0 },
+      "transparent": true,
       "fieldConfig": {
         "defaults": {
           "unit": "s",
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
+              { "color": "text", "value": null },
               { "color": "red", "value": 0 }
             ]
           },
           "mappings": [
             {
               "type": "range",
-              "options": { "from": -1e9, "to": -0.5, "result": { "text": "Stable — no Spot interruption notice", "color": "green" } }
+              "options": { "from": -1e9, "to": -0.5, "result": { "text": ".", "color": "text" } }
             }
           ],
-          "noValue": "Stable — no Spot interruption notice"
+          "noValue": "."
         }
       },
       "options": {
-        "colorMode": "background",
+        "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "center",
         "textMode": "value",
+        "text": { "valueSize": 12 },
         "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
       },
       "targets": [
@@ -47,7 +49,7 @@
       "type": "timeseries",
       "title": "per-hop p99 latency (ns) — aggregate across all sessions",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 3 },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 2 },
       "fieldConfig": {
         "defaults": {
           "unit": "ns",
@@ -64,7 +66,7 @@
       "type": "timeseries",
       "title": "per-hop p50 latency (ns)",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 12 },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 11 },
       "fieldConfig": { "defaults": { "unit": "ns" } },
       "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean"] } },
       "targets": [
@@ -75,7 +77,7 @@
       "type": "stat",
       "title": "active sessions",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 21 },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 20 },
       "options": { "colorMode": "value", "graphMode": "area" },
       "targets": [{ "expr": "latency_e2e_active_sessions", "refId": "A" }]
     },
@@ -83,7 +85,7 @@
       "type": "stat",
       "title": "orders rate (per s)",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 21 },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 20 },
       "options": { "colorMode": "value", "graphMode": "area" },
       "targets": [{ "expr": "rate(latency_e2e_admitted_total[1m])", "refId": "A" }]
     },
@@ -91,7 +93,7 @@
       "type": "stat",
       "title": "rejected orders (cap reached)",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 21 },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 20 },
       "options": { "colorMode": "value", "graphMode": "area" },
       "targets": [{ "expr": "increase(latency_e2e_rejected_total[5m])", "refId": "A" }]
     },
@@ -99,7 +101,7 @@
       "type": "traces",
       "title": "your session traces — $session",
       "datasource": { "type": "tempo", "uid": "tempo" },
-      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 25 },
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 24 },
       "targets": [
         {
           "queryType": "traceql",

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/README.md
@@ -35,7 +35,7 @@ on cached images).
                                                             │
                                                   Prometheus scrapes :9092
                                                             │
-                                                Grafana banner shows countdown
+                                                Grafana status strip shows countdown
 ```
 
 - **EIP is reattached on every boot** by `user_data.sh` via
@@ -43,7 +43,7 @@ on cached images).
 - **`spot_watcher.py`** runs as a systemd unit, polling
   `http://169.254.169.254/latest/meta-data/spot/instance-action` every 5 s and
   exposing `wingfoil_spot_termination_seconds_remaining` on `:9092`. Prometheus
-  scrapes it; the Grafana dashboard shows a red banner with the countdown.
+  scrapes it; the Grafana dashboard shows a red countdown in the slim status strip.
 - **Single AZ** (default `eu-west-2a`) — keeps EIP/EBS reattach simple. London
   region is chosen for proximity to LMAX LD4 (Slough).
 
@@ -201,9 +201,10 @@ baseline.
 # WS server — `-k` because the cert is self-signed.
 curl -fsSk https://<eip>/
 
-# Grafana — load the dashboard, the "Spot interruption status" banner should
-# read green ("Stable — no Spot interruption notice"). Click through the
-# browser's "Your connection is not private" warning the first time.
+# Grafana — load the dashboard. The slim Spot status strip at the top reads
+# "." when stable and switches to a red countdown (seconds remaining) on
+# reclaim. Click through the browser's "Your connection is not private"
+# warning the first time.
 open https://<eip>:3000
 ```
 
@@ -211,7 +212,7 @@ open https://<eip>:3000
 
 1. **T-120s** — AWS sets the IMDS `spot/instance-action` flag.
 2. **T-115s** — `spot_watcher.py` picks it up on its next 5 s poll. The
-   Grafana banner switches red and counts down (`wingfoil_spot_termination_seconds_remaining`).
+   Grafana status strip switches red and counts down (`wingfoil_spot_termination_seconds_remaining`).
 3. **T-0s** — instance terminates.
 4. **T+~30s** — the ASG launches a replacement in the same AZ.
 5. **T+~60–90s** — `user_data.sh` finishes: EIP reattached, secrets fetched,
@@ -266,11 +267,11 @@ matching this stack. The launch template's `tag_specifications` must apply
 those tags at instance creation; verify with
 `aws ec2 describe-instances --filters Name=tag:Stack,Values=demo`.
 
-**Grafana banner stays "Stable" during a real reclaim**: check that
+**Grafana status strip stays "." during a real reclaim**: check that
 `spot_watcher.service` is running (`systemctl status wingfoil-spot-watcher`)
 and that Prometheus is reaching `localhost:9092` (the
 `latency_e2e_spot_watcher` job in `prometheus.yml`). On non-EC2-Spot stacks
-the metric is unscraped — that's expected, and the banner stays green.
+the metric is unscraped — that's expected, and the strip stays at ".".
 
 **`fix_gw` can't log in**: secrets fetch happens in `user_data.sh`. Inspect
 `/var/log/cloud-init-output.log` on the instance for `aws secretsmanager`


### PR DESCRIPTION
## Summary
Redesigned the EC2 Spot interruption status panel in the Grafana dashboard to be more compact and visually subtle, changing from a large colored banner to a slim status strip at the top of the dashboard.

## Key Changes

**Dashboard Panel Updates:**
- Reduced panel height from 3 to 2 units and made it transparent for a minimal footprint
- Changed title from "Spot interruption status" to empty (relying on context)
- Simplified description to be more concise
- Updated display text from "Stable — no Spot interruption notice" to "." for stable state
- Changed color scheme from green/red background to text-based coloring
- Modified color mode from "background" to "value" for subtle text-only display
- Added explicit text size configuration (12px)
- Adjusted all subsequent panel positions to accommodate the reduced height

**Documentation Updates:**
- Updated README to reflect the new "status strip" terminology instead of "banner"
- Clarified that the display shows "." when stable and a red countdown when a reclaim is scheduled
- Updated troubleshooting section to reference the new compact display format
- Corrected references throughout to match the new visual design

## Implementation Details
The panel now uses a minimal aesthetic with a single dot ("." character) to indicate stability, switching to a red countdown timer only when AWS schedules an instance reclaim. This reduces visual clutter while maintaining critical status visibility at a glance.

https://claude.ai/code/session_013JRyU61LSN3WYL2h7xGEUn