### PR TITLE
ci: add timeout-minutes to every job (no more 6h burns)

### DIFF
--- a/.github/workflows/adapter-integration.yml
+++ b/.github/workflows/adapter-integration.yml
@@ -18,6 +18,7 @@ jobs:
   integration:
     name: ${{ matrix.adapter }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-latency-e2e-ami.yml
+++ b/.github/workflows/build-latency-e2e-ami.yml
@@ -56,6 +56,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-latency-e2e-images.yml
+++ b/.github/workflows/build-latency-e2e-images.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/bulk-rebase.yml
+++ b/.github/workflows/bulk-rebase.yml
@@ -4,6 +4,7 @@ on:
 jobs:
   rebase-all:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
 

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-latency-e2e.yml
+++ b/.github/workflows/deploy-latency-e2e.yml
@@ -61,6 +61,7 @@ env:
 jobs:
   plan:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       targets: ${{ steps.pick.outputs.targets }}
     steps:
@@ -74,6 +75,7 @@ jobs:
   deploy:
     needs: plan
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -17,6 +17,7 @@ jobs:
   etcd-integration:
     name: etcd Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -17,6 +17,7 @@ jobs:
   iceoryx2-integration:
     name: iceoryx2 Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/kafka-python-integration.yml
+++ b/.github/workflows/kafka-python-integration.yml
@@ -17,6 +17,7 @@ jobs:
   kafka-python-integration:
     name: Kafka Python Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     services:
       redpanda:

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -17,6 +17,7 @@ jobs:
   kdb-integration:
     name: KDB Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -17,6 +17,7 @@ jobs:
   otlp-integration:
     name: OTLP Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -15,6 +15,7 @@ jobs:
   prometheus-integration:
     name: Prometheus Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-wheels:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -57,6 +58,7 @@ jobs:
 
   upload-pypi:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: build-wheels
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   preflight:
     name: Preflight — version check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -48,6 +49,7 @@ jobs:
     name: ZMQ Integration Tests
     needs: preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -68,6 +70,7 @@ jobs:
     name: Cut release tag
     needs: [preflight, all-tests, integration-tests, zmq-integration]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   format-and-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -24,6 +24,7 @@ jobs:
   ci:
     name: Build, Test, & Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -18,6 +18,7 @@ jobs:
   wingfoil-wasm-build:
     name: wingfoil-wasm build + unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +47,7 @@ jobs:
   wingfoil-js-typecheck:
     name: wingfoil-js build + typecheck
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: wingfoil-wasm-build
 
     steps:

--- a/.github/workflows/zmq-etcd-integration.yml
+++ b/.github/workflows/zmq-etcd-integration.yml
@@ -17,6 +17,7 @@ jobs:
   zmq-etcd-integration:
     name: ZMQ etcd Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- No workflow set `timeout-minutes`, so every job inherited GitHub's 360-min default. Release run #3 took advantage of that: the `python-test` job hung for the full six hours before the platform killed it, blocking the release and producing zero diagnostic signal in the meantime.
- Cap every job. Default **30 min**, which comfortably covers every non-pathological run observed (rust full test ~2–3m, integration tests 1–5m, fmt seconds).
- Use **60 min** for the four heavy-infra jobs where 30 isn't enough headroom:
  - `pypi-publish` build-wheels (3 OS × 4 Python cold cargo builds per matrix item)
  - `build-latency-e2e-ami` (Packer AMI bake)
  - `build-latency-e2e-images` (Docker image build)
  - `deploy-latency-e2e` deploy (Pulumi up to AWS, sequential matrix)
- `python-test` was already at 30 from the earlier hang-diagnostics fix; left as-is.

20 workflow files touched, 25 jobs newly capped.

## Test plan

- [ ] Next push triggers `rust-test` / `rust-fmt` / `python-test` and they all complete inside their caps.
- [ ] Future hung job fails within minutes with a job-timeout annotation that names the step in progress, instead of silently burning 6h.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X63YqSFYEW4BtA6ESSkZU7)_