### PR TITLE
Refactor latency stamping to use mode-driven stream architecture

### DIFF
--- a/wingfoil-derive/src/lib.rs
+++ b/wingfoil-derive/src/lib.rs
@@ -271,7 +271,8 @@ fn pascal_to_snake(s: &str) -> String {
 ///
 /// // Markers live in a snake_case sub-module named after the struct:
 /// use trade_latency::strategy;
-/// let stamped = upstream.stamp::<strategy>();
+/// let mode = wingfoil::constant(wingfoil::StampMode::On);
+/// let stamped = upstream.stamp::<strategy>(&mode);
 /// ```
 #[proc_macro]
 pub fn latency_stages(item: TokenStream) -> TokenStream {

--- a/wingfoil-python/examples/latency.py
+++ b/wingfoil-python/examples/latency.py
@@ -11,7 +11,7 @@ Run:
   cd wingfoil-python && maturin develop --features iceoryx2-beta && python examples/latency.py
 """
 
-from wingfoil import ticker, Latency, TracedBytes, Graph
+from wingfoil import ticker, Latency, TracedBytes, Graph, StampMode, StampModeHandle
 
 STAGES = ["produce", "encode", "decode", "strategy", "ack"]
 
@@ -22,22 +22,24 @@ def make_payload(seq):
 
 
 def main():
-    stamp = True  # flip to False to disable all stamping (zero cost)
+    # Share one handle across every stamp call; flip stamping on/off (or
+    # toggle to precise) at runtime via handle.set(...).
+    mode = StampModeHandle(StampMode.On)
 
     pipeline = (
         ticker(0.01)
         .count()
         .map(make_payload)
-        .stamp_if("produce", stamp)
-        .stamp_if("encode", stamp)
+        .stamp("produce", mode)
+        .stamp("encode", mode)
         # ── pretend strategy work happens here ──
         .map(lambda t: t)  # identity (placeholder for real logic)
-        .stamp_if("decode", stamp)
-        .stamp_precise_if("strategy", stamp)
-        .stamp_if("ack", stamp)
+        .stamp("decode", mode)
+        .stamp("strategy", StampMode.OnPrecise)
+        .stamp("ack", mode)
     )
 
-    report = pipeline.latency_report_if(STAGES, stamp, print_on_teardown=True)
+    report = pipeline.latency_report_if(STAGES, True, print_on_teardown=True)
 
     print("Running latency pipeline for 0.5 seconds...")
     Graph([report]).run(realtime=True, duration=0.5)

--- a/wingfoil-python/python/wingfoil/__init__.py
+++ b/wingfoil-python/python/wingfoil/__init__.py
@@ -16,7 +16,9 @@ __all__ = list(getattr(_ext, "__all__", [])) + ["to_dataframe", "build_dataframe
 # Latency measurement classes
 Latency = _ext.Latency
 TracedBytes = _ext.TracedBytes
-__all__.extend(["Latency", "TracedBytes"])
+StampMode = _ext.StampMode
+StampModeHandle = _ext.StampModeHandle
+__all__.extend(["Latency", "TracedBytes", "StampMode", "StampModeHandle"])
 
 # User-friendly aliases for CSV functions
 csv_read = _ext.py_csv_read

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -213,6 +213,8 @@ fn _wingfoil(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<py_prometheus::PyPrometheusExporter>()?;
     module.add_class::<py_latency::PyLatency>()?;
     module.add_class::<py_latency::PyTracedBytes>()?;
+    module.add_class::<py_latency::PyStampMode>()?;
+    module.add_class::<py_latency::PyStampModeHandle>()?;
     module.add_class::<py_web::PyWebServer>()?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())

--- a/wingfoil-python/src/py_latency.rs
+++ b/wingfoil-python/src/py_latency.rs
@@ -3,10 +3,11 @@
 //! Provides `Latency` and `TracedBytes` pyclasses, plus Rust-side stamp and
 //! report nodes that operate on `PyElement`-wrapped `TracedBytes` values.
 
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use pyo3::exceptions::PyKeyError;
+use pyo3::exceptions::{PyKeyError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
@@ -233,7 +234,50 @@ impl PyTracedBytes {
 }
 
 // ---------------------------------------------------------------------------
-// PyStampNode — stamps one named stage on each upstream tick
+// PyStampMode + PyStampModeHandle — runtime-toggleable stamp mode
+// ---------------------------------------------------------------------------
+
+#[pyclass(eq, eq_int, name = "StampMode")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PyStampMode {
+    /// Don't write anything. Forward the upstream unchanged.
+    Off,
+    /// Stamp with the cycle-start wall-clock snap (one u64 load).
+    On,
+    /// Stamp with a fresh TSC read (~5-10 ns) for intra-cycle resolution.
+    OnPrecise,
+}
+
+/// Mutable handle to a stamp-mode setting shared with one or more
+/// `stamp(...)` nodes. Construct with `StampModeHandle(initial)` and pass
+/// the same handle into multiple `stamp` calls to flip them together.
+#[pyclass(unsendable, name = "StampModeHandle")]
+#[derive(Clone)]
+pub struct PyStampModeHandle {
+    cell: Rc<Cell<PyStampMode>>,
+}
+
+#[pymethods]
+impl PyStampModeHandle {
+    #[new]
+    #[pyo3(signature = (initial = PyStampMode::On))]
+    fn new(initial: PyStampMode) -> Self {
+        Self {
+            cell: Rc::new(Cell::new(initial)),
+        }
+    }
+
+    fn set(&self, mode: PyStampMode) {
+        self.cell.set(mode);
+    }
+
+    fn get(&self) -> PyStampMode {
+        self.cell.get()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PyStampNode — stamps one named stage on each upstream tick, mode-driven
 // ---------------------------------------------------------------------------
 
 pub struct PyStampNode {
@@ -241,17 +285,21 @@ pub struct PyStampNode {
     value: PyElement,
     stage_name: String,
     stage_idx: Option<usize>,
-    precise: bool,
+    mode: Rc<Cell<PyStampMode>>,
 }
 
 impl PyStampNode {
-    pub fn new(upstream: Rc<dyn Stream<PyElement>>, stage_name: String, precise: bool) -> Self {
+    pub fn new(
+        upstream: Rc<dyn Stream<PyElement>>,
+        stage_name: String,
+        mode: Rc<Cell<PyStampMode>>,
+    ) -> Self {
         Self {
             upstream,
             value: PyElement::default(),
             stage_name,
             stage_idx: None,
-            precise,
+            mode,
         }
     }
 }
@@ -263,42 +311,44 @@ impl MutableNode for PyStampNode {
 
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
         let elem = self.upstream.peek_value();
-        let wall_ns: u64 = if self.precise {
-            state.wall_time_precise().into()
-        } else {
-            state.wall_time().into()
+        let wall_ns: Option<u64> = match self.mode.get() {
+            PyStampMode::Off => None,
+            PyStampMode::On => Some(state.wall_time().into()),
+            PyStampMode::OnPrecise => Some(state.wall_time_precise().into()),
         };
 
-        Python::attach(|py| -> anyhow::Result<()> {
-            let obj = elem.as_ref().bind(py);
-            let traced: PyRef<PyTracedBytes> = obj.extract().map_err(|_| {
-                anyhow::anyhow!(
-                    "stamp('{}'): expected TracedBytes, got {}",
-                    self.stage_name,
-                    obj.get_type()
-                        .qualname()
-                        .map(|n| n.to_string())
-                        .unwrap_or_else(|_| "?".to_string())
-                )
+        if let Some(wall_ns) = wall_ns {
+            Python::attach(|py| -> anyhow::Result<()> {
+                let obj = elem.as_ref().bind(py);
+                let traced: PyRef<PyTracedBytes> = obj.extract().map_err(|_| {
+                    anyhow::anyhow!(
+                        "stamp('{}'): expected TracedBytes, got {}",
+                        self.stage_name,
+                        obj.get_type()
+                            .qualname()
+                            .map(|n| n.to_string())
+                            .unwrap_or_else(|_| "?".to_string())
+                    )
+                })?;
+                let mut lat = traced.latency.borrow_mut(py);
+                let idx = match self.stage_idx {
+                    Some(i) => i,
+                    None => {
+                        let i = lat.stage_index(&self.stage_name).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "stamp: unknown stage '{}' (known: {:?})",
+                                self.stage_name,
+                                lat.stages
+                            )
+                        })?;
+                        self.stage_idx = Some(i);
+                        i
+                    }
+                };
+                lat.stamp_by_index(idx, wall_ns);
+                Ok(())
             })?;
-            let mut lat = traced.latency.borrow_mut(py);
-            let idx = match self.stage_idx {
-                Some(i) => i,
-                None => {
-                    let i = lat.stage_index(&self.stage_name).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "stamp: unknown stage '{}' (known: {:?})",
-                            self.stage_name,
-                            lat.stages
-                        )
-                    })?;
-                    self.stage_idx = Some(i);
-                    i
-                }
-            };
-            lat.stamp_by_index(idx, wall_ns);
-            Ok(())
-        })?;
+        }
 
         self.value = elem;
         Ok(true)
@@ -403,9 +453,18 @@ impl MutableNode for PyLatencyReportNode {
 pub fn py_stamp_inner(
     stream: &Rc<dyn Stream<PyElement>>,
     stage: String,
-    precise: bool,
-) -> Rc<dyn Stream<PyElement>> {
-    PyStampNode::new(stream.clone(), stage, precise).into_stream()
+    mode: &Bound<'_, PyAny>,
+) -> PyResult<Rc<dyn Stream<PyElement>>> {
+    let cell = if let Ok(handle) = mode.extract::<PyStampModeHandle>() {
+        handle.cell.clone()
+    } else if let Ok(m) = mode.extract::<PyStampMode>() {
+        Rc::new(Cell::new(m))
+    } else {
+        return Err(PyTypeError::new_err(
+            "stamp(stage, mode): mode must be StampMode or StampModeHandle",
+        ));
+    };
+    Ok(PyStampNode::new(stream.clone(), stage, cell).into_stream())
 }
 
 pub fn py_latency_report_inner(

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -430,44 +430,21 @@ impl PyStream {
 
     // ── Latency stamping ─────────────────────────────────────────────────
 
-    /// Stamp a named latency stage on each tick using the cycle-start
-    /// wall-clock time. The stream must carry `TracedBytes` values.
+    /// Stamp a named latency stage on each tick. Behaviour is selected by
+    /// `mode`, which may be a fixed `StampMode` or a `StampModeHandle` that
+    /// flips at runtime. The stream must carry `TracedBytes` values.
     ///
     /// Args:
     ///     stage: Stage name (must match one of the names in the `Latency`).
+    ///     mode: `StampMode.OFF` | `StampMode.ON` | `StampMode.ON_PRECISE`,
+    ///         or a `StampModeHandle` shared with other stamp nodes.
     ///
     /// Returns:
-    ///     A new Stream with the stage stamped.
-    fn stamp(&self, stage: String) -> PyStream {
-        PyStream(crate::py_latency::py_stamp_inner(&self.0, stage, false))
-    }
-
-    /// Like `stamp`, but only inserts the stamp node when `enabled` is True.
-    /// When False, returns the stream unchanged — zero runtime cost.
-    #[pyo3(signature = (stage, enabled))]
-    fn stamp_if(&self, stage: String, enabled: bool) -> PyStream {
-        if enabled {
-            self.stamp(stage)
-        } else {
-            self.clone()
-        }
-    }
-
-    /// Stamp a named latency stage with a precise wall-clock read (~5-10ns
-    /// TSC read per tick). Gives intra-cycle resolution.
-    fn stamp_precise(&self, stage: String) -> PyStream {
-        PyStream(crate::py_latency::py_stamp_inner(&self.0, stage, true))
-    }
-
-    /// Like `stamp_precise`, but only inserts the stamp node when `enabled`
-    /// is True. When False, returns the stream unchanged.
-    #[pyo3(signature = (stage, enabled))]
-    fn stamp_precise_if(&self, stage: String, enabled: bool) -> PyStream {
-        if enabled {
-            self.stamp_precise(stage)
-        } else {
-            self.clone()
-        }
+    ///     A new Stream with the stage stamped according to the current mode.
+    fn stamp(&self, stage: String, mode: &Bound<'_, PyAny>) -> PyResult<PyStream> {
+        Ok(PyStream(crate::py_latency::py_stamp_inner(
+            &self.0, stage, mode,
+        )?))
     }
 
     /// Install a latency report sink. The stream must carry `TracedBytes`

--- a/wingfoil-python/tests/test_latency.py
+++ b/wingfoil-python/tests/test_latency.py
@@ -2,7 +2,14 @@
 
 import unittest
 
-from wingfoil import Graph, Latency, TracedBytes, ticker
+from wingfoil import (
+    Graph,
+    Latency,
+    StampMode,
+    StampModeHandle,
+    TracedBytes,
+    ticker,
+)
 
 
 class TestLatency(unittest.TestCase):
@@ -90,9 +97,9 @@ class TestStamp(unittest.TestCase):
             ticker(0.01)
             .count()
             .map(self._traced)
-            .stamp("start")
-            .stamp("mid")
-            .stamp("end")
+            .stamp("start", StampMode.On)
+            .stamp("mid", StampMode.On)
+            .stamp("end", StampMode.On)
         )
         node = stream.for_each(lambda tb, _t: received.append(tb.latency.stamps[:]))
         node.run(realtime=False, cycles=3)
@@ -111,9 +118,9 @@ class TestStamp(unittest.TestCase):
             ticker(0.01)
             .count()
             .map(self._traced)
-            .stamp_precise("start")
-            .stamp_precise("mid")
-            .stamp_precise("end")
+            .stamp("start", StampMode.OnPrecise)
+            .stamp("mid", StampMode.OnPrecise)
+            .stamp("end", StampMode.OnPrecise)
         )
         node = stream.for_each(lambda tb, _t: received.append(tb.latency.stamps[:]))
         node.run(realtime=False, cycles=2)
@@ -121,30 +128,28 @@ class TestStamp(unittest.TestCase):
         for stamps in received:
             self.assertTrue(all(s > 0 for s in stamps))
 
-    def test_stamp_if_enabled_false_is_noop(self):
-        # When disabled, stamp_if / stamp_precise_if pass the stream through
-        # unchanged (no stamping happens).
+    def test_stamp_mode_off_is_noop(self):
+        # StampMode.Off forwards the payload without writing any stamp.
         stream = (
             ticker(0.01)
             .count()
             .map(self._traced)
-            .stamp_if("start", False)
-            .stamp_precise_if("mid", False)
+            .stamp("start", StampMode.Off)
+            .stamp("mid", StampMode.Off)
         )
         received = []
         node = stream.for_each(lambda tb, _t: received.append(tb.latency.stamps[:]))
         node.run(realtime=False, cycles=2)
-        # No stage was stamped, so all zero.
         for stamps in received:
             self.assertEqual(stamps, [0, 0, 0])
 
-    def test_stamp_if_enabled_true_stamps(self):
+    def test_stamp_mode_mix(self):
         stream = (
             ticker(0.01)
             .count()
             .map(self._traced)
-            .stamp_if("start", True)
-            .stamp_precise_if("end", True)
+            .stamp("start", StampMode.On)
+            .stamp("end", StampMode.OnPrecise)
         )
         received = []
         node = stream.for_each(lambda tb, _t: received.append(tb.latency.stamps[:]))
@@ -154,9 +159,35 @@ class TestStamp(unittest.TestCase):
             self.assertEqual(stamps[1], 0)  # mid untouched
             self.assertGreater(stamps[2], 0)  # end stamped
 
+    def test_stamp_mode_handle_flips_at_runtime(self):
+        # A StampModeHandle shared across stamps lets us flip them all from
+        # within the graph. Start Off, then turn On after first tick.
+        handle = StampModeHandle(StampMode.Off)
+        received = []
+
+        def observe(tb, _t):
+            received.append(tb.latency.stamps[:])
+            if len(received) == 1:
+                handle.set(StampMode.On)
+            return tb
+
+        stream = (
+            ticker(0.01)
+            .count()
+            .map(self._traced)
+            .stamp("start", handle)
+            .map(observe)
+        )
+        node = stream.for_each(lambda _tb, _t: None)
+        node.run(realtime=False, cycles=3)
+
+        self.assertGreaterEqual(len(received), 2)
+        self.assertEqual(received[0][0], 0)  # first tick: Off
+        self.assertGreater(received[1][0], 0)  # later tick: On
+
     def test_stamp_on_non_traced_raises(self):
         # stamp() on a non-TracedBytes stream should fail at runtime.
-        stream = ticker(0.01).count().stamp("stage")
+        stream = ticker(0.01).count().stamp("stage", StampMode.On)
         node = stream.for_each(lambda _v, _t: None)
         with self.assertRaises(Exception):
             node.run(realtime=False, cycles=1)
@@ -171,9 +202,9 @@ class TestLatencyReport(unittest.TestCase):
             ticker(0.01)
             .count()
             .map(self._traced)
-            .stamp("a")
-            .stamp("b")
-            .stamp("c")
+            .stamp("a", StampMode.On)
+            .stamp("b", StampMode.On)
+            .stamp("c", StampMode.On)
         )
         node = stream.latency_report(["a", "b", "c"], print_on_teardown=False)
         node.run(realtime=False, cycles=5)  # no exception => pass
@@ -183,9 +214,9 @@ class TestLatencyReport(unittest.TestCase):
             ticker(0.01)
             .count()
             .map(self._traced)
-            .stamp("a")
-            .stamp("b")
-            .stamp("c")
+            .stamp("a", StampMode.On)
+            .stamp("b", StampMode.On)
+            .stamp("c", StampMode.On)
         )
         node = stream.latency_report(["a", "b", "c"], print_on_teardown=True)
         node.run(realtime=False, cycles=3)  # prints report, no exception
@@ -201,9 +232,9 @@ class TestLatencyReport(unittest.TestCase):
             ticker(0.01)
             .count()
             .map(self._traced)
-            .stamp("a")
-            .stamp("b")
-            .stamp("c")
+            .stamp("a", StampMode.On)
+            .stamp("b", StampMode.On)
+            .stamp("c", StampMode.On)
         )
         node = stream.latency_report_if(
             ["a", "b", "c"], enabled=True, print_on_teardown=False

--- a/wingfoil-python/tests/test_latency.py
+++ b/wingfoil-python/tests/test_latency.py
@@ -165,7 +165,7 @@ class TestStamp(unittest.TestCase):
         handle = StampModeHandle(StampMode.Off)
         received = []
 
-        def observe(tb, _t):
+        def observe(tb):
             received.append(tb.latency.stamps[:])
             if len(received) == 1:
                 handle.set(StampMode.On)

--- a/wingfoil/examples/latency/pub.rs
+++ b/wingfoil/examples/latency/pub.rs
@@ -30,6 +30,7 @@ fn main() {
     // produce → publish:
     //   `produce` is stamped immediately after the message is constructed,
     //   `publish` is stamped just before it crosses the iceoryx2 boundary.
+    let mode = constant(StampMode::On);
     let stream = ticker(period)
         .count()
         .map(|seq: u64| {
@@ -38,8 +39,8 @@ fn main() {
                 price: 100.0 + (seq as f64) * 0.01,
             })
         })
-        .stamp::<quote_latency::produce>()
-        .stamp::<quote_latency::publish>();
+        .stamp::<quote_latency::produce>(&mode)
+        .stamp::<quote_latency::publish>(&mode);
 
     // iceoryx2_pub takes a `Burst<T>`; wrap each sample.
     let burst_stream = stream.map(|t| {

--- a/wingfoil/examples/latency/sub.rs
+++ b/wingfoil/examples/latency/sub.rs
@@ -27,18 +27,19 @@ fn main() {
     // The subscriber yields a `Burst<Traced<Quote, QuoteLatency>>` per tick.
     // collapse() drops empty bursts and unwraps single-message bursts to the
     // inner Traced value.
+    let mode = constant(StampMode::On);
     let pipeline = iceoryx2_sub::<Traced<Quote, QuoteLatency>>(SERVICE_NAME)
         .collapse::<Traced<Quote, QuoteLatency>>()
-        .stamp::<quote_latency::receive>()
+        .stamp::<quote_latency::receive>(&mode)
         // ── pretend strategy work happens here ─────────────────────
         .map(|mut t: Traced<Quote, QuoteLatency>| {
             // Touch the payload so the compiler can't fold the work away.
             t.payload.price *= 1.0001;
             t
         })
-        .stamp::<quote_latency::strategy>()
+        .stamp::<quote_latency::strategy>(&mode)
         // ── pretend reply construction happens here ────────────────
-        .stamp::<quote_latency::ack>();
+        .stamp::<quote_latency::ack>(&mode);
 
     // LatencyReport sink prints the per-stage delta histogram on shutdown.
     let (sink, _stats) = pipeline.latency_report(true);

--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -96,6 +96,11 @@ fn main() -> anyhow::Result<()> {
         .ok();
 
     let precise = precise_stamps_enabled();
+    let stamp_mode = constant(if precise {
+        StampMode::OnPrecise
+    } else {
+        StampMode::On
+    });
     // LMAX London Demo updates EUR/USD only every few seconds during quiet
     // periods — observed gaps of 20+ seconds when the book is dormant — so
     // even 5 s rejects most orders outside of busy windows. 60 s keeps the
@@ -141,8 +146,7 @@ fn main() -> anyhow::Result<()> {
                 t.payload.side,
             );
         })
-        .stamp_if::<round_trip_latency::gw_recv>(!precise)
-        .stamp_precise_if::<round_trip_latency::gw_recv>(precise);
+        .stamp::<round_trip_latency::gw_recv>(&stamp_mode);
 
     let priced = bimap(
         Dep::Active(orders),
@@ -167,10 +171,8 @@ fn main() -> anyhow::Result<()> {
             order
         },
     )
-    .stamp_if::<round_trip_latency::gw_price>(!precise)
-    .stamp_precise_if::<round_trip_latency::gw_price>(precise)
-    .stamp_if::<round_trip_latency::fix_send>(!precise)
-    .stamp_precise_if::<round_trip_latency::fix_send>(precise);
+    .stamp::<round_trip_latency::gw_price>(&stamp_mode)
+    .stamp::<round_trip_latency::fix_send>(&stamp_mode);
 
     // Side branch: send NewOrderSingle to the FIX order session via the
     // lock-free kanal channel (see wingfoil FIX adapter PR #225).
@@ -305,10 +307,8 @@ fn main() -> anyhow::Result<()> {
         }),
     )
     .into_stream()
-    .stamp_if::<round_trip_latency::fix_recv>(!precise)
-    .stamp_precise_if::<round_trip_latency::fix_recv>(precise)
-    .stamp_if::<round_trip_latency::gw_publish>(!precise)
-    .stamp_precise_if::<round_trip_latency::gw_publish>(precise);
+    .stamp::<round_trip_latency::fix_recv>(&stamp_mode)
+    .stamp::<round_trip_latency::gw_publish>(&stamp_mode);
 
     let pub_fills = iceoryx2_pub(
         fills

--- a/wingfoil/examples/latency_e2e/ws_server.rs
+++ b/wingfoil/examples/latency_e2e/ws_server.rs
@@ -150,6 +150,11 @@ fn main() -> anyhow::Result<()> {
         static_dir.display(),
     );
     log::info!("session_cap={session_cap} ttl={session_ttl}s precise={precise}");
+    let stamp_mode = constant(if precise {
+        StampMode::OnPrecise
+    } else {
+        StampMode::On
+    });
 
     let sessions = Arc::new(Mutex::new(Sessions::new(session_cap, session_ttl)));
 
@@ -186,20 +191,16 @@ fn main() -> anyhow::Result<()> {
                 ..Default::default()
             })
         })
-        .stamp_if::<round_trip_latency::ws_recv>(!precise)
-        .stamp_precise_if::<round_trip_latency::ws_recv>(precise)
-        .stamp_if::<round_trip_latency::ws_publish>(!precise)
-        .stamp_precise_if::<round_trip_latency::ws_publish>(precise);
+        .stamp::<round_trip_latency::ws_recv>(&stamp_mode)
+        .stamp::<round_trip_latency::ws_publish>(&stamp_mode);
 
     let pub_orders = iceoryx2_pub(traced_orders.map(|t| burst![t]), SVC_ORDERS);
 
     // ── Inbound leg ──────────────────────────────────────────────────────
     let fills_in = iceoryx2_sub::<Traced<RoundTrip, RoundTripLatency>>(SVC_FILLS)
         .collapse::<Traced<RoundTrip, RoundTripLatency>>()
-        .stamp_if::<round_trip_latency::ws_sub_recv>(!precise)
-        .stamp_precise_if::<round_trip_latency::ws_sub_recv>(precise)
-        .stamp_if::<round_trip_latency::ws_send>(!precise)
-        .stamp_precise_if::<round_trip_latency::ws_send>(precise);
+        .stamp::<round_trip_latency::ws_sub_recv>(&stamp_mode)
+        .stamp::<round_trip_latency::ws_send>(&stamp_mode);
 
     let (inbound_report, inbound_stats) = fills_in.latency_report(true);
 

--- a/wingfoil/src/adapters/iceoryx2/local_tests.rs
+++ b/wingfoil/src/adapters/iceoryx2/local_tests.rs
@@ -9,7 +9,7 @@
 
 use super::*;
 use crate::latency::*;
-use crate::nodes::{NodeOperators, StreamOperators};
+use crate::nodes::{NodeOperators, StreamOperators, constant};
 use crate::types::Burst;
 use crate::{Graph, RunFor, RunMode, latency_stages, ticker};
 use iceoryx2::prelude::ZeroCopySend;
@@ -350,18 +350,19 @@ fn test_local_latency_round_trip() -> anyhow::Result<()> {
         &service_name,
         Iceoryx2ServiceVariant::Local,
     );
+    let mode = constant(StampMode::On);
     let collected = sub
         .collapse::<Traced<TestQuote, TestLatency>>()
-        .stamp::<test_latency::receive>()
-        .stamp::<test_latency::ack>()
+        .stamp::<test_latency::receive>(&mode)
+        .stamp::<test_latency::ack>(&mode)
         .collect();
 
     // Publisher side: build payload, stamp produce and publish.
     let upstream = ticker(Duration::from_millis(5))
         .count()
         .map(|seq: u64| Traced::<TestQuote, TestLatency>::new(TestQuote { seq }))
-        .stamp::<test_latency::produce>()
-        .stamp::<test_latency::publish>()
+        .stamp::<test_latency::produce>(&mode)
+        .stamp::<test_latency::publish>(&mode)
         .map(|t| {
             let mut b: Burst<Traced<TestQuote, TestLatency>> = Burst::default();
             b.push(t);

--- a/wingfoil/src/latency.rs
+++ b/wingfoil/src/latency.rs
@@ -19,28 +19,30 @@
 //!
 //! Stamps always read the wall clock (never [`GraphState::time`], which is
 //! source-driven in historical mode and would be useless for latency).
-//! Two variants:
+//! Each stamp node is driven by a `Stream<`[`StampMode`]`>` peeked passively
+//! on every data tick:
 //!
-//! - [`LatencyStreamOps::stamp`] reads [`GraphState::wall_time`] — a
-//!   cycle-start wall-clock snap, one `u64` load, cheap. Stages sharing an
-//!   engine cycle get the same stamp.
-//! - [`LatencyStreamOps::stamp_precise`] reads
-//!   [`GraphState::wall_time_precise`] — a fresh TSC read (~5-10 ns), giving
-//!   distinct stamps to stages that run in the same engine cycle.
+//! - [`StampMode::Off`] — forward the upstream unchanged, write nothing.
+//! - [`StampMode::On`] — write [`GraphState::wall_time`] (cycle-start
+//!   wall-clock snap, one `u64` load). Stages sharing an engine cycle get
+//!   the same stamp.
+//! - [`StampMode::OnPrecise`] — write [`GraphState::wall_time_precise`]
+//!   (fresh TSC read, ~5-10 ns), giving distinct stamps to stages running
+//!   in the same engine cycle.
 //!
-//! Both variants behave identically in realtime and historical mode — the
-//! graph wiring stays the same across environments and the numbers mean
+//! Mode behaves identically in realtime and historical mode — the graph
+//! wiring stays the same across environments and the numbers mean
 //! "wall-clock time spent between stages". In historical mode this
 //! measures backtest replay performance; in realtime it measures production
 //! latency.
 //!
-//! # Toggling
+//! # Toggling on the fly
 //!
-//! Each stamping and reporting method has an `_if` variant that takes a
-//! boolean and returns the upstream unchanged when disabled — zero runtime
-//! cost, no node inserted into the graph. Thread a single config flag
-//! through your pipeline builder to disable stamping for ultra-hot paths or
-//! backtests.
+//! Because the mode is itself a stream, every stamp node re-reads it on
+//! every tick. Wire a fixed mode with [`constant`](crate::nodes::constant),
+//! a runtime-toggleable handle with [`stamp_mode_control`], or compute the
+//! mode from any other on-graph signal. Switching to [`StampMode::Off`]
+//! at runtime suppresses stamping with no graph rewiring.
 //!
 //! # Example
 //!
@@ -56,19 +58,33 @@
 //!     }
 //! }
 //!
-//! // Markers live in a snake_case sub-module named after the struct.
-//! fn build(stream: std::rc::Rc<dyn Stream<Traced<u64, TradeLatency>>>)
-//!     -> std::rc::Rc<dyn Stream<Traced<u64, TradeLatency>>>
-//! {
+//! // Static mode: always cycle-start stamping.
+//! fn build_static(
+//!     stream: std::rc::Rc<dyn Stream<Traced<u64, TradeLatency>>>,
+//! ) -> std::rc::Rc<dyn Stream<Traced<u64, TradeLatency>>> {
+//!     let mode = constant(StampMode::On);
 //!     stream
-//!         .stamp::<trade_latency::ingest>()
-//!         .stamp::<trade_latency::strategy>()
+//!         .stamp::<trade_latency::ingest>(&mode)
+//!         .stamp::<trade_latency::strategy>(&mode)
+//! }
+//!
+//! // Dynamic mode: flip from Off → OnPrecise → On at runtime via a handle.
+//! fn build_dynamic(
+//!     stream: std::rc::Rc<dyn Stream<Traced<u64, TradeLatency>>>,
+//! ) -> (std::rc::Rc<dyn Stream<Traced<u64, TradeLatency>>>, StampModeHandle) {
+//!     let (mode, handle) = stamp_mode_control(StampMode::On);
+//!     let stamped = stream
+//!         .stamp::<trade_latency::ingest>(&mode)
+//!         .stamp::<trade_latency::strategy>(&mode);
+//!     (stamped, handle)
 //! }
 //! ```
 
+use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
+use crate::graph::GraphState;
 use crate::types::*;
 
 /// Declarative macro that generates a `#[repr(C)]` named-field latency record
@@ -213,22 +229,42 @@ fn traced_type_name(t: &'static str, l: &'static str) -> &'static str {
 }
 
 // ---------------------------------------------------------------------------
-// StampStream / StampPreciseStream — wrapper nodes that stamp one stage
+// StampMode + StampStream — single wrapper node that consults a mode stream
 // ---------------------------------------------------------------------------
 
-/// A node that forwards its upstream value while stamping
-/// [`GraphState::wall_time`] (cycle-start wall-clock snap) into a single
+/// Selects how a [`StampStream`] writes its stage timestamp on each tick.
+///
+/// Threaded through the graph as a `Stream<StampMode>` so the choice can be
+/// flipped at runtime without rewiring.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum StampMode {
+    /// Don't write anything. Forward the upstream value unchanged.
+    #[default]
+    Off,
+    /// Stamp [`GraphState::wall_time`] — one `u64` load, cycle-start snap.
+    /// Stages sharing an engine cycle get the same value.
+    On,
+    /// Stamp [`GraphState::wall_time_precise`] — a fresh TSC read (~5-10 ns)
+    /// giving intra-cycle resolution between stages that run together.
+    OnPrecise,
+}
+
+/// A node that forwards its upstream value while optionally stamping a single
 /// named stage of the embedded [`Latency`] record.
 ///
-/// One `u64` store per tick, no allocation. Stages that tick in the same
-/// engine cycle share the same timestamp — use [`StampPreciseStream`] for
-/// intra-cycle resolution.
+/// The behaviour on each tick is driven by a passive `Stream<`[`StampMode`]`>`
+/// peeked at the start of [`cycle`](Self::cycle). [`StampMode::Off`] forwards
+/// without writing; [`StampMode::On`] writes the cycle-start wall-clock snap;
+/// [`StampMode::OnPrecise`] writes a fresh TSC read.
 pub struct StampStream<P, S>
 where
     P: Element + HasLatency,
     S: Stage<P::L> + 'static,
 {
     upstream: Rc<dyn Stream<P>>,
+    mode: Rc<dyn Stream<StampMode>>,
     value: P,
     _stage: PhantomData<fn() -> S>,
 }
@@ -238,16 +274,17 @@ where
     P: Element + HasLatency,
     S: Stage<P::L> + 'static,
 {
-    pub fn new(upstream: Rc<dyn Stream<P>>) -> Self {
+    pub fn new(upstream: Rc<dyn Stream<P>>, mode: Rc<dyn Stream<StampMode>>) -> Self {
         Self {
             upstream,
+            mode,
             value: P::default(),
             _stage: PhantomData,
         }
     }
 }
 
-#[node(active = [upstream], output = value: P)]
+#[node(output = value: P)]
 impl<P, S> MutableNode for StampStream<P, S>
 where
     P: Element + HasLatency,
@@ -255,89 +292,111 @@ where
 {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
         self.value = self.upstream.peek_value();
-        S::stamp(self.value.latency_mut(), state.wall_time().into());
-        Ok(true)
-    }
-}
-
-/// Like [`StampStream`] but reads [`GraphState::wall_time_precise`] — a fresh
-/// TSC snap on every tick. Costs ~5-10 ns per stamp on x86 but gives
-/// intra-cycle resolution, so stages running in the same engine cycle get
-/// distinct timestamps.
-pub struct StampPreciseStream<P, S>
-where
-    P: Element + HasLatency,
-    S: Stage<P::L> + 'static,
-{
-    upstream: Rc<dyn Stream<P>>,
-    value: P,
-    _stage: PhantomData<fn() -> S>,
-}
-
-impl<P, S> StampPreciseStream<P, S>
-where
-    P: Element + HasLatency,
-    S: Stage<P::L> + 'static,
-{
-    pub fn new(upstream: Rc<dyn Stream<P>>) -> Self {
-        Self {
-            upstream,
-            value: P::default(),
-            _stage: PhantomData,
+        match self.mode.peek_value() {
+            StampMode::Off => {}
+            StampMode::On => S::stamp(self.value.latency_mut(), state.wall_time().into()),
+            StampMode::OnPrecise => {
+                S::stamp(self.value.latency_mut(), state.wall_time_precise().into())
+            }
         }
-    }
-}
-
-#[node(active = [upstream], output = value: P)]
-impl<P, S> MutableNode for StampPreciseStream<P, S>
-where
-    P: Element + HasLatency,
-    S: Stage<P::L> + 'static,
-{
-    fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
-        self.value = self.upstream.peek_value();
-        S::stamp(self.value.latency_mut(), state.wall_time_precise().into());
         Ok(true)
     }
+
+    fn upstreams(&self) -> UpStreams {
+        UpStreams::new(
+            vec![self.upstream.clone().as_node()],
+            vec![self.mode.clone().as_node()],
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
-// Public ergonomics: .stamp::<Stage>() on Stream<P> where P: HasLatency
+// StampModeControl — externally-mutable Stream<StampMode> source
 // ---------------------------------------------------------------------------
 
-/// Extension trait adding `.stamp::<Stage>()` and friends to streams whose
-/// values carry a [`Latency`] record.
+/// Handle to a [`StampModeControl`] source that flips its emitted mode at
+/// runtime. Cheap to clone (one [`Rc`] bump); changes are observed by every
+/// stamp node sharing the underlying stream on its next tick.
+#[derive(Clone, Debug)]
+pub struct StampModeHandle {
+    cell: Rc<Cell<StampMode>>,
+}
+
+impl StampModeHandle {
+    pub fn set(&self, mode: StampMode) {
+        self.cell.set(mode);
+    }
+
+    pub fn get(&self) -> StampMode {
+        self.cell.get()
+    }
+}
+
+/// Source node for [`stamp_mode_control`]. `peek_value` reads the shared
+/// cell directly, so external mutations are visible without the node having
+/// to re-tick.
+pub struct StampModeControl {
+    cell: Rc<Cell<StampMode>>,
+    snapshot: StampMode,
+}
+
+impl MutableNode for StampModeControl {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.snapshot = self.cell.get();
+        Ok(true)
+    }
+
+    fn upstreams(&self) -> UpStreams {
+        UpStreams::none()
+    }
+
+    fn start(&mut self, state: &mut GraphState) -> anyhow::Result<()> {
+        state.add_callback(state.start_time());
+        Ok(())
+    }
+}
+
+impl StreamPeekRef<StampMode> for StampModeControl {
+    fn peek_ref(&self) -> &StampMode {
+        &self.snapshot
+    }
+
+    // Bypass the snapshot field so external mutations on the handle are
+    // visible to downstream peeks even though this source only cycles once.
+    fn clone_from_cell_ref(&self, _cell_ref: std::cell::Ref<'_, StampMode>) -> StampMode {
+        self.cell.get()
+    }
+}
+
+/// Build a [`Stream<StampMode>`] plus a handle that mutates the emitted mode
+/// at runtime. The stream can be passed to any number of [`stamp`] calls; a
+/// single `handle.set(...)` then drives them all on their next tick.
+#[must_use]
+pub fn stamp_mode_control(initial: StampMode) -> (Rc<dyn Stream<StampMode>>, StampModeHandle) {
+    let cell = Rc::new(Cell::new(initial));
+    let stream = StampModeControl {
+        cell: cell.clone(),
+        snapshot: initial,
+    }
+    .into_stream();
+    (stream, StampModeHandle { cell })
+}
+
+// ---------------------------------------------------------------------------
+// Public ergonomics: .stamp::<Stage>(&mode) on Stream<P> where P: HasLatency
+// ---------------------------------------------------------------------------
+
+/// Extension trait adding `.stamp::<Stage>(&mode)` to streams whose values
+/// carry a [`Latency`] record.
 pub trait LatencyStreamOps<P>
 where
     P: Element + HasLatency,
 {
-    /// Wrap this stream in a [`StampStream`] for stage `S`. Each tick writes
-    /// [`GraphState::wall_time`] (cycle-start snap, one `u64` store) into the
-    /// stage's slot before forwarding.
+    /// Wrap this stream in a [`StampStream`] for stage `S`. Each tick peeks
+    /// `mode` and acts per [`StampMode`]. Pass [`constant`](crate::nodes::constant)
+    /// for a fixed mode or [`stamp_mode_control`] for a runtime-toggleable one.
     #[must_use]
-    fn stamp<S>(self: &Rc<Self>) -> Rc<dyn Stream<P>>
-    where
-        S: Stage<P::L> + 'static;
-
-    /// Conditional variant of [`stamp`](Self::stamp). When `enabled` is false,
-    /// returns `self` unchanged — no node is inserted into the graph and
-    /// there is zero runtime cost. Useful for flipping stamping on/off at
-    /// graph-construction time via a config flag.
-    #[must_use]
-    fn stamp_if<S>(self: &Rc<Self>, enabled: bool) -> Rc<dyn Stream<P>>
-    where
-        S: Stage<P::L> + 'static;
-
-    /// Like [`stamp`](Self::stamp) but uses [`GraphState::wall_time_precise`]
-    /// (fresh TSC read, ~5-10ns) for intra-cycle resolution.
-    #[must_use]
-    fn stamp_precise<S>(self: &Rc<Self>) -> Rc<dyn Stream<P>>
-    where
-        S: Stage<P::L> + 'static;
-
-    /// Conditional variant of [`stamp_precise`](Self::stamp_precise).
-    #[must_use]
-    fn stamp_precise_if<S>(self: &Rc<Self>, enabled: bool) -> Rc<dyn Stream<P>>
+    fn stamp<S>(self: &Rc<Self>, mode: &Rc<dyn Stream<StampMode>>) -> Rc<dyn Stream<P>>
     where
         S: Stage<P::L> + 'static;
 }
@@ -346,40 +405,11 @@ impl<P> LatencyStreamOps<P> for dyn Stream<P>
 where
     P: Element + HasLatency + 'static,
 {
-    fn stamp<S>(self: &Rc<Self>) -> Rc<dyn Stream<P>>
+    fn stamp<S>(self: &Rc<Self>, mode: &Rc<dyn Stream<StampMode>>) -> Rc<dyn Stream<P>>
     where
         S: Stage<P::L> + 'static,
     {
-        StampStream::<P, S>::new(self.clone()).into_stream()
-    }
-
-    fn stamp_if<S>(self: &Rc<Self>, enabled: bool) -> Rc<dyn Stream<P>>
-    where
-        S: Stage<P::L> + 'static,
-    {
-        if enabled {
-            self.stamp::<S>()
-        } else {
-            self.clone()
-        }
-    }
-
-    fn stamp_precise<S>(self: &Rc<Self>) -> Rc<dyn Stream<P>>
-    where
-        S: Stage<P::L> + 'static,
-    {
-        StampPreciseStream::<P, S>::new(self.clone()).into_stream()
-    }
-
-    fn stamp_precise_if<S>(self: &Rc<Self>, enabled: bool) -> Rc<dyn Stream<P>>
-    where
-        S: Stage<P::L> + 'static,
-    {
-        if enabled {
-            self.stamp_precise::<S>()
-        } else {
-            self.clone()
-        }
+        StampStream::<P, S>::new(self.clone(), mode.clone()).into_stream()
     }
 }
 
@@ -648,7 +678,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nodes::{CallBackStream, NodeOperators, StreamOperators};
+    use crate::nodes::{CallBackStream, NodeOperators, StreamOperators, constant};
     use crate::queue::ValueAt;
     use std::cell::RefCell;
     use std::mem::{align_of, offset_of, size_of};
@@ -770,10 +800,11 @@ mod tests {
             crate::time::NanoTime::new(250),
         ));
 
+        let mode = constant(StampMode::On);
         let stamped = cb
             .clone()
             .as_stream()
-            .stamp::<trade_latency::strategy>()
+            .stamp::<trade_latency::strategy>(&mode)
             .collect();
 
         stamped
@@ -802,11 +833,13 @@ mod tests {
         // regardless of RunMode.
         use std::time::Duration;
         fn run_one(mode: crate::graph::RunMode) -> crate::time::NanoTime {
+            let on = constant(StampMode::On);
+            let precise = constant(StampMode::OnPrecise);
             let stream = crate::nodes::ticker(Duration::from_millis(1))
                 .count()
                 .map(|seq: u64| Traced::<u64, TradeLatency>::new(seq))
-                .stamp::<trade_latency::ingest>()
-                .stamp_precise::<trade_latency::publish>()
+                .stamp::<trade_latency::ingest>(&on)
+                .stamp::<trade_latency::publish>(&precise)
                 .collect();
             stream.run(mode, crate::graph::RunFor::Cycles(3)).unwrap();
             let values = stream.peek_value();
@@ -846,23 +879,42 @@ mod tests {
     }
 
     #[test]
-    fn stamp_if_disabled_inserts_no_node() {
-        // stamp_if(false) must return the upstream unchanged.
+    fn stamp_off_writes_nothing() {
+        // mode=Off forwards the upstream without writing any stamp.
         let cb = Rc::new(RefCell::new(
             CallBackStream::<Traced<u64, TradeLatency>>::new(),
         ));
-        let upstream = cb.clone().as_stream();
-        let stamped = upstream.stamp_if::<trade_latency::strategy>(false);
-        assert!(
-            Rc::ptr_eq(&upstream, &stamped),
-            "stamp_if(false) should be identity"
-        );
+        cb.borrow_mut().push(ValueAt::new(
+            Traced::new(7u64),
+            crate::time::NanoTime::new(100),
+        ));
+
+        let mode = constant(StampMode::Off);
+        let stamped = cb
+            .clone()
+            .as_stream()
+            .stamp::<trade_latency::strategy>(&mode)
+            .collect();
+
+        stamped
+            .run(
+                crate::graph::RunMode::HistoricalFrom(crate::time::NanoTime::ZERO),
+                crate::graph::RunFor::Forever,
+            )
+            .unwrap();
+
+        let collected = stamped.peek_value();
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].value.payload, 7);
+        // No stage was written.
+        assert_eq!(collected[0].value.latency.strategy, 0);
+        assert_eq!(collected[0].value.latency.ingest, 0);
     }
 
     #[test]
     fn stamp_precise_writes_fresh_timestamps() {
-        // Two stamp_precise wrappers in series should give different stamps
-        // even in the same engine cycle — that is the whole point of _precise.
+        // Two precise stamps in series should give different stamps even in
+        // the same engine cycle — that is the whole point of OnPrecise.
         let cb = Rc::new(RefCell::new(
             CallBackStream::<Traced<u64, TradeLatency>>::new(),
         ));
@@ -871,11 +923,12 @@ mod tests {
             crate::time::NanoTime::new(100),
         ));
 
+        let precise = constant(StampMode::OnPrecise);
         let stamped = cb
             .clone()
             .as_stream()
-            .stamp_precise::<trade_latency::ingest>()
-            .stamp_precise::<trade_latency::publish>()
+            .stamp::<trade_latency::ingest>(&precise)
+            .stamp::<trade_latency::publish>(&precise)
             .collect();
 
         stamped
@@ -890,6 +943,48 @@ mod tests {
         let l = collected[0].value.latency;
         assert!(l.ingest > 0);
         assert!(l.publish >= l.ingest);
+    }
+
+    #[test]
+    fn stamp_mode_handle_flips_at_runtime() {
+        // Driving the same stamp node with a control source: the first
+        // cycle sees Off (no stamp), then we flip to On and the next cycle
+        // writes a real wall-clock value.
+        use crate::nodes::ticker;
+        use std::time::Duration;
+
+        let (mode_stream, handle) = stamp_mode_control(StampMode::Off);
+        let snapshots = Rc::new(RefCell::new(Vec::<TradeLatency>::new()));
+        let snapshots_inner = snapshots.clone();
+        let handle_inner = handle.clone();
+
+        let stream = ticker(Duration::from_millis(1))
+            .count()
+            .map(|seq: u64| Traced::<u64, TradeLatency>::new(seq))
+            .stamp::<trade_latency::ingest>(&mode_stream)
+            .map(move |t: Traced<u64, TradeLatency>| {
+                snapshots_inner.borrow_mut().push(t.latency);
+                // Flip mode once we've captured the first (Off) observation.
+                if snapshots_inner.borrow().len() == 1 {
+                    handle_inner.set(StampMode::On);
+                }
+                t
+            })
+            .collect();
+
+        stream
+            .run(
+                crate::graph::RunMode::HistoricalFrom(crate::time::NanoTime::ZERO),
+                crate::graph::RunFor::Cycles(3),
+            )
+            .unwrap();
+
+        let snaps = snapshots.borrow();
+        assert!(snaps.len() >= 2, "expected at least 2 ticks");
+        // First tick saw Off → no stamp.
+        assert_eq!(snaps[0].ingest, 0);
+        // Subsequent ticks saw On → real wall-clock stamp.
+        assert!(snaps[1].ingest > 0);
     }
 
     // ── LatencyStats / LatencyReport ────────────────────────────────────────
@@ -1012,12 +1107,13 @@ mod tests {
             crate::time::NanoTime::new(50),
         ));
 
+        let mode = constant(StampMode::On);
         let stamped = cb
             .clone()
             .as_stream()
-            .stamp::<trade_latency::ingest>()
-            .stamp::<trade_latency::strategy>()
-            .stamp::<trade_latency::publish>()
+            .stamp::<trade_latency::ingest>(&mode)
+            .stamp::<trade_latency::strategy>(&mode)
+            .stamp::<trade_latency::publish>(&mode)
             .collect();
 
         stamped


### PR DESCRIPTION
## Summary

Consolidates the dual-method stamping API (`stamp` / `stamp_precise` / `stamp_if` / `stamp_precise_if`) into a single unified `.stamp(&mode)` method driven by a `Stream<StampMode>`. This enables runtime toggling of stamping behavior without graph rewiring and simplifies the API surface.

## Key Changes

- **New `StampMode` enum**: Replaces boolean flags with three explicit modes:
  - `Off` — forward upstream unchanged, write nothing
  - `On` — write cycle-start wall-clock snap
  - `OnPrecise` — write fresh TSC read (~5-10 ns)

- **Unified `StampStream<P, S>` node**: Merges `StampStream` and `StampPreciseStream` into a single implementation that peeks a `Stream<StampMode>` on every tick and acts accordingly. Removed the `#[node(active = [upstream])]` attribute to make the mode stream a passive dependency.

- **New `StampModeControl` + `StampModeHandle`**: Provides runtime-mutable mode control:
  - `stamp_mode_control(initial)` returns a `(Stream<StampMode>, StampModeHandle)` pair
  - `handle.set(mode)` flips the mode for all stamp nodes sharing that stream on their next tick
  - Uses `Cell<StampMode>` for cheap interior mutability without graph rewiring

- **Simplified `LatencyStreamOps` trait**: Single `.stamp::<S>(&mode)` method replaces four variants. Callers pass:
  - `constant(StampMode::On)` for fixed modes
  - `stamp_mode_control(...)` for runtime-toggleable modes
  - Any other `Stream<StampMode>` for computed modes

- **Python bindings updated**:
  - New `PyStampMode` enum (Off, On, OnPrecise) with `__eq__` support
  - New `PyStampModeHandle` class for runtime control
  - `.stamp(stage, mode)` method accepts either a `StampMode` or `StampModeHandle`
  - Removed `stamp_if`, `stamp_precise`, `stamp_precise_if` methods

- **Examples and tests updated**: All call sites now use the new unified API with explicit mode selection.

## Implementation Details

- The `StampStream` node now declares the mode stream as a passive upstream via `upstreams()`, ensuring it's available for peeking but doesn't trigger the node independently.
- `StampModeControl` implements `StreamPeekRef<StampMode>` with a custom `clone_from_cell_ref` override to bypass the snapshot field, making external mutations visible immediately.
- The Python binding's `py_stamp_inner` function accepts a `Bound<'_, PyAny>` and extracts either a `PyStampModeHandle` (extracting its inner `Rc<Cell<PyStampMode>>`) or a direct `PyStampMode`, providing flexibility for both static and dynamic modes.

https://claude.ai/code/session_01F1QYdzrL68pj8TfhokJipZ