### PR TITLE
fix(bump): sed-bump wingfoil-wasm instead of cargo set-version

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -58,9 +58,12 @@ jobs:
         run: |
           NEW_VERSION="${{ steps.bump_cargo.outputs.new_version }}"
           WASM_TOML="wingfoil-wasm/Cargo.toml"
-          cargo set-version "$NEW_VERSION" --manifest-path "$WASM_TOML"
-          # cargo set-version doesn't touch the wingfoil-wire-types path-dep pin
-          # here because wingfoil-wire-types lives in the outer workspace.
+          # `cargo set-version --manifest-path` is not usable here: it runs
+          # `cargo metadata` first, which refuses to resolve when the existing
+          # path-dep pin (wingfoil-wire-types = "^OLD") doesn't match the
+          # already-bumped workspace member (NEW). Sed-bump both lines
+          # directly — pure text edit, no resolver involvement.
+          sed -i -E "0,/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/s||version = \"${NEW_VERSION}\"|" "$WASM_TOML"
           sed -i -E "s|(wingfoil-wire-types = \\{ path = \"\\.\\./wingfoil-wire-types\", version = \")[0-9]+\\.[0-9]+\\.[0-9]+(\")|\\1${NEW_VERSION}\\2|" "$WASM_TOML"
 
       - name: Update conf.py with new version


### PR DESCRIPTION
## Summary

The "Bump wingfoil-wasm (excluded from workspace)" step (added in commit `ea58a4e`) failed on the first real bump attempt: https://github.com/wingfoil-io/wingfoil/actions/runs/26437843723/job/77824722439

**Root cause:** `cargo set-version` internally invokes `cargo metadata` before writing anything. `cargo metadata` refuses to resolve because `wingfoil-wasm`'s path-dep pin (`wingfoil-wire-types = "^4.0.1"`) doesn't match the workspace member's already-bumped version (`5.0.0`):

```
error: failed to select a version for the requirement `wingfoil-wire-types = "^4.0.1"`
candidate versions found which didn't match: 5.0.0
required by package `wingfoil-wasm v4.0.1`
```

So `cargo set-version` exits 1 *before* writing the new version, and the subsequent `sed` (which would have fixed the pin) never runs. Chicken-and-egg.

**Fix:** Drop the `cargo set-version` call entirely. Both the package version line and the path-dep pin are simple text — a `sed` pass on each gets the job done with no resolver involvement. Verified locally against the current state of `wingfoil-wasm/Cargo.toml` on main.

## Test plan

- [ ] Re-run `release.bump` (any bump type). The "Bump wingfoil-wasm" step now succeeds, both lines in `wingfoil-wasm/Cargo.toml` move to the new version.
- [ ] On main post-bump, all five `version = "..."` declarations match.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X63YqSFYEW4BtA6ESSkZU7)_