### PR TITLE
chore(deps): drop dead deps and stop shipping criterion to consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,15 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "astral-tokio-tar"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6662,7 +6653,6 @@ version = "5.0.2"
 dependencies = [
  "anyhow",
  "arc-swap",
- "arrayvec",
  "async-stream",
  "axum",
  "axum-server",
@@ -6689,7 +6679,6 @@ dependencies = [
  "libc",
  "lobster",
  "log",
- "num",
  "num-traits",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -6697,7 +6686,6 @@ dependencies = [
  "ordered-float 4.6.0",
  "priority-queue",
  "quanta",
- "rand 0.9.2",
  "rcgen",
  "rdkafka",
  "reqwest",
@@ -6709,7 +6697,6 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "sha2",
- "smallvec",
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "testcontainers",

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -1,6 +1,9 @@
 [features]
 default = ["async"]
 full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2", "prometheus", "otlp", "fix", "web", "web-tls", "kafka"]
+# Exposes the `bencher` helper (`add_bench`, used by the criterion benches).
+# Off by default so consumers don't pull in criterion's dependency tree.
+bench = ["dep:criterion"]
 dynamic-graph-beta = []
 kdb-integration-test = ["kdb"]
 async = ["dep:tokio", "dep:futures", "dep:async-stream", "dep:futures-util", "tokio/time"]
@@ -76,27 +79,25 @@ log = {workspace=true}
 # project
 priority-queue = "2.7.0"
 itertools = "0.14.0"
-num = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 crossbeam = "0.8.4"
-lobster = "0.7.0"
 num-traits = "0.2"
 derive-new = "0.7"
 serde-aux = "4.7.0"
-smallvec = "1.15.1"
-rand = "0.9.2"
 tynm = "0.2.0"
 kanal = "0.1.1"
-scopeguard = "1.2.0"
 strum = {version = "0.27.2", features = ["derive"]}
 strum_macros = "0.27.2"
 formato = "0.3.0"
 anyhow = "1.0.100"
 thiserror = "2.0.11"
 tinyvec = { version = "1.10.0", features = ["alloc"] }
-arrayvec = { version = "0.7", features = ["serde"] }
-criterion = { version = "0.8.1" }
+# `criterion` is only needed by the `bencher` helper module, which is gated
+# behind the `bench` feature so normal consumers don't pull in its heavy
+# (plotters, etc.) dependency tree. The benches themselves get it via
+# dev-dependencies.
+criterion = { version = "0.8.1", optional = true }
 quanta = "0.9.3"
 ordered-float = "4.5.0"
 bincode = { version = "1.3.3", optional = true }
@@ -146,6 +147,12 @@ tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 libc = "0.2"
+# Used directly by the criterion benches in `benches/`.
+criterion = "0.8.1"
+# Used only by the order_book example.
+lobster = "0.7.0"
+# Used only by the web integration test.
+scopeguard = "1.2.0"
 # Used only by the web-tls integration test to generate a fresh self-signed
 # cert at test-time. Cheaper and more deterministic than shipping a static
 # fixture that would need rotating before its 1-year expiry.
@@ -195,6 +202,7 @@ name = "run_mode"
 [[bench]]
 name = "graph"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "nanotime"
@@ -204,6 +212,7 @@ harness = false
 name = "bfs_vs_dfs_wingfoil"
 path = "benches/bfs_vs_dfs/wingfoil.rs"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "bfs_vs_dfs_reactive"

--- a/wingfoil/src/lib.rs
+++ b/wingfoil/src/lib.rs
@@ -225,6 +225,7 @@ macro_rules! tracing_log_enabled {
 
 pub mod adapters;
 
+#[cfg(feature = "bench")]
 mod bencher;
 mod channel;
 mod graph;
@@ -234,6 +235,7 @@ mod queue;
 mod time;
 mod types;
 
+#[cfg(feature = "bench")]
 pub use bencher::*;
 pub use graph::*;
 pub use latency::*;

--- a/wingfoil/src/nodes/tick.rs
+++ b/wingfoil/src/nodes/tick.rs
@@ -59,7 +59,7 @@ mod tests {
         average
             .iter()
             .for_each(|x| println!("{:} {:?}", x.time, x.value));
-        let err = num::abs(period.as_nanos() as f64 - average.last().unwrap().value);
+        let err = (period.as_nanos() as f64 - average.last().unwrap().value).abs();
         debug_assert!(err < Duration::from_millis(10).as_nanos() as f64)
     }
 }


### PR DESCRIPTION
## Dependency hygiene for the `wingfoil` crate

Part 1 of 3 from a codebase quality review. Pure build/manifest hygiene — no behaviour change.

### Changes
- **Remove unused dependencies**: `rand`, `smallvec`, `arrayvec` — these have no references anywhere in the workspace (verified by grep + a clean build without them).
- **Relocate example/test-only deps to `[dev-dependencies]`**: `lobster` (used only by the `order_book` example) and `scopeguard` (used only by the web integration test, which is `#[cfg(test)]`).
- **Drop `num`**: its only use was `num::abs` in one unit test, replaced with `f64::abs`.
- **Stop shipping `criterion` to every consumer**: the public `bencher` helper module (`add_bench`) is now gated behind a new `bench` feature, so `criterion` (and its heavy plotters/etc. transitive tree) is no longer a hard dependency of the library. `criterion` is `optional` for the lib and a dev-dependency for the benches; the two benches that call `wingfoil::add_bench` (`graph`, `bfs_vs_dfs_wingfoil`) declare `required-features = ["bench"]`.

### Why
`criterion` was a non-`dev` dependency purely because the shipped `bencher` module used it, pulling a large dependency tree into every downstream build. The other crates were either dead or only needed by examples/tests.

### Verification
- `cargo build -p wingfoil` + `cargo test -p wingfoil --lib` (default features) — 210 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` (default features) — clean
- `cargo check -p wingfoil --features bench --benches` — compiles
- `cargo check -p wingfoil --example order_book --features csv` — compiles (lobster via dev-deps)

https://claude.ai/code/session_015dUcZyYghTkFuF4pimrWTe

---
_Generated by [Claude Code](https://claude.ai/code/session_015dUcZyYghTkFuF4pimrWTe)_