### PR TITLE
ci: fix crates.io and PyPI release publish failures

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -35,6 +35,19 @@ jobs:
       - name: Wait for wingfoil-derive index
         run: sleep 15
 
+      # Publish wingfoil-wire-types next — wingfoil has an optional
+      # dependency on it (the `web` feature), and cargo resolves all
+      # dependencies during publish regardless of feature gating.
+      - name: Publish wingfoil-wire-types
+        working-directory: wingfoil-wire-types
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
+        run: cargo publish --registry crates-io
+
+      # Wait for crates.io to index wingfoil-wire-types
+      - name: Wait for wingfoil-wire-types index
+        run: sleep 15
+
       # Publish wingfoil
       - name: Publish wingfoil
         working-directory: wingfoil

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -48,6 +48,14 @@ jobs:
           toolchain: stable
           override: true
 
+      # Several transitive deps of the Python build (etcd-client, fluvio,
+      # opentelemetry-proto) compile .proto files via prost-build at build
+      # time, which needs the protobuf compiler. Install it cross-platform.
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install maturin
         run: pip install maturin
 


### PR DESCRIPTION
## Summary

The `release` workflow (run [27169617252](https://github.com/wingfoil-io/wingfoil/actions/runs/27169617252)) failed in three publish jobs. This PR fixes the two that are repo/workflow bugs.

### 1. crates.io publish — `no matching package named wingfoil-wire-types`
```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `wingfoil-wire-types` found
  required by package `wingfoil v6.0.1`
```
`wingfoil` declares an optional dependency on `wingfoil-wire-types` (the `web` feature). `cargo publish` resolves all dependencies regardless of feature gating, but `wingfoil-wire-types` was never published to crates.io. Added a publish step for it (plus an indexing wait) before publishing `wingfoil`, mirroring the existing `wingfoil-derive` handling.

### 2. PyPI wheel build — `Could not find protoc`
```
error: failed to run custom build command for `etcd-client v0.18.0`
  Failed to compile proto files: Could not find `protoc`.
💥 maturin failed
```
The Python wheel build compiles `wingfoil-python` with the `etcd`, `fluvio`/`kafka`, and `otlp` features. Their transitive deps (`etcd-client`, `fluvio`, `opentelemetry-proto`) invoke `prost-build` to compile `.proto` files at build time, which needs the protobuf compiler. The `build-wheels` job had no `protoc`. Added a cross-platform `arduino/setup-protoc@v3` step so the Linux/macOS/Windows × Python 3.8–3.11 matrix all have it.

## Not included here

### 3. npm publish — `404 ... not in this registry`
This is **not** a repo bug. The workflow switched to OIDC trusted publishing in #398, but npm has no trusted publisher registered for `@wingfoil/client`, so it rejects the OIDC token with a 404. This is resolved on npmjs.com (register `wingfoil-io/wingfoil` + workflow `npm-publish.yml` as a trusted publisher) — no workflow change needed.

## Testing
Workflow-only changes; validated by the failing CI logs and confirmed `wingfoil-wire-types` is absent from crates.io (404) while `wingfoil`/`wingfoil-derive` are present.

https://claude.ai/code/session_01VWHfks6tawkNkTbiec5Dpv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWHfks6tawkNkTbiec5Dpv)_