### PR TITLE
Add two LinkedIn drafts: /new-adapter call for contributors + three-language stack

### DIFF
--- a/marketing/README.md
+++ b/marketing/README.md
@@ -13,6 +13,7 @@
 | 7 | KDB+ follow-up | [`linkedin/kdb-group-followup.md`](linkedin/kdb-group-followup.md) | Deeper-dive companion for the KDB LinkedIn group — caller-owned q, time slicing, `kdb_read_cached`. |
 | 8 | Fluvio adapter | [`linkedin/fluvio.md`](linkedin/fluvio.md) | Two nodes, per-burst flush, absolute-offset resume, SC+SPU cluster shape. |
 | 9 | `/new-adapter` call for contributors | [`linkedin/new-adapter-skill-contributors.md`](linkedin/new-adapter-skill-contributors.md) | Companion to #4 — same speed/consistency story, framed as an open call to build whatever adapter you need, with specced-out issues to pick up. |
+| 10 | Three-language stack | [`linkedin/three-language-stack.md`](linkedin/three-language-stack.md) | Rust/Python/TS as the foundation Wingfoil is built on (Rust core, PyO3, JS/TS edge). Framed as an open "what else earns a seat?" discussion rather than a three-is-enough claim. |
 
 ## Other drafts
 

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -13,7 +13,7 @@
 | 7 | KDB+ follow-up | [`linkedin/kdb-group-followup.md`](linkedin/kdb-group-followup.md) | Deeper-dive companion for the KDB LinkedIn group — caller-owned q, time slicing, `kdb_read_cached`. |
 | 8 | Fluvio adapter | [`linkedin/fluvio.md`](linkedin/fluvio.md) | Two nodes, per-burst flush, absolute-offset resume, SC+SPU cluster shape. |
 | 9 | `/new-adapter` call for contributors | [`linkedin/new-adapter-skill-contributors.md`](linkedin/new-adapter-skill-contributors.md) | Companion to #4 — same speed/consistency story, framed as an open call to build whatever adapter you need, with specced-out issues to pick up. |
-| 10 | Three-language stack | [`linkedin/three-language-stack.md`](linkedin/three-language-stack.md) | Rust/Python/TS as the foundation Wingfoil is built on (Rust core, PyO3, JS/TS edge). Framed as an open "what else earns a seat?" discussion rather than a three-is-enough claim. |
+| 10 | Three-language stack | [`linkedin/three-language-stack.md`](linkedin/three-language-stack.md) | Rust/Python/TS is enough for greenfield work (Rust core, PyO3, JS/TS edge); C++/Java/C#/Go on new projects driven by codebase inertia and talent constraints, not technical merit. Deliberately provocative — ends by daring readers to name the counterexample. |
 
 ## Other drafts
 

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -12,6 +12,7 @@
 | 6 | Kafka adapter | [`linkedin/kafka.md`](linkedin/kafka.md) | Two nodes, multi-topic publish, per-burst delivery via `FuturesUnordered`. |
 | 7 | KDB+ follow-up | [`linkedin/kdb-group-followup.md`](linkedin/kdb-group-followup.md) | Deeper-dive companion for the KDB LinkedIn group — caller-owned q, time slicing, `kdb_read_cached`. |
 | 8 | Fluvio adapter | [`linkedin/fluvio.md`](linkedin/fluvio.md) | Two nodes, per-burst flush, absolute-offset resume, SC+SPU cluster shape. |
+| 9 | `/new-adapter` call for contributors | [`linkedin/new-adapter-skill-contributors.md`](linkedin/new-adapter-skill-contributors.md) | Companion to #4 — same speed/consistency story, framed as an open call to build whatever adapter you need, with specced-out issues to pick up. |
 
 ## Other drafts
 

--- a/marketing/linkedin/new-adapter-skill-contributors.md
+++ b/marketing/linkedin/new-adapter-skill-contributors.md
@@ -1,0 +1,26 @@
+# LinkedIn — `/new-adapter` skill (call for contributors)
+
+## Post
+
+We're opening up I/O adapter contributions to Wingfoil, and there's now a tool that makes it worth your time.
+
+Some background. An adapter — Kafka, etcd, ZMQ, KDB+, and the rest — used to take us about a month to land. Most of that wasn't the protocol code. It was the surrounding decisions: where the feature flag goes, which threading model fits the client library, how the integration test starts a container, whether the Python binding ships in the same PR. We wrote those decisions down as a Claude Code skill, `/new-adapter`, reverse-engineered from the adapters we'd already built by hand. The last few took a weekend each.
+
+The part worth flagging for anyone thinking about contributing: the skill didn't only make adapters faster, it made them more consistent, and that turned out to matter more. Same file layout, same test scaffolding, same feature gating every time. A reviewer who's read one adapter can read the next without relearning where things live, and the "why is this one shaped differently" class of bug mostly stopped happening.
+
+So the ask. If there's a transport or store you want Wingfoil to talk to, run `/new-adapter <name>` and build it. You don't have to reverse-engineer our conventions first — the skill carries them, including the bits that are easy to forget, like CI registration and the example index. We have a handful specced out as issues already if you'd rather pick one up than start cold, and the other open issues are fair game too.
+
+Links in the first comment.
+
+## First comment
+
+- `/new-adapter` skill: https://github.com/wingfoil-io/wingfoil/blob/main/.claude/commands/new-adapter.md
+- Existing adapters as reference: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters
+- Adapters already specced out:
+  - `ws_client` (outbound WebSocket feeds): https://github.com/wingfoil-io/wingfoil/issues/148
+  - `sql` (relational DBs): https://github.com/wingfoil-io/wingfoil/issues/105
+  - `arrow` (Arrow IPC + Parquet): https://github.com/wingfoil-io/wingfoil/issues/104
+  - `candle` (neural inference on streams): https://github.com/wingfoil-io/wingfoil/issues/239
+  - `augurs` (time-series analytics): https://github.com/wingfoil-io/wingfoil/issues/238
+- All open adapter issues: https://github.com/wingfoil-io/wingfoil/issues?q=is%3Aissue+is%3Aopen+label%3Aio-adapter
+- Claude Code skills docs: https://docs.claude.com/en/docs/claude-code/skills

--- a/marketing/linkedin/three-language-stack.md
+++ b/marketing/linkedin/three-language-stack.md
@@ -1,0 +1,21 @@
+# LinkedIn — three-language stack (Rust / Python / TypeScript)
+
+## Post
+
+Rust, Python, and TypeScript have quietly become the foundation a lot of new projects build on. Not because they crowd everything else out, but because between them they cover three distinct jobs well.
+
+- **Rust for the systems layer** — bare-metal performance with memory safety out of the box. It keeps showing up in infrastructure, high-throughput services, and anywhere resources are tight.
+- **Python for data and orchestration** — not the fastest at raw execution, but the default interface for AI/ML, data science, and prototyping, and that isn't changing soon.
+- **TypeScript for the interface** — it owns the browser, and will until WebAssembly is ready to displace the frontend frameworks.
+
+That's the split we landed on at Wingfoil. Wingfoil is a graph-based stream processing framework: the core is Rust for predictable latency and memory safety, the runtime is exposed to Python through PyO3 so data engineers and scientists can drive it natively, and the edge integrates with JS/TS to move data in and out of browser and web environments. Performance where it matters, productivity where it counts.
+
+To be clear, this isn't a claim that three is the magic number, or that the rest are on the way out. Plenty of solid systems run on Java, C#, C, C++, and Go for good reasons — some technical, some about the codebase and team you already have, which are legitimate engineering inputs, not excuses.
+
+So the open question, not the rhetorical one: if Rust, Python, and TypeScript are the foundation, what else earns a place at the table, and for which jobs? Go for network services? Something for the JVM ecosystem you can't easily give up? Curious where other people draw the line and why.
+
+## First comment
+
+- Wingfoil on GitHub (a star helps if the architecture is useful to you): https://github.com/wingfoil-io/wingfoil/
+- Python bindings via PyO3: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil-python
+- WebSocket / JS edge: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/web

--- a/marketing/linkedin/three-language-stack.md
+++ b/marketing/linkedin/three-language-stack.md
@@ -2,17 +2,22 @@
 
 ## Post
 
-Rust, Python, and TypeScript have quietly become the foundation a lot of new projects build on. Not because they crowd everything else out, but because between them they cover three distinct jobs well.
+Here's a position I'll defend: for a greenfield project in 2026, three languages cover almost everything that matters, and the rest are mostly kept alive by inertia rather than merit.
 
-- **Rust for the systems layer** — bare-metal performance with memory safety out of the box. It keeps showing up in infrastructure, high-throughput services, and anywhere resources are tight.
-- **Python for data and orchestration** — not the fastest at raw execution, but the default interface for AI/ML, data science, and prototyping, and that isn't changing soon.
+- **Rust for the systems layer** — C and C++ performance with memory safety out of the box. Infrastructure, high-throughput services, anything resource-constrained.
+- **Python for data and orchestration** — not fast, but the non-negotiable interface for AI/ML, data science, and prototyping. That isn't changing soon.
 - **TypeScript for the interface** — it owns the browser, and will until WebAssembly is ready to displace the frontend frameworks.
 
 That's the split we landed on at Wingfoil. Wingfoil is a graph-based stream processing framework: the core is Rust for predictable latency and memory safety, the runtime is exposed to Python through PyO3 so data engineers and scientists can drive it natively, and the edge integrates with JS/TS to move data in and out of browser and web environments. Performance where it matters, productivity where it counts.
 
-To be clear, this isn't a claim that three is the magic number, or that the rest are on the way out. Plenty of solid systems run on Java, C#, C, C++, and Go for good reasons — some technical, some about the codebase and team you already have, which are legitimate engineering inputs, not excuses.
+So where does that leave C++, Java, C#, and Go for *new* work? Strip away the marketing and I think the honest reasons usually come down to two, and neither is technical:
 
-So the open question, not the rhetorical one: if Rust, Python, and TypeScript are the foundation, what else earns a place at the table, and for which jobs? Go for network services? Something for the JVM ecosystem you can't easily give up? Curious where other people draw the line and why.
+- **Codebase inertia** — there's a large, working footprint you have to extend or integrate with.
+- **Talent constraints** — the hiring pool in your org or region is weighted toward those ecosystems.
+
+Both are real, and on a given Monday they're often decisive. But they're constraints you've inherited, not capabilities the language uniquely brings. On a clean slate, Rust + Python + TypeScript handles almost any modern requirement with less sprawl and sharper specialization.
+
+Tell me where this breaks. What's the workload — a real one, not a hypothetical — where reaching for the JVM, Go, or C++ on a new project is the *technical* call and not the inherited one?
 
 ## First comment
 


### PR DESCRIPTION
Merges into the `marketing` branch. Drafts only, no code changes.

## New posts

- **`linkedin/new-adapter-skill-contributors.md`** — companion to the existing `/new-adapter` post (#4). Same month-to-weekend / consistency story, reframed as an open call for outside contributors to build whatever adapter they need. Links to specced-out adapter issues (ws_client, sql, arrow, candle, augurs) in the first comment.
- **`linkedin/three-language-stack.md`** — argues Rust + Python + TypeScript covers greenfield work, with C++/Java/C#/Go on new projects driven by codebase inertia and talent constraints rather than technical merit. Deliberately provocative; ends by daring readers to name a real counterexample. Ties to Wingfoil's Rust core / PyO3 / JS-TS edge split.

Both registered in `marketing/README.md` (posting order #9 and #10).

## Before posting

Spot-check the first-comment URLs and the specced-out issue numbers, per the note in `marketing/README.md`.

https://claude.ai/code/session_01MURqLHouaVPxb8epdUdqeF