### PR TITLE
fix(zmq): don't error when publisher cleanly ends mid-run

### DIFF
--- a/wingfoil/src/adapters/zmq/integration_tests.rs
+++ b/wingfoil/src/adapters/zmq/integration_tests.rs
@@ -247,6 +247,45 @@ fn zmq_sub_stops_cleanly_without_publisher_endofstream() {
     );
 }
 
+#[test]
+fn zmq_sub_survives_publisher_endofstream_mid_run() {
+    _ = env_logger::try_init();
+    let period = Duration::from_millis(50);
+    let port = 5557;
+    let address = format!("tcp://127.0.0.1:{port}");
+
+    // Publisher runs its own graph for a short while, then stops — which sends
+    // EndOfStream over the wire. The subscriber graph keeps running afterwards.
+    // The subscriber must treat the publisher's clean shutdown as end-of-stream
+    // rather than erroring with "Receiver thread exited unexpectedly".
+    let pub_handle = std::thread::spawn(move || {
+        sender(period, port)
+            .run(RunMode::RealTime, RunFor::Duration(period * 8))
+            .unwrap();
+    });
+
+    let (data, _status) = zmq_sub::<u64>(&address).unwrap();
+    let received = data.collect().finally(|res, _| {
+        let values: Vec<u64> = res.into_iter().flat_map(|item| item.value).collect();
+        assert!(
+            !values.is_empty(),
+            "no data received before publisher ended"
+        );
+        Ok(())
+    });
+
+    // Outlive the publisher so the subscriber observes its EndOfStream mid-run.
+    Graph::new(
+        vec![received],
+        RunMode::RealTime,
+        RunFor::Duration(period * 16),
+    )
+    .run()
+    .unwrap();
+
+    pub_handle.join().unwrap();
+}
+
 // --- shared etcd test helpers (requires zmq-etcd-integration-test) ---
 
 /// Start an etcd container and return (container_handle, endpoint_url).

--- a/wingfoil/src/nodes/channel.rs
+++ b/wingfoil/src/nodes/channel.rs
@@ -267,3 +267,14 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
         Ok(())
     }
 }
+
+// Only consumed by `ReceiverStream`, which is itself gated on the zmq/aeron
+// adapters; mirror that gate so the default build doesn't flag it as dead code.
+#[cfg(any(feature = "zmq", feature = "aeron", feature = "aeron-rs-beta"))]
+impl<T: Element + Send> ChannelReceiverStream<T> {
+    /// `true` once the channel has delivered `EndOfStream`; the stream is
+    /// complete and no further messages will arrive.
+    pub(crate) fn is_finished(&self) -> bool {
+        self.finished
+    }
+}

--- a/wingfoil/src/nodes/receiver.rs
+++ b/wingfoil/src/nodes/receiver.rs
@@ -78,7 +78,14 @@ impl<T: Element + Send> MutableNode for ReceiverStream<T> {
         // checked first, a still-running thread would skip error handling, and
         // nothing would wake the graph once the sender drops.
         let cycle_result = self.inner.cycle(state)?;
-        if let Err(thread_err) = self.state.check_running() {
+        // Once the channel has delivered EndOfStream the stream is complete, so a
+        // background thread returning is following the normal end-of-stream path,
+        // not dying unexpectedly. Stop monitoring it to avoid surfacing a spurious
+        // "exited unexpectedly" error — e.g. a ZMQ publisher cleanly shutting down
+        // while the subscriber graph is still running.
+        if !self.inner.is_finished()
+            && let Err(thread_err) = self.state.check_running()
+        {
             self.pending_err = Some(thread_err);
             // Self-notify: schedule one more graph cycle to propagate the error.
             if let Some(notifier) = &self.notifier {


### PR DESCRIPTION
## What failed

CI job **`test.integration.zmq-etcd` → "Run Python zmq+etcd integration tests"** failed on `test_zmq_pub_etcd_end_to_end`. The exception was truncated to just the node stack:

```
Exception: Error in node [0]:
>>> [00] ReceiverStream<ZmqEvent<Vec<u8>>>
```

The real cause was hidden because anyhow's `to_string()` only surfaces the outermost context, not the source chain.

## Root cause

The test runs a **publisher** (0.7s) and a **subscriber** (0.5s) as two separate graphs. When the publisher's graph stops, its `stop()` sends `Message::EndOfStream` over the wire (`zmq/write.rs`). If the subscriber is still running, its background read loop receives EndOfStream and returns `Ok(())` cleanly (`zmq/read.rs`).

But `ReceiverStream::cycle` then called `check_running()`, which treated **any** `Ok(Ok(()))` thread exit as `"Receiver thread exited unexpectedly"` → graph error → Python exception (`nodes/receiver.rs`). It was flaky because it only fired when the subscriber's run window overlapped the publisher's shutdown.

This test is identical on `main` and the `simplify-e2e-example` branch where it surfaced — a pre-existing flake unrelated to that branch's `latency_e2e` changes.

## The fix

- `nodes/receiver.rs`: skip the thread-liveness check once the inner channel has delivered EndOfStream — a returning thread is then the expected end-of-stream path, not a failure. The genuine deserialize-error path is unaffected (it propagates via `Message::Error` through `inner.cycle()?` before any liveness check).
- `nodes/channel.rs`: added a `pub(crate) is_finished()` accessor, cfg-gated to match `receiver.rs`'s own zmq/aeron gate so the default build doesn't flag it as dead code.
- `zmq/integration_tests.rs`: added `zmq_sub_survives_publisher_endofstream_mid_run`, a Rust regression test reproducing the overlap.

## Verification

- New test **fails without the fix** ("exited unexpectedly"), **passes with it**.
- All 10 zmq integration tests pass; clippy clean on default, `zmq-integration-test`, and `zmq-etcd-integration-test`; `cargo fmt` clean.

`cargo lint-all` could not run in the dev container (the Aeron adapter's `rusteron-media-driver` needs CMake/clang/libuuid, which aren't installed) — unrelated to this change, and the failing CI job doesn't build Aeron.

https://claude.ai/code/session_01JxzhzV78DkgMcPw7R57tbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxzhzV78DkgMcPw7R57tbv)_