### PR TITLE
Add Aeron LinkedIn marketing draft

### DIFF
--- a/marketing/README.md
+++ b/marketing/README.md
@@ -13,6 +13,7 @@
 | 7 | Fluvio adapter | | [`linkedin/fluvio.md`](linkedin/fluvio.md) | Two nodes, per-burst flush, absolute-offset resume, SC+SPU cluster shape. |
 | 8 | `/new-adapter` call for contributors | | [`linkedin/new-adapter-skill-contributors.md`](linkedin/new-adapter-skill-contributors.md) | Month-to-weekend speedup for new I/O adapters; consistency as a quality multiplier, framed as an open call to build whatever adapter you need, with specced-out issues to pick up. |
 | 9 | Three-language stack | | [`linkedin/three-language-stack.md`](linkedin/three-language-stack.md) | Rust/Python/TS is enough for greenfield work (Rust core, PyO3, JS/TS edge); C++/Java/C#/Go on new projects driven by codebase inertia and talent constraints, not technical merit. Deliberately provocative — ends by daring readers to name the counterexample. |
+| 10 | Aeron adapter | | [`linkedin/aeron.md`](linkedin/aeron.md) | Low-latency UDP/IPC transport, two nodes, spin vs threaded polling, and a status side-channel that turns backpressure/disconnects into graph events for circuit breaking. Two backends (rusteron C++, pure-Rust beta). |
 
 ## Other drafts
 

--- a/marketing/linkedin/aeron.md
+++ b/marketing/linkedin/aeron.md
@@ -1,0 +1,24 @@
+# LinkedIn — Aeron adapter
+
+## Post
+
+We added an Aeron adapter to Wingfoil, behind the `aeron` feature flag.
+
+Aeron is the low-latency UDP/IPC message transport a lot of trading systems already standardise on, so wiring it into the graph directly was an obvious one. The adapter is two nodes: `aeron_sub_fragment` consumes a channel and emits a `Burst<T>` into the graph; `aeron_pub` (fluent on a stream) offers each burst back out over a channel.
+
+Two polling modes, same trade-off as our other low-latency adapters:
+- Spin — poll Aeron inside the graph `cycle()` on the graph thread. Zero thread-crossing latency, burns a core.
+- Threaded — poll on a background thread and deliver over a channel. One channel hop, frees the graph thread.
+
+The part we're happiest with is the status side-channel. `aeron_sub_fragment_with_status` / `aeron_pub_with_status` hand you a second stream of `AeronStatus` (Connected / Disconnected / BackPressured / Closed) alongside the data, so backpressure and disconnects are just events in the graph — you can wire them into a circuit breaker rather than discovering them in a log.
+
+Two backends to pick from: `aeron` uses the production rusteron C++ client; `aeron-rs-beta` is a pure-Rust backend for when you'd rather not pull in cmake and clang. Either way you point it at a running media driver.
+
+Available in Rust and via the PyO3 Python bindings.
+
+## First comment
+
+- Adapter source: https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/src/adapters/aeron
+- Example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/aeron/main.rs
+- Status circuit breaker example: https://github.com/wingfoil-io/wingfoil/blob/main/wingfoil/examples/aeron/status_circuit_breaker.rs
+- Aeron: https://github.com/aeron-io/aeron


### PR DESCRIPTION
Adds an Aeron entry to the marketing drafts, in the same style as the existing adapter posts (iceoryx2, fluvio, kafka).

## Changes
- **`marketing/linkedin/aeron.md`** — new LinkedIn draft with the standard **Post** / **First comment** sections. Covers the two nodes (`aeron_sub_fragment` / `aeron_pub`), Spin vs Threaded polling, the `AeronStatus` side-channel for backpressure/circuit-breaking, the rusteron C++ vs pure-Rust `aeron-rs-beta` backends, and the PyO3 bindings.
- **`marketing/README.md`** — appended row **#10 Aeron adapter** to the LinkedIn posting-order table, status left blank (not yet posted), consistent with the other unposted entries.

https://claude.ai/code/session_01RF8vo8XzBQqEeWp5zF9n4T

---
_Generated by [Claude Code](https://claude.ai/code/session_01RF8vo8XzBQqEeWp5zF9n4T)_