### PR TITLE
fix(adapters): iceoryx2 spin real-time guard + fluvio test marker

### DIFF
--- a/wingfoil-python/pyproject.toml
+++ b/wingfoil-python/pyproject.toml
@@ -51,6 +51,7 @@ markers = [
     "requires_iceoryx2: needs wingfoil built with --features iceoryx2",
     "requires_web: needs a wingfoil web server (runs in-process)",
     "requires_kafka: needs a Kafka-compatible broker on localhost:9092",
+    "requires_fluvio: needs a Fluvio cluster on localhost:9003",
     "requires_aeron: needs an Aeron media driver (and wingfoil built with --features aeron)",
 ]
-addopts = "-m 'not requires_etcd and not requires_kdb and not requires_otel and not requires_iceoryx2 and not requires_web and not requires_kafka and not requires_aeron'"
+addopts = "-m 'not requires_etcd and not requires_kdb and not requires_otel and not requires_iceoryx2 and not requires_web and not requires_kafka and not requires_fluvio and not requires_aeron'"

--- a/wingfoil-python/tests/test_fluvio.py
+++ b/wingfoil-python/tests/test_fluvio.py
@@ -1,36 +1,23 @@
 """Tests for the Fluvio Python bindings.
 
-Integration tests (TestFluvioSub, TestFluvioPub) are skipped automatically
-when a Fluvio cluster is not running on localhost:9003. Start a local
-cluster with:
+Integration tests (TestFluvioSub, TestFluvioPub) are selected via
+`-m requires_fluvio` and deselected from the default `pytest` run. Without a
+Fluvio cluster on localhost:9003 they fail loudly — they do not silently skip.
+Start a local cluster with:
 
     fluvio cluster start --local
 
 The TestFluvioConstruction and TestFluvioUnreachable suites exercise the
 Python binding code without requiring a live cluster: stream/node setup,
 the dict_to_record marshaling closure, and error propagation when the
-SC is unreachable or the start offset is invalid.
+SC is unreachable or the start offset is invalid. They run by default (no marker).
 """
 
-import socket
-import urllib.request
 import unittest
 
+import pytest
+
 FLUVIO_ENDPOINT = "127.0.0.1:9003"
-FLUVIO_HOST = "127.0.0.1"
-FLUVIO_SC_PORT = 9003
-
-
-def fluvio_available() -> bool:
-    """Return True if a Fluvio SC is accepting connections on localhost:9003."""
-    try:
-        with socket.create_connection((FLUVIO_HOST, FLUVIO_SC_PORT), timeout=1):
-            return True
-    except OSError:
-        return False
-
-
-FLUVIO_AVAILABLE = fluvio_available()
 
 # An endpoint that's guaranteed not to host a Fluvio SC: TCP reject on loopback.
 UNREACHABLE_ENDPOINT = "127.0.0.1:1"
@@ -123,7 +110,7 @@ class TestFluvioUnreachable(unittest.TestCase):
             node.run(realtime=True, cycles=1)
 
 
-@unittest.skipUnless(FLUVIO_AVAILABLE, f"Fluvio not running on {FLUVIO_ENDPOINT}")
+@pytest.mark.requires_fluvio
 class TestFluvioSub(unittest.TestCase):
     """Tests for py_fluvio_sub / fluvio_sub."""
 
@@ -158,7 +145,7 @@ class TestFluvioSub(unittest.TestCase):
             self.assertIsInstance(event["offset"], int)
 
 
-@unittest.skipUnless(FLUVIO_AVAILABLE, f"Fluvio not running on {FLUVIO_ENDPOINT}")
+@pytest.mark.requires_fluvio
 class TestFluvioPub(unittest.TestCase):
     """Tests for the .fluvio_pub() stream method."""
 

--- a/wingfoil/src/adapters/iceoryx2/read.rs
+++ b/wingfoil/src/adapters/iceoryx2/read.rs
@@ -377,6 +377,9 @@ where
     fn start(&mut self, state: &mut crate::GraphState) -> anyhow::Result<()> {
         match self.opts.mode {
             Iceoryx2Mode::Spin => {
+                if state.run_mode() != crate::RunMode::RealTime {
+                    anyhow::bail!("iceoryx2 spin mode only supports real-time");
+                }
                 state.always_callback();
 
                 match self.opts.variant {
@@ -565,6 +568,9 @@ impl crate::MutableNode for Iceoryx2SliceReceiverStream {
     fn start(&mut self, state: &mut crate::GraphState) -> anyhow::Result<()> {
         match self.opts.mode {
             Iceoryx2Mode::Spin => {
+                if state.run_mode() != crate::RunMode::RealTime {
+                    anyhow::bail!("iceoryx2 spin mode only supports real-time");
+                }
                 state.always_callback();
                 match self.opts.variant {
                     Iceoryx2ServiceVariant::Ipc => {


### PR DESCRIPTION
Part 1 of 4 from an adapter compliance review against the `new-adapter` skill. These are the two **high-severity** behavioral findings.

## 1. iceoryx2 spin mode does not reject non-real-time runs

`Iceoryx2ReceiverNode::start()` called `state.always_callback()` in `Spin` mode without checking the run mode. A `HistoricalFrom` (backtest) run would therefore busy-spin against a live IPC socket instead of failing fast. The skill's spin-loop pattern (step 7) requires a `run_mode() != RealTime` bail guard, which the FIX spin source already has.

Added the guard at both `Spin` `start()` sites in `iceoryx2/read.rs` (typed + slice subscribers):

```rust
Iceoryx2Mode::Spin => {
    if state.run_mode() != crate::RunMode::RealTime {
        anyhow::bail!("iceoryx2 spin mode only supports real-time");
    }
    state.always_callback();
    ...
```

## 2. fluvio Python tests silently skip

`test_fluvio.py` gated its live-cluster suites with `@unittest.skipUnless(FLUVIO_AVAILABLE, ...)` driven by a TCP probe — the exact "never silently skip" anti-pattern the skill forbids (step 13.f). With no `requires_fluvio` marker registered, the default `pytest` run could be falsely green against a down cluster.

- Replaced both `skipUnless` decorators with `@pytest.mark.requires_fluvio`.
- Removed the `fluvio_available()` TCP probe and the now-unused `socket`/`urllib` imports.
- Registered the `requires_fluvio` marker in `pyproject.toml` and added it to the default `addopts` deselect list, so live tests fail loudly under `-m requires_fluvio` and are skipped by default.

The construction / unreachable unit suites are unchanged — they still run by default with no marker.

## Verification

- `cargo check -p wingfoil --features iceoryx2` passes.
- `cargo fmt --all` clean.
- `python -m py_compile tests/test_fluvio.py` passes; no stale probe references remain; marker registered in both `markers` and `addopts`.

https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX)_