### PR TITLE
perf(nodes): cache upstream indices to avoid per-tick map lookups

### DIFF
--- a/wingfoil/src/nodes/channel.rs
+++ b/wingfoil/src/nodes/channel.rs
@@ -38,6 +38,10 @@ pub(crate) struct SenderNode<T: Element + Send> {
     source: Rc<dyn Stream<T>>,
     sender: ChannelSender<T>,
     trigger: Option<Rc<dyn Node>>,
+    /// Graph index of `source`, resolved once on the first cycle so the
+    /// tick-check avoids an `Rc` clone plus hash-map lookup every tick.
+    #[new(default)]
+    source_index: Option<usize>,
 }
 
 impl<T: Element + Send> MutableNode for SenderNode<T> {
@@ -51,7 +55,12 @@ impl<T: Element + Send> MutableNode for SenderNode<T> {
 
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
         //println!("SenderNode::cycle");
-        if state.ticked(self.source.clone().as_node()) {
+        let source_index = *self.source_index.get_or_insert_with(|| {
+            state
+                .node_index(self.source.clone().as_node())
+                .expect("invariant: channel sender source wired at graph init")
+        });
+        if state.node_index_ticked(source_index) {
             self.sender.send(state, self.source.peek_value())?;
             Ok(true)
         } else {

--- a/wingfoil/src/nodes/delay.rs
+++ b/wingfoil/src/nodes/delay.rs
@@ -15,6 +15,10 @@ pub(crate) struct DelayStream<T: Element + Hash + Eq> {
     queue: TimeQueue<T>,
     #[new(default)]
     initialized: bool,
+    /// Graph index of `upstream`, resolved once on the first cycle so the
+    /// tick-check avoids an `Rc` clone plus hash-map lookup every tick.
+    #[new(default)]
+    upstream_index: Option<usize>,
     upstream: Rc<dyn Stream<T>>,
     delay: NanoTime,
 }
@@ -29,14 +33,20 @@ impl<T: Element + Hash + Eq> MutableNode for DelayStream<T> {
         } else {
             let current_time = state.time();
             let mut ticked = false;
-            if state.ticked(self.upstream.clone().as_node()) {
+            let upstream_index = *self.upstream_index.get_or_insert_with(|| {
+                state
+                    .node_index(self.upstream.clone().as_node())
+                    .expect("invariant: delay upstream wired at graph init")
+            });
+            if state.node_index_ticked(upstream_index) {
+                let value = self.upstream.peek_value();
                 if !self.initialized {
-                    self.value = self.upstream.peek_value();
+                    self.value = value.clone();
                     self.initialized = true;
                 }
                 let next_time = current_time + self.delay;
                 state.add_callback(next_time);
-                self.queue.push(self.upstream.peek_value(), next_time)
+                self.queue.push(value, next_time)
             }
             while let Some(value) = self.queue.pop_if_pending(current_time) {
                 self.value = value;

--- a/wingfoil/src/nodes/delay_with_reset.rs
+++ b/wingfoil/src/nodes/delay_with_reset.rs
@@ -17,6 +17,12 @@ pub(crate) struct DelayWithResetStream<T: Element + Hash + Eq> {
     queue: TimeQueue<T>,
     #[new(default)]
     initialized: bool,
+    /// Graph indices of `trigger` / `upstream`, resolved once on the first
+    /// cycle so the per-tick checks avoid an `Rc` clone plus hash-map lookup.
+    #[new(default)]
+    trigger_index: Option<usize>,
+    #[new(default)]
+    upstream_index: Option<usize>,
     upstream: Rc<dyn Stream<T>>,
     trigger: Rc<dyn Node>,
     delay: NanoTime,
@@ -25,7 +31,12 @@ pub(crate) struct DelayWithResetStream<T: Element + Hash + Eq> {
 #[node(active = [upstream, trigger], output = value: T)]
 impl<T: Element + Hash + Eq> MutableNode for DelayWithResetStream<T> {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
-        if state.ticked(self.trigger.clone()) {
+        let trigger_index = *self.trigger_index.get_or_insert_with(|| {
+            state
+                .node_index(self.trigger.clone())
+                .expect("invariant: delay_with_reset trigger wired at graph init")
+        });
+        if state.node_index_ticked(trigger_index) {
             // Reset: snap to current upstream value, clear pending queue
             self.value = self.upstream.peek_value();
             self.queue.clear();
@@ -39,14 +50,20 @@ impl<T: Element + Hash + Eq> MutableNode for DelayWithResetStream<T> {
         } else {
             let current_time = state.time();
             let mut ticked = false;
-            if state.ticked(self.upstream.clone().as_node()) {
+            let upstream_index = *self.upstream_index.get_or_insert_with(|| {
+                state
+                    .node_index(self.upstream.clone().as_node())
+                    .expect("invariant: delay_with_reset upstream wired at graph init")
+            });
+            if state.node_index_ticked(upstream_index) {
+                let value = self.upstream.peek_value();
                 if !self.initialized {
-                    self.value = self.upstream.peek_value();
+                    self.value = value.clone();
                     self.initialized = true;
                 }
                 let next_time = current_time + self.delay;
                 state.add_callback(next_time);
-                self.queue.push(self.upstream.peek_value(), next_time)
+                self.queue.push(value, next_time)
             }
             while let Some(value) = self.queue.pop_if_pending(current_time) {
                 self.value = value;

--- a/wingfoil/src/nodes/difference.rs
+++ b/wingfoil/src/nodes/difference.rs
@@ -19,14 +19,15 @@ pub(crate) struct DifferenceStream<T: Element> {
 #[node(active = [upstream], output = diff: T)]
 impl<T: Element + Sub<Output = T>> MutableNode for DifferenceStream<T> {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        let ticked = match self.prev_val.clone() {
+        let value = self.upstream.peek_value();
+        let ticked = match self.prev_val.take() {
             Some(prv) => {
-                self.diff = self.upstream.peek_value() - prv;
+                self.diff = value.clone() - prv;
                 true
             }
             None => false,
         };
-        self.prev_val = Some(self.upstream.peek_value());
+        self.prev_val = Some(value);
         Ok(ticked)
     }
 }

--- a/wingfoil/src/nodes/merge.rs
+++ b/wingfoil/src/nodes/merge.rs
@@ -3,10 +3,16 @@ use derive_new::new;
 
 use std::rc::Rc;
 
-/// Counts how many times upstream has ticked.
+/// Merges several upstreams into one, emitting the value of whichever ticked
+/// (the earliest-supplied wins ties). Used by [merge](crate::nodes::merge).
 #[derive(new)]
 pub struct MergeStream<T: Element> {
     upstreams: Vec<Rc<dyn Stream<T>>>,
+    /// Graph indices of `upstreams`, resolved once on the first cycle so the
+    /// per-tick tick-check is an O(1) array read rather than an `Rc` clone plus
+    /// hash-map lookup per upstream.
+    #[new(default)]
+    upstream_indices: Vec<usize>,
     #[new(default)]
     value: T,
 }
@@ -14,13 +20,26 @@ pub struct MergeStream<T: Element> {
 #[node(active = [upstreams], output = value: T)]
 impl<T: Element> MutableNode for MergeStream<T> {
     fn cycle(&mut self, state: &mut GraphState) -> anyhow::Result<bool> {
-        for stream in self.upstreams.iter() {
-            if state.ticked(stream.clone().as_node()) {
+        if self.upstream_indices.is_empty() && !self.upstreams.is_empty() {
+            self.upstream_indices = self
+                .upstreams
+                .iter()
+                .map(|stream| {
+                    state
+                        .node_index(stream.clone().as_node())
+                        .expect("invariant: merge upstream wired at graph init")
+                })
+                .collect();
+        }
+        let mut ticked = false;
+        for (stream, &index) in self.upstreams.iter().zip(&self.upstream_indices) {
+            if state.node_index_ticked(index) {
                 self.value = stream.peek_value();
+                ticked = true;
                 break;
             }
         }
-        Ok(true)
+        Ok(ticked)
     }
 }
 


### PR DESCRIPTION
## Hot-path tick-check optimization

Part 2 of 3 from a codebase quality review. Behaviour-preserving performance work in node `cycle()` paths.

### Problem
Several hot `cycle()` bodies determine "did this upstream tick this cycle?" via:
```rust
state.ticked(stream.clone().as_node())
```
Per call that clones an `Rc`, builds a `dyn Node` fat pointer, and performs a `HashByRef` hash-map lookup. In `MergeStream` it runs once **per upstream per tick** (O(n)).

### Fix
Each affected node resolves its upstream graph index **once**, lazily on the first cycle, then checks tick status via the O(1) `node_index_ticked` array read:
- `merge`, `delay`, `delay_with_reset`, `channel` (`SenderNode`)

Graph indices are stable for statically-wired upstreams (assigned at graph init, never reused), so a cached index remains valid for the run. `node_index_ticked` reads the same `node_ticked` array that `ticked()` consults, so **semantics are unchanged**.

### Also included
- Bind `upstream.peek_value()` once where it was cloned 2–3× per tick (`delay`, `delay_with_reset`, `difference`).
- `MergeStream::cycle` now returns whether an upstream actually ticked instead of an unconditional `Ok(true)` (equivalent in practice, but more correct).
- Fixed a stale copy-pasted doc comment on `MergeStream` ("Counts how many times upstream has ticked").

### Scope note
`dynamic_group` and `graph_node` also use this pattern but involve dynamic membership, so they're intentionally left for a follow-up.

### Verification
- `cargo test -p wingfoil --lib` (default features) — 216 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo check -p wingfoil --features dynamic-graph-beta` — compiles

https://claude.ai/code/session_015dUcZyYghTkFuF4pimrWTe

---
_Generated by [Claude Code](https://claude.ai/code/session_015dUcZyYghTkFuF4pimrWTe)_