### PR TITLE
Rename iceoryx2-beta feature flag to iceoryx2

### DIFF
--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           python -m venv wingfoil-python/.venv
           wingfoil-python/.venv/bin/pip install maturin pytest
-          cd wingfoil-python && .venv/bin/maturin develop --features iceoryx2-beta
+          cd wingfoil-python && .venv/bin/maturin develop --features iceoryx2
 
       - name: Run Python iceoryx2 integration tests
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           cd wingfoil-python
-          .venv/bin/maturin develop --features iceoryx2-beta
+          .venv/bin/maturin develop --features iceoryx2
           .venv/bin/pytest tests/ \
             --cov=wingfoil \
             --cov-report=lcov:lcov-python.info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ cargo bench
 
 # Lint (these aliases live in .cargo/config.toml and mirror CI exactly)
 cargo lint        # default features
-cargo lint-all    # all features — catches code behind `fix`, `csv`, `iceoryx2-beta`, etc.
+cargo lint-all    # all features — catches code behind `fix`, `csv`, `iceoryx2`, etc.
 cargo fmt --all -- --check
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ cargo lint-all                 # clippy, all features  ← most-missed step
 cargo test -p wingfoil --features full
 ```
 
-`cargo lint-all` is the step that most often surfaces issues that pass locally but fail in CI — it exercises code behind feature flags (`fix`, `csv`, `iceoryx2-beta`, `kdb`, etc.) that the default build skips. Please run it before pushing.
+`cargo lint-all` is the step that most often surfaces issues that pass locally but fail in CI — it exercises code behind feature flags (`fix`, `csv`, `iceoryx2`, `kdb`, etc.) that the default build skips. Please run it before pushing.
 
 
 

--- a/wingfoil-derive/src/lib.rs
+++ b/wingfoil-derive/src/lib.rs
@@ -335,9 +335,9 @@ pub fn latency_stages(item: TokenStream) -> TokenStream {
 
         // SAFETY: `#[repr(C)]` packed `u64` fields are self-contained and
         // have a uniform memory representation, satisfying `ZeroCopySend`'s
-        // invariants. Only emitted when the `iceoryx2-beta` feature is on
+        // invariants. Only emitted when the `iceoryx2` feature is on
         // in the consuming crate.
-        #[cfg(feature = "iceoryx2-beta")]
+        #[cfg(feature = "iceoryx2")]
         unsafe impl ::iceoryx2::prelude::ZeroCopySend for #name {
             #zero_copy_send_body
         }

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 [features]
 default = ["etcd"]
 etcd = ["wingfoil/etcd"]
-iceoryx2-beta = ["wingfoil/iceoryx2-beta"]
+iceoryx2 = ["wingfoil/iceoryx2"]
 
 [dependencies]
 

--- a/wingfoil-python/README.md
+++ b/wingfoil-python/README.md
@@ -475,7 +475,7 @@ For multi-host deployments where `127.0.0.1` isn't routable, use
 ### iceoryx2 (shared memory)
 
 Zero-copy pub/sub over shared memory. Requires building wingfoil with the
-`iceoryx2-beta` feature (opt-in; see [Build from Source](#-build-from-source)).
+`iceoryx2` feature (opt-in; see [Build from Source](#-build-from-source)).
 
 ```python
 from wingfoil import ticker, iceoryx2_sub, Iceoryx2ServiceVariant, Iceoryx2Mode, Graph
@@ -602,14 +602,14 @@ from wingfoil import ticker
 ## 🛠️ Build from Source
 
 Most users should `pip install wingfoil`. To build locally (e.g. to enable the
-`iceoryx2-beta` feature or develop against the bindings), see
+`iceoryx2` feature or develop against the bindings), see
 [`build.md`](https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil-python/build.md).
 
 ```bash
 git clone https://github.com/wingfoil-io/wingfoil
 cd wingfoil/wingfoil-python
 pip install maturin
-maturin develop                               # or: maturin develop --features iceoryx2-beta
+maturin develop                               # or: maturin develop --features iceoryx2
 pytest
 ```
 

--- a/wingfoil-python/build.md
+++ b/wingfoil-python/build.md
@@ -22,7 +22,7 @@ uv sync --extra dev --locked
 uv run maturin develop --release
 
 # build with the optional iceoryx2 bindings enabled
-uv run maturin develop --release --features iceoryx2-beta
+uv run maturin develop --release --features iceoryx2
 
 # run tests
 uv run pytest

--- a/wingfoil-python/examples/latency.py
+++ b/wingfoil-python/examples/latency.py
@@ -8,7 +8,7 @@ Demonstrates:
   - Printing per-stage delta stats with .latency_report()
 
 Run:
-  cd wingfoil-python && maturin develop --features iceoryx2-beta && python examples/latency.py
+  cd wingfoil-python && maturin develop --features iceoryx2 && python examples/latency.py
 """
 
 from wingfoil import ticker, Latency, TracedBytes, Graph

--- a/wingfoil-python/pyproject.toml
+++ b/wingfoil-python/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dev = ["maturin>=1.4,<2.0", "pytest>=7", "pyzmq>=25"]
 
 [tool.maturin]
-# Keep `iceoryx2-beta` opt-in for Python builds. Enabling it by default can
+# Keep `iceoryx2` opt-in for Python builds. Enabling it by default can
 # make wheels Linux/POSIX-only due to iceoryx2 dependencies.
 features = ["pyo3/extension-module"]
 python-source = "python"
@@ -48,7 +48,7 @@ markers = [
     "requires_etcd: needs etcd on localhost:2379",
     "requires_kdb: needs KDB+ on localhost:5000",
     "requires_otel: needs an OTel collector on localhost:4318",
-    "requires_iceoryx2: needs wingfoil built with --features iceoryx2-beta",
+    "requires_iceoryx2: needs wingfoil built with --features iceoryx2",
     "requires_web: needs a wingfoil web server (runs in-process)",
     "requires_kafka: needs a Kafka-compatible broker on localhost:9092",
 ]

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -5,7 +5,7 @@ mod py_element;
 mod py_etcd;
 mod py_fix;
 mod py_fluvio;
-#[cfg(feature = "iceoryx2-beta")]
+#[cfg(feature = "iceoryx2")]
 mod py_iceoryx2;
 mod py_kafka;
 mod py_kdb;
@@ -196,7 +196,7 @@ fn _wingfoil(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(py_kdb::py_kdb_read, module)?)?;
     module.add_function(wrap_pyfunction!(py_kdb::py_kdb_write, module)?)?;
     module.add_function(wrap_pyfunction!(py_zmq::py_zmq_sub, module)?)?;
-    #[cfg(feature = "iceoryx2-beta")]
+    #[cfg(feature = "iceoryx2")]
     module.add_function(wrap_pyfunction!(py_iceoryx2::py_iceoryx2_sub, module)?)?;
     #[cfg(feature = "etcd")]
     module.add_function(wrap_pyfunction!(py_zmq::py_zmq_sub_etcd, module)?)?;
@@ -206,9 +206,9 @@ fn _wingfoil(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyNode>()?;
     module.add_class::<PyStream>()?;
     module.add_class::<PyGraph>()?;
-    #[cfg(feature = "iceoryx2-beta")]
+    #[cfg(feature = "iceoryx2")]
     module.add_class::<py_iceoryx2::PyIceoryx2ServiceVariant>()?;
-    #[cfg(feature = "iceoryx2-beta")]
+    #[cfg(feature = "iceoryx2")]
     module.add_class::<py_iceoryx2::PyIceoryx2Mode>()?;
     module.add_class::<py_prometheus::PyPrometheusExporter>()?;
     module.add_class::<py_latency::PyLatency>()?;

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -539,7 +539,7 @@ impl PyStream {
     ///
     /// Returns:
     ///     A Node that drives the publish operation.
-    #[cfg(feature = "iceoryx2-beta")]
+    #[cfg(feature = "iceoryx2")]
     #[pyo3(signature = (service_name, variant=crate::py_iceoryx2::PyIceoryx2ServiceVariant::Ipc, history_size=5, initial_max_slice_len=128*1024, stages=None))]
     fn iceoryx2_pub(
         &self,

--- a/wingfoil-python/src/types.rs
+++ b/wingfoil-python/src/types.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 
 use ::wingfoil::{NanoTime, RunFor, RunMode};
 
-#[cfg(feature = "iceoryx2-beta")]
+#[cfg(feature = "iceoryx2")]
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
@@ -15,14 +15,14 @@ pub trait ToPyResult<T> {
     fn to_pyresult(self) -> PyResult<T>;
 }
 
-#[cfg(feature = "iceoryx2-beta")]
+#[cfg(feature = "iceoryx2")]
 #[derive(Debug, thiserror::Error)]
 pub enum PyBindingError {
     #[error("{0}")]
     TypeError(String),
 }
 
-#[cfg(feature = "iceoryx2-beta")]
+#[cfg(feature = "iceoryx2")]
 pub fn py_type_error(msg: impl Into<String>) -> anyhow::Error {
     anyhow!(PyBindingError::TypeError(msg.into()))
 }
@@ -30,7 +30,7 @@ pub fn py_type_error(msg: impl Into<String>) -> anyhow::Error {
 impl<T> ToPyResult<T> for anyhow::Result<T> {
     fn to_pyresult(self) -> PyResult<T> {
         self.map_err(|e| {
-            #[cfg(feature = "iceoryx2-beta")]
+            #[cfg(feature = "iceoryx2")]
             if let Some(PyBindingError::TypeError(msg)) = e.downcast_ref::<PyBindingError>() {
                 return PyTypeError::new_err(msg.clone());
             }

--- a/wingfoil-python/tests/test_iceoryx2.py
+++ b/wingfoil-python/tests/test_iceoryx2.py
@@ -1,7 +1,7 @@
 """iceoryx2 integration tests.
 
 Selected via `-m requires_iceoryx2`. These tests require wingfoil-python to
-be built with `--features iceoryx2-beta`; if the bindings are absent, the
+be built with `--features iceoryx2`; if the bindings are absent, the
 `wf.iceoryx2_sub` / `wf.Iceoryx2Mode` references below fail loudly on the
 first access rather than silently skipping the module.
 """

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -1,6 +1,6 @@
 [features]
 default = ["async"]
-full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2-beta", "prometheus", "otlp", "fix", "web", "web-tls", "kafka"]
+full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2", "prometheus", "otlp", "fix", "web", "web-tls", "kafka"]
 dynamic-graph-beta = []
 kdb-integration-test = ["kdb"]
 async = ["dep:tokio", "dep:futures", "dep:async-stream", "dep:futures-util", "tokio/time"]
@@ -25,8 +25,8 @@ instrument-default = ["instrument-run", "instrument-cycle", "instrument-apply-no
 instrument-all = ["instrument-default", "instrument-cycle-node"]
 fluvio = ["dep:fluvio", "async"]
 fluvio-integration-test = ["fluvio", "dep:testcontainers", "dep:fluvio-controlplane-metadata"]
-iceoryx2-integration-test = ["iceoryx2-beta", "dep:testcontainers"]
-iceoryx2-beta = ["dep:iceoryx2"]
+iceoryx2-integration-test = ["iceoryx2", "dep:testcontainers"]
+iceoryx2 = ["dep:iceoryx2"]
 prometheus = ["dep:arc-swap"]
 prometheus-integration-test = ["prometheus", "dep:reqwest"]
 otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "async"]
@@ -219,12 +219,12 @@ required-features = ["async"]
 [[bench]]
 name = "iceoryx2"
 harness = false
-required-features = ["iceoryx2-beta"]
+required-features = ["iceoryx2"]
 
 [[bench]]
 name = "iceoryx2_modes"
 harness = false
-required-features = ["iceoryx2-beta"]
+required-features = ["iceoryx2"]
 
 [[example]]
 name = "prometheus"
@@ -239,22 +239,22 @@ required-features = ["otlp", "prometheus"]
 [[example]]
 name = "iceoryx2_pub"
 path = "examples/iceoryx2/pub.rs"
-required-features = ["iceoryx2-beta"]
+required-features = ["iceoryx2"]
 
 [[example]]
 name = "iceoryx2_sub"
 path = "examples/iceoryx2/sub.rs"
-required-features = ["iceoryx2-beta"]
+required-features = ["iceoryx2"]
 
 [[example]]
 name = "latency_pub"
 path = "examples/latency/pub.rs"
-required-features = ["iceoryx2-beta"]
+required-features = ["iceoryx2"]
 
 [[example]]
 name = "latency_sub"
 path = "examples/latency/sub.rs"
-required-features = ["iceoryx2-beta"]
+required-features = ["iceoryx2"]
 
 [[example]]
 name = "tracing"
@@ -328,9 +328,9 @@ required-features = ["kafka"]
 [[example]]
 name = "latency_e2e_ws_server"
 path = "examples/latency_e2e/ws_server.rs"
-required-features = ["web-tls", "iceoryx2-beta", "prometheus", "otlp"]
+required-features = ["web-tls", "iceoryx2", "prometheus", "otlp"]
 
 [[example]]
 name = "latency_e2e_fix_gw"
 path = "examples/latency_e2e/fix_gw.rs"
-required-features = ["fix", "iceoryx2-beta"]
+required-features = ["fix", "iceoryx2"]

--- a/wingfoil/benches/iceoryx2.rs
+++ b/wingfoil/benches/iceoryx2.rs
@@ -1,6 +1,6 @@
 //! Benchmark for iceoryx2 adapter - Burst operations
 //!
-//! Run with: cargo bench --features iceoryx2-beta -- iceoryx2
+//! Run with: cargo bench --features iceoryx2 -- iceoryx2
 
 use criterion::{Criterion, criterion_group, criterion_main};
 

--- a/wingfoil/benches/iceoryx2_modes.rs
+++ b/wingfoil/benches/iceoryx2_modes.rs
@@ -1,6 +1,6 @@
 //! Benchmarks for iceoryx2 adapter modes (Spin vs Threaded vs Signaled)
 //!
-//! Run with: cargo bench --features iceoryx2-beta -- iceoryx2_modes
+//! Run with: cargo bench --features iceoryx2 -- iceoryx2_modes
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/wingfoil/examples/iceoryx2/README.md
+++ b/wingfoil/examples/iceoryx2/README.md
@@ -21,9 +21,9 @@ The wingfoil adapter supports three subscriber polling modes, selected via `Iceo
 The subscriber example lets you try all three:
 
 ```bash
-cargo run --example iceoryx2_sub --features iceoryx2-beta -- spin
-cargo run --example iceoryx2_sub --features iceoryx2-beta -- threaded
-cargo run --example iceoryx2_sub --features iceoryx2-beta -- signaled
+cargo run --example iceoryx2_sub --features iceoryx2 -- spin
+cargo run --example iceoryx2_sub --features iceoryx2 -- threaded
+cargo run --example iceoryx2_sub --features iceoryx2 -- signaled
 ```
 
 ## Service Variants
@@ -39,10 +39,10 @@ Start the publisher in one terminal, then the subscriber in another:
 
 ```bash
 # Terminal 1: publisher
-RUST_LOG=info cargo run --example iceoryx2_pub --features iceoryx2-beta
+RUST_LOG=info cargo run --example iceoryx2_pub --features iceoryx2
 
 # Terminal 2: subscriber (pick a mode)
-RUST_LOG=info cargo run --example iceoryx2_sub --features iceoryx2-beta -- spin
+RUST_LOG=info cargo run --example iceoryx2_sub --features iceoryx2 -- spin
 ```
 
 ## Publisher

--- a/wingfoil/examples/iceoryx2/pub.rs
+++ b/wingfoil/examples/iceoryx2/pub.rs
@@ -1,4 +1,3 @@
-// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2` feature flag.
 // Run with: RUST_LOG=info cargo run --example iceoryx2_pub --features iceoryx2
 //
 // This publishes a simple counter over iceoryx2 shared memory.

--- a/wingfoil/examples/iceoryx2/pub.rs
+++ b/wingfoil/examples/iceoryx2/pub.rs
@@ -1,5 +1,5 @@
-// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2-beta` feature flag.
-// Run with: RUST_LOG=info cargo run --example iceoryx2_pub --features iceoryx2-beta
+// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2` feature flag.
+// Run with: RUST_LOG=info cargo run --example iceoryx2_pub --features iceoryx2
 //
 // This publishes a simple counter over iceoryx2 shared memory.
 // Start the subscriber first (`iceoryx2_sub`), then run this publisher.

--- a/wingfoil/examples/iceoryx2/sub.rs
+++ b/wingfoil/examples/iceoryx2/sub.rs
@@ -1,5 +1,3 @@
-// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2` feature flag.
-//
 // Subscribes to the counter published by `iceoryx2_pub` and demonstrates all
 // three polling modes.  Pass the mode as a CLI argument:
 //

--- a/wingfoil/examples/iceoryx2/sub.rs
+++ b/wingfoil/examples/iceoryx2/sub.rs
@@ -1,11 +1,11 @@
-// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2-beta` feature flag.
+// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2` feature flag.
 //
 // Subscribes to the counter published by `iceoryx2_pub` and demonstrates all
 // three polling modes.  Pass the mode as a CLI argument:
 //
-//   cargo run --example iceoryx2_sub --features iceoryx2-beta -- spin
-//   cargo run --example iceoryx2_sub --features iceoryx2-beta -- threaded
-//   cargo run --example iceoryx2_sub --features iceoryx2-beta -- signaled
+//   cargo run --example iceoryx2_sub --features iceoryx2 -- spin
+//   cargo run --example iceoryx2_sub --features iceoryx2 -- threaded
+//   cargo run --example iceoryx2_sub --features iceoryx2 -- signaled
 //
 // Defaults to `spin` if no argument is given.
 //

--- a/wingfoil/examples/latency/README.md
+++ b/wingfoil/examples/latency/README.md
@@ -44,10 +44,10 @@ publisher:
 
 ```bash
 # Terminal 1: subscriber
-cargo run --example latency_sub --features iceoryx2-beta
+cargo run --example latency_sub --features iceoryx2
 
 # Terminal 2: publisher
-cargo run --example latency_pub --features iceoryx2-beta
+cargo run --example latency_pub --features iceoryx2
 ```
 
 Stop both with Ctrl-C. The subscriber prints a report like:

--- a/wingfoil/examples/latency/pub.rs
+++ b/wingfoil/examples/latency/pub.rs
@@ -10,8 +10,6 @@
 //
 // Then in another terminal:
 //   cargo run --example latency_sub --features iceoryx2
-//
-// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2` feature flag.
 
 #[path = "shared.rs"]
 mod shared;

--- a/wingfoil/examples/latency/pub.rs
+++ b/wingfoil/examples/latency/pub.rs
@@ -6,12 +6,12 @@
 // statistics on shutdown.
 //
 // Run with:
-//   cargo run --example latency_pub --features iceoryx2-beta
+//   cargo run --example latency_pub --features iceoryx2
 //
 // Then in another terminal:
-//   cargo run --example latency_sub --features iceoryx2-beta
+//   cargo run --example latency_sub --features iceoryx2
 //
-// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2-beta` feature flag.
+// NOTE: iceoryx2 support is beta. Enable with the `iceoryx2` feature flag.
 
 #[path = "shared.rs"]
 mod shared;

--- a/wingfoil/examples/latency/sub.rs
+++ b/wingfoil/examples/latency/sub.rs
@@ -6,7 +6,7 @@
 // shutdown.
 //
 // Run with:
-//   cargo run --example latency_sub --features iceoryx2-beta
+//   cargo run --example latency_sub --features iceoryx2
 
 #[path = "shared.rs"]
 mod shared;

--- a/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
+++ b/wingfoil/examples/latency_e2e/Dockerfile.fix_gw
@@ -16,7 +16,7 @@ COPY . .
 RUN cargo build --release \
     -p wingfoil \
     --example latency_e2e_fix_gw \
-    --features "fix,iceoryx2-beta"
+    --features "fix,iceoryx2"
 
 # Runtime stage — bookworm-slim matches the builder's glibc (2.36); pairing
 # it with ubuntu:22.04 (glibc 2.35) risks a runtime ABI break.

--- a/wingfoil/examples/latency_e2e/Dockerfile.ws_server
+++ b/wingfoil/examples/latency_e2e/Dockerfile.ws_server
@@ -16,7 +16,7 @@ COPY . .
 RUN cargo build --release \
     -p wingfoil \
     --example latency_e2e_ws_server \
-    --features "web-tls,iceoryx2-beta,prometheus,otlp"
+    --features "web-tls,iceoryx2,prometheus,otlp"
 
 # Runtime stage — bookworm-slim matches the builder's glibc (2.36); pairing
 # it with ubuntu:22.04 (glibc 2.35) risks a runtime ABI break.

--- a/wingfoil/examples/latency_e2e/README.md
+++ b/wingfoil/examples/latency_e2e/README.md
@@ -54,13 +54,13 @@ export LMAX_PASSWORD=...
 
 # Terminal 1
 cargo run --release --example latency_e2e_fix_gw \
-  --features "fix,iceoryx2-beta"
+  --features "fix,iceoryx2"
 
 # Terminal 2 — local dev: plain HTTP (skip --tls-cert/--tls-key).
 # For HTTPS / WSS, pass --tls-cert / --tls-key (or set
 # WINGFOIL_TLS_CERT / WINGFOIL_TLS_KEY); the cargo feature is the same.
 cargo run --release --example latency_e2e_ws_server \
-  --features "web-tls,iceoryx2-beta,prometheus,otlp" -- --addr 0.0.0.0:8080
+  --features "web-tls,iceoryx2,prometheus,otlp" -- --addr 0.0.0.0:8080
 
 # Terminal 3 (operator stack — Prometheus + Tempo + Grafana, auto-provisioned)
 docker compose -f wingfoil/examples/latency_e2e/docker-compose.yml up -d

--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -19,7 +19,7 @@
 // Run:
 //   LMAX_USERNAME=xxx LMAX_PASSWORD=yyy \
 //     cargo run --release --example latency_e2e_fix_gw \
-//     --features "fix,iceoryx2-beta" -- [--no-precise]
+//     --features "fix,iceoryx2" -- [--no-precise]
 //
 // Without LMAX_USERNAME / LMAX_PASSWORD the binary refuses to start —
 // real order routing requires real creds. (We deliberately removed the

--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/README.md
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/README.md
@@ -67,9 +67,9 @@ pulumi config set ingress_cidr 203.0.113.4/32
 ```bash
 # 1. Build release binaries (Pulumi reads them from target/release/examples)
 cargo build --release -p wingfoil --example latency_e2e_ws_server \
-    --features "web-tls,iceoryx2-beta,prometheus,otlp"
+    --features "web-tls,iceoryx2,prometheus,otlp"
 cargo build --release -p wingfoil --example latency_e2e_fix_gw \
-    --features "fix,iceoryx2-beta"
+    --features "fix,iceoryx2"
 
 # 2. Bring the stack up — uploads binaries to S3, provisions infra
 pulumi up

--- a/wingfoil/examples/latency_e2e/pulumi/baremetal/__main__.py
+++ b/wingfoil/examples/latency_e2e/pulumi/baremetal/__main__.py
@@ -27,9 +27,9 @@ isolated cores.
 Prerequisites:
 
   cargo build --release -p wingfoil --example latency_e2e_ws_server \\
-      --features "web-tls,iceoryx2-beta,prometheus,otlp"
+      --features "web-tls,iceoryx2,prometheus,otlp"
   cargo build --release -p wingfoil --example latency_e2e_fix_gw \\
-      --features "fix,iceoryx2-beta"
+      --features "fix,iceoryx2"
   pulumi config set --secret lmax_username <...>
   pulumi config set --secret lmax_password <...>
 """
@@ -54,8 +54,8 @@ WS_SERVER_BIN = TARGET_RELEASE / "latency_e2e_ws_server"
 FIX_GW_BIN = TARGET_RELEASE / "latency_e2e_fix_gw"
 
 for path, hint in [
-    (WS_SERVER_BIN, "cargo build --release -p wingfoil --example latency_e2e_ws_server --features 'web,iceoryx2-beta,prometheus,otlp'"),
-    (FIX_GW_BIN, "cargo build --release -p wingfoil --example latency_e2e_fix_gw --features 'fix,iceoryx2-beta'"),
+    (WS_SERVER_BIN, "cargo build --release -p wingfoil --example latency_e2e_ws_server --features 'web,iceoryx2,prometheus,otlp'"),
+    (FIX_GW_BIN, "cargo build --release -p wingfoil --example latency_e2e_fix_gw --features 'fix,iceoryx2'"),
 ]:
     if not path.exists():
         raise pulumi.RunError(

--- a/wingfoil/examples/latency_e2e/ws_server.rs
+++ b/wingfoil/examples/latency_e2e/ws_server.rs
@@ -12,7 +12,7 @@
 //
 // Run (after starting fix_gw):
 //   cargo run --example latency_e2e_ws_server \
-//     --features "web-tls,iceoryx2-beta,prometheus,otlp" -- \
+//     --features "web-tls,iceoryx2,prometheus,otlp" -- \
 //     --addr 0.0.0.0:8080 [--no-precise] \
 //     [--tls-cert /etc/wingfoil/tls/cert.pem --tls-key /etc/wingfoil/tls/key.pem]
 //

--- a/wingfoil/src/adapters/iceoryx2/CLAUDE.md
+++ b/wingfoil/src/adapters/iceoryx2/CLAUDE.md
@@ -42,12 +42,11 @@ A `#[repr(C)]` fixed-size byte buffer implementing `ZeroCopySend`. Bridges the g
 ```bash
 cargo fmt --all
 cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings
-cargo test -p wingfoil --features iceoryx2-beta
+cargo test -p wingfoil --features iceoryx2
 cargo test -p wingfoil --features iceoryx2-integration-test -- --test-threads=1
 ```
 
 ## Gotchas
 
-- Feature flag is `iceoryx2-beta` (not `iceoryx2`) because the iceoryx2 crate is pre-1.0.
 - Shared memory paths on Linux live under `/dev/shm/`; stale files from crashed processes may need manual cleanup.
 - Service names must be non-empty and follow iceoryx2's naming rules — invalid names fail fast in `start()`.

--- a/wingfoil/src/adapters/iceoryx2/integration_tests.rs
+++ b/wingfoil/src/adapters/iceoryx2/integration_tests.rs
@@ -8,7 +8,7 @@
 //! - The `iceoryx2-integration-test` feature flag.
 //!
 //! In-process `Local`-variant tests live in `local_tests.rs` and run as part
-//! of the standard `cargo test --features iceoryx2-beta` suite.
+//! of the standard `cargo test --features iceoryx2` suite.
 //!
 //! Run locally with:
 //! ```sh

--- a/wingfoil/src/adapters/iceoryx2/local_tests.rs
+++ b/wingfoil/src/adapters/iceoryx2/local_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These exercise the `Local` service variant end-to-end — no shared memory,
 //! no subprocesses. They run as part of the standard
-//! `cargo test -p wingfoil --features iceoryx2-beta` suite.
+//! `cargo test -p wingfoil --features iceoryx2` suite.
 //!
 //! The cross-process IPC tests live in `integration_tests.rs` and are gated by
 //! the `iceoryx2-integration-test` feature.

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -11,7 +11,7 @@ pub mod etcd;
 pub mod fix;
 #[cfg(feature = "fluvio")]
 pub mod fluvio;
-#[cfg(feature = "iceoryx2-beta")]
+#[cfg(feature = "iceoryx2")]
 #[doc(hidden)]
 pub mod iceoryx2;
 #[cfg(feature = "kafka")]

--- a/wingfoil/src/latency.rs
+++ b/wingfoil/src/latency.rs
@@ -185,7 +185,7 @@ impl<T, L: Latency> HasLatency for Traced<T, L> {
 // the paths differ and iceoryx2 reports `IncompatibleTypes` even though the
 // memory layouts are identical. We compose the name from `T::type_name()` and
 // `L::type_name()` so leaf overrides via `#[type_name(...)]` propagate up.
-#[cfg(feature = "iceoryx2-beta")]
+#[cfg(feature = "iceoryx2")]
 unsafe impl<T, L> iceoryx2::prelude::ZeroCopySend for Traced<T, L>
 where
     T: iceoryx2::prelude::ZeroCopySend,
@@ -196,7 +196,7 @@ where
     }
 }
 
-#[cfg(feature = "iceoryx2-beta")]
+#[cfg(feature = "iceoryx2")]
 fn traced_type_name(t: &'static str, l: &'static str) -> &'static str {
     use std::collections::HashMap;
     use std::sync::{Mutex, OnceLock};
@@ -1043,7 +1043,7 @@ mod tests {
     // modules can still match an iceoryx2 service. This test pins the
     // composed-name format and confirms the macro's `#[type_name(...)]`
     // attribute is honoured.
-    #[cfg(feature = "iceoryx2-beta")]
+    #[cfg(feature = "iceoryx2")]
     mod type_name_propagation {
         use super::*;
         use iceoryx2::prelude::ZeroCopySend;


### PR DESCRIPTION
Drops the "beta" qualifier from the feature flag name across Cargo
manifests, CI workflows, examples, benches, and documentation.

https://claude.ai/code/session_01RDXuZW6husE4iNLVDY4c7f