### PR TITLE
Add workflow_call support for automated multi-platform releases

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -2,6 +2,7 @@ name: publish.crates
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   publish:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,7 @@ name: publish.npm
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,6 +11,12 @@ on:
         options:
           - test
           - prod
+  workflow_call:
+    inputs:
+      pypi-target:
+        description: 'Choose PyPI target (test or prod)'
+        required: true
+        type: string
 
 jobs:
   build-wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,23 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: tag
+    uses: ./.github/workflows/crates-publish.yml
+    secrets: inherit
+
+  publish-npm:
+    name: Publish to npm
+    needs: tag
+    uses: ./.github/workflows/npm-publish.yml
+    secrets: inherit
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: tag
+    uses: ./.github/workflows/pypi-publish.yml
+    secrets: inherit
+    with:
+      pypi-target: prod


### PR DESCRIPTION
## Summary

Enable the release workflow to automatically publish to crates.io, npm, and PyPI by converting the individual publish workflows to support `workflow_call` triggers. This allows the main release job to orchestrate all three platform deployments in parallel after tagging.

## Changes

- **release.yml**: Added three new jobs (`publish-crates`, `publish-npm`, `publish-pypi`) that trigger their respective publish workflows after the `tag` job completes. The PyPI job passes the `pypi-target: prod` input to publish to production.

- **crates-publish.yml**: Added `workflow_call` trigger to allow invocation from the release workflow.

- **npm-publish.yml**: Added `workflow_call` trigger to allow invocation from the release workflow.

- **pypi-publish.yml**: Added `workflow_call` trigger with a new `pypi-target` input parameter (required, type string) to support both test and production deployments. The input mirrors the existing `workflow_dispatch` option.

## Implementation Details

- All three publish workflows now support both manual dispatch (`workflow_dispatch`) and automated calls from the release workflow (`workflow_call`).
- The release workflow uses `needs: tag` to ensure the tag job completes before publishing, and `secrets: inherit` to pass credentials to the publish jobs.
- PyPI publishing is explicitly configured for production (`pypi-target: prod`) to distinguish from test deployments that may be triggered manually.

https://claude.ai/code/session_01QR1Gapa4yAtkhbqGNtor3U