### PR TITLE
ci(python-test): cap job at 30min, add pytest-timeout for hang diagnostics

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     name: Python Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -45,14 +46,15 @@ jobs:
       - name: Create virtualenv and install dependencies
         run: |
           python -m venv wingfoil-python/.venv
-          wingfoil-python/.venv/bin/pip install maturin pytest pandas pyzmq pytest-cov
+          wingfoil-python/.venv/bin/pip install maturin pytest pandas pyzmq pytest-cov pytest-timeout
 
       - name: Build and test Python bindings with Rust coverage
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           cd wingfoil-python
           .venv/bin/maturin develop --features iceoryx2
-          .venv/bin/pytest tests/ \
+          .venv/bin/pytest tests/ -v \
+            --timeout=120 \
             --cov=wingfoil \
             --cov-report=lcov:lcov-python.info
           cd ..


### PR DESCRIPTION
Release run #3 burned a full 6h before being killed by GitHub's job
ceiling because the python-test job hung in maturin develop + pytest
with --features iceoryx2. With no job-level timeout and no per-test
timeout, the logs offered no signal about which step or test was stuck
— making the failure impossible to triage post-hoc.

- Set timeout-minutes: 30 on the job. Anything past this is a hang;
  fail fast instead of waiting 6h.
- Install pytest-timeout and pass --timeout=120 so any single test that
  hangs is killed with a traceback that names the test.
- Add -v so the in-progress test name appears in the log right before
  any hang/crash.

This is purely diagnostic — it doesn't fix the underlying hang (no
recent code change to wingfoil-python obviously regressed). The next
release attempt that hits this will surface the offending test in
minutes with a stack trace.