### PR TITLE
Clarify ci-logs job ID resolution from Actions URLs

### DIFF
--- a/.claude/commands/ci-logs.md
+++ b/.claude/commands/ci-logs.md
@@ -6,12 +6,23 @@ This skill wraps `scripts/ci-logs.sh`, which resolves a job's signed log URL via
 
 `scripts/ci-logs.sh` takes a **job** ID, not a run ID. Resolve whatever the user gave you:
 
+- **Full Actions URL** (e.g. `.../actions/runs/<run_id>/job/<job_id>?pr=<n>`) —
+  parse the IDs from the **path only**. Use the `job/<job_id>` segment directly
+  as the job ID; if only `runs/<run_id>` is present, resolve it as a Run ID below.
+  **Ignore `?pr=` and every other query parameter.** The `?pr=` value is a UI
+  scoping hint, not part of the job's identity, and it can be flat-out wrong — a
+  run is associated with the PR whose branch triggered it, which need not match
+  whatever `?pr=` the user copied. Trust the path's job/run IDs over the query
+  string, always. (A mismatched `?pr=` is also why the web page 404s even though
+  the run and job exist.)
 - **Bare numeric job ID** (the script's native input) — use it directly.
 - **Run ID** — list its jobs and pick the failed one:
   `GET /repos/wingfoil-io/wingfoil/actions/runs/<run_id>/jobs`
 - **Branch name** — find the latest run, then its failed job:
   `GET /repos/wingfoil-io/wingfoil/actions/runs?branch=<branch>&per_page=1`
-- **PR number** — read the PR's head branch (`mcp__github__pull_request_read`), then resolve as a branch.
+- **Bare PR number** (not from a URL) — read the PR's head branch
+  (`mcp__github__pull_request_read`), then resolve as a branch. Do **not** derive
+  a PR number from a URL's `?pr=` — see the Full Actions URL note above.
 - **Nothing / "the failing one"** — list recent failures and pick the most recent:
   `GET /repos/wingfoil-io/wingfoil/actions/runs?per_page=10&status=failure`
 


### PR DESCRIPTION
## Summary

Updated the `ci-logs` command documentation to clarify how to resolve job IDs from GitHub Actions URLs, with emphasis on parsing the URL path correctly and ignoring misleading query parameters.

## Changes

- **Added comprehensive guidance for Full Actions URLs**: Documented how to parse job and run IDs from the path segment (`job/<job_id>` or `runs/<run_id>`) rather than relying on query parameters.
- **Explained `?pr=` parameter handling**: Clarified that the `?pr=` query parameter is a UI scoping hint that can be incorrect or mismatched, and should never be used to derive a PR number or validate job identity. This explains why the web page sometimes 404s even though the run and job exist.
- **Distinguished bare PR numbers from URL-derived ones**: Updated the PR number resolution bullet to explicitly state that PR numbers should only be used when provided directly by the user, not extracted from a URL's `?pr=` parameter.

## Implementation Details

The changes are purely documentation—no script behavior changes. The guidance ensures users understand:
1. Trust the URL path's job/run IDs over any query string
2. Query parameters like `?pr=` are UI hints and can be stale or wrong
3. Always resolve from the path-based IDs to avoid 404s and incorrect job lookups

https://claude.ai/code/session_01QYDqnxMrz9cAbkVbTeLLrw