### PR TITLE
ci(adapter-integration): drop aeron matrix entry (no impl on main)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@
 workflows below. `all-tests.yml` runs `rust-test.yml` + `python-test.yml` +
 `integration-tests.yml`.
 
-* `adapter-integration.yml` — matrix: aeron, fix, fluvio, kafka, zmq.
+* `adapter-integration.yml` — matrix: fix, fluvio, kafka, zmq.
   Pure-Rust adapter integration tests sharing the same shape.
 * `kdb-integration.yml` — KDB+ (custom Docker image, license secret).
 * `etcd-integration.yml` — etcd (Docker container, Python tests).

--- a/.github/workflows/adapter-integration.yml
+++ b/.github/workflows/adapter-integration.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'wingfoil/src/adapters/aeron/**'
       - 'wingfoil/src/adapters/fix/**'
       - 'wingfoil/src/adapters/fluvio/**'
       - 'wingfoil/src/adapters/kafka/**'
@@ -24,10 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - adapter: aeron
-            feature: aeron-integration-test
-            test-filter: 'aeron::integration_tests'
-            extra-deps: 'cmake clang libclang-dev uuid-dev libbsd-dev'
           - adapter: fix
             feature: fix-integration-test
             test-filter: 'fix::integration_tests'


### PR DESCRIPTION
## Summary

- The aeron entry in the `adapter-integration` matrix references a feature flag (`aeron-integration-test`), a test module (`aeron::integration_tests`), and a source path (`wingfoil/src/adapters/aeron/`) that don't exist on main.
- Cargo aborts with exit 101 when `--features` names an unknown feature, so this job has been guaranteed to fail every run. It surfaced in release run #3 as *"Adapter Integration Tests (aeron) — Process exited with code 101"*.
- Remove the matrix entry, the matching push-path trigger, and the workflows README listing.

**Note:** The aeron adapter is being developed on a separate branch. When that branch lands, its PR should re-add this matrix entry alongside the actual adapter/feature/tests.

## Test plan

- [ ] Next push to a non-aeron adapter (`fix`, `fluvio`, `kafka`, `zmq`) triggers `adapter-integration.yml` as before.
- [ ] Next release run no longer contains a failing aeron job.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X63YqSFYEW4BtA6ESSkZU7)_