### PR TITLE
ci(release): drop duplicate integration-tests invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,6 @@ jobs:
     uses: ./.github/workflows/all-tests.yml
     secrets: inherit
 
-  integration-tests:
-    name: Integration Tests
-    needs: preflight
-    uses: ./.github/workflows/integration-tests.yml
-    secrets: inherit
-
   zmq-integration:
     name: ZMQ Integration Tests
     needs: preflight
@@ -68,7 +62,7 @@ jobs:
 
   tag:
     name: Cut release tag
-    needs: [preflight, all-tests, integration-tests, zmq-integration]
+    needs: [preflight, all-tests, zmq-integration]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- `release.yml` called `integration-tests.yml` directly AND via `all-tests.yml`, which in turn already calls `integration-tests.yml`.
- Every adapter integration test (adapter, kdb, etcd, prometheus, otlp, zmq-etcd, iceoryx2, web, kafka-python) ran twice per release — a full duplicate matrix of 9 jobs.
- Remove the top-level `integration-tests` invocation and drop it from the `tag` job's `needs`. Same coverage, half the CI minutes for that slice of the release.

`zmq-integration` stays inline — it's unique (no reusable counterpart) and not duplicated.

## Test plan

- [ ] Next `release` run shows the integration suites only once (under `All Tests → Integration Tests`), not at top level too.
- [ ] `Cut release tag` still gates on the integration suites via `all-tests`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X63YqSFYEW4BtA6ESSkZU7)_