### PR TITLE
Add filter_map operator to StreamOperators trait

### DIFF
--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -193,25 +193,25 @@ fn main() -> anyhow::Result<()> {
     // Inbound: ExecutionReports from the order session. Filter here so
     // only MsgType=8 frames propagate — admin / heartbeat frames never
     // show up in the matcher's burst.
-    let exec_events: Rc<dyn Stream<MatcherEvent>> = MapFilterStream::new(
-        fix_ord.data.clone().collapse::<FixMessage>(),
-        Box::new(|m: FixMessage| {
-            let is_exec = m.msg_type == "8";
-            if is_exec {
+    let exec_events: Rc<dyn Stream<MatcherEvent>> = fix_ord
+        .data
+        .clone()
+        .collapse::<FixMessage>()
+        .filter_map(|m: FixMessage| {
+            if m.msg_type == "8" {
                 log::info!(
                     "fix_gw: ExecutionReport received cl_ord={} exec_type={}",
                     m.field(TAG_CL_ORD_ID).unwrap_or(""),
                     m.field(TAG_EXEC_TYPE).unwrap_or(""),
                 );
+                Some(MatcherEvent::Exec(m))
             } else {
                 log::debug!("fix_gw: non-exec msg_type={} dropped at filter", m.msg_type);
+                None
             }
-            (MatcherEvent::Exec(m), is_exec)
-        }),
-    )
-    .into_stream();
+        });
 
-    // ── Matcher: combine + fold + map_filter ─────────────────────────────
+    // ── Matcher: combine + fold + filter_map ─────────────────────────────
     //
     // `combine` collects the ticked values from both upstreams into a
     // single `Burst<MatcherEvent>` per cycle — if an Order and an
@@ -220,7 +220,7 @@ fn main() -> anyhow::Result<()> {
     // `RefCell<HashMap<ClOrdID, Traced>>` of parked orders in its
     // captured state. Each cycle, we walk the burst in order, parking
     // orders or matching ExecReports. The output value is the last
-    // matched fill this cycle (or None); downstream `MapFilterStream`
+    // matched fill this cycle (or None); the downstream `filter_map`
     // drops the Nones.
     //
     // Invariant: each upstream emits at most one event per cycle
@@ -297,18 +297,12 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Drop Nones, stamp the inbound stages, publish back via iceoryx2.
-    let fills = MapFilterStream::new(
-        matched,
-        Box::new(|v: Option<Traced<RoundTrip, RoundTripLatency>>| {
-            let ticked = v.is_some();
-            (v.unwrap_or_default(), ticked)
-        }),
-    )
-    .into_stream()
-    .stamp_if::<round_trip_latency::fix_recv>(!precise)
-    .stamp_precise_if::<round_trip_latency::fix_recv>(precise)
-    .stamp_if::<round_trip_latency::gw_publish>(!precise)
-    .stamp_precise_if::<round_trip_latency::gw_publish>(precise);
+    let fills = matched
+        .filter_map(|v: Option<Traced<RoundTrip, RoundTripLatency>>| v)
+        .stamp_if::<round_trip_latency::fix_recv>(!precise)
+        .stamp_precise_if::<round_trip_latency::fix_recv>(precise)
+        .stamp_if::<round_trip_latency::gw_publish>(!precise)
+        .stamp_precise_if::<round_trip_latency::gw_publish>(precise);
 
     let pub_fills = iceoryx2_pub(
         fills

--- a/wingfoil/src/nodes/mod.rs
+++ b/wingfoil/src/nodes/mod.rs
@@ -486,6 +486,14 @@ pub trait StreamOperators<T: Element> {
     #[must_use]
     fn filter_value(self: &Rc<Self>, predicate: impl Fn(&T) -> bool + 'static)
     -> Rc<dyn Stream<T>>;
+    /// Maps and filters in a single step: applies `func` to each value and
+    /// ticks the returned `Some`, dropping `None`. Mirrors
+    /// [`Iterator::filter_map`].
+    #[must_use]
+    fn filter_map<OUT: Element>(
+        self: &Rc<Self>,
+        func: impl Fn(T) -> Option<OUT> + 'static,
+    ) -> Rc<dyn Stream<OUT>>;
     /// Passes through values unchanged while calling the supplied closure
     /// on a reference to each value, for side effects (debugging, logging, etc.).
     #[must_use]
@@ -723,6 +731,17 @@ where
     ) -> Rc<dyn Stream<T>> {
         let condition = self.clone().map(move |val| predicate(&val));
         FilterStream::new(self.clone(), condition).into_stream()
+    }
+
+    fn filter_map<OUT: Element>(
+        self: &Rc<Self>,
+        func: impl Fn(T) -> Option<OUT> + 'static,
+    ) -> Rc<dyn Stream<OUT>> {
+        let f = move |val: T| match func(val) {
+            Some(out) => (out, true),
+            None => (OUT::default(), false),
+        };
+        MapFilterStream::new(self.clone(), Box::new(f)).into_stream()
     }
 
     fn finally<F: FnOnce(T, &GraphState) -> anyhow::Result<()> + 'static>(
@@ -1023,6 +1042,19 @@ mod tests {
         // only the non-empty vec produces a tick
         assert_eq!(ticks.len(), 1);
         assert_eq!(ticks[0].value, 2u64); // last() of [1,2]
+    }
+
+    #[test]
+    fn filter_map_keeps_some_drops_none() {
+        // count() → 1,2,3,4,5,6; keep squares of odd inputs only: 1,9,25
+        let source = ticker(Duration::from_nanos(100)).count();
+        let out = source.filter_map(|x: u64| (x % 2 == 1).then_some(x * x));
+        let collected = out.collect();
+        collected
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(6))
+            .unwrap();
+        let values: Vec<u64> = collected.peek_value().iter().map(|v| v.value).collect();
+        assert_eq!(values, vec![1, 9, 25]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Introduces a new `filter_map` operator to the `StreamOperators` trait that combines filtering and mapping in a single step, mirroring the behavior of `Iterator::filter_map`. This simplifies code that needs to both transform and selectively drop values.

## Key Changes

- **Added `filter_map` trait method** to `StreamOperators<T>` that takes a closure `Fn(T) -> Option<OUT>` and returns `Rc<dyn Stream<OUT>>`
  - Ticks `Some` values and drops `None` values
  - Implemented via `MapFilterStream` with internal conversion from `Option` to `(value, bool)` tuple
  
- **Refactored example code** in `wingfoil/examples/latency_e2e/fix_gw.rs` to use the new operator:
  - Replaced `MapFilterStream::new()` with explicit `Box::new()` closures with two instances of `filter_map()`
  - Simplified ExecutionReport filtering logic (lines 196–211)
  - Simplified fill output filtering logic (lines 300–308)
  - Updated related comments to reference `filter_map` instead of `map_filter`

- **Added comprehensive test** `filter_map_keeps_some_drops_none()` demonstrating:
  - Filtering odd numbers from a count stream
  - Mapping to squares (1→1, 3→9, 5→25)
  - Verifying only `Some` values propagate downstream

## Implementation Details

The `filter_map` implementation wraps the user's `Option`-returning closure in a conversion function that produces the `(value, bool)` tuple expected by `MapFilterStream`:
- `Some(out)` → `(out, true)` (ticks)
- `None` → `(OUT::default(), false)` (dropped)

This maintains consistency with the existing `MapFilterStream` infrastructure while providing a more ergonomic API for the common filter-and-map pattern.

https://claude.ai/code/session_01F5ZzBq5D4cxBdsP74KFaTj