### PR TITLE
Add CI log fetching skill for Claude Code

### DIFF
--- a/.claude/commands/ci-logs.md
+++ b/.claude/commands/ci-logs.md
@@ -1,0 +1,42 @@
+Fetch GitHub Actions CI logs for `$ARGUMENTS` and surface the failure. `$ARGUMENTS` may be a job ID, a run ID, a branch name, or a PR number — resolve it to a failed job ID, then dump the relevant log lines. Read-only: never push, comment, or rerun workflows.
+
+This skill wraps `scripts/ci-logs.sh`, which resolves a job's signed log URL via the GitHub API and downloads it. The signed URL carries its own auth, so the bearer header is intentionally **not** forwarded to it.
+
+## 1. Resolve `$ARGUMENTS` to a failed job ID
+
+`scripts/ci-logs.sh` takes a **job** ID, not a run ID. Resolve whatever the user gave you:
+
+- **Bare numeric job ID** (the script's native input) — use it directly.
+- **Run ID** — list its jobs and pick the failed one:
+  `GET /repos/wingfoil-io/wingfoil/actions/runs/<run_id>/jobs`
+- **Branch name** — find the latest run, then its failed job:
+  `GET /repos/wingfoil-io/wingfoil/actions/runs?branch=<branch>&per_page=1`
+- **PR number** — read the PR's head branch (`mcp__github__pull_request_read`), then resolve as a branch.
+- **Nothing / "the failing one"** — list recent failures and pick the most recent:
+  `GET /repos/wingfoil-io/wingfoil/actions/runs?per_page=10&status=failure`
+
+Prefer the `mcp__github__*` tools for PR/branch metadata. There is no MCP tool for workflow runs or job logs in this repo's server, so the run/job lookups above and the log download itself go through the API via `curl` with `$GH_TOKEN`. Confirm the job's `conclusion` is `failure` and note which step failed before fetching.
+
+## 2. Fetch the logs
+
+```bash
+scripts/ci-logs.sh <job_id>
+```
+
+Pipe through `tail -60` (or `grep` for `error\|panicked\|FAILED\|assertion`) rather than dumping the full log into the conversation. Lead with the failing step name and the smallest excerpt that explains the failure.
+
+## 3. Network caveat (Claude Code on the web)
+
+GitHub serves Actions logs as a short-lived signed URL on `*.blob.core.windows.net`. In a remote/web environment the network policy may allowlist `api.github.com` but not blob storage — the second `curl` then fails with `Host not in allowlist` and no log body is returned.
+
+If that happens, do not treat it as a script bug. Report it and offer the options:
+1. Run `scripts/ci-logs.sh <job_id>` somewhere with open egress (it works as-is).
+2. Loosen the environment's network policy to allow `*.blob.core.windows.net`, then rerun (see https://code.claude.com/docs/en/claude-code-on-the-web).
+
+Either way, still report what you learned from the API: failing workflow, branch, job, and which step failed.
+
+## 4. Reporting
+
+- One-line summary: workflow → job → failing step.
+- The minimal log excerpt that pinpoints the cause.
+- A suggested next step (the fix, or a rerun) — but do not act on it unless asked. This skill only reads.

--- a/scripts/ci-logs.sh
+++ b/scripts/ci-logs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# usage: scripts/ci-logs.sh <job_id>   (or pipe failed-only run logs)
+set -euo pipefail
+job="$1"; repo="wingfoil-io/wingfoil"
+url=$(curl -s -o /dev/null -w '%{redirect_url}' \
+  -H "Authorization: Bearer $GH_TOKEN" \
+  "https://api.github.com/repos/$repo/actions/jobs/$job/logs")
+curl -s "$url"   # signed URL carries its own auth; no header forwarded


### PR DESCRIPTION
## Summary

Add a new Claude Code skill and supporting script to fetch and surface GitHub Actions CI logs for failed jobs. This enables quick diagnosis of CI failures directly from the Claude Code environment.

## Changes

- **`.claude/commands/ci-logs.md`** — New skill documentation that:
  - Resolves user input (job ID, run ID, branch name, or PR number) to a failed job ID
  - Fetches logs via `scripts/ci-logs.sh` and surfaces minimal, actionable excerpts
  - Handles network constraints in web environments (blob storage allowlist issues)
  - Enforces read-only behavior (no pushes, comments, or workflow reruns)

- **`scripts/ci-logs.sh`** — New bash script that:
  - Takes a job ID and resolves its signed log URL via the GitHub API
  - Downloads logs without forwarding the bearer token (signed URL carries its own auth)
  - Outputs raw log content for filtering and analysis

## Implementation Details

- The skill uses existing MCP tools (`mcp__github__*`) for PR and branch metadata lookups
- Run and job queries go through the GitHub API via `curl` with `$GH_TOKEN`
- Log downloads use the signed URL directly (no auth header) to avoid token exposure
- Includes guidance for handling network policy restrictions in remote/web environments
- Reporting focuses on one-line summaries and minimal log excerpts to pinpoint root causes

https://claude.ai/code/session_01N8mzdBNGxz1jcgJhKrhRqd