### PR TITLE
Switch default EC2 instance type to t3.micro for free-tier compatibility

### DIFF
--- a/.github/workflows/build-latency-e2e-ami.yml
+++ b/.github/workflows/build-latency-e2e-ami.yml
@@ -36,13 +36,12 @@ on:
         default: "latest"
       instance_type:
         description: >-
-          EC2 instance type for the Packer builder. Default `c6in.large` is
-          network-optimised (up to 25 Gbps) and finishes near the ~3-4 min
-          floor; on AWS Free-plan accounts override to a free-tier-eligible
-          type (e.g. `t3.micro`, much slower) since Free rejects non-free-
-          tier launches.
+          EC2 instance type for the Packer builder. Default `t3.micro` is
+          free-tier-eligible and works on every account, but is ~4-5× slower
+          than network-optimised types; on Paid AWS accounts override to
+          `c6in.large` (up to 25 Gbps) to finish near the ~3-4 min floor.
         required: false
-        default: "c6in.large"
+        default: "t3.micro"
 
 env:
   # Single region for AMI build + ECR pulls + ec2-spot stack launch (London,
@@ -50,7 +49,7 @@ env:
   # `pulumi/ec2-spot/Pulumi.yaml`'s aws:region default.
   AWS_REGION: ${{ secrets.AWS_REGION || 'eu-west-2' }}
   IMAGE_TAG: ${{ inputs.image_tag || 'latest' }}
-  INSTANCE_TYPE: ${{ inputs.instance_type || 'c6in.large' }}
+  INSTANCE_TYPE: ${{ inputs.instance_type || 't3.micro' }}
   SSM_AMI_PARAM: /wingfoil/latency-e2e/ec2-spot/ami_id
 
 jobs:

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/packer/wingfoil-latency.pkr.hcl
@@ -33,15 +33,13 @@ variable "region" {
 
 variable "instance_type" {
   type = string
-  # `c6in.large` is network-optimised (up to 25 Gbps) — purpose-built for the
-  # ECR-pull-bound work that dominates this build. Wall-clock floor is ~3-4
-  # min (cloud-init + AMI snapshot/register), and c6in.large gets close to it
-  # without paying for unused CPU/RAM. Requires a Paid AWS account — the AWS
-  # Free plan rejects non-free-tier launches with `InvalidParameterCombination:
-  # ... not eligible for Free Tier`; fall back to `t3.micro` (free-tier-
-  # eligible, ~4-5× slower) by overriding via the workflow input or
-  # `PKR_VAR_instance_type` if the account is on Free.
-  default = "c6in.large"
+  # `t3.micro` is free-tier-eligible and works on every AWS account, at the
+  # cost of being ~4-5× slower than network-optimised types on the ECR-pull-
+  # bound work that dominates this build. On a Paid account, override to
+  # `c6in.large` (network-optimised, up to 25 Gbps) via the workflow input or
+  # `PKR_VAR_instance_type` to get close to the ~3-4 min wall-clock floor
+  # (cloud-init + AMI snapshot/register).
+  default = "t3.micro"
 }
 
 variable "ws_server_image"  { type = string }


### PR DESCRIPTION
## Summary

Changed the default EC2 instance type for the latency e2e AMI build from `c6in.large` to `t3.micro` to ensure compatibility with AWS Free-tier accounts while maintaining the ability to override to faster instance types on paid accounts.

## Changes

- **Packer configuration** (`wingfoil-latency.pkr.hcl`):
  - Updated `instance_type` variable default from `c6in.large` to `t3.micro`
  - Revised comment to reflect that `t3.micro` is the default (free-tier-eligible, ~4-5× slower) with `c6in.large` as the recommended override for paid accounts

- **GitHub Actions workflow** (`build-latency-e2e-ami.yml`):
  - Updated `instance_type` input description to clarify that `t3.micro` is the new default
  - Changed default value in workflow input from `c6in.large` to `t3.micro`
  - Updated `INSTANCE_TYPE` environment variable default from `c6in.large` to `t3.micro`

## Rationale

This change makes the build accessible to users on AWS Free-tier accounts by default, which would previously fail with `InvalidParameterCombination` errors. Users on paid accounts can still achieve faster builds (~3-4 min wall-clock floor) by overriding the instance type to `c6in.large` (network-optimised, up to 25 Gbps) via workflow input or `PKR_VAR_instance_type` environment variable.

https://claude.ai/code/session_01LrieVXtdGNLqeCNTAogbro