### PR TITLE
ci: npm publish via npm CLI (OIDC) + build rdkafka on Windows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,10 +41,10 @@ jobs:
 
       # NB: do NOT pass `registry-url` here. setup-node's registry-url support
       # writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into a temp
-      # .npmrc and exports a placeholder NODE_AUTH_TOKEN. pnpm then sees a
-      # (bogus) credential and uses token auth instead of OIDC trusted
-      # publishing, which fails with a 404. With no token configured, pnpm
-      # falls back to OIDC. The default registry is already registry.npmjs.org.
+      # .npmrc and exports a placeholder NODE_AUTH_TOKEN. The npm client then
+      # sees a (bogus) credential and uses token auth instead of OIDC trusted
+      # publishing, which fails with a 404. With no token configured it uses
+      # OIDC. The default registry is already registry.npmjs.org.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -86,10 +86,16 @@ jobs:
             exit 1
           fi
 
-      # Auth is handled by npm OIDC trusted publishing (id-token: write above);
-      # the trusted publisher for wingfoil-io/wingfoil + npm-publish.yml must be
+      # Publish with the npm CLI, not pnpm: OIDC trusted publishing is only
+      # implemented in npm (>= 11.5.1), not pnpm (see pnpm/pnpm#9812), so
+      # `pnpm publish` falls through to ENEEDAUTH. Node 22 ships npm 10.x, so
+      # upgrade npm first. Auth is handled by OIDC (id-token: write above); the
+      # trusted publisher for wingfoil-io/wingfoil + npm-publish.yml must be
       # registered on npmjs.com for @wingfoil/client. No NPM_TOKEN needed, and
       # provenance is emitted automatically.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         working-directory: wingfoil-js
-        run: pnpm publish --access public --no-git-checks
+        run: npm publish --access public

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7079,6 +7079,7 @@ dependencies = [
  "log",
  "openssl",
  "pyo3",
+ "rdkafka",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -44,14 +44,19 @@ futures = "0.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
 
-# Several enabled features pull OpenSSL via native-tls (kdb-plus-fixed, reqwest,
-# tokio-native-tls). On Windows MSVC there is no system OpenSSL to link against,
-# so the wheel build fails with "couldn't detect an OpenSSL installation".
-# Declaring openssl with the `vendored` feature on Windows makes openssl-sys
-# build OpenSSL from source (feature-unified across the whole graph). No effect
-# on the Linux/macOS legs, which link the system OpenSSL.
+# Windows MSVC has none of the system C libraries these features need, so build
+# them from source there. Feature-unified across the whole graph; no effect on
+# the Linux/macOS legs, which link the system libraries.
+#   - openssl (native-tls via kdb-plus-fixed, reqwest, tokio-native-tls):
+#     `vendored` builds OpenSSL from source instead of "couldn't detect an
+#     OpenSSL installation".
+#   - rdkafka (kafka): `cmake-build` builds librdkafka via CMake instead of the
+#     Unix-only ./configure script ("%1 is not a valid Win32 application").
+# CMake is present on the windows-latest runner. (zmq needs no flag here:
+# zmq-sys 0.12 always builds libzmq from source via zeromq-src/cc.)
 [target.'cfg(windows)'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
+rdkafka = { version = "0.37", features = ["cmake-build"] }
 
 
 [package.metadata.maturin]


### PR DESCRIPTION
## Summary

Third round of release fixes (follow-up to #399, #400). The previous fixes moved both failures forward to new errors; this addresses those.

### npm — `pnpm publish` → `ENEEDAUTH`
Removing the token placeholder (#400) got us past the 404, but pnpm then failed with `ENEEDAUTH`. Root cause: **pnpm does not implement OIDC trusted publishing** (open issue [pnpm/pnpm#9812](https://github.com/pnpm/pnpm/issues/9812)). OIDC is only in the **npm CLI ≥ 11.5.1**.

Fix (`npm-publish.yml`): keep building with pnpm, but **publish with npm**, upgrading npm first (Node 22 ships npm 10.x):
```yaml
- run: npm install -g npm@latest
- run: npm publish --access public   # in wingfoil-js
```
Auth + provenance come from OIDC via the `id-token: write` permission (already wired). The npmjs.com trusted-publisher config stays as-is.

### PyPI Windows wheel — `rdkafka-sys` build
With OpenSSL vendored (#400), Linux + macOS wheels build. Windows then failed in `rdkafka-sys`, which tries to compile librdkafka through the Unix-only `./configure` script (`%1 is not a valid Win32 application`).

Fix (`wingfoil-python/Cargo.toml`): enable rdkafka's **`cmake-build`** feature on Windows so librdkafka builds via CMake (present on the runner):
```toml
[target.'cfg(windows)'.dependencies]
openssl = { version = "0.10", features = ["vendored"] }
rdkafka = { version = "0.37", features = ["cmake-build"] }
```
`zmq` needs no change — `zmq-sys 0.12` already vendors libzmq from source via `zeromq-src`/`cc` unconditionally.

## Verification & caveats
- Verified `rdkafka@0.37` exposes `cmake-build` and `zmq-sys@0.12`'s build script always vendors libzmq (read the crate source), so these are the correct knobs.
- Could **not** build the Windows leg locally (Linux host). Native-lib builds on Windows can surface further issues (e.g. librdkafka + zlib under CMake); the next release run will confirm. Shipping full features on Windows per maintainer request.

https://claude.ai/code/session_01VWHfks6tawkNkTbiec5Dpv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWHfks6tawkNkTbiec5Dpv)_