### PR TITLE
test(fluvio): probe SC port before admin handshake to close startup race

### DIFF
--- a/wingfoil/src/adapters/fluvio/integration_tests.rs
+++ b/wingfoil/src/adapters/fluvio/integration_tests.rs
@@ -62,6 +62,11 @@ fn start_fluvio() -> anyhow::Result<(impl Drop, String)> {
 
     let endpoint = format!("127.0.0.1:{FLUVIO_SC_PORT}");
 
+    // The SC logs "started successfully" before its 9003 listener is bound.
+    // With host networking and back-to-back test containers this race shows up
+    // as ECONNREFUSED on the next admin call. Probe the port until accept() works.
+    wait_for_port(&endpoint, std::time::Duration::from_secs(10))?;
+
     // Register the custom SPU with the SC before starting the SPU process.
     register_spu(&endpoint)?;
 
@@ -80,6 +85,27 @@ fn start_fluvio() -> anyhow::Result<(impl Drop, String)> {
     std::thread::sleep(std::time::Duration::from_secs(3));
 
     Ok((container, endpoint))
+}
+
+/// Block until `endpoint` accepts a TCP connection, or `timeout` elapses.
+fn wait_for_port(endpoint: &str, timeout: std::time::Duration) -> anyhow::Result<()> {
+    let addr: std::net::SocketAddr = endpoint
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid endpoint {endpoint}: {e}"))?;
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(200)) {
+            Ok(_) => return Ok(()),
+            Err(_) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "fluvio SC never accepted on {endpoint}: {e}"
+                ));
+            }
+        }
+    }
 }
 
 /// Register a custom SPU spec with the SC via the admin API.


### PR DESCRIPTION
## Summary

Release run #4 ([26453261892](https://github.com/wingfoil-io/wingfoil/actions/runs/26453261892)) failed in the `adapter-integration / fluvio` matrix entry with:

```
test test_pub_keyed_record       ... ok
Error: fluvio admin connect failed: Socket io Connection refused (os error 111),
                                    can't connect to 127.0.0.1:9003
test test_pub_keyless_record     ... FAILED
test test_pub_round_trip         ... ok    ← passed after
```

**Root cause.** Each test spins up its own SC container with host networking (`network_mode = "host"`) on port 9003. The container's `WaitFor::message_on_stdout("Streaming Controller started successfully")` matches the SC log line *before* the SC has bound its 9003 listener. With `--test-threads=1` running tests in alphabetical order, the back-to-back create/destroy on the same host port loses the race for whichever test happens to land in that small window — here `test_pub_keyless_record` (the second container-using test, immediately after `test_pub_keyed_record`'s teardown). `register_spu` then fires off `FluvioAdmin::connect_with_config` while the bind is still pending and gets ECONNREFUSED.

Not a fluvio bug, not the etcd "bytes remaining on stream" registry flake, and unrelated to the image version. Pure startup-readiness race in the test harness.

**Fix.** Add a `wait_for_port` helper that polls `connect_timeout` against 9003 with a 10 s deadline after `.start()?` returns and before `register_spu` runs. Deterministic, localized to the test module, no change to host networking (still required for the SPU's public endpoint).

## Test plan

- [ ] Next `adapter-integration / fluvio` run completes with all 7 tests passing (the previous run's other 6 already passed, including the same `test_pub_keyless_record` body once the race didn't fire).
- [ ] If the SC ever genuinely never binds, the new path fails with a clear `fluvio SC never accepted on 127.0.0.1:9003` instead of the misleading admin-handshake ECONNREFUSED.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQWw4cgiwVrxbo6kZHjoxM)_