### PR TITLE
latency_e2e/ec2-spot: sync static/ from S3 so JS-only deploys skip AMI rebake

### DIFF
--- a/.github/workflows/sync-latency-e2e-static.yml
+++ b/.github/workflows/sync-latency-e2e-static.yml
@@ -1,0 +1,117 @@
+# Sync the latency_e2e browser-side static/ tree to the ec2-spot stack's
+# S3 assets bucket. Lets pure-JS changes (index.html, app.js, vendored deps)
+# reach demo.wingfoil.io without rebuilding the ws_server image or rebaking
+# the AMI — the bucket overlays the AMI's baked copy at /opt/wingfoil/static
+# on every spot boot, via user_data.sh.
+#
+# Triggers:
+#   - workflow_dispatch (manual)
+#   - push to main when wingfoil/examples/latency_e2e/static/** changes
+#
+# Deploy flow:
+#   JS push -> this workflow syncs to S3 -> (optionally) cycle the ASG so
+#   a fresh instance boots and pulls the new static. Live instances keep
+#   serving the previous static from the AMI's baked /opt/wingfoil/static
+#   (bind-mounted into ws_server) until they're cycled.
+#
+# Required GitHub secrets:
+#   - AWS_ROLE_TO_ASSUME  IAM role with ssm:GetParameter on
+#                         /wingfoil/latency-e2e/ec2-spot/* and s3:* on the
+#                         static-assets bucket.
+#   - AWS_REGION          (optional, default eu-west-2)
+#
+# Prerequisite: the ec2-spot Pulumi stack has been deployed at least once,
+# so the S3 bucket exists and its name is written to SSM.
+
+name: latency-e2e.sync.static
+
+on:
+  workflow_dispatch:
+    inputs:
+      cycle_asg:
+        description: "Terminate the spot instance after sync so the new static is picked up immediately"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+  push:
+    branches: [main]
+    paths:
+      - "wingfoil/examples/latency_e2e/static/**"
+      - ".github/workflows/sync-latency-e2e-static.yml"
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION || 'eu-west-2' }}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve static-assets bucket from SSM
+        id: bucket
+        run: |
+          BUCKET=$(aws ssm get-parameter \
+            --name /wingfoil/latency-e2e/ec2-spot/static_bucket \
+            --region "$AWS_REGION" \
+            --query 'Parameter.Value' --output text)
+          if [ -z "$BUCKET" ] || [ "$BUCKET" = "None" ]; then
+            echo "::error::SSM parameter /wingfoil/latency-e2e/ec2-spot/static_bucket is empty. Run latency-e2e.deploy (target=ec2-spot) first." >&2
+            exit 1
+          fi
+          echo "bucket=$BUCKET" >> "$GITHUB_OUTPUT"
+
+      - name: aws s3 sync
+        run: |
+          aws s3 sync \
+            wingfoil/examples/latency_e2e/static/ \
+            "s3://${{ steps.bucket.outputs.bucket }}/static/" \
+            --delete --no-progress
+
+      # Optional. Without this the new static is dormant in S3 until the
+      # next spot reclaim (auto) or operator action. With it, the running
+      # instance is terminated and the ASG launches a fresh one whose
+      # user_data syncs from S3 before docker-compose comes up.
+      - name: Cycle ASG to pick up new static (optional)
+        if: github.event_name == 'workflow_dispatch' && inputs.cycle_asg == 'true'
+        run: |
+          # Find the single managed instance via tags (matches the launch
+          # template's TagSpecifications). ASG name isn't required.
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --region "$AWS_REGION" \
+            --filters \
+              "Name=tag:Project,Values=wingfoil-latency-ec2-spot" \
+              "Name=instance-state-name,Values=running,pending" \
+            --query 'Reservations[].Instances[].InstanceId' --output text)
+          if [ -z "$INSTANCE_ID" ]; then
+            echo "::warning::No running ec2-spot instance found; nothing to cycle."
+            exit 0
+          fi
+          echo "Terminating $INSTANCE_ID; ASG will relaunch."
+          aws ec2 terminate-instances \
+            --region "$AWS_REGION" \
+            --instance-ids "$INSTANCE_ID" >/dev/null
+
+      - name: Summary
+        run: |
+          {
+            echo "## Synced static/ -> \`s3://${{ steps.bucket.outputs.bucket }}/static/\`"
+            echo ""
+            if [ "${{ inputs.cycle_asg }}" = "true" ]; then
+              echo "- ASG cycled: new spot instance will pull the new static on boot."
+            else
+              echo "- ASG not cycled: live instance keeps serving the previous static from its AMI-baked copy until the next reclaim, or trigger this workflow again with \`cycle_asg=true\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/__main__.py
@@ -32,6 +32,7 @@ Prerequisites:
 """
 
 import json
+import mimetypes
 from pathlib import Path
 
 import pulumi
@@ -39,6 +40,7 @@ import pulumi_aws as aws
 
 # ── Paths ────────────────────────────────────────────────────────────────
 HERE = Path(__file__).resolve().parent
+EXAMPLE_DIR = HERE.parent.parent  # wingfoil/examples/latency_e2e
 
 # ── Config ───────────────────────────────────────────────────────────────
 config = pulumi.Config()
@@ -282,6 +284,71 @@ if dns_hostname:
         restrict_public_buckets=True,
     )
 
+# ── Static assets bucket ────────────────────────────────────────────────
+# Browser-side `static/` (index.html, app.js, deps) lives in S3 so JS-only
+# changes deploy by `aws s3 sync` + an ASG cycle — no AMI rebake, no image
+# rebuild. The AMI still bakes a baseline copy under /opt/wingfoil/static
+# (packer/install.sh), so a first boot before any S3 sync still serves
+# something; subsequent boots overwrite with whatever's in the bucket.
+
+static_bucket = aws.s3.BucketV2(
+    f"{prefix}-static-assets",
+    force_destroy=True,
+    tags={**tags, "Name": f"{prefix}-static-assets"},
+)
+aws.s3.BucketPublicAccessBlock(
+    f"{prefix}-static-assets-pab",
+    bucket=static_bucket.id,
+    block_public_acls=True,
+    block_public_policy=True,
+    ignore_public_acls=True,
+    restrict_public_buckets=True,
+)
+aws.s3.BucketServerSideEncryptionConfigurationV2(
+    f"{prefix}-static-assets-sse",
+    bucket=static_bucket.id,
+    rules=[aws.s3.BucketServerSideEncryptionConfigurationV2RuleArgs(
+        apply_server_side_encryption_by_default=aws.s3.BucketServerSideEncryptionConfigurationV2RuleApplyServerSideEncryptionByDefaultArgs(
+            sse_algorithm="AES256",
+        ),
+    )],
+)
+
+# Upload one object per file so cloud-init can grab the lot with
+# `aws s3 sync`. Resource names are deterministic on the file path so
+# Pulumi diffs cleanly when a static asset changes. Mirrors baremetal.
+def upload_static_tree(local_dir: Path, key_prefix: str) -> None:
+    if not local_dir.is_dir():
+        return
+    for path in sorted(local_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(local_dir).as_posix()
+        key = f"{key_prefix}/{rel}"
+        resource_name = f"{prefix}-static-{key}".replace("/", "-").replace(".", "-")
+        content_type, _ = mimetypes.guess_type(path.name)
+        aws.s3.BucketObject(
+            resource_name,
+            bucket=static_bucket.id,
+            key=key,
+            source=pulumi.FileAsset(str(path)),
+            content_type=content_type or "application/octet-stream",
+        )
+
+upload_static_tree(EXAMPLE_DIR / "static", "static")
+
+# SSM parameter so `latency-e2e.sync.static` can resolve the bucket name
+# without a Pulumi token — mirrors the `ami_id` parameter pattern used by
+# `latency-e2e.deploy` for the AMI.
+aws.ssm.Parameter(
+    f"{prefix}-static-bucket-ssm",
+    name="/wingfoil/latency-e2e/ec2-spot/static_bucket",
+    type="String",
+    value=static_bucket.bucket,
+    overwrite=True,
+    tags=tags,
+)
+
 # ── Secrets ──────────────────────────────────────────────────────────────
 lmax_username_secret = aws.secretsmanager.Secret(f"{prefix}-lmax-username", tags=tags)
 aws.secretsmanager.SecretVersion(
@@ -313,7 +380,7 @@ instance_role = aws.iam.Role(
 account_id = aws.get_caller_identity().account_id
 
 def _instance_policy(args):
-    user_arn, pw_arn, eip_alloc, bucket_arn = args
+    user_arn, pw_arn, eip_alloc, bucket_arn, static_bucket_arn = args
     statements = [
         {
             "Effect": "Allow",
@@ -367,6 +434,23 @@ def _instance_policy(args):
                 "Resource": [bucket_arn],
             }
         )
+    # Static assets bucket — read-only. user_data syncs s3://<bucket>/static/
+    # to /opt/wingfoil/static on every boot so JS-only changes ride along
+    # without an AMI rebake.
+    statements.append(
+        {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject"],
+            "Resource": [f"{static_bucket_arn}/*"],
+        }
+    )
+    statements.append(
+        {
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": [static_bucket_arn],
+        }
+    )
     return json.dumps({"Version": "2012-10-17", "Statement": statements})
 
 
@@ -375,6 +459,7 @@ _policy_inputs = [
     lmax_password_secret.arn,
     eip.allocation_id,
     cert_bucket.arn if cert_bucket is not None else pulumi.Output.from_input(None),
+    static_bucket.arn,
 ]
 aws.iam.RolePolicy(
     f"{prefix}-instance-policy",
@@ -410,7 +495,7 @@ user_data_template = (HERE / "user_data.sh").read_text()
 
 
 def render_user_data(args):
-    eip_alloc, user_arn, pw_arn, cert_bucket_name = args
+    eip_alloc, user_arn, pw_arn, cert_bucket_name, static_bucket_name = args
     rendered = (
         user_data_template
         .replace("__EIP_ALLOCATION_ID__",     eip_alloc)
@@ -419,6 +504,7 @@ def render_user_data(args):
         .replace("__AWS_REGION__",            aws_region)
         .replace("__DNS_HOSTNAME__",          dns_hostname or "")
         .replace("__CERT_BUCKET__",           cert_bucket_name or "")
+        .replace("__STATIC_BUCKET__",         static_bucket_name)
     )
     # gzip before base64 — cloud-init auto-detects and decompresses gzip
     # user_data, and EC2's 16 KiB user_data limit applies to the raw
@@ -435,6 +521,7 @@ user_data_b64 = pulumi.Output.all(
     lmax_username_secret.arn,
     lmax_password_secret.arn,
     cert_bucket.bucket if cert_bucket is not None else pulumi.Output.from_input(None),
+    static_bucket.bucket,
 ).apply(render_user_data)
 
 launch_template = aws.ec2.LaunchTemplate(
@@ -524,3 +611,4 @@ pulumi.export("asg_name",       asg.name)
 pulumi.export("availability_zones", [s.availability_zone for s in subnets])
 if cert_bucket is not None:
     pulumi.export("cert_bucket", cert_bucket.bucket)
+pulumi.export("static_bucket", static_bucket.bucket)

--- a/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
+++ b/wingfoil/examples/latency_e2e/pulumi/ec2-spot/user_data.sh
@@ -24,6 +24,11 @@ AWS_REGION="__AWS_REGION__"
 # Pulumi config, in which case we keep the self-signed-cert path below.
 DNS_HOSTNAME="__DNS_HOSTNAME__"
 CERT_BUCKET="__CERT_BUCKET__"
+# S3 bucket holding the latest browser-side static/ assets. The AMI bakes a
+# baseline copy under /opt/wingfoil/static (packer/install.sh), and this
+# sync overlays whatever's newer in S3 — so JS-only deploys push to the
+# bucket and cycle the ASG, no AMI rebake.
+STATIC_BUCKET="__STATIC_BUCKET__"
 
 # IMDSv2 — fetch our instance ID for the EIP association call.
 IMDS_TOKEN=$(curl -fsSL -X PUT \
@@ -327,6 +332,22 @@ chmod 0600 /opt/wingfoil/.env
 # pre-#298 AMI fails fast here with a clear message instead of as an opaque
 # OCI runtime error during `compose up`.
 #
+# Refresh /opt/wingfoil/static from S3 if the bucket name was templated in
+# (post-#345 stacks). Best-effort: a failed sync is non-fatal, the AMI's
+# baked copy of /opt/wingfoil/static stays in place and the bind-mount
+# check below still passes against it. `--delete` so files removed from the
+# source tree disappear here too. Older AMIs that don't bind-mount
+# /opt/wingfoil/static will simply ignore the refresh.
+if [ -n "${STATIC_BUCKET}" ] && [ -d /opt/wingfoil/static ]; then
+  if aws s3 sync "s3://${STATIC_BUCKET}/static/" /opt/wingfoil/static/ \
+      --region "${AWS_REGION}" --delete --no-progress; then
+    chown -R root:root /opt/wingfoil/static
+    chmod -R u+rwX,go+rX /opt/wingfoil/static
+  else
+    echo "WARN: s3 sync of static/ from ${STATIC_BUCKET} failed; using AMI-baked copy." >&2
+  fi
+fi
+
 # The static/ bind mount was only added in #324, so its source path
 # (/opt/wingfoil/static) is checked conditionally — gated on whether the
 # baked compose.yml actually references it. An older AMI (pre-#324) whose


### PR DESCRIPTION
Browser-side static/ now lives in a per-stack S3 bucket (mirrors the
baremetal pattern). user_data syncs s3://<bucket>/static/ to
/opt/wingfoil/static on every spot boot, layering on top of the AMI's
baked baseline. The AMI's static stays as a fallback so a first boot
before the bucket is populated still serves something.

Pulumi: new static-assets BucketV2 + PAB + SSE, one BucketObject per
file under static/, instance role gains s3:GetObject/ListBucket on it,
bucket name written to /wingfoil/latency-e2e/ec2-spot/static_bucket
in SSM so workflows can resolve it without a Pulumi token.

New workflow `latency-e2e.sync.static` triggers on push-to-main affecting
static/** (and on manual dispatch), reads the bucket from SSM, runs
`aws s3 sync --delete`, and optionally terminates the spot instance so
the ASG relaunches with the new static. Cycle time: ~3 min end-to-end
vs ~15 min for image rebuild + AMI rebake.

Fargate is unaffected — it still bakes static into the image (no host
filesystem to bind-mount over).