### PR TITLE
test(python): default-run unit tests for kafka and kdb bindings (step 13.g)

### DIFF
--- a/wingfoil-python/tests/test_kafka.py
+++ b/wingfoil-python/tests/test_kafka.py
@@ -1,9 +1,14 @@
-"""Integration tests for Kafka sub/pub Python bindings.
+"""Tests for the Kafka sub/pub Python bindings.
 
-Selected via `-m requires_kafka`. Without a Kafka-compatible broker on
-localhost:9092 the tests fail loudly with a real connection error — they
-do NOT silently skip, so CI cannot be falsely green against a broker that
-never came up.
+The TestKafkaConstruction and TestKafkaUnreachable suites run by default (no
+marker): they exercise the binding wiring and the dict_to_record marshaling
+closure without a live broker.
+
+The TestKafkaSub and TestKafkaPub integration suites are selected via
+`-m requires_kafka` and deselected from the default run. Without a
+Kafka-compatible broker on localhost:9092 they fail loudly with a real
+connection error — they do NOT silently skip, so CI cannot be falsely green
+against a broker that never came up.
 
 Local setup (Redpanda):
     docker run --rm -p 9092:9092 \\
@@ -18,6 +23,74 @@ import pytest
 
 BROKERS = "localhost:9092"
 TOPIC_PREFIX = "wingfoil_pytest_"
+
+# A broker address guaranteed not to accept Kafka: TCP reject on loopback.
+# The producer's message.timeout.ms (5s) bounds how long a delivery waits
+# before the run fails, so the marshaling-failure tests take a few seconds.
+UNREACHABLE_BROKERS = "127.0.0.1:1"
+
+
+class TestKafkaConstruction(unittest.TestCase):
+    """Binding construction paths that don't need a running broker.
+
+    Exercises py_kafka_sub / kafka_pub wiring, including the fluent
+    .kafka_pub() stream method, without connecting.
+    """
+
+    def test_kafka_sub_constructs_stream(self):
+        from wingfoil import kafka_sub
+
+        stream = kafka_sub(UNREACHABLE_BROKERS, "topic", "group")
+        self.assertIsNotNone(stream)
+
+    def test_kafka_pub_method_constructs_node(self):
+        from wingfoil import constant
+
+        node = constant({"value": b"v"}).kafka_pub(UNREACHABLE_BROKERS, "topic")
+        self.assertIsNotNone(node)
+
+    def test_kafka_pub_from_list_constructs_node(self):
+        from wingfoil import constant
+
+        records = [{"key": b"k", "value": b"v"}, {"value": b"v2"}]
+        node = constant(records).kafka_pub(UNREACHABLE_BROKERS, "topic")
+        self.assertIsNotNone(node)
+
+
+class TestKafkaUnreachable(unittest.TestCase):
+    """Running against an unreachable broker exercises the dict_to_record
+    marshaling closure (which runs on the upstream tick) before the delivery
+    to the unreachable broker fails and propagates to the graph.
+    """
+
+    def test_pub_single_dict_marshals_then_errors(self):
+        from wingfoil import constant
+
+        node = constant({"topic": "t", "key": b"k", "value": b"v"}).kafka_pub(
+            UNREACHABLE_BROKERS, "t"
+        )
+        with self.assertRaises(Exception):
+            node.run(realtime=True, cycles=1)
+
+    def test_pub_list_of_dicts_marshals_then_errors(self):
+        from wingfoil import constant
+
+        records = [
+            {"topic": "t", "key": b"k", "value": b"v"},
+            {"topic": "t", "value": b"v2"},  # keyless path
+        ]
+        node = constant(records).kafka_pub(UNREACHABLE_BROKERS, "t")
+        with self.assertRaises(Exception):
+            node.run(realtime=True, cycles=1)
+
+    def test_pub_bad_value_type_marshals_empty_burst(self):
+        # Neither dict nor list: the closure logs an error and emits an empty
+        # burst, so nothing is produced and the run completes without error.
+        from wingfoil import constant
+
+        constant("not a dict").kafka_pub(UNREACHABLE_BROKERS, "t").run(
+            realtime=True, cycles=1
+        )
 
 
 @pytest.mark.requires_kafka

--- a/wingfoil-python/tests/test_kdb.py
+++ b/wingfoil-python/tests/test_kdb.py
@@ -1,7 +1,12 @@
-"""Integration tests for KDB+ read/write Python bindings.
+"""Tests for the KDB+ read/write Python bindings.
 
-Selected via `-m requires_kdb`. Without a KDB+ instance on localhost:5000
-the tests will fail loudly — they do not silently skip.
+The TestKdbConstruction and TestKdbUnreachable suites run by default (no
+marker): they exercise the binding wiring and the connection-error path
+without a live KDB+ instance.
+
+The TestKdbRead and TestKdbWrite integration suites are selected via
+`-m requires_kdb` and deselected from the default run. Without a KDB+ instance
+on localhost:5000 they fail loudly — they do not silently skip.
 
 Setup:
     q -p 5000
@@ -16,6 +21,13 @@ import pytest
 TABLE = "py_kdb_test_trades"
 HOST = "localhost"
 PORT = 5000
+
+# A host:port guaranteed not to host a KDB+ instance: TCP reject on loopback.
+# QStream::connect fails fast with ECONNREFUSED, so these tests are quick.
+UNREACHABLE_HOST = "127.0.0.1"
+UNREACHABLE_PORT = 1
+# 2000-01-01 00:00:00 UTC in Unix seconds — historical reads need a non-zero start.
+EPOCH_2000 = 946684800.0
 
 
 def q_exec(query: str):
@@ -63,6 +75,68 @@ def _recv_exact(s: socket.socket, n: int) -> bytes:
             raise EOFError(f"connection closed after {len(buf)}/{n} bytes")
         buf += chunk
     return buf
+
+
+class TestKdbConstruction(unittest.TestCase):
+    """Binding construction paths that don't need a running KDB+ instance.
+
+    Exercises py_kdb_read / py_kdb_write wiring, including the fluent
+    .kdb_write() stream method and #[pyo3(signature = ...)] defaults, without
+    connecting.
+    """
+
+    def test_kdb_read_constructs_stream(self):
+        from wingfoil import kdb_read
+
+        stream = kdb_read(
+            host=UNREACHABLE_HOST,
+            port=UNREACHABLE_PORT,
+            query="select from t",
+            time_col="time",
+        )
+        self.assertIsNotNone(stream)
+
+    def test_kdb_write_method_constructs_node(self):
+        from wingfoil import constant
+
+        node = constant({"sym": "X", "price": 1.0, "qty": 1}).kdb_write(
+            host=UNREACHABLE_HOST,
+            port=UNREACHABLE_PORT,
+            table="t",
+            columns=[("sym", "symbol"), ("price", "float"), ("qty", "long")],
+        )
+        self.assertIsNotNone(node)
+
+
+class TestKdbUnreachable(unittest.TestCase):
+    """Running against an unreachable instance exercises the connect-error
+    path in the async producer / consumer (ECONNREFUSED on loopback port 1).
+    """
+
+    def test_kdb_read_unreachable_errors(self):
+        from wingfoil import kdb_read
+
+        stream = kdb_read(
+            host=UNREACHABLE_HOST,
+            port=UNREACHABLE_PORT,
+            query="select from t",
+            time_col="time",
+            chunk_size=10000,
+        ).collect()
+        with self.assertRaises(Exception):
+            stream.run(realtime=False, start=EPOCH_2000, duration=86400.0)
+
+    def test_kdb_write_unreachable_errors(self):
+        from wingfoil import constant
+
+        node = constant({"sym": "X", "price": 1.0, "qty": 1}).kdb_write(
+            host=UNREACHABLE_HOST,
+            port=UNREACHABLE_PORT,
+            table="t",
+            columns=[("sym", "symbol"), ("price", "float"), ("qty", "long")],
+        )
+        with self.assertRaises(Exception):
+            node.run(realtime=False, start=EPOCH_2000, cycles=1)
 
 
 @pytest.mark.requires_kdb


### PR DESCRIPTION
Part 2 of 4 from the adapter compliance review. Closes the **step-13.g** gap: every adapter whose Python bindings compile in the default build must ship unit-level tests that run **without** a live service, so the binding module stays visible in coverage and pyo3 marshaling-glue regressions are caught. `test_kafka.py` and `test_kdb.py` previously had **only** `-m requires_*` integration tests, which the default `pytest` run deselects — contributing nothing to default coverage.

## Added (no marker — run by default)

**kafka** (`tests/test_kafka.py`)
- `TestKafkaConstruction` — `kafka_sub` / fluent `.kafka_pub()` wiring without connecting.
- `TestKafkaUnreachable` — `dict_to_record` runs on the upstream tick, then delivery to an unreachable broker (`127.0.0.1:1`) fails and propagates. Covers single dict, list of dicts, and the non-dict/list fallthrough that emits an empty burst. (Bounded by the producer's `message.timeout.ms=5000`, so these take a few seconds.)

**kdb** (`tests/test_kdb.py`)
- `TestKdbConstruction` — `kdb_read` / fluent `.kdb_write()` wiring and `#[pyo3(signature)]` defaults.
- `TestKdbUnreachable` — connect-error path via ECONNREFUSED on loopback port 1, for both read (historical) and write.

## On the CI findings (#3, #4) — no workflows needed

The review flagged "no Rust CI for kafka/fluvio integration tests." On inspection that is a **false positive**: `.github/workflows/adapter-integration.yml` is a matrix over **fix, fluvio, kafka, zmq** that already runs `cargo test --features <adapter>-integration-test`, and it is wired into `integration-tests.yml` as the `adapter-integration` job. So the Rust integration suites for kafka and fluvio already run in CI — no standalone `kafka-integration.yml` / `fluvio-integration.yml` is required.

(The fluvio *Python* `requires_fluvio` marker — added in the part-1 PR — is exercised manually against a local cluster; a full SC+SPU topology isn't reliably reproducible as a standalone CI service, and the fluvio round-trip is already covered at the Rust layer.)

## Verification

Built `wingfoil-python` with `maturin develop` and ran the new suites:

```
10 passed in 10.41s   # kafka + kdb construction/unreachable
```

Default collection deselects the `requires_kafka` / `requires_kdb` integration classes (6 deselected) and picks up the new unit tests.

https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX)_