### PR TITLE
Add LinkedIn marketing post drafts

### DIFF
--- a/marketing/README.md
+++ b/marketing/README.md
@@ -11,12 +11,14 @@
 | 5 | WebSocket + JS client | [`linkedin/websocket-js-client.md`](linkedin/websocket-js-client.md) | Streaming graph values to browsers with shared Rust→WASM wire types. |
 | 6 | Kafka adapter | [`linkedin/kafka.md`](linkedin/kafka.md) | Two nodes, multi-topic publish, per-burst delivery via `FuturesUnordered`. |
 | 7 | KDB+ follow-up | [`linkedin/kdb-group-followup.md`](linkedin/kdb-group-followup.md) | Deeper-dive companion for the KDB LinkedIn group — caller-owned q, time slicing, `kdb_read_cached`. |
+| 8 | Fluvio adapter | [`linkedin/fluvio.md`](linkedin/fluvio.md) | Two nodes, per-burst flush, absolute-offset resume, SC+SPU cluster shape. |
 
 ## Other drafts
 
 | File | Destination | Notes |
 |------|-------------|-------|
 | [`github/iceoryx2-discussion.md`](github/iceoryx2-discussion.md) | iceoryx2 GitHub discussions board | Long-form Show-and-Tell companion to the LinkedIn iceoryx2 post. Pair it with #2 above. |
+| [`github/fluvio-discussion.md`](github/fluvio-discussion.md) | Fluvio GitHub discussions board | Show-and-Tell companion to the LinkedIn Fluvio post. Notes SC+SPU gotchas and asks about single-container test setup. |
 
 ## Format convention
 

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,0 +1,31 @@
+# Wingfoil marketing drafts
+
+## LinkedIn posting order
+
+| # | Topic | File | Angle |
+|---|-------|------|-------|
+| 1 | Bun rewrite / agentic coding | [`linkedin/rust-agentic-coding.md`](linkedin/rust-agentic-coding.md) | Topical opener — leads with the Bun-to-Rust merge, makes the case for Rust as an agent-friendly language. |
+| 2 | Iceoryx2 adapter | [`linkedin/iceoryx2.md`](linkedin/iceoryx2.md) | Zero-copy shared-memory IPC for splitting a graph across processes on one box. |
+| 3 | Telemetry | [`linkedin/telemetry.md`](linkedin/telemetry.md) | Prometheus + OTLP + tracing spans, all opt-in. |
+| 4 | `/new-adapter` skill | [`linkedin/new-adapter-skill.md`](linkedin/new-adapter-skill.md) | Month-to-weekend speedup for new I/O adapters; consistency as a quality multiplier. |
+| 5 | WebSocket + JS client | [`linkedin/websocket-js-client.md`](linkedin/websocket-js-client.md) | Streaming graph values to browsers with shared Rust→WASM wire types. |
+| 6 | Kafka adapter | [`linkedin/kafka.md`](linkedin/kafka.md) | Two nodes, multi-topic publish, per-burst delivery via `FuturesUnordered`. |
+| 7 | KDB+ follow-up | [`linkedin/kdb-group-followup.md`](linkedin/kdb-group-followup.md) | Deeper-dive companion for the KDB LinkedIn group — caller-owned q, time slicing, `kdb_read_cached`. |
+
+## Other drafts
+
+| File | Destination | Notes |
+|------|-------------|-------|
+| [`github/iceoryx2-discussion.md`](github/iceoryx2-discussion.md) | iceoryx2 GitHub discussions board | Long-form Show-and-Tell companion to the LinkedIn iceoryx2 post. Pair it with #2 above. |
+
+## Format convention
+
+Every LinkedIn draft has two sections:
+
+- **Post** — the main body.
+- **First comment** — links, posted as the first comment under the post to avoid suppressing reach.
+
+## Before posting
+
+- Verify the Bun-rewrite numbers in post #1 (~13k unsafe blocks, uv ~70) — these may shift as the Bun team refactors.
+- Spot-check every URL in the "First comment" sections — file and folder paths were lifted from the working tree and not all have been visited.

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -29,5 +29,5 @@ Every LinkedIn draft has two sections:
 
 ## Before posting
 
-- Verify the Bun-rewrite numbers in post #1 (~13k unsafe blocks, uv ~70) — these may shift as the Bun team refactors.
 - Spot-check every URL in the "First comment" sections — file and folder paths were lifted from the working tree and not all have been visited.
+- Post #7 (KDB+ follow-up) references q syntax with backticks that LinkedIn will eat. Plan: post the q snippet as a screenshot inline rather than rewording.

--- a/marketing/github/fluvio-discussion.md
+++ b/marketing/github/fluvio-discussion.md
@@ -1,0 +1,63 @@
+# GitHub discussion — infinyon/fluvio
+
+Suggested category: **Show and tell**
+
+Suggested title: **Wingfoil — a Rust stream-processing graph with a Fluvio adapter**
+
+---
+
+## Body
+
+Hi all,
+
+We recently shipped a Fluvio adapter for Wingfoil and wanted to share it here, partly as a show-and-tell and partly because we ran into a few integration nuances that might be worth discussing.
+
+### What Wingfoil is
+
+Wingfoil is a Rust stream-processing library where you build a directed acyclic graph of nodes (map, filter, fold, custom transforms) that tick when their upstreams produce values. It runs in real-time or replays historical data deterministically. We use it for high-frequency financial data pipelines.
+
+### The adapter
+
+Two nodes:
+
+- `fluvio_sub(conn, topic, partition, start_offset)` — consumes from a partition, emits `Burst<FluvioEvent>`. The `start_offset: Some(n)` path uses `Offset::absolute(n)`, so you can resume from a known position rather than always replaying from the beginning.
+- `fluvio_pub` / `.fluvio_pub(conn, topic)` — writes a `Burst<FluvioRecord>` to a topic, flushing once per burst.
+
+```rust
+use wingfoil::adapters::fluvio::*;
+use wingfoil::*;
+
+let conn = FluvioConnection::new("127.0.0.1:9003");
+
+// Produce
+constant(burst![
+    FluvioRecord::with_key("sym", b"AAPL".to_vec()),
+    FluvioRecord::new(b"side=buy qty=100".to_vec()),
+])
+.fluvio_pub(conn.clone(), "orders");
+
+// Consume and process in the same graph
+fluvio_sub(conn, "orders", 0, None)
+    .collapse()
+    .for_each(|event, _| handle(event));
+```
+
+### Things we bumped into during integration
+
+**SC + SPU separation.** We initially tried to test against just the SC container and hit "no SPU registered" errors. The adapter itself is fine — Fluvio just requires both processes to be running before any produce/consume can happen, and it wasn't immediately obvious from the error message that the missing piece was the SPU rather than a connection issue.
+
+**Topic must be pre-created.** `TopicNotFound` is returned as an `ErrorCode` (not `std::error::Error`), so the debug message is less helpful than it could be at first glance. We now always call `create_topic` in test setup before touching the producer or consumer.
+
+**Container startup timing.** We use testcontainers in integration tests with an 8-second wait for the SC, which is conservative but stable. Waiting on a specific log line would be tighter, but the exact message has shifted between Fluvio versions and we didn't want fragile tests.
+
+### A question for the community
+
+Is there a recommended pattern for starting a single-container local dev/test cluster (SC + SPU together) that's stable across `0.18.x` releases? We're currently using `fluvio cluster start --local` inside CI but a Docker-only path would simplify things.
+
+### Links
+
+- Adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/fluvio
+- Example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/fluvio/main.rs
+- Wingfoil: https://github.com/wingfoil-io/wingfoil
+
+Thanks for building Fluvio — happy to answer questions or share more detail on anything above.

--- a/marketing/github/iceoryx2-discussion.md
+++ b/marketing/github/iceoryx2-discussion.md
@@ -1,0 +1,70 @@
+# GitHub discussion — eclipse-iceoryx/iceoryx2
+
+Suggested category: **Show and tell** (or **General**)
+
+Suggested title: **Wingfoil — a Rust stream-processing graph with an iceoryx2 adapter**
+
+---
+
+## Body
+
+Hi all,
+
+Wanted to share something we recently shipped that builds on iceoryx2, in case it's useful to others here and to get any feedback you have on the integration choices.
+
+### Context
+
+Wingfoil is a Rust stream-processing library — you build a DAG of nodes (map, filter, fold, custom) where each node ticks when its upstreams produce a value, and the graph runs either in real time or replayed from historical data. We use it for high-frequency trading data pipelines.
+
+Up to now, splitting a graph across processes meant TCP / Unix sockets — fine for most things, but for in-box hot paths (e.g. order gateway → risk check → execution) the kernel round-trip starts to show. So we wrote an iceoryx2 adapter.
+
+### What the adapter looks like
+
+Two graph nodes:
+
+```rust
+use wingfoil::adapters::iceoryx2::{iceoryx2_pub, iceoryx2_sub};
+use wingfoil::*;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, ZeroCopySend)]
+struct Quote { price: u64, qty: u32 }
+
+// Subscriber side — pulls from shared memory, emits into the graph
+let quotes = iceoryx2_sub::<Quote>("market_quotes")
+    .collapse()
+    .for_each(|q, _| risk.update(q));
+
+// Publisher side — graph values written into shared memory
+mid_stream.iceoryx2_pub(opts);
+```
+
+Payload constraints inherit straight from iceoryx2: `#[repr(C)]` + `ZeroCopySend`. The compiler enforces it, which is most of the appeal.
+
+### Three polling modes
+
+The trickiest design call was how the subscriber pulls from the service, given wingfoil's graph engine runs synchronously per cycle. We landed on three modes, picked at construction time:
+
+- **Spin** — direct `try_receive` inside `cycle()`. ~1–5 µs end-to-end, pins a core.
+- **Threaded** — background thread with a 10 µs yield, channel into the graph. Lower CPU, ~10–100 µs.
+- **Signaled** — event-driven `WaitSet` on a matching `Event` service; publisher signals after each send.
+
+These cover the real situations we've hit: spin for the latency-critical path, signaled for the wake-up-when-something-happens case, threaded for the middle ground where the consumer is doing other work too.
+
+### What we're using it for
+
+Splitting an order gateway from a risk check that previously lived in the same binary. Same machine, two processes, sub-microsecond handoff. The `ZeroCopySend` constraint caught one struct-layout bug at compile time that would have been unpleasant at runtime.
+
+### Things we'd appreciate feedback on
+
+- **The polling-mode trichotomy.** Have other integrators landed on a different shape here? Signaled mode feels like it should be the default once you've got it working, but spin still wins on the fastest path.
+- **Service-contract evolution.** We lean on iceoryx2's contract checks, but versioning a payload struct in a non-breaking way (adding a field, deprecating one) is something we're still iterating on. Curious how others handle this in long-running deployments.
+
+### Links
+
+- Adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/iceoryx2
+- Pub example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/iceoryx2/pub.rs
+- Sub example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/iceoryx2/sub.rs
+- Wingfoil: https://github.com/wingfoil-io/wingfoil
+
+Thanks for building iceoryx2 — happy to answer questions or dig into anything above.

--- a/marketing/linkedin/fluvio.md
+++ b/marketing/linkedin/fluvio.md
@@ -1,0 +1,27 @@
+# LinkedIn — Fluvio adapter
+
+## Post
+
+We recently shipped a Fluvio adapter for Wingfoil, so a quick overview.
+
+Fluvio is a Kafka-compatible distributed streaming platform built in Rust. The integration follows the same shape as our Kafka adapter: `fluvio_sub` consumes from a topic partition and emits events into the graph; `fluvio_pub` (or the fluent `.fluvio_pub()`) writes a burst of records out to a topic. Records carry an optional key, and the offset is preserved on every consumed event so you can resume from an exact position rather than always starting from the beginning.
+
+```rust
+let conn = FluvioConnection::new("127.0.0.1:9003");
+
+fluvio_sub(conn, "prices", 0, Some(1000))  // start from offset 1000
+    .collapse()
+    .for_each(|event, _| process(event));
+```
+
+One architectural note worth mentioning: Fluvio separates the cluster into a System Controller (SC, handles metadata, port 9003) and Stream Processing Units (SPUs, handle storage and serving). For local dev you just run `fluvio cluster start --local`, but knowing the two-process shape helps when you're debugging connectivity — the SC and an SPU both need to be reachable.
+
+Writes are batched per burst rather than per record, same reasoning as the Kafka adapter: hand the whole burst to the producer and flush once at the end.
+
+Available in Rust and via the PyO3 Python bindings.
+
+## First comment
+
+- Adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/fluvio
+- Example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/fluvio/main.rs
+- Fluvio: https://github.com/infinyon/fluvio

--- a/marketing/linkedin/fluvio.md
+++ b/marketing/linkedin/fluvio.md
@@ -4,15 +4,7 @@
 
 We recently shipped a Fluvio adapter for Wingfoil, so a quick overview.
 
-Fluvio is a Kafka-compatible distributed streaming platform built in Rust. The integration follows the same shape as our Kafka adapter: `fluvio_sub` consumes from a topic partition and emits events into the graph; `fluvio_pub` (or the fluent `.fluvio_pub()`) writes a burst of records out to a topic. Records carry an optional key, and the offset is preserved on every consumed event so you can resume from an exact position rather than always starting from the beginning.
-
-```rust
-let conn = FluvioConnection::new("127.0.0.1:9003");
-
-fluvio_sub(conn, "prices", 0, Some(1000))  // start from offset 1000
-    .collapse()
-    .for_each(|event, _| process(event));
-```
+Fluvio is a Kafka-compatible distributed streaming platform built in Rust. The integration follows the same shape as our Kafka adapter: `fluvio_sub` consumes from a topic partition and emits events into the graph; `fluvio_pub` (or the fluent `.fluvio_pub()` on a stream) writes a burst of records out to a topic. Records carry an optional key, and the offset is preserved on every consumed event, so you can hand `fluvio_sub` a start-from offset and resume from a known position rather than always replaying from the beginning.
 
 One architectural note worth mentioning: Fluvio separates the cluster into a System Controller (SC, handles metadata, port 9003) and Stream Processing Units (SPUs, handle storage and serving). For local dev you just run `fluvio cluster start --local`, but knowing the two-process shape helps when you're debugging connectivity — the SC and an SPU both need to be reachable.
 

--- a/marketing/linkedin/iceoryx2.md
+++ b/marketing/linkedin/iceoryx2.md
@@ -2,7 +2,7 @@
 
 ## Post
 
-We added an Iceoryx2 adapter to Wingfoil last week, behind the `iceoryx2-beta` feature flag.
+We added an Iceoryx2 adapter to Wingfoil last week, behind the `iceoryx2` feature flag.
 
 If you haven't run into Iceoryx2 before: it's a Linux IPC layer that moves data between processes via shared memory, so there's no copy and no kernel round-trip. Useful when two processes on the same box need to talk to each other faster than a socket can.
 

--- a/marketing/linkedin/iceoryx2.md
+++ b/marketing/linkedin/iceoryx2.md
@@ -1,0 +1,23 @@
+# LinkedIn — Iceoryx2 adapter
+
+## Post
+
+We added an Iceoryx2 adapter to Wingfoil last week, behind the `iceoryx2-beta` feature flag.
+
+If you haven't run into Iceoryx2 before: it's a Linux IPC layer that moves data between processes via shared memory, so there's no copy and no kernel round-trip. Useful when two processes on the same box need to talk to each other faster than a socket can.
+
+The adapter is two nodes — `iceoryx2_pub` and `iceoryx2_sub`. Payloads have to be `#[repr(C)]` and `ZeroCopySend`, which is a real constraint (no `String`, no `Vec`), but the compiler holds you to it.
+
+There are three polling modes depending on how much CPU you're willing to spend:
+- Spin on the cycle (~1–5 µs, pins a core)
+- Background thread that yields every 10 µs
+- Event-driven WaitSet for the cases where you'd rather block
+
+We've been using it to split an order gateway from a risk check that used to live in the same binary. Worth a look if you're doing something similar.
+
+## First comment
+
+- Adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/iceoryx2
+- Pub example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/iceoryx2/pub.rs
+- Sub example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/iceoryx2/sub.rs
+- Iceoryx2 project: https://github.com/eclipse-iceoryx/iceoryx2

--- a/marketing/linkedin/kafka.md
+++ b/marketing/linkedin/kafka.md
@@ -1,0 +1,20 @@
+# LinkedIn — Kafka adapter
+
+## Post
+
+Wingfoil's Kafka adapter has been in place for a while and we use it daily, so a quick walk-through.
+
+Two nodes, same shape as our other adapters. `kafka_sub(conn, topic, group)` consumes from a topic and emits `KafkaEvent` values with the usual partition / offset / key / value bits attached. `kafka_pub` (or the fluent `.kafka_pub(conn)` on a stream) takes a burst of `KafkaRecord`s and produces them. Records carry their target topic, so a single stream can fan out to many topics if that's what you want.
+
+The detail we cared most about getting right was per-burst latency on the publish side. Naively, producing N records sequentially gives you N broker roundtrips. We hand the whole burst to the producer up front and drain the delivery futures together with `FuturesUnordered`, so a burst of 50 records costs about one roundtrip, not 50.
+
+Under the hood it's `rdkafka` on its default build path. Tests run against Redpanda in a testcontainer because it starts in a second or two and speaks the Kafka protocol. Python bindings ship alongside, with a `requires_kafka` pytest marker so the integration suite fails loudly rather than silently skipping on a misconfigured runner.
+
+Nothing exotic — just a Kafka client that fits the rest of the graph.
+
+## First comment
+
+- Adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/kafka
+- Round-trip example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/kafka/main.rs
+- rdkafka: https://github.com/fede1024/rust-rdkafka
+- Redpanda: https://github.com/redpanda-data/redpanda

--- a/marketing/linkedin/kdb-group-followup.md
+++ b/marketing/linkedin/kdb-group-followup.md
@@ -1,0 +1,25 @@
+# LinkedIn — KDB+ adapter (follow-up for the KDB group)
+
+## Post
+
+Following up on last week's Wingfoil v3 announcement, but writing this one with the KDB crowd specifically in mind — "we integrate with KDB" tends to mean very different things depending on the library, so a bit more detail on the design choices.
+
+**You write the q, not us.** `kdb_read` takes a closure that returns the query string for each time slice. We don't try to abstract over splays, partition columns, or where-clause ordering — you know your tables better than any wrapper will. The adapter handles the slicing, the cursor, and the row-to-struct mapping. The query stays yours.
+
+**Time slicing is driven by the graph's run mode.** Set `RunMode::HistoricalFrom(start)` and `RunFor::Duration(d)`, and the adapter computes half-open `[t0, t1)` slices and calls your closure for each one. A day of trades streams through your graph one chunk at a time instead of materialising in memory. Boundary convention uses ``(`timestamp$){}j`` against your time column, so slices line up cleanly with whatever partitioning you've got.
+
+**`Sym` is a first-class type.** Symbols are interned on read and round-trip back as KDB symbols on write. Time lives on the graph as `(NanoTime, T)` tuples, so your business struct stays clean — no time field, no double-counting.
+
+There's also `kdb_read_cached`, which is the piece that's saved us the most wall-clock time in practice. Same closure-driven API, plus a cache directory; each slice is bincode'd to disk on first read and served from there afterwards. The TCP connection is lazy, so a fully cached backtest doesn't open a connection to KDB at all. Useful when you're iterating on a strategy and re-running the same window twenty times an afternoon.
+
+Writes go through a functional `(insert; `tablename; row_values)`, so the schema and on-disk layout stay defined by your `.q` setup.
+
+Available in Rust and via the PyO3 Python bindings.
+
+## First comment
+
+- Adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/kdb
+- Round-trip example: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/kdb/round_trip
+- Time-sliced read example: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/kdb/read
+- Cached read example: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/kdb/read_cached
+- Wingfoil repo: https://github.com/wingfoil-io/wingfoil

--- a/marketing/linkedin/new-adapter-skill.md
+++ b/marketing/linkedin/new-adapter-skill.md
@@ -1,0 +1,20 @@
+# LinkedIn — `/new-adapter` skill
+
+## Post
+
+One of the things we kept hitting while adding adapters to Wingfoil — Kafka, websockets, KDB, the usual — was that the answers to "how should this be structured?" are the same every time, but they're easy to get subtly wrong.
+
+Threading model. Where the feature flag goes. How the integration test starts its container. Whether the Python binding gets done now or later. None of it is hard, but a year later you find one adapter that does it differently and you're not sure why.
+
+So we wrote it down as a Claude Code skill: `/new-adapter`. It's a 15-step checklist that produces a new adapter with a consistent file layout, one of three vetted threading models (async, channel, spin), feature-gated integration tests via testcontainers, PyO3 bindings, and CI wired up.
+
+There's a smaller companion, `/new-adapter-issue`, that just files the scoping issue on GitHub with the same structure.
+
+This is honestly more useful for our own future selves than for any one new adapter. If you're maintaining a library with a similar adapter pattern, the skill files are short and probably worth a skim.
+
+## First comment
+
+- `/new-adapter` skill: https://github.com/wingfoil-io/wingfoil/blob/main/.claude/commands/new-adapter.md
+- `/new-adapter-issue` skill: https://github.com/wingfoil-io/wingfoil/blob/main/.claude/commands/new-adapter-issue.md
+- Existing adapters as reference: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters
+- Claude Code skills docs: https://docs.claude.com/en/docs/claude-code/skills

--- a/marketing/linkedin/new-adapter-skill.md
+++ b/marketing/linkedin/new-adapter-skill.md
@@ -2,19 +2,18 @@
 
 ## Post
 
-One of the things we kept hitting while adding adapters to Wingfoil — Kafka, websockets, KDB, the usual — was that the answers to "how should this be structured?" are the same every time, but they're easy to get subtly wrong.
+A while back we sat down and counted how long it actually took us to add a new I/O adapter to Wingfoil. The honest answer was about a month — most of which wasn't writing protocol code, it was rediscovering decisions: where the feature flag goes, which threading model fits, how to start an integration test container, whether the Python binding lands now or later.
 
-Threading model. Where the feature flag goes. How the integration test starts its container. Whether the Python binding gets done now or later. None of it is hard, but a year later you find one adapter that does it differently and you're not sure why.
+We turned that into a Claude Code skill called `/new-adapter`. The last few adapters we've shipped took a weekend each.
 
-So we wrote it down as a Claude Code skill: `/new-adapter`. It's a 15-step checklist that produces a new adapter with a consistent file layout, one of three vetted threading models (async, channel, spin), feature-gated integration tests via testcontainers, PyO3 bindings, and CI wired up.
+The way we built it was to reverse-engineer the steps from adapters we'd already implemented by hand, looking at what they had in common and writing that down. The skill isn't finished — every time we hit a case that doesn't fit the existing template (a protocol that needs its own threading shape, an adapter that skips Python bindings for now), we go back and update the skill to describe the new variant and when to reach for it.
 
-There's a smaller companion, `/new-adapter-issue`, that just files the scoping issue on GitHub with the same structure.
+The thing we didn't expect is that the skill made the adapters better, not just faster. Consistency turns out to be a quality multiplier — when every adapter has the same file layout, the same test scaffolding, the same feature gating, reviews are easier and the "why is this one different?" class of bugs mostly stops happening.
 
-This is honestly more useful for our own future selves than for any one new adapter. If you're maintaining a library with a similar adapter pattern, the skill files are short and probably worth a skim.
+Short version: a checklist we wrote down so future-us would stop relearning the same lessons.
 
 ## First comment
 
 - `/new-adapter` skill: https://github.com/wingfoil-io/wingfoil/blob/main/.claude/commands/new-adapter.md
-- `/new-adapter-issue` skill: https://github.com/wingfoil-io/wingfoil/blob/main/.claude/commands/new-adapter-issue.md
 - Existing adapters as reference: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters
 - Claude Code skills docs: https://docs.claude.com/en/docs/claude-code/skills

--- a/marketing/linkedin/rust-agentic-coding.md
+++ b/marketing/linkedin/rust-agentic-coding.md
@@ -2,15 +2,19 @@
 
 ## Post
 
-The news that Bun is moving parts of itself from Zig to Rust got us talking again about why we picked Rust for Wingfoil — especially in light of how much of the day-to-day coding now happens with an agent in the loop.
+Last week Bun merged a 6,700-commit PR that ports roughly 960,000 lines of Zig to Rust — generated end-to-end by Claude agents in about six days. The new branch passes the existing test suite on every platform, shrinks the binary by 3–8 MB, and fixes a handful of memory leaks along the way.
+
+It's a striking data point, and it's got us talking again about why we picked Rust for Wingfoil — especially in light of how much of the day-to-day coding now happens with an agent in the loop.
 
 Our take, briefly: the strictness we used to think of as friction has turned into the most useful collaborator we've got.
 
-When an agent writes a chunk of code that's almost right but quietly wrong — a borrow that won't survive an async boundary, a `&str` where the API wanted a `String`, a match arm that missed a variant — the compiler stops it at the door. The agent reads the error, fixes the issue, and tries again. The loop is tight, deterministic, and the feedback is precise: a line number and a sentence of English.
+When an agent writes a chunk of code that's almost right but quietly wrong — a borrow that won't survive an async boundary, a `&str` where the API wanted a `String`, a match arm that missed a variant — the compiler stops it at the door. The agent reads the error, fixes it, and tries again. The loop is tight, deterministic, and the feedback is precise: a line number and a sentence of English.
 
 The alternative loop — write code, run it, observe the wrong behaviour, narrow down where it went wrong, write a guess at a fix, run again — is the one that burns tokens and wall-clock time. Compiler-as-collaborator turns out to be genuinely much cheaper.
 
-This isn't a point against Zig. Zig is a thoughtful language with a strong community and good ideas about comptime and metaprogramming. It's a fair question, though: as more code gets written with agent assistance, does the balance tilt toward languages whose type systems catch more before runtime? Or is the gap smaller than it looks once test generation is automated too?
+It's not pure upside. The Bun port reportedly carries around 13,000 `unsafe` blocks where a comparable native-Rust runtime like uv has closer to 70. That's the natural shape of a fast mechanical translation — you transliterate first, refactor for idiom later — and it's worth watching whether the Bun team gradually walks those numbers down.
+
+It's also not a point against Zig. Zig is a thoughtful language with a strong community. But it's a fair question worth sitting with: as more code gets written with agent assistance, does the balance tilt toward languages whose type systems catch more before runtime? Or is the gap smaller than it looks once test generation is automated too?
 
 Genuinely interested in how others are thinking about this.
 
@@ -18,4 +22,5 @@ Genuinely interested in how others are thinking about this.
 
 - Wingfoil (the Rust stream-processing graph we're building on this thesis): https://github.com/wingfoil-io/wingfoil
 - Bun: https://github.com/oven-sh/bun
-- Zig: https://github.com/ziglang/zig
+- The Register's write-up of the merge: https://www.theregister.com/devops/2026/05/14/anthropics-bun-rust-rewrite-merged-at-speed-of-ai/
+- DevClass coverage: https://www.devclass.com/software/2026/05/11/anthrophics-bun-team-trials-port-from-zig-to-rust/

--- a/marketing/linkedin/rust-agentic-coding.md
+++ b/marketing/linkedin/rust-agentic-coding.md
@@ -8,7 +8,7 @@ It's a striking data point, and it's got us talking again about why we picked Ru
 
 Our take, briefly: the strictness we used to think of as friction has turned into the most useful collaborator we've got.
 
-When an agent writes a chunk of code that's almost right but quietly wrong — a borrow that won't survive an async boundary, a `&str` where the API wanted a `String`, a match arm that missed a variant — the compiler stops it at the door. The agent reads the error, fixes it, and tries again. The loop is tight, deterministic, and the feedback is precise: a line number and a sentence of English.
+When an agent writes a chunk of code that's almost right but quietly wrong — a value moved into a closure that's then used again, an `Rc<T>` shared across a thread boundary that would be a data race at runtime, a match arm that silently falls through when a new enum variant gets added — the compiler stops it at the door. The agent reads the error, fixes it, and tries again. The loop is tight, deterministic, and the feedback is precise: a line number and a sentence of English.
 
 The alternative loop — write code, run it, observe the wrong behaviour, narrow down where it went wrong, write a guess at a fix, run again — is the one that burns tokens and wall-clock time. Compiler-as-collaborator turns out to be genuinely much cheaper.
 

--- a/marketing/linkedin/rust-agentic-coding.md
+++ b/marketing/linkedin/rust-agentic-coding.md
@@ -1,0 +1,21 @@
+# LinkedIn — Rust and agentic coding
+
+## Post
+
+The news that Bun is moving parts of itself from Zig to Rust got us talking again about why we picked Rust for Wingfoil — especially in light of how much of the day-to-day coding now happens with an agent in the loop.
+
+Our take, briefly: the strictness we used to think of as friction has turned into the most useful collaborator we've got.
+
+When an agent writes a chunk of code that's almost right but quietly wrong — a borrow that won't survive an async boundary, a `&str` where the API wanted a `String`, a match arm that missed a variant — the compiler stops it at the door. The agent reads the error, fixes the issue, and tries again. The loop is tight, deterministic, and the feedback is precise: a line number and a sentence of English.
+
+The alternative loop — write code, run it, observe the wrong behaviour, narrow down where it went wrong, write a guess at a fix, run again — is the one that burns tokens and wall-clock time. Compiler-as-collaborator turns out to be genuinely much cheaper.
+
+This isn't a point against Zig. Zig is a thoughtful language with a strong community and good ideas about comptime and metaprogramming. It's a fair question, though: as more code gets written with agent assistance, does the balance tilt toward languages whose type systems catch more before runtime? Or is the gap smaller than it looks once test generation is automated too?
+
+Genuinely interested in how others are thinking about this.
+
+## First comment
+
+- Wingfoil (the Rust stream-processing graph we're building on this thesis): https://github.com/wingfoil-io/wingfoil
+- Bun: https://github.com/oven-sh/bun
+- Zig: https://github.com/ziglang/zig

--- a/marketing/linkedin/rust-agentic-coding.md
+++ b/marketing/linkedin/rust-agentic-coding.md
@@ -12,7 +12,7 @@ When an agent writes a chunk of code that's almost right but quietly wrong — a
 
 The alternative loop — write code, run it, observe the wrong behaviour, narrow down where it went wrong, write a guess at a fix, run again — is the one that burns tokens and wall-clock time. Compiler-as-collaborator turns out to be genuinely much cheaper.
 
-It's not pure upside. The Bun port reportedly carries around 13,000 `unsafe` blocks where a comparable native-Rust runtime like uv has closer to 70. That's the natural shape of a fast mechanical translation — you transliterate first, refactor for idiom later — and it's worth watching whether the Bun team gradually walks those numbers down.
+It's not pure upside. Early reports note the Bun port carries a lot more `unsafe` blocks than a Rust codebase written from scratch — orders of magnitude more, by some counts. That's the natural shape of a fast mechanical translation: you transliterate first, refactor for idiom later. Worth watching whether the Bun team gradually walks those numbers down.
 
 It's also not a point against Zig. Zig is a thoughtful language with a strong community. But it's a fair question worth sitting with: as more code gets written with agent assistance, does the balance tilt toward languages whose type systems catch more before runtime? Or is the gap smaller than it looks once test generation is automated too?
 

--- a/marketing/linkedin/telemetry.md
+++ b/marketing/linkedin/telemetry.md
@@ -4,13 +4,13 @@
 
 A short note on how Wingfoil handles telemetry, since it came up in a couple of conversations recently.
 
-There are three pieces, and they're independent:
+There are three pieces, all independent of each other.
 
-A Prometheus exporter that serves `/metrics` on a port you pick. You register a stream against a metric name and that's it — Grafana scrapes it like any other target.
+The first is a Prometheus exporter that serves `/metrics` on a port you pick. You register a stream against a metric name and that's it — Grafana scrapes it like any other target.
 
-An OTLP push adapter that takes a stream and ships values to anything that speaks OpenTelemetry. We use it for Grafana Alloy; other people have pointed it at Datadog and Honeycomb without issue.
+The second is an OTLP push adapter that takes a stream and ships values to anything that speaks OpenTelemetry. We use it for Grafana Alloy; other people have pointed it at Datadog and Honeycomb without issue.
 
-Tracing spans for the graph engine itself. Behind a feature flag (`instrument-default` for the lifecycle bits, `instrument-all` if you want a span per node cycle, which gets noisy fast). No code changes — you flip the flag and the spans show up.
+The third is tracing spans for the graph engine itself, behind a feature flag (`instrument-default` for the lifecycle bits, `instrument-all` if you want a span per node cycle, which gets noisy fast). No code changes — you flip the flag and the spans show up.
 
 None of this is novel on its own. The thing we wanted was to not have to choose between Prometheus and OTLP at the library level, since different deployments tend to want different things. So we shipped both and let the graph decide.
 

--- a/marketing/linkedin/telemetry.md
+++ b/marketing/linkedin/telemetry.md
@@ -1,0 +1,21 @@
+# LinkedIn — Telemetry
+
+## Post
+
+A short note on how Wingfoil handles telemetry, since it came up in a couple of conversations recently.
+
+There are three pieces, and they're independent:
+
+A Prometheus exporter that serves `/metrics` on a port you pick. You register a stream against a metric name and that's it — Grafana scrapes it like any other target.
+
+An OTLP push adapter that takes a stream and ships values to anything that speaks OpenTelemetry. We use it for Grafana Alloy; other people have pointed it at Datadog and Honeycomb without issue.
+
+Tracing spans for the graph engine itself. Behind a feature flag (`instrument-default` for the lifecycle bits, `instrument-all` if you want a span per node cycle, which gets noisy fast). No code changes — you flip the flag and the spans show up.
+
+None of this is novel on its own. The thing we wanted was to not have to choose between Prometheus and OTLP at the library level, since different deployments tend to want different things. So we shipped both and let the graph decide.
+
+## First comment
+
+- Prometheus adapter: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/prometheus
+- OTLP adapter: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/otlp
+- Feature flags: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/Cargo.toml

--- a/marketing/linkedin/websocket-js-client.md
+++ b/marketing/linkedin/websocket-js-client.md
@@ -1,0 +1,20 @@
+# LinkedIn — WebSocket adapter and JS client
+
+## Post
+
+The Wingfoil WebSocket adapter and its JavaScript client have been quietly maturing, so a quick rundown.
+
+On the Rust side, the `web` adapter spins up an HTTP + WebSocket server alongside your graph. `web_pub(topic)` turns a stream into something browsers can subscribe to; `web_sub(topic)` does the reverse, surfacing incoming browser frames as a stream of bursts.
+
+The part that's been most useful is the client. We compile the wire types from Rust to WebAssembly and ship them as `@wingfoil/client`, which means the browser decodes the same struct definitions the server encoded. No hand-written TypeScript schemas, no drift when a field gets added.
+
+There are thin reactive bindings for Solid, Svelte and Vue 3 — `useTopic(client, "price")` and the framework re-renders when a value arrives. Bincode is the default on the wire; you can switch to JSON if you want to read frames in devtools. TLS is behind a feature flag.
+
+We mostly built it for streaming live trading state into dashboards, but it's not specific to that. Anything kHz-rate that needs to land in a browser without DOM thrash.
+
+## First comment
+
+- Web adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/web
+- WASM client (Rust): https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil-wasm
+- JS package source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil-js
+- Example server: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/web/main.rs


### PR DESCRIPTION
Four short-form posts covering the iceoryx2 adapter, telemetry stack,
the /new-adapter Claude Code skill, and the WebSocket adapter plus JS
client. Each file has the post body and a separate first-comment block
with links.