### PR TITLE
test(python): bound .run() calls that relied on LimitStream stopping the graph

### DIFF
--- a/wingfoil-python/tests/test_pandas.py
+++ b/wingfoil-python/tests/test_pandas.py
@@ -52,8 +52,8 @@ def test_dict_of_streams():
         "col_b": stream_b
     }
     
-    Graph([stream_a, stream_b]).run(realtime=False)
-  
+    Graph([stream_a, stream_b]).run(realtime=False, cycles=10)
+
     df = build_dataframe(data)
 
     assert len(df) == 3
@@ -81,7 +81,7 @@ def test_async_frequencies():
     slow_stream = slow_source.map(lambda x: x * 100).dataframe()
     
 
-    Graph([fast_stream, slow_stream]).run(realtime=False)
+    Graph([fast_stream, slow_stream]).run(realtime=False, cycles=20)
     
     df = build_dataframe({"fast": fast_stream, "slow": slow_stream})
   
@@ -106,7 +106,7 @@ def test_massive_fan_out():
     s_sub = source.map(lambda x: x - 5).dataframe()
     s_mult = source.map(lambda x: x * 5).dataframe()
     
-    Graph([s_add, s_sub, s_mult]).run(realtime=False)
+    Graph([s_add, s_sub, s_mult]).run(realtime=False, cycles=10)
     
     df = build_dataframe({
         "add": s_add, 
@@ -145,7 +145,7 @@ def test_build_dataframe_skips_empty_streams():
     live_stream = ticker(0.01).count().limit(3).dataframe()
 
     # Only run live_stream — empty_stream stays empty
-    live_stream.run(realtime=False)
+    live_stream.run(realtime=False, cycles=10)
 
     df = build_dataframe({"empty": empty_stream, "live": live_stream})
     # Only "live" column should appear (empty_stream's val is falsy)

--- a/wingfoil-python/tests/test_streams.py
+++ b/wingfoil-python/tests/test_streams.py
@@ -201,7 +201,7 @@ class TestNodeAndGraph(unittest.TestCase):
     def test_graph_with_multiple_streams(self):
         a = ticker(0.01).count().limit(3).collect()
         b = ticker(0.02).count().limit(2).collect()
-        Graph([a, b]).run(realtime=False)
+        Graph([a, b]).run(realtime=False, cycles=10)
         self.assertEqual(a.peek_value(), [1, 2, 3])
         self.assertEqual(b.peek_value(), [1, 2])
 


### PR DESCRIPTION
## Summary

The python-test CI job was hitting its 30-minute timeout after `test_pandas.py::test_to_dataframe_legacy_primitives` (44%). Root cause: PR #341 made `LimitStream` suppress further values instead of halting the graph, but five Python tests still called `.run(realtime=False)` with no `cycles`/`duration` and relied on the old terminating behaviour, so the graph spun forever.

Passed bounded `cycles=` to each:
- `test_pandas.py`: `test_dict_of_streams`, `test_async_frequencies`, `test_massive_fan_out`, `test_build_dataframe_skips_empty_streams`
- `test_streams.py`: `test_graph_with_multiple_streams`

## Test plan

- [x] `pytest tests/` locally — 133 passed, 5 skipped in 12s (was hanging indefinitely)
- [ ] CI python-test job completes well under the 30-minute timeout

https://claude.ai/code/session_017v8qq4rqdhVFzZvCcKuJeR

---
_Generated by [Claude Code](https://claude.ai/code/session_017v8qq4rqdhVFzZvCcKuJeR)_