### PR TITLE
ci: fix npm OIDC publish and Windows wheel OpenSSL build

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,11 +39,17 @@ jobs:
           # >=10.12 required for npm OIDC trusted publishing
           version: 10
 
+      # NB: do NOT pass `registry-url` here. setup-node's registry-url support
+      # writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into a temp
+      # .npmrc and exports a placeholder NODE_AUTH_TOKEN. pnpm then sees a
+      # (bogus) credential and uses token auth instead of OIDC trusted
+      # publishing, which fails with a 404. With no token configured, pnpm
+      # falls back to OIDC. The default registry is already registry.npmjs.org.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          # Node >= 22.14 is required for npm OIDC trusted publishing.
+          node-version: '22'
           cache: 'pnpm'
           cache-dependency-path: wingfoil-js/pnpm-lock.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,11 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: tag
+    # id-token must be granted at the caller for OIDC to reach the reusable
+    # workflow (reusable-workflow permissions are capped by the caller).
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/npm-publish.yml
     secrets: inherit
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7067,6 +7067,7 @@ dependencies = [
  "futures",
  "kdb-plus-fixed",
  "log",
+ "openssl",
  "pyo3",
  "serde",
  "serde_json",

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -44,6 +44,15 @@ futures = "0.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+# Several enabled features pull OpenSSL via native-tls (kdb-plus-fixed, reqwest,
+# tokio-native-tls). On Windows MSVC there is no system OpenSSL to link against,
+# so the wheel build fails with "couldn't detect an OpenSSL installation".
+# Declaring openssl with the `vendored` feature on Windows makes openssl-sys
+# build OpenSSL from source (feature-unified across the whole graph). No effect
+# on the Linux/macOS legs, which link the system OpenSSL.
+[target.'cfg(windows)'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 
 [package.metadata.maturin]
 name = "wingfoil"


### PR DESCRIPTION
## Summary

Follow-up to #399. That PR fixed the crates.io and Linux PyPI failures, but it was merged before two further release fixes landed, so they're still missing from `main`. This PR adds them.

### npm publish — `404 ... not in this registry` (OIDC never attempted)
The publish kept 404ing even after registering the trusted publisher on npmjs.com. Root cause (from the run logs): `actions/setup-node` with `registry-url:` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into a temp `.npmrc` and exports a placeholder `NODE_AUTH_TOKEN` (`XXXXX-XXXXX-XXXXX-XXXXX`). pnpm sees a credential and uses **token auth instead of OIDC**, so the bogus token is rejected with a 404 and OIDC is never tried.

Fixes:
- Drop `registry-url` from `setup-node` so no `.npmrc` token is written → pnpm falls back to OIDC. Default registry is already `registry.npmjs.org`.
- Bump Node `20 → 22` (npm OIDC trusted publishing requires Node ≥ 22.14).
- Grant `id-token: write` on the `publish-npm` caller job in `release.yml`, since reusable-workflow permissions are capped by the caller — without it the OIDC token can't reach `npm-publish.yml`.

### PyPI Windows wheel — `couldn't detect an OpenSSL installation`
With `protoc` fixed in #399, the Windows leg then failed linking OpenSSL. OpenSSL is pulled via `native-tls` (`kdb-plus-fixed`, `reqwest`, `tokio-native-tls`); Windows MSVC has no system OpenSSL.

Fix: add a windows-only `openssl = { version = "0.10", features = ["vendored"] }` dependency to `wingfoil-python` so `openssl-sys` builds from source (feature-unified across the graph). No effect on Linux/macOS.

## Testing
Workflow/manifest changes validated by the failing CI logs, dependency-graph analysis, and YAML/TOML syntax checks. The Windows leg couldn't be built locally (Linux host; workspace also has a non-crates.io `aeron-rs` dep), so it'll be confirmed by the next release run.

https://claude.ai/code/session_01VWHfks6tawkNkTbiec5Dpv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWHfks6tawkNkTbiec5Dpv)_