### PR TITLE
ci(release): drop inline etcd / zmq-etcd duplicates, defer to reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,55 +64,9 @@ jobs:
         env:
           RUST_LOG: INFO
 
-  etcd-integration:
-    name: etcd Integration Tests
-    needs: preflight
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust Build Artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
-      - name: Run etcd integration tests
-        run: |
-          cargo test --features etcd-integration-test -p wingfoil \
-            -- --test-threads=1 etcd::integration_tests
-        env:
-          RUST_LOG: INFO
-
-  zmq-etcd-integration:
-    name: ZMQ etcd Integration Tests
-    needs: preflight
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust Build Artifacts
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
-      - name: Run ZMQ etcd integration tests
-        run: |
-          cargo test --features zmq-etcd-integration-test -p wingfoil \
-            -- --test-threads=1 zmq::integration_tests::etcd_tests
-        env:
-          RUST_LOG: INFO
-
   tag:
     name: Cut release tag
-    needs: [preflight, all-tests, integration-tests, zmq-integration, etcd-integration, zmq-etcd-integration]
+    needs: [preflight, all-tests, integration-tests, zmq-integration]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
release.yml had its own inline etcd-integration and zmq-etcd-integration
jobs that duplicated work already covered by the integration-tests
reusable workflow. The inline copies were a degraded fork: they ran the
same `cargo test ... etcd::integration_tests` command, but lacked the
"Pre-pull etcd image" step (with retries) that
.github/workflows/etcd-integration.yml and
.github/workflows/zmq-etcd-integration.yml added specifically to guard
against testcontainers' lazy-pull registry flakes
("bytes remaining on stream").

In release run #3 these inline jobs failed with exit 1 after ~2m, while
the reusable workflows invoked through integration-tests passed. Delete
the duplicates and update the tag job's `needs` list. The same
adapters still run in this pipeline via integration-tests, now with the
pre-pull-and-retry protection.

The zmq-integration inline job stays — it's unique and not duplicated
by any reusable workflow.