### PR TITLE
ci(python-test): drop --features iceoryx2 (tests don't run here)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           cd wingfoil-python
-          .venv/bin/maturin develop --features iceoryx2
+          .venv/bin/maturin develop
           .venv/bin/pytest tests/ -v \
             --timeout=120 \
             --cov=wingfoil \


### PR DESCRIPTION
## Summary

The `python-test` job was built with `--features iceoryx2` but never actually ran any iceoryx2 tests:

- `pyproject.toml`'s default `addopts` excludes `requires_iceoryx2` markers.
- The pytest invocation here doesn't pass `-m requires_iceoryx2`.
- `iceoryx2-integration.yml` is where the actual iceoryx2 suite runs (with the feature and the marker).

That meant every `python-test` run paid the full cargo cost of compiling iceoryx2's transitive deps just to expose the binding symbols at import time. The `cargo llvm-cov report` already excludes `py_iceoryx2` via `--ignore-filename-regex`, so the only thing the feature changed in this workflow was Python-side coverage of the 4-line `hasattr`/alias branch in `wingfoil/__init__.py:42-46` — a build-config signal, not behaviour.

## Trade-off (small but real)

Python codecov will report those 4 lines of `__init__.py` as uncovered after this change. The same import path is still exercised in `iceoryx2-integration.yml`, just without coverage upload. If we want zero coverage delta, a follow-up could add coverage upload to that workflow.

## Test plan

- [ ] Next `python-test` run completes faster (no iceoryx2 transitive build).
- [ ] No iceoryx2-related test failure surfaces here (those tests are marker-gated off anyway).
- [ ] `iceoryx2-integration.yml` continues to run the actual iceoryx2 suite unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X63YqSFYEW4BtA6ESSkZU7)_