### PR TITLE
fix(aeron): keep poll loops off the graph thread's lock/IO budget

### DIFF
--- a/wingfoil/src/adapters/aeron/CLAUDE.md
+++ b/wingfoil/src/adapters/aeron/CLAUDE.md
@@ -92,9 +92,14 @@ thread, violating wingfoil's "no locks in `cycle()`" invariant.
 Guidance:
 - Use the `aeron` (rusteron) backend for low-latency / production — its
   `poll()` / `offer()` are genuinely lock-free.
-- If you must use `aeron-rs-beta`, prefer `AeronMode::Threaded` so the
-  subscriber lock runs on the background poll thread. The publisher has no
-  threaded mode and always locks on the calling thread.
+- The `aeron-rs-beta` subscriber reports `supports_graph_thread_poll() == false`,
+  so `aeron_sub_fragment` **automatically downgrades `AeronMode::Spin` to
+  `Threaded`** for it (logging a warning) — the subscriber lock can only ever run
+  on the background poll thread. `Spin` is unreachable for this backend by
+  construction.
+- The publisher has no threaded mode and always locks on the calling thread;
+  there is no automatic downgrade for the publish side, so avoid the
+  `aeron-rs-beta` publisher on latency-sensitive paths.
 
 This is why `aeron-rs-beta` is named `-beta` and is excluded from the `full`
 feature set.

--- a/wingfoil/src/adapters/aeron/aeron_rs_backend.rs
+++ b/wingfoil/src/adapters/aeron/aeron_rs_backend.rs
@@ -211,6 +211,15 @@ impl AeronSubscriberBackend for AeronRsSubscriber {
     fn with_fragment_limit(self, fragment_limit: usize) -> Self {
         AeronRsSubscriber::with_fragment_limit(self, fragment_limit)
     }
+
+    /// `aeron-rs` polls under a `Mutex` shared with its conductor thread, so it
+    /// is unsafe to poll on the graph thread. Returning `false` makes the
+    /// factory downgrade `AeronMode::Spin` to `Threaded`, keeping the lock off
+    /// the graph `cycle()`. See the module-level "Lock on the graph thread"
+    /// note for why this lock cannot be hoisted.
+    fn supports_graph_thread_poll(&self) -> bool {
+        false
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/wingfoil/src/adapters/aeron/mod.rs
+++ b/wingfoil/src/adapters/aeron/mod.rs
@@ -23,18 +23,22 @@
 //! The `aeron-rs` crate returns its `Subscription` / `Publication` handles as
 //! `Arc<Mutex<…>>` and shares them with its own background client-conductor
 //! thread, which locks them on every publisher connect/disconnect. The backend
-//! therefore **acquires that `Mutex` on every `poll()` / `offer()`** — and in
-//! [`AeronMode::Spin`] those calls run inside the graph `cycle()` on the graph
-//! thread. That contended lock on the hot path is antithetical to Aeron's
-//! lock-free design and violates wingfoil's "no locks in `cycle()`" invariant.
+//! therefore **acquires that `Mutex` on every `poll()` / `offer()`**. To keep
+//! that lock off the graph `cycle()`, the subscriber backend reports
+//! [`supports_graph_thread_poll`](AeronSubscriberBackend::supports_graph_thread_poll)
+//! `= false`, and [`aeron_sub_fragment`] **automatically downgrades a requested
+//! [`AeronMode::Spin`] to [`AeronMode::Threaded`]** for it (logging a warning) —
+//! so its lock can never land on the graph thread. `Spin` is unreachable for
+//! the `aeron-rs-beta` subscriber by construction.
 //!
 //! Consequences and guidance:
 //! - For latency-sensitive or production workloads, use the `aeron` (rusteron)
-//!   backend, whose `poll()` / `offer()` are genuinely lock-free.
-//! - If you must use `aeron-rs-beta`, prefer [`AeronMode::Threaded`] so the lock
-//!   is taken on the background poll thread rather than the graph thread.
-//! - The `aeron-rs-beta` publisher has no threaded mode; its `offer()` always
-//!   locks on the calling (graph) thread. Treat it as functional-but-slow.
+//!   backend, whose `poll()` / `offer()` are genuinely lock-free and run on the
+//!   graph thread in [`AeronMode::Spin`] without a lock.
+//! - The `aeron-rs-beta` **publisher** has no threaded mode; its `offer()`
+//!   always locks on the calling (graph) thread. It remains functional-but-slow
+//!   and there is no automatic downgrade for the publish side — avoid it on
+//!   latency-sensitive paths.
 //!
 //! # Polling modes
 //!
@@ -203,6 +207,30 @@ impl Default for AeronSubOptions {
     }
 }
 
+/// Resolve the polling mode actually used for `subscriber`.
+///
+/// A backend that cannot be polled on the graph thread (see
+/// [`AeronSubscriberBackend::supports_graph_thread_poll`]) downgrades a
+/// requested [`AeronMode::Spin`] to [`AeronMode::Threaded`], so its lock never
+/// runs inside the graph `cycle()`. This keeps the `aeron-rs-beta` backend
+/// from violating the "no locks in `cycle()`" invariant by construction —
+/// `Spin` is simply unreachable for it. Lock-free backends (rusteron, mocks)
+/// pass the requested mode through unchanged.
+fn effective_mode<B: transport::AeronSubscriberBackend>(
+    requested: AeronMode,
+    subscriber: &B,
+) -> AeronMode {
+    if requested == AeronMode::Spin && !subscriber.supports_graph_thread_poll() {
+        log::warn!(
+            "aeron sub: backend cannot be polled on the graph thread (it locks on poll); \
+             downgrading AeronMode::Spin to Threaded to honour the no-locks-in-cycle invariant"
+        );
+        AeronMode::Threaded
+    } else {
+        requested
+    }
+}
+
 // ---------------------------------------------------------------------------
 // aeron_sub_fragment — typed-parser surface
 // ---------------------------------------------------------------------------
@@ -237,7 +265,7 @@ where
     B: transport::AeronSubscriberBackend,
 {
     let subscriber = subscriber.with_fragment_limit(opts.fragment_limit);
-    match opts.mode {
+    match effective_mode(opts.mode, &subscriber) {
         AeronMode::Spin => {
             sub_fragment_node::AeronSpinSubFragmentNode::new(subscriber, parser).into_stream()
         }
@@ -298,7 +326,7 @@ where
     B: transport::AeronSubscriberBackend,
 {
     let subscriber = subscriber.with_fragment_limit(opts.fragment_limit);
-    match opts.mode {
+    match effective_mode(opts.mode, &subscriber) {
         AeronMode::Spin => {
             // The spin subscriber records status on the graph thread; wire it as
             // the status node's active upstream so transitions are forwarded once
@@ -357,6 +385,46 @@ mod tests {
     #[test]
     fn given_aeron_sub_options_when_default_then_mode_is_spin() {
         assert!(matches!(AeronSubOptions::default().mode, AeronMode::Spin));
+    }
+
+    /// Minimal subscriber that reports it cannot be polled on the graph thread,
+    /// to exercise the `Spin` → `Threaded` downgrade in [`effective_mode`].
+    struct NoGraphThreadPollSubscriber;
+
+    impl transport::AeronSubscriberBackend for NoGraphThreadPollSubscriber {
+        fn poll(&mut self, _handler: &mut dyn FnMut(&[u8])) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+
+        fn supports_graph_thread_poll(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn given_non_graph_thread_backend_when_spin_requested_then_downgraded_to_threaded() {
+        let backend = NoGraphThreadPollSubscriber;
+        assert_eq!(
+            effective_mode(AeronMode::Spin, &backend),
+            AeronMode::Threaded,
+            "a backend that locks on poll must never run Spin on the graph thread"
+        );
+    }
+
+    #[test]
+    fn given_non_graph_thread_backend_when_threaded_requested_then_stays_threaded() {
+        let backend = NoGraphThreadPollSubscriber;
+        assert_eq!(
+            effective_mode(AeronMode::Threaded, &backend),
+            AeronMode::Threaded
+        );
+    }
+
+    #[test]
+    fn given_lock_free_backend_when_spin_requested_then_stays_spin() {
+        // The default `MockSubscriber` inherits `supports_graph_thread_poll() == true`.
+        let backend = transport::MockSubscriber::from_messages(vec![]);
+        assert_eq!(effective_mode(AeronMode::Spin, &backend), AeronMode::Spin);
     }
 
     #[test]

--- a/wingfoil/src/adapters/aeron/sub_fragment_node.rs
+++ b/wingfoil/src/adapters/aeron/sub_fragment_node.rs
@@ -110,16 +110,15 @@ where
         }
         let parser = &mut self.parser;
         let value = &mut self.value;
-        self.backend.poll_fragments(&mut |frag| match parser(frag) {
-            Ok(Some(v)) => value.push(v),
-            Ok(None) => {}
-            Err(e) => {
-                eprintln!(
-                    "[wingfoil::adapters::aeron] WARN parser dropped fragment at position {}: {e}",
+        self.backend
+            .poll_fragments(&mut |frag| match parser(frag) {
+                Ok(Some(v)) => value.push(v),
+                Ok(None) => {}
+                Err(e) => log::warn!(
+                    "aeron sub: parser dropped fragment at position {}: {e}",
                     frag.position()
-                );
-            }
-        })?;
+                ),
+            })?;
         let transition = if let Some(status) = &self.status {
             let new_status = if self.backend.is_closed() {
                 AeronStatus::Closed
@@ -237,12 +236,10 @@ where
                         let _ = sender.send_message(Message::RealtimeValue(v));
                     }
                     Ok(None) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "[wingfoil::adapters::aeron] WARN parser dropped fragment at position {}: {e}",
-                            frag.position()
-                        );
-                    }
+                    Err(e) => log::warn!(
+                        "aeron sub: parser dropped fragment at position {}: {e}",
+                        frag.position()
+                    ),
                 })?;
 
                 if count == 0 {
@@ -398,12 +395,10 @@ where
                         let _ = sender.send_message(Message::RealtimeValue(AeronItem::Data(v)));
                     }
                     Ok(None) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "[wingfoil::adapters::aeron] WARN parser dropped fragment at position {}: {e}",
-                            frag.position()
-                        );
-                    }
+                    Err(e) => log::warn!(
+                        "aeron sub: parser dropped fragment at position {}: {e}",
+                        frag.position()
+                    ),
                 })?;
 
                 // Derive the lifecycle status and propagate it in-band on change.

--- a/wingfoil/src/adapters/aeron/transport.rs
+++ b/wingfoil/src/adapters/aeron/transport.rs
@@ -49,6 +49,23 @@ pub trait AeronSubscriberBackend: Send + 'static {
         false
     }
 
+    /// Whether this backend may be polled inside the graph `cycle()` on the
+    /// graph thread (i.e. is safe for [`AeronMode::Spin`]).
+    ///
+    /// Default `true` — lock-free backends (rusteron, the mocks) poll without
+    /// blocking. Backends whose `poll()` takes a lock or otherwise blocks (the
+    /// `aeron-rs` backend, whose handle is an `Arc<Mutex<…>>` shared with a
+    /// client-conductor thread) override this to `false`. The
+    /// [`aeron_sub_fragment`] factory honours it by downgrading a requested
+    /// `Spin` mode to `Threaded` rather than running a contended lock on the
+    /// graph thread — see the crate's "no locks in `cycle()`" invariant.
+    ///
+    /// [`AeronMode::Spin`]: crate::adapters::aeron::AeronMode::Spin
+    /// [`aeron_sub_fragment`]: crate::adapters::aeron::aeron_sub_fragment
+    fn supports_graph_thread_poll(&self) -> bool {
+        true
+    }
+
     /// Override the per-`poll()` fragment cap for this subscriber.
     ///
     /// Default impl is the identity move — backends without a tunable cap


### PR DESCRIPTION
Two hot-path discipline fixes for the Aeron adapter, surfaced during a quality review of the `aeron` branch. Targets `aeron` so they land alongside the rest of the adapter work.

## 1. Log dropped fragments via `log::warn!` instead of `eprintln!`
The three fragment-drop sites in the spin and threaded subscriber poll loops used `eprintln!`, which grabs the process-wide **stderr lock** and does a **write syscall on the graph thread** inside `cycle()` — unthrottled, so a burst of malformed fragments can serialise and stall the hot path (exactly the `cycle()`-blocking the adapter invariant forbids). It also bypassed the `log` facade every other adapter (fix, iceoryx2, kdb, otlp, prometheus) already uses.

Routed through `log::warn!` so level filtering controls volume and messages flow through the configured logger.

## 2. Never run the aeron-rs `Spin` poll on the graph thread
The `aeron-rs` backend polls under a `Mutex` shared with its conductor thread, so `AeronMode::Spin` would take that lock inside the graph `cycle()` — violating the "no locks in `cycle()`" invariant. Previously this was only documented as guidance ("prefer Threaded"); nothing stopped a caller selecting `Spin`.

- Added `AeronSubscriberBackend::supports_graph_thread_poll()` (default `true`; overridden to `false` for `AeronRsSubscriber`).
- `aeron_sub_fragment{,_with_status}` now **downgrade a requested `Spin` to `Threaded`** for such backends via a new `effective_mode()` helper, logging a warning.
- `Spin` is unreachable for the aeron-rs subscriber by construction; the rusteron backend is unaffected (inherits the `true` default and stays lock-free on the graph thread).

The aeron-rs **publisher** still has no threaded mode and locks on the calling thread — documented, with no automatic downgrade for the publish side (would need a threaded publisher impl; flagged as a possible follow-up).

## Tests / verification
- Added 3 unit tests for the downgrade (`Spin`→`Threaded` for non-graph-thread backends, pass-through on `Threaded`, no downgrade for lock-free backends).
- Updated module-level docs and the adapter `CLAUDE.md` design note.
- `cargo test -p wingfoil --features aeron-rs-beta aeron::` → 89 passed.
- `cargo fmt --all --check` and `cargo clippy -p wingfoil --features aeron-rs-beta --all-targets` clean.

⚠️ The rusteron (`aeron`) FFI path was **not** compiled locally (needs cmake ≥3.30 + clang). Its only change is the inherited trait default (`true`), so it's low-risk — CI should confirm.

https://claude.ai/code/session_01SMZSZWwtq5uiAkBGxpVGPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMZSZWwtq5uiAkBGxpVGPu)_