### PR TITLE
Python bindings: propagate PyErr instead of panicking on Python ops

### DIFF
--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -91,29 +91,33 @@ fn constant(val: Py<PyAny>) -> PyStream {
 
 /// maps steams a amd b into a new stream using func (e.g lambda a, b: a + b)
 #[pyfunction]
-fn bimap(a: Py<PyAny>, b: Py<PyAny>, func: Py<PyAny>) -> PyStream {
+fn bimap(a: Py<PyAny>, b: Py<PyAny>, func: Py<PyAny>) -> PyResult<PyStream> {
     Python::attach(|py| {
         let a = a
             .as_ref()
             .extract::<PyRef<PyStream>>(py)
-            .unwrap()
+            .map_err(|_| types::py_type_error("bimap: first argument must be a Stream"))
+            .to_pyresult()?
             .inner_stream();
         let b = b
             .as_ref()
             .extract::<PyRef<PyStream>>(py)
-            .unwrap()
+            .map_err(|_| types::py_type_error("bimap: second argument must be a Stream"))
+            .to_pyresult()?
             .inner_stream();
-        let stream = ::wingfoil::bimap(
+        let stream = ::wingfoil::try_bimap(
             Dep::Active(a),
             Dep::Active(b),
             move |a: PyElement, b: PyElement| {
                 Python::attach(|py: Python<'_>| {
-                    let res = func.call1(py, (a.value(), b.value())).unwrap();
-                    PyElement::new(res)
+                    let res = func
+                        .call1(py, (a.value(), b.value()))
+                        .map_err(py_callback_error)?;
+                    Ok(PyElement::new(res))
                 })
             },
         );
-        PyStream(stream)
+        Ok(PyStream(stream))
     })
 }
 

--- a/wingfoil-python/src/proxy_stream.rs
+++ b/wingfoil-python/src/proxy_stream.rs
@@ -30,10 +30,17 @@ impl Clone for PyProxyStream {
 
 impl MutableNode for PyProxyStream {
     fn upstreams(&self) -> UpStreams {
+        // `MutableNode::upstreams` is infallible, so a malformed Python proxy
+        // (wrong `upstreams()` return type / element type) is an unrecoverable
+        // contract violation and surfaces as a panic with a descriptive message.
         let ups = Python::attach(|py| {
             let this = self.0.bind(py);
-            let res = this.call_method0("upstreams").unwrap();
-            let res = res.extract::<Vec<Py<PyAny>>>().unwrap();
+            let res = this
+                .call_method0("upstreams")
+                .expect("invariant: Python proxy must implement upstreams()");
+            let res = res
+                .extract::<Vec<Py<PyAny>>>()
+                .expect("invariant: upstreams() must return a list of Stream/Node");
             res.iter()
                 .map(|obj| {
                     let bound = obj.bind(py);
@@ -42,7 +49,7 @@ impl MutableNode for PyProxyStream {
                     } else if let Ok(stream) = bound.extract::<PyProxyStream>() {
                         stream.into_node()
                     } else {
-                        panic!("Unexpected upstream type");
+                        panic!("upstreams() returned an unexpected type: expected Stream or Node");
                     }
                 })
                 .collect::<Vec<_>>()
@@ -75,7 +82,10 @@ impl StreamPeekRef<PyElement> for PyProxyStream {
 
     fn clone_from_cell_ref(&self, _cell_ref: std::cell::Ref<'_, PyElement>) -> PyElement {
         Python::attach(|py| {
-            let res = self.0.call_method0(py, "peek").unwrap();
+            let res = self
+                .0
+                .call_method0(py, "peek")
+                .expect("invariant: Python proxy must implement peek()");
             PyElement::new(res)
         })
     }

--- a/wingfoil-python/src/py_csv.rs
+++ b/wingfoil-python/src/py_csv.rs
@@ -2,6 +2,7 @@
 
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use anyhow::Context;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::cell::RefCell;
@@ -39,7 +40,8 @@ pub fn py_csv_read(path: String, time_column: String) -> PyStream {
         Python::attach(|py| {
             let dict = PyDict::new(py);
             for (key, value) in &row {
-                dict.set_item(key, value).unwrap();
+                dict.set_item(key, value)
+                    .expect("invariant: inserting str keys/values into a dict cannot fail");
             }
             PyElement::new(dict.into_any().unbind())
         })
@@ -56,13 +58,13 @@ struct CsvWriteState {
 }
 
 impl CsvWriteState {
-    fn new(path: &str) -> Self {
+    fn new(path: &str) -> anyhow::Result<Self> {
         let file = std::fs::File::create(path)
-            .unwrap_or_else(|e| panic!("failed to open CSV file for writing: {e}"));
-        Self {
+            .with_context(|| format!("failed to open CSV file for writing: {path}"))?;
+        Ok(Self {
             file: std::io::LineWriter::new(file),
             headers: None,
-        }
+        })
     }
 
     fn write_row(&mut self, values: &[String]) {
@@ -93,10 +95,13 @@ impl CsvWriteState {
 ///
 /// Writes each dict as a CSV row. Headers are inferred from the first dict's keys.
 /// A `time` column is prepended with the graph time in nanoseconds.
-pub fn py_csv_write_inner(stream: &Rc<dyn Stream<PyElement>>, path: String) -> Rc<dyn Node> {
-    let state: RefCell<CsvWriteState> = RefCell::new(CsvWriteState::new(&path));
+pub fn py_csv_write_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    path: String,
+) -> anyhow::Result<Rc<dyn Node>> {
+    let state: RefCell<CsvWriteState> = RefCell::new(CsvWriteState::new(&path)?);
 
-    stream.for_each(move |elem, time| {
+    Ok(stream.for_each(move |elem, time| {
         Python::attach(|py| {
             let obj = elem.as_ref().bind(py);
             if let Ok(dict) = obj.cast::<PyDict>() {
@@ -114,7 +119,10 @@ pub fn py_csv_write_inner(stream: &Rc<dyn Stream<PyElement>>, path: String) -> R
                     guard.headers = Some(keys);
                 }
 
-                let h = guard.headers.clone().unwrap();
+                let h = guard
+                    .headers
+                    .clone()
+                    .expect("invariant: headers set above before this point");
                 let time_nanos: u64 = time.into();
                 let mut values = vec![time_nanos.to_string()];
                 for key in &h {
@@ -129,5 +137,5 @@ pub fn py_csv_write_inner(stream: &Rc<dyn Stream<PyElement>>, path: String) -> R
                 guard.write_row(&values);
             }
         });
-    })
+    }))
 }

--- a/wingfoil-python/src/py_element.rs
+++ b/wingfoil-python/src/py_element.rs
@@ -13,7 +13,9 @@ impl PyElement {
     }
 
     pub fn as_ref(&self) -> &Py<PyAny> {
-        self.0.as_ref().unwrap()
+        self.0
+            .as_ref()
+            .expect("invariant: as_ref called on an empty (None) PyElement")
     }
 
     pub fn value(&self) -> Py<PyAny> {
@@ -33,10 +35,11 @@ impl std::fmt::Debug for PyElement {
             let res = self
                 .as_ref()
                 .call_method0(py, "__str__")
-                .unwrap()
-                .extract::<String>(py)
-                .unwrap();
-            write!(f, "{res}")
+                .and_then(|s| s.extract::<String>(py));
+            match res {
+                Ok(res) => write!(f, "{res}"),
+                Err(err) => write!(f, "<PyElement __str__ failed: {err}>"),
+            }
         })
     }
 }
@@ -55,7 +58,10 @@ impl std::ops::Not for PyElement {
 
     fn not(self) -> Self::Output {
         Python::attach(|py| {
-            let res = self.as_ref().call_method0(py, "__neg__").unwrap();
+            let res = self
+                .as_ref()
+                .call_method0(py, "__neg__")
+                .expect("invariant: PyElement value must support __neg__ for `not`/`!`");
             PyElement::new(res)
         })
     }
@@ -69,7 +75,7 @@ impl std::ops::Add for PyElement {
             let res = self
                 .as_ref()
                 .call_method1(py, "__add__", (rhs.as_ref(),))
-                .unwrap();
+                .expect("invariant: PyElement value must support __add__ for `+`/`sum`");
             PyElement::new(res)
         })
     }
@@ -83,7 +89,7 @@ impl std::ops::Sub for PyElement {
             let res = self
                 .as_ref()
                 .call_method1(py, "__sub__", (rhs.as_ref(),))
-                .unwrap();
+                .expect("invariant: PyElement value must support __sub__ for `-`/`difference`");
             PyElement::new(res)
         })
     }
@@ -127,12 +133,14 @@ impl Hash for PyElement {
                     let bound = obj_ref.bind(py);
                     match bound.hash() {
                         Ok(hash_val) => state.write_isize(hash_val),
-                        Err(err) => panic!("hash failed, {err:?}"),
+                        Err(err) => {
+                            panic!("invariant: PyElement value must be hashable: {err:?}")
+                        }
                     }
                 });
             }
             None => {
-                panic!("can not hash empty PyElement")
+                panic!("invariant: cannot hash an empty (None) PyElement")
             }
         }
     }

--- a/wingfoil-python/src/py_etcd.rs
+++ b/wingfoil-python/src/py_etcd.rs
@@ -2,6 +2,7 @@
 
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use crate::types::{DICT_INSERT_INFALLIBLE, LIST_NEW_INFALLIBLE};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
@@ -37,15 +38,23 @@ pub fn py_etcd_sub(endpoint: String, prefix: String) -> PyStream {
                         EtcdEventKind::Put => "put",
                         EtcdEventKind::Delete => "delete",
                     };
-                    dict.set_item("kind", kind_str).unwrap();
-                    dict.set_item("key", &event.entry.key).unwrap();
+                    dict.set_item("kind", kind_str)
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.set_item("key", &event.entry.key)
+                        .expect(DICT_INSERT_INFALLIBLE);
                     dict.set_item("value", PyBytes::new(py, &event.entry.value))
-                        .unwrap();
-                    dict.set_item("revision", event.revision).unwrap();
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.set_item("revision", event.revision)
+                        .expect(DICT_INSERT_INFALLIBLE);
                     dict.into_any().unbind()
                 })
                 .collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 

--- a/wingfoil-python/src/py_fix.rs
+++ b/wingfoil-python/src/py_fix.rs
@@ -2,6 +2,7 @@
 
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use crate::types::{DICT_INSERT_INFALLIBLE, INTO_PY_INFALLIBLE, LIST_NEW_INFALLIBLE};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -39,14 +40,24 @@ pub fn py_fix_connect(
     let py_data = data.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|msg| msg_to_py(py, &msg)).collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 
     let py_status = status.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|s| status_to_py(py, &s)).collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 
@@ -87,14 +98,24 @@ pub fn py_fix_connect_tls(
     let py_data = fix.data.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|msg| msg_to_py(py, &msg)).collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 
     let py_status = fix.status.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|s| status_to_py(py, &s)).collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 
@@ -102,7 +123,9 @@ pub fn py_fix_connect_tls(
         let sender_cls = PyFixSender {
             sender: fix.sender(),
         };
-        Py::new(py, sender_cls).unwrap().into_any()
+        Py::new(py, sender_cls)
+            .expect("invariant: allocating a PyFixSender pyclass cannot fail")
+            .into_any()
     });
 
     (PyStream(py_data), PyStream(py_status), sender_obj)
@@ -130,14 +153,24 @@ pub fn py_fix_accept(
     let py_data = data.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|msg| msg_to_py(py, &msg)).collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 
     let py_status = status.map(|burst| {
         Python::attach(|py| {
             let items: Vec<Py<PyAny>> = burst.into_iter().map(|s| status_to_py(py, &s)).collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 
@@ -193,10 +226,13 @@ impl PyFixSender {
 
 fn msg_to_py(py: Python<'_>, msg: &FixMessage) -> Py<PyAny> {
     let dict = PyDict::new(py);
-    dict.set_item("msg_type", &msg.msg_type).unwrap();
-    dict.set_item("seq_num", msg.seq_num).unwrap();
+    dict.set_item("msg_type", &msg.msg_type)
+        .expect(DICT_INSERT_INFALLIBLE);
+    dict.set_item("seq_num", msg.seq_num)
+        .expect(DICT_INSERT_INFALLIBLE);
     let fields: Vec<(u32, &str)> = msg.fields.iter().map(|(t, v)| (*t, v.as_str())).collect();
-    dict.set_item("fields", fields).unwrap();
+    dict.set_item("fields", fields)
+        .expect(DICT_INSERT_INFALLIBLE);
     dict.into_any().unbind()
 }
 
@@ -204,22 +240,33 @@ fn status_to_py(py: Python<'_>, status: &FixSessionStatus) -> Py<PyAny> {
     match status {
         FixSessionStatus::Disconnected => "disconnected"
             .into_pyobject(py)
-            .unwrap()
+            .expect(INTO_PY_INFALLIBLE)
             .into_any()
             .unbind(),
-        FixSessionStatus::LoggingIn => "logging_in".into_pyobject(py).unwrap().into_any().unbind(),
-        FixSessionStatus::LoggedIn => "logged_in".into_pyobject(py).unwrap().into_any().unbind(),
+        FixSessionStatus::LoggingIn => "logging_in"
+            .into_pyobject(py)
+            .expect(INTO_PY_INFALLIBLE)
+            .into_any()
+            .unbind(),
+        FixSessionStatus::LoggedIn => "logged_in"
+            .into_pyobject(py)
+            .expect(INTO_PY_INFALLIBLE)
+            .into_any()
+            .unbind(),
         FixSessionStatus::LoggedOut(reason) => {
             let dict = PyDict::new(py);
-            dict.set_item("status", "logged_out").unwrap();
+            dict.set_item("status", "logged_out")
+                .expect(DICT_INSERT_INFALLIBLE);
             dict.set_item("reason", reason.as_deref().unwrap_or(""))
-                .unwrap();
+                .expect(DICT_INSERT_INFALLIBLE);
             dict.into_any().unbind()
         }
         FixSessionStatus::Error(msg) => {
             let dict = PyDict::new(py);
-            dict.set_item("status", "error").unwrap();
-            dict.set_item("message", msg.as_str()).unwrap();
+            dict.set_item("status", "error")
+                .expect(DICT_INSERT_INFALLIBLE);
+            dict.set_item("message", msg.as_str())
+                .expect(DICT_INSERT_INFALLIBLE);
             dict.into_any().unbind()
         }
     }

--- a/wingfoil-python/src/py_fluvio.rs
+++ b/wingfoil-python/src/py_fluvio.rs
@@ -2,6 +2,7 @@
 
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use crate::types::{DICT_INSERT_INFALLIBLE, LIST_NEW_INFALLIBLE};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
@@ -42,16 +43,26 @@ pub fn py_fluvio_sub(
                 .map(|event| {
                     let dict = PyDict::new(py);
                     match &event.key {
-                        Some(k) => dict.set_item("key", PyBytes::new(py, k)).unwrap(),
-                        None => dict.set_item("key", py.None()).unwrap(),
+                        Some(k) => dict
+                            .set_item("key", PyBytes::new(py, k))
+                            .expect(DICT_INSERT_INFALLIBLE),
+                        None => dict
+                            .set_item("key", py.None())
+                            .expect(DICT_INSERT_INFALLIBLE),
                     }
                     dict.set_item("value", PyBytes::new(py, &event.value))
-                        .unwrap();
-                    dict.set_item("offset", event.offset).unwrap();
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.set_item("offset", event.offset)
+                        .expect(DICT_INSERT_INFALLIBLE);
                     dict.into_any().unbind()
                 })
                 .collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 

--- a/wingfoil-python/src/py_iceoryx2.rs
+++ b/wingfoil-python/src/py_iceoryx2.rs
@@ -109,14 +109,18 @@ pub fn py_iceoryx2_sub(
                                     bytes.len()
                                 );
                                 let payload = PyBytes::new(py, &bytes).into_any().unbind();
-                                let lat = Py::new(py, PyLatency::create(stage_names.clone())).unwrap();
-                                let traced = Py::new(py, PyTracedBytes::create(payload, lat)).unwrap();
+                                let lat = Py::new(py, PyLatency::create(stage_names.clone()))
+                                    .expect("invariant: allocating a PyLatency pyclass cannot fail");
+                                let traced = Py::new(py, PyTracedBytes::create(payload, lat))
+                                    .expect("invariant: allocating a PyTracedBytes pyclass cannot fail");
                                 return traced.into_any();
                             }
                             let lat = PyLatency::create_from_bytes(&bytes[..header_len], stage_names.clone());
                             let payload = PyBytes::new(py, &bytes[header_len..]).into_any().unbind();
-                            let lat = Py::new(py, lat).unwrap();
-                            let traced = Py::new(py, PyTracedBytes::create(payload, lat)).unwrap();
+                            let lat = Py::new(py, lat)
+                                .expect("invariant: allocating a PyLatency pyclass cannot fail");
+                            let traced = Py::new(py, PyTracedBytes::create(payload, lat))
+                                .expect("invariant: allocating a PyTracedBytes pyclass cannot fail");
                             traced.into_any()
                         })
                         .collect();

--- a/wingfoil-python/src/py_kafka.rs
+++ b/wingfoil-python/src/py_kafka.rs
@@ -2,6 +2,7 @@
 
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use crate::types::{DICT_INSERT_INFALLIBLE, LIST_NEW_INFALLIBLE};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
@@ -29,23 +30,33 @@ pub fn py_kafka_sub(brokers: String, topic: String, group_id: String) -> PyStrea
                 .into_iter()
                 .map(|event| {
                     let dict = PyDict::new(py);
-                    dict.set_item("topic", &event.topic).unwrap();
-                    dict.set_item("partition", event.partition).unwrap();
-                    dict.set_item("offset", event.offset).unwrap();
+                    dict.set_item("topic", &event.topic)
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.set_item("partition", event.partition)
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.set_item("offset", event.offset)
+                        .expect(DICT_INSERT_INFALLIBLE);
                     match &event.key {
                         Some(k) => {
-                            dict.set_item("key", PyBytes::new(py, k)).unwrap();
+                            dict.set_item("key", PyBytes::new(py, k))
+                                .expect(DICT_INSERT_INFALLIBLE);
                         }
                         None => {
-                            dict.set_item("key", py.None()).unwrap();
+                            dict.set_item("key", py.None())
+                                .expect(DICT_INSERT_INFALLIBLE);
                         }
                     }
                     dict.set_item("value", PyBytes::new(py, &event.value))
-                        .unwrap();
+                        .expect(DICT_INSERT_INFALLIBLE);
                     dict.into_any().unbind()
                 })
                 .collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 

--- a/wingfoil-python/src/py_kdb.rs
+++ b/wingfoil-python/src/py_kdb.rs
@@ -3,6 +3,7 @@
 use crate::PyNode;
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use crate::types::INTO_PY_INFALLIBLE;
 
 use pyo3::conversion::IntoPyObject;
 use pyo3::prelude::*;
@@ -43,12 +44,37 @@ impl Default for PyKdbValue {
 impl PyKdbValue {
     fn to_py(&self, py: Python<'_>) -> Py<PyAny> {
         match self {
-            PyKdbValue::Long(v) => v.into_pyobject(py).unwrap().into_any().unbind(),
-            PyKdbValue::Float(v) => v.into_pyobject(py).unwrap().into_any().unbind(),
-            PyKdbValue::Symbol(v) => v.into_pyobject(py).unwrap().into_any().unbind(),
-            PyKdbValue::Bool(v) => v.into_pyobject(py).unwrap().to_owned().into_any().unbind(),
-            PyKdbValue::Int(v) => v.into_pyobject(py).unwrap().into_any().unbind(),
-            PyKdbValue::Real(v) => v.into_pyobject(py).unwrap().into_any().unbind(),
+            PyKdbValue::Long(v) => v
+                .into_pyobject(py)
+                .expect(INTO_PY_INFALLIBLE)
+                .into_any()
+                .unbind(),
+            PyKdbValue::Float(v) => v
+                .into_pyobject(py)
+                .expect(INTO_PY_INFALLIBLE)
+                .into_any()
+                .unbind(),
+            PyKdbValue::Symbol(v) => v
+                .into_pyobject(py)
+                .expect(INTO_PY_INFALLIBLE)
+                .into_any()
+                .unbind(),
+            PyKdbValue::Bool(v) => v
+                .into_pyobject(py)
+                .expect(INTO_PY_INFALLIBLE)
+                .to_owned()
+                .into_any()
+                .unbind(),
+            PyKdbValue::Int(v) => v
+                .into_pyobject(py)
+                .expect(INTO_PY_INFALLIBLE)
+                .into_any()
+                .unbind(),
+            PyKdbValue::Real(v) => v
+                .into_pyobject(py)
+                .expect(INTO_PY_INFALLIBLE)
+                .into_any()
+                .unbind(),
         }
     }
 }
@@ -139,7 +165,8 @@ pub fn py_kdb_read(
         Python::attach(|py| {
             let dict = PyDict::new(py);
             for (name, value) in &row.columns {
-                dict.set_item(name, value.to_py(py)).unwrap();
+                dict.set_item(name, value.to_py(py))
+                    .expect("invariant: inserting into a fresh dict cannot fail");
             }
             PyElement::new(dict.into_any().unbind())
         })

--- a/wingfoil-python/src/py_latency.rs
+++ b/wingfoil-python/src/py_latency.rs
@@ -105,7 +105,11 @@ impl PyLatency {
         let stamps: Vec<u64> = (0..n)
             .map(|i| {
                 let offset = i * 8;
-                u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
+                u64::from_le_bytes(
+                    data[offset..offset + 8]
+                        .try_into()
+                        .expect("invariant: an 8-byte slice always converts to [u8; 8]"),
+                )
             })
             .collect();
         Ok(Self {
@@ -156,7 +160,11 @@ impl PyLatency {
             .map(|i| {
                 let offset = i * 8;
                 if offset + 8 <= data.len() {
-                    u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap())
+                    u64::from_le_bytes(
+                        data[offset..offset + 8]
+                            .try_into()
+                            .expect("invariant: an 8-byte slice always converts to [u8; 8]"),
+                    )
                 } else {
                     0
                 }

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -14,6 +14,14 @@ use crate::py_element::PyElement;
 use crate::types::*;
 use crate::*;
 
+/// Wrap a Python exception raised inside a user callback into an `anyhow::Error`
+/// so it can flow through the fallible (`try_*`) graph operators. The original
+/// `PyErr` is recovered by [`ToPyResult`] at the `#[pymethods]` boundary, so the
+/// Python type, message and traceback propagate unchanged.
+pub(crate) fn py_callback_error(err: PyErr) -> anyhow::Error {
+    anyhow::Error::new(err)
+}
+
 #[derive(Clone)]
 #[pyclass(subclass, unsendable, name = "Stream")]
 pub struct PyStream(pub Rc<dyn Stream<PyElement>>);
@@ -23,12 +31,14 @@ impl PyStream {
     where
         T: Element + for<'a, 'py> FromPyObject<'a, 'py>,
     {
-        self.0.map(move |x: PyElement| {
-            Python::attach(|py| match x.as_ref().extract::<T>(py) {
-                Ok(val) => val,
-                Err(_err) => {
-                    panic!("Failed to convert from python type to native rust type")
-                }
+        self.0.try_map(move |x: PyElement| {
+            Python::attach(|py| {
+                x.as_ref().extract::<T>(py).map_err(|e| {
+                    py_callback_error(e.into()).context(format!(
+                        "failed to convert Python value to native {}",
+                        type_name::<T>()
+                    ))
+                })
             })
         })
     }
@@ -42,18 +52,33 @@ impl PyStream {
     }
 }
 
+/// Convert a native Rust value into a `Py<PyAny>`.
+///
+/// Only ever called with concrete types (`f64`, `u64`, `Vec<Py<PyAny>>`) whose
+/// `IntoPyObject` impl is infallible, so a failure here is an invariant
+/// violation rather than a user-facing error.
 pub fn to_pyany<T>(x: T) -> Py<PyAny>
 where
     T: for<'py> IntoPyObject<'py>,
 {
-    Python::attach(|py| match x.into_pyobject(py) {
-        Ok(bound) => bound.into_any().unbind(),
-        Err(_) => panic!("Conversion to PyAny from type {} failed", type_name::<T>()),
+    Python::attach(|py| {
+        x.into_pyobject(py)
+            .map(|bound| bound.into_any().unbind())
+            .unwrap_or_else(|_| {
+                panic!(
+                    "invariant: IntoPyObject for {} is expected to be infallible",
+                    type_name::<T>()
+                )
+            })
     })
 }
 
 pub fn vec_any_to_pyany(x: Vec<Py<PyAny>>) -> Py<PyAny> {
-    Python::attach(|py| x.into_pyobject(py).unwrap().into_any().unbind())
+    Python::attach(|py| {
+        x.into_pyobject(py)
+            .map(|bound| bound.into_any().unbind())
+            .expect("invariant: IntoPyObject for Vec<Py<PyAny>> is infallible")
+    })
 }
 
 pub trait AsPyStream<T>
@@ -149,11 +174,14 @@ impl PyStream {
                     let py_tuple = pyo3::types::PyTuple::new(
                         py,
                         &[
-                            time_secs.into_pyobject(py).unwrap().into_any(),
+                            time_secs
+                                .into_pyobject(py)
+                                .expect("invariant: IntoPyObject for f64 is infallible")
+                                .into_any(),
                             val.value().into_bound(py),
                         ],
                     )
-                    .unwrap();
+                    .expect("invariant: fixed-size tuple construction cannot fail");
 
                     PyElement::new(py_tuple.into_any().unbind())
                 })
@@ -191,34 +219,39 @@ impl PyStream {
     }
 
     fn finally(&self, func: Py<PyAny>) -> PyNode {
-        let node = self.0.finally(|py_elmnt, _| {
+        let node = self.0.finally(move |py_elmnt, _| {
             Python::attach(move |py| {
                 let res = py_elmnt.as_ref().clone_ref(py);
                 let args = (res,);
-                func.call1(py, args).unwrap();
-            });
-            Ok(())
+                func.call1(py, args).map_err(py_callback_error)?;
+                Ok(())
+            })
         });
         PyNode(node)
     }
 
     fn for_each(&self, func: Py<PyAny>) -> PyNode {
-        let node = self.0.for_each(move |py_elmnt, t| {
+        let node = self.0.try_for_each(move |py_elmnt, t| {
             Python::attach(|py| {
                 let res = py_elmnt.as_ref().clone_ref(py);
                 let t: f64 = t.into();
                 let args = (res, t);
-                func.call1(py, args).unwrap();
-            });
+                func.call1(py, args).map_err(py_callback_error)?;
+                Ok(())
+            })
         });
         PyNode(node)
     }
 
     fn inspect(&self, func: Py<PyAny>) -> PyStream {
-        let stream = self.0.inspect(move |x| {
+        // No fallible `inspect` operator exists in core; express the
+        // side-effecting pass-through as a `try_map` that returns the value
+        // unchanged so a Python exception in `func` propagates.
+        let stream = self.0.try_map(move |x: PyElement| {
             Python::attach(|py| {
-                func.call1(py, (x.value(),)).unwrap();
-            });
+                func.call1(py, (x.value(),)).map_err(py_callback_error)?;
+                Ok(x)
+            })
         });
         PyStream(stream)
     }
@@ -241,13 +274,14 @@ impl PyStream {
 
     /// drops source contingent on supplied predicate (Python callable)
     fn filter(&self, keep_func: Py<PyAny>) -> PyStream {
-        let keep = self.0.map(move |x| {
+        let keep = self.0.try_map(move |x: PyElement| {
             Python::attach(|py| {
-                keep_func
+                let res = keep_func
                     .call1(py, (x.value(),))
-                    .unwrap()
-                    .extract::<bool>(py)
-                    .unwrap()
+                    .map_err(py_callback_error)?;
+                res.extract::<bool>(py).map_err(|e| {
+                    py_callback_error(e).context("filter predicate must return a bool")
+                })
             })
         });
         PyStream(self.0.filter(keep))
@@ -265,10 +299,10 @@ impl PyStream {
 
     /// Map’s its source into a new Stream using the supplied Python callable.
     fn map(&self, func: Py<PyAny>) -> PyStream {
-        let stream = self.0.map(move |x| {
+        let stream = self.0.try_map(move |x: PyElement| {
             Python::attach(|py| {
-                let res = func.call1(py, (x.value(),)).unwrap();
-                PyElement::new(res)
+                let res = func.call1(py, (x.value(),)).map_err(py_callback_error)?;
+                Ok(PyElement::new(res))
             })
         });
         PyStream(stream)
@@ -279,16 +313,17 @@ impl PyStream {
         PyStream(self.0.not())
     }
 
-    fn sample(&self, trigger: Py<PyAny>) -> PyStream {
+    fn sample(&self, trigger: Py<PyAny>) -> PyResult<PyStream> {
         Python::attach(|py| {
             let obj = trigger.as_ref();
             if let Ok(node) = obj.extract::<PyRef<PyNode>>(py) {
-                return PyStream(self.0.sample(node.0.clone()));
+                return Ok(PyStream(self.0.sample(node.0.clone())));
             }
             if let Ok(stream) = obj.extract::<PyRef<PyStream>>(py) {
-                return PyStream(self.0.sample(stream.0.clone()));
+                return Ok(PyStream(self.0.sample(stream.0.clone())));
             }
-            panic!("Expected a PyNode or PyStream");
+            Err::<PyStream, _>(py_type_error("sample: expected a Node or Stream trigger"))
+                .to_pyresult()
         })
     }
 
@@ -310,11 +345,14 @@ impl PyStream {
                 let py_tuple = pyo3::types::PyTuple::new(
                     py,
                     &[
-                        time_secs.into_pyobject(py).unwrap().into_any(),
+                        time_secs
+                            .into_pyobject(py)
+                            .expect("invariant: IntoPyObject for f64 is infallible")
+                            .into_any(),
                         v.value().into_bound(py),
                     ],
                 )
-                .unwrap();
+                .expect("invariant: fixed-size tuple construction cannot fail");
                 PyElement::new(py_tuple.into_any().unbind())
             })
         });
@@ -331,8 +369,9 @@ impl PyStream {
     ///
     /// Returns:
     ///     A Node that drives the write operation.
-    fn csv_write(&self, path: String) -> PyNode {
-        PyNode::new(crate::py_csv::py_csv_write_inner(&self.0, path))
+    fn csv_write(&self, path: String) -> PyResult<PyNode> {
+        let node = crate::py_csv::py_csv_write_inner(&self.0, path).to_pyresult()?;
+        Ok(PyNode::new(node))
     }
 
     /// Write this stream to a KDB+ table.

--- a/wingfoil-python/src/py_web.rs
+++ b/wingfoil-python/src/py_web.rs
@@ -15,6 +15,7 @@ use wingfoil::{Burst, Node, Stream, StreamOperators};
 
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use crate::types::{DICT_INSERT_INFALLIBLE, INTO_PY_INFALLIBLE, LIST_NEW_INFALLIBLE};
 
 /// Python-facing handle to a running [`WebServer`].
 ///
@@ -123,7 +124,12 @@ pub fn py_web_sub(server: &WebServer, topic: String) -> PyStream {
                 .into_iter()
                 .map(|v| serde_to_py(py, &v).unbind())
                 .collect();
-            PyElement::new(PyList::new(py, items).unwrap().into_any().unbind())
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
     PyStream(py_stream)
@@ -204,24 +210,31 @@ fn serde_to_py<'py>(py: Python<'py>, value: &serde_json::Value) -> Bound<'py, Py
         V::Bool(b) => PyBool::new(py, *b).to_owned().into_any(),
         V::Number(n) => {
             if let Some(i) = n.as_i64() {
-                i.into_pyobject(py).unwrap().into_any()
+                i.into_pyobject(py).expect(INTO_PY_INFALLIBLE).into_any()
             } else if let Some(u) = n.as_u64() {
-                u.into_pyobject(py).unwrap().into_any()
+                u.into_pyobject(py).expect(INTO_PY_INFALLIBLE).into_any()
             } else if let Some(f) = n.as_f64() {
-                f.into_pyobject(py).unwrap().into_any()
+                f.into_pyobject(py).expect(INTO_PY_INFALLIBLE).into_any()
             } else {
                 py.None().into_bound(py)
             }
         }
-        V::String(s) => s.as_str().into_pyobject(py).unwrap().into_any(),
+        V::String(s) => s
+            .as_str()
+            .into_pyobject(py)
+            .expect(INTO_PY_INFALLIBLE)
+            .into_any(),
         V::Array(arr) => {
             let items: Vec<Bound<'py, PyAny>> = arr.iter().map(|v| serde_to_py(py, v)).collect();
-            PyList::new(py, items).unwrap().into_any()
+            PyList::new(py, items)
+                .expect(LIST_NEW_INFALLIBLE)
+                .into_any()
         }
         V::Object(obj) => {
             let d = PyDict::new(py);
             for (k, v) in obj.iter() {
-                d.set_item(k, serde_to_py(py, v)).unwrap();
+                d.set_item(k, serde_to_py(py, v))
+                    .expect(DICT_INSERT_INFALLIBLE);
             }
             d.into_any()
         }

--- a/wingfoil-python/src/py_zmq.rs
+++ b/wingfoil-python/src/py_zmq.rs
@@ -2,6 +2,7 @@
 
 use crate::py_element::PyElement;
 use crate::py_stream::PyStream;
+use crate::types::{INTO_PY_INFALLIBLE, LIST_NEW_INFALLIBLE};
 
 use pyo3::prelude::*;
 use std::rc::Rc;
@@ -64,7 +65,7 @@ fn streams_to_py(
                 .collect();
             PyElement::new(
                 pyo3::types::PyList::new(py, items)
-                    .unwrap()
+                    .expect(LIST_NEW_INFALLIBLE)
                     .into_any()
                     .unbind(),
             )
@@ -77,7 +78,13 @@ fn streams_to_py(
                 ZmqStatus::Connected => "connected",
                 ZmqStatus::Disconnected => "disconnected",
             };
-            PyElement::new(s_str.into_pyobject(py).unwrap().into_any().unbind())
+            PyElement::new(
+                s_str
+                    .into_pyobject(py)
+                    .expect(INTO_PY_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
         })
     });
 

--- a/wingfoil-python/src/types.rs
+++ b/wingfoil-python/src/types.rs
@@ -1,11 +1,9 @@
 use anyhow::anyhow;
-use pyo3::exceptions::PyException;
+use pyo3::exceptions::{PyException, PyTypeError, PyValueError};
 use std::time::SystemTime;
 
 use ::wingfoil::{NanoTime, RunFor, RunMode};
 
-#[cfg(feature = "iceoryx2")]
-use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
 use std::time::Duration;
@@ -15,27 +13,53 @@ pub trait ToPyResult<T> {
     fn to_pyresult(self) -> PyResult<T>;
 }
 
-#[cfg(feature = "iceoryx2")]
+/// `expect` message for inserting into a freshly-created `PyDict`. Inserting
+/// hashable str/bytes/primitive keys into a new dict cannot fail.
+pub const DICT_INSERT_INFALLIBLE: &str = "invariant: inserting into a fresh dict cannot fail";
+
+/// `expect` message for constructing a `PyList` from an in-memory `Vec`.
+pub const LIST_NEW_INFALLIBLE: &str = "invariant: PyList::new from a Vec cannot fail";
+
+/// `expect` message for `IntoPyObject` on primitive / `String` values whose
+/// conversion is infallible.
+pub const INTO_PY_INFALLIBLE: &str =
+    "invariant: IntoPyObject for this primitive type is infallible";
+
+/// Typed binding errors that map to specific Python exception classes when
+/// surfaced through [`ToPyResult`]. Construct via the helpers
+/// [`py_type_error`] / [`py_value_error`] so the variant rides inside the
+/// `anyhow::Error` and is downcast at the `#[pymethods]` boundary.
 #[derive(Debug, thiserror::Error)]
 pub enum PyBindingError {
     #[error("{0}")]
     TypeError(String),
+    #[error("{0}")]
+    ValueError(String),
 }
 
-#[cfg(feature = "iceoryx2")]
+/// Build an `anyhow::Error` that surfaces as a Python `TypeError`.
 pub fn py_type_error(msg: impl Into<String>) -> anyhow::Error {
     anyhow!(PyBindingError::TypeError(msg.into()))
+}
+
+/// Build an `anyhow::Error` that surfaces as a Python `ValueError`.
+pub fn py_value_error(msg: impl Into<String>) -> anyhow::Error {
+    anyhow!(PyBindingError::ValueError(msg.into()))
 }
 
 impl<T> ToPyResult<T> for anyhow::Result<T> {
     fn to_pyresult(self) -> PyResult<T> {
         self.map_err(|e| {
-            #[cfg(feature = "iceoryx2")]
-            if let Some(PyBindingError::TypeError(msg)) = e.downcast_ref::<PyBindingError>() {
-                return PyTypeError::new_err(msg.clone());
+            // Preserve a Python exception raised inside a user callback so the
+            // original type / message / traceback propagate unchanged.
+            if let Some(py_err) = e.downcast_ref::<PyErr>() {
+                return Python::attach(|py| py_err.clone_ref(py));
             }
-
-            PyException::new_err(e.to_string())
+            match e.downcast_ref::<PyBindingError>() {
+                Some(PyBindingError::TypeError(msg)) => PyTypeError::new_err(msg.clone()),
+                Some(PyBindingError::ValueError(msg)) => PyValueError::new_err(msg.clone()),
+                None => PyException::new_err(e.to_string()),
+            }
         })
     }
 }
@@ -48,10 +72,10 @@ pub fn parse_run_args(
     cycles: Option<u32>,
 ) -> anyhow::Result<(RunMode, RunFor)> {
     if duration.is_some() && cycles.is_some() {
-        panic!("Cannot specify both duration and cycles");
+        anyhow::bail!(py_value_error("Cannot specify both duration and cycles"));
     }
     if realtime && start.is_some() {
-        panic!("Cannot specify start in realtime mode");
+        anyhow::bail!(py_value_error("Cannot specify start in realtime mode"));
     }
     let run_mode = if realtime {
         RunMode::RealTime

--- a/wingfoil-python/tests/test_streams.py
+++ b/wingfoil-python/tests/test_streams.py
@@ -288,5 +288,61 @@ class TestDataframe(unittest.TestCase):
         self.assertTrue(all(times[i] < times[i + 1] for i in range(len(times) - 1)))
 
 
+class TestCallbackExceptionPropagation(unittest.TestCase):
+    """A Python exception raised inside a user callback must propagate out of
+    `run()` with its original type / message instead of aborting the process."""
+
+    def test_map_callback_exception_propagates(self):
+        class Boom(Exception):
+            pass
+
+        def explode(_x):
+            raise Boom("map blew up")
+
+        stream = constant(1).map(explode).collect()
+        with self.assertRaises(Boom) as ctx:
+            stream.run(realtime=False, cycles=1)
+        self.assertIn("map blew up", str(ctx.exception))
+
+    def test_filter_callback_exception_propagates(self):
+        def explode(_x):
+            raise ValueError("filter predicate blew up")
+
+        stream = ticker(0.1).count().filter(explode).collect()
+        with self.assertRaises(ValueError):
+            stream.run(realtime=False, cycles=1)
+
+    def test_filter_non_bool_return_raises(self):
+        stream = ticker(0.1).count().filter(lambda x: "not a bool").collect()
+        with self.assertRaises(Exception):
+            stream.run(realtime=False, cycles=1)
+
+    def test_for_each_callback_exception_propagates(self):
+        def explode(_value, _t):
+            raise RuntimeError("for_each blew up")
+
+        node = ticker(0.1).count().for_each(explode)
+        with self.assertRaises(RuntimeError):
+            node.run(realtime=False, cycles=1)
+
+    def test_inspect_callback_exception_propagates(self):
+        def explode(_x):
+            raise KeyError("inspect blew up")
+
+        stream = ticker(0.1).count().inspect(explode).collect()
+        with self.assertRaises(KeyError):
+            stream.run(realtime=False, cycles=1)
+
+    def test_bimap_callback_exception_propagates(self):
+        def explode(_a, _b):
+            raise TypeError("bimap blew up")
+
+        a = ticker(0.1).count()
+        b = ticker(0.1).count()
+        stream = bimap(a, b, explode).collect()
+        with self.assertRaises(TypeError):
+            stream.run(realtime=False, cycles=1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #372.

Replaces the pervasive `panic!`/`.unwrap()` on fallible Python operations in the binding layer with propagated `PyErr`s. 16 files, +423/−137. **Zero** non-test `.unwrap()` remain; **4** `panic!`s remain, all in infallible Rust trait contexts (justified below).

## The user-visible win

An exception raised inside a user callback (a `map`/`filter`/`finally`/`for_each`/`inspect` lambda) previously became a **Rust panic unwinding across FFI**. Now it propagates as the **same Python exception, with original type, message, and traceback**:

- `ToPyResult::to_pyresult` downcasts a `PyErr` carried inside the `anyhow::Error` and re-raises it unchanged (`types.rs`).
- The callback closures now use the fallible core operators (`try_map` / `try_for_each` / `finally`), mapping `func.call1(...)`'s error through `py_callback_error` so it rides the graph as `anyhow::Error` and is recovered at the `#[pymethods]` boundary.

## Changes (items 1–6 from the issue)

1. **Ungated** `PyBindingError` / `py_type_error` / the `ToPyResult` downcast arm (previously `#[cfg(feature = "iceoryx2")]`), so typed exceptions work under default features. Added `py_value_error` + the `PyErr` passthrough downcast.
2. **`parse_run_args`** — both `panic!`s → `bail!(py_value_error(...))`, now catchable `ValueError`s.
3. **Callback propagation** — `map`/`filter`/`finally`/`for_each`/`inspect`/`bimap`/`extract` use `try_*` and propagate the lambda's exception. (`inspect` is expressed as a pass-through `try_map` since core has no fallible `inspect`; added `.context()` for the "filter must return bool" and conversion cases.)
4. **Type errors → `PyTypeError`** — `sample` and `bimap` argument extraction return `py_type_error(...)` instead of panicking.
5. **Remaining `.unwrap()`** — `csv_write` file-open is now fallible and propagated; all other adapter unwraps (kdb/kafka/fluvio/etcd/fix/web/zmq/latency/iceoryx2/element) converted to `.expect("invariant: …")` with three shared constant messages in `types.rs`.
6. Standardized touched `#[pymethods]` returns on `ToPyResult`/`PyErr`.

## Residual `panic!`s (4 — all infallible trait contexts)

- `py_element.rs:137,143` — inside the `Hash` trait impl (signature can't return `Result`); unhashable/empty `PyElement` is a contract violation.
- `proxy_stream.rs:52` — `MutableNode::upstreams()` is infallible by the core trait (off-limits); a malformed Python proxy is unrecoverable.
- `py_stream.rs:68` — `to_pyany` documented invariant: `IntoPyObject` for the concrete primitive types it's called with cannot fail.

## Tests

Added `TestCallbackExceptionPropagation` to `tests/test_streams.py`, asserting exceptions raised in `map`/`filter`/`for_each`/`inspect`/`bimap` lambdas (and a non-bool filter return) propagate out of `run()` with their original types.

## Verification (offline)

- `cargo fmt --all -- --check` — clean
- `cargo build -p wingfoil-python` — Finished
- `cargo clippy -p wingfoil-python --all-targets -- -D warnings` — no warnings
- Pre-push hook ran the full Rust suite — 215 tests + doctests passing.

**Could not run pytest locally** — `maturin` isn't installed in this environment, so the new Python test will execute in CI. The `iceoryx2` feature (needs `bindgen`/network) wasn't clippy-checked offline; its edits are mechanical `.unwrap()`→`.expect()` swaps that `cargo lint-all` will cover in CI.

https://claude.ai/code/session_01FnvspopUDh1kKUZaUtfCTx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnvspopUDh1kKUZaUtfCTx)_