### PR TITLE
ci(rust-test): make codecov upload non-blocking, forward secrets

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -8,10 +8,12 @@ jobs:
   rust-test:
     name: Rust
     uses: ./.github/workflows/rust-test.yml
+    secrets: inherit
 
   python-test:
     name: Python
     uses: ./.github/workflows/python-test.yml
+    secrets: inherit
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -71,11 +71,12 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
+        continue-on-error: true
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          
+          fail_ci_if_error: false
+
       - name: Run rustfmt
         run: |
           cargo fmt --all -- --check


### PR DESCRIPTION
Two issues caused the Rust job in the release workflow to fail at the
codecov upload step:

1. all-tests.yml forwarded secrets to the integration-tests reusable
   workflow but not to rust-test / python-test, so CODECOV_TOKEN was
   unavailable when those reusable workflows ran via the release
   pipeline.
2. rust-test.yml set fail_ci_if_error: true with no continue-on-error,
   so a missing token (or any codecov outage) killed the whole job and
   blocked the release. Python coverage already used the
   continue-on-error / fail_ci_if_error: false pattern.

Forward secrets from all-tests.yml and align the rust codecov step with
the python convention so coverage-reporter outages can never gate
releases.