### PR TITLE
Remove graph-level stop mechanism from limit node

### DIFF
--- a/wingfoil/src/graph.rs
+++ b/wingfoil/src/graph.rs
@@ -123,7 +123,6 @@ pub struct GraphState {
     /// strict-advance check so the very first cycle can fire at NanoTime::ZERO.
     first_cycle: bool,
     is_last_cycle: bool,
-    stop_requested: bool,
     current_node_index: Option<usize>,
     scheduled_callbacks: TimeQueue<usize>,
     always_callbacks: Vec<usize>,
@@ -155,7 +154,6 @@ impl GraphState {
             wall_time: NanoTime::ZERO,
             first_cycle: true,
             is_last_cycle: false,
-            stop_requested: false,
             current_node_index: None,
             scheduled_callbacks: TimeQueue::new(),
             always_callbacks: Vec::new(),
@@ -260,13 +258,6 @@ impl GraphState {
 
     pub fn is_last_cycle(&self) -> bool {
         self.is_last_cycle
-    }
-
-    /// Request early termination of the graph execution.
-    /// This is useful for nodes like `limit` that need to stop the graph
-    /// when they've finished producing values, even with RunFor::Forever.
-    pub fn request_stop(&mut self) {
-        self.stop_requested = true;
     }
 
     /// Returns true if node has ticked on the current engine cycle.
@@ -584,10 +575,6 @@ impl Graph {
              */
             cycles += 1;
             debug!("cycles={cycles}");
-            if self.state.stop_requested {
-                debug!("Stop requested by node, terminating early.");
-                break;
-            }
         }
         let elapsed = run_timer.elapsed();
         debug!("{empty_cycles} empty cycles");

--- a/wingfoil/src/nodes/limit.rs
+++ b/wingfoil/src/nodes/limit.rs
@@ -14,11 +14,8 @@ pub struct LimitStream<T: Element> {
 
 #[node(active = [source], output = value: T)]
 impl<T: Element> MutableNode for LimitStream<T> {
-    fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
         if self.tick_count >= self.limit {
-            // Request graph termination when limit is reached
-            // This allows RunFor::Forever to stop gracefully
-            state.request_stop();
             Ok(false)
         } else {
             self.tick_count += 1;
@@ -34,10 +31,10 @@ mod tests {
     use crate::nodes::*;
 
     #[test]
-    fn stops_after_n_ticks_with_run_forever() {
-        // RunFor::Forever would run indefinitely without limit; limit(3) must stop it.
+    fn suppresses_after_limit_reached() {
+        // Source ticks 10 times; limit(3) lets 3 through and suppresses the rest.
         let out = ticker(Duration::from_nanos(100)).count().limit(3).collect();
-        out.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        out.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10))
             .unwrap();
         assert_eq!(out.peek_value().len(), 3);
     }
@@ -45,7 +42,7 @@ mod tests {
     #[test]
     fn emits_correct_values_up_to_limit() {
         let out = ticker(Duration::from_nanos(100)).count().limit(4).collect();
-        out.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        out.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10))
             .unwrap();
         let values: Vec<u64> = out.peek_value().iter().map(|v| v.value).collect();
         assert_eq!(values, vec![1, 2, 3, 4]);


### PR DESCRIPTION
## Summary

Remove the `stop_requested` mechanism from `GraphState` and the `request_stop()` method that was used by the `limit` node to terminate graph execution early. The `limit` node now simply suppresses output after reaching its limit, relying on the caller to specify an appropriate `RunFor` duration instead of requesting early termination.

## Changes

- **graph.rs**: Removed `stop_requested` field from `GraphState` and the `request_stop()` public method that allowed nodes to request early graph termination
- **graph.rs**: Removed the early termination check in the main execution loop that would break when `stop_requested` was true
- **limit.rs**: Updated `cycle()` to no longer call `state.request_stop()` when the limit is reached; the node now simply returns `false` to suppress further output
- **limit.rs**: Updated tests to use `RunFor::Cycles(10)` instead of `RunFor::Forever`, making the test intent clearer (the source ticks 10 times, limit lets N through and suppresses the rest)
- **limit.rs**: Renamed test `stops_after_n_ticks_with_run_forever` to `suppresses_after_limit_reached` to better reflect the actual behavior

## Rationale

The `stop_requested` mechanism was a form of implicit control flow where nodes could terminate the entire graph. This change simplifies the execution model by removing this capability—nodes control their own output (by returning `false` from `cycle()`), but graph termination is determined by the explicit `RunFor` parameter provided by the caller. This makes execution behavior more predictable and easier to reason about.

https://claude.ai/code/session_01HAgv8fX2pVQdLtDkfaVTp2