### PR TITLE
docs(adapters): web + iceoryx2 example snippets, cache module docs

### DIFF
--- a/wingfoil/examples/README.md
+++ b/wingfoil/examples/README.md
@@ -172,6 +172,38 @@ Service discovery via etcd is also supported — see [`zmq/etcd`](zmq/etcd/) for
 
 [Full example.](zmq/)
 
+### iceoryx2
+
+Zero-copy IPC over shared memory between processes. The payload is a `#[repr(C)]` `ZeroCopySend` type; the subscriber picks a polling mode (`Spin`, `Threaded`, or `Signaled`) trading latency for CPU:
+
+```rust,ignore
+use iceoryx2::prelude::ZeroCopySend;
+use wingfoil::adapters::iceoryx2::{Iceoryx2Mode, Iceoryx2SubOpts, iceoryx2_pub, iceoryx2_sub_opts};
+use wingfoil::*;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, ZeroCopySend)]
+struct Counter {
+    seq: u64,
+}
+
+// publisher
+let upstream = ticker(Duration::from_millis(100)).count().map(|seq: u64| burst![Counter { seq }]);
+iceoryx2_pub(upstream, "wingfoil/examples/counter")
+    .run(RunMode::RealTime, RunFor::Forever)?;
+```
+
+```rust,ignore
+// subscriber (in another process)
+let opts = Iceoryx2SubOpts { mode: Iceoryx2Mode::Spin, ..Default::default() };
+iceoryx2_sub_opts::<Counter>("wingfoil/examples/counter", opts)
+    .collapse()
+    .inspect(|c: &Counter| println!("received seq={}", c.seq))
+    .run(RunMode::RealTime, RunFor::Forever)?;
+```
+
+[Full example.](iceoryx2/)
+
 ### Aeron
 
 Publish `i64` values over a low-latency Aeron channel and subscribe to them back. The subscriber polls Aeron directly inside the graph `cycle()` (spin mode) for zero thread-crossing latency:
@@ -245,6 +277,35 @@ RUST_LOG=info cargo run --example fix_loopback --features fix
 ```
 
 [Full examples.](fix/)
+
+### Web
+
+Stream values to one or more browsers over WebSocket and receive UI events back, all as on-graph streams. The `WebServer` hosts an HTTP + WebSocket listener on its own tokio runtime:
+
+```rust,ignore
+use wingfoil::adapters::web::*;
+use wingfoil::*;
+
+let server = WebServer::bind("127.0.0.1:0").start()?;
+let port = server.port();
+println!("open ws://127.0.0.1:{port}/ws");
+
+// publish: graph → browser
+ticker(Duration::from_millis(10))
+    .count()
+    .web_pub(&server, "tick")
+    .run(RunMode::RealTime, RunFor::Forever)?;
+```
+
+```rust,ignore
+// subscribe: browser → graph
+let clicks: Rc<dyn Stream<Burst<u32>>> = web_sub(&server, "ui_events");
+clicks.collapse().print().run(RunMode::RealTime, RunFor::Forever)?;
+```
+
+Serve a static UI bundle with `.serve_static("./dist")`, and enable the `web-tls` feature with `.tls(cert, key)` for HTTPS/WSS.
+
+[Full example.](web/)
 
 ### Telemetry
 

--- a/wingfoil/src/adapters/cache/CLAUDE.md
+++ b/wingfoil/src/adapters/cache/CLAUDE.md
@@ -1,0 +1,58 @@
+# cache (KDB+ result cache)
+
+**This is not a standalone I/O adapter.** It is an internal support module for the
+KDB+ adapter and is intentionally exempt from most of the new-adapter checklist
+(no feature flag of its own, no graph nodes, no example, no Python bindings, no
+CI workflow). It lives in its own directory only to keep the file-cache logic
+separate from the kdb read/write code.
+
+## What it is
+
+A disk-backed result cache used exclusively by
+[`kdb_read_cached`](../kdb/read_cached.rs). When a backtest replays the same
+time-sliced query repeatedly, the rows fetched for each slice are cached on disk
+so subsequent runs skip the round-trip to the database.
+
+It is gated under the **`kdb`** feature (see `adapters/mod.rs`:
+`#[cfg(feature = "kdb")] pub mod cache;`) — there is no separate `cache` feature.
+
+## Module Structure
+
+```
+cache/
+  mod.rs         # CacheKey (SHA-256 of host/port/query), CacheConfig (folder + LRU cap)
+  file_cache.rs  # FileCache<T> — async get/put of serialized rows, LRU eviction
+  CLAUDE.md      # This file
+```
+
+## Key Design Decisions
+
+- **Cache key** — `CacheKey::from_parts([host, port, query])` is the first 64 bits
+  of a SHA-256 digest, with `\0` separators so `["ab","c"]` ≠ `["a","bc"]`.
+  SHA-256 (not `DefaultHasher`) keeps keys stable across toolchain versions; a
+  unit test pins the exact hex prefix so an accidental algorithm change is caught.
+- **File format** — each `<hex>.cache` file starts with the query string and a
+  `\n`, then the bincode-encoded `Vec<(u64 nanos, T)>`. The header makes files
+  self-documenting (`head -1 <hex>.cache` shows the producing query).
+- **LRU eviction** — `CacheConfig { folder, max_size_bytes }`. On `put`, if the
+  total on-disk size of `*.cache` files would exceed `max_size_bytes`, the oldest
+  files (by mtime) are deleted first. A `get` rewrites the file to bump its mtime
+  so a cache hit counts as "recently used". Set `max_size_bytes` to `u64::MAX`
+  for an unbounded cache.
+- **Atomic writes** — `put` writes to `<hex>.tmp` then `rename`s, so a `.cache`
+  file is never left torn. Concurrent writers for the same key share the `.tmp`
+  path and may clobber each other's serialization work, but the rename stays
+  atomic — harmless for the intended single-process backtesting use case.
+- **No locks on the graph thread** — all I/O is `tokio::fs` inside `async`
+  `get`/`put`, driven off-graph by kdb's `produce_async`. There is no `cycle()`.
+
+## Pre-Commit Requirements
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test -p wingfoil --features kdb -- adapters::cache
+```
+
+The cache is also exercised end-to-end by the kdb cached-read integration tests
+(`cargo test --features kdb-integration-test -p wingfoil -- kdb::cache`).

--- a/wingfoil/src/adapters/cache/mod.rs
+++ b/wingfoil/src/adapters/cache/mod.rs
@@ -1,3 +1,15 @@
+//! File-based result cache backing the KDB+ adapter's [`kdb_read_cached`].
+//!
+//! This is **not** a standalone I/O adapter — it exposes no graph nodes. It is
+//! a support module gated under the `kdb` feature and consumed only by
+//! [`kdb_read_cached`](crate::adapters::kdb::kdb_read_cached), which caches the
+//! rows fetched for each time slice to disk so repeated backtests over the same
+//! query skip the round-trip to the database.
+//!
+//! - [`CacheKey`] — a stable SHA-256 digest of `[host, port, query]`.
+//! - [`CacheConfig`] — the cache directory plus an LRU on-disk size cap.
+//! - [`FileCache`] — async get/put of serialized rows, with LRU eviction.
+
 pub mod file_cache;
 pub use file_cache::FileCache;
 


### PR DESCRIPTION
Part 3 of 4 from the adapter compliance review — documentation-completeness fixes.

## 1. Missing example snippets (step 10.3)

`wingfoil/examples/README.md` has a `## Snippets` section with a ~15-line block per adapter (KDB+, etcd, Fluvio, Kafka, ZeroMQ, Aeron, FIX, Telemetry). **web** and **iceoryx2** had table rows and example directories but no snippet section. Added both:

- `### Web` — `web_pub` (graph → browser) and `web_sub` (browser → graph), mirroring the module doc.
- `### iceoryx2` — `iceoryx2_pub` / `iceoryx2_sub_opts` with a `#[repr(C)] ZeroCopySend` payload and a `Iceoryx2Mode` poll mode, mirroring the example.

## 2. cache module docs (step 11)

The `adapters/cache/` directory had no `CLAUDE.md` and no module-level `//!` doc, leaving it ambiguous whether it's a standalone adapter. It isn't — it's an internal KDB+ result cache backing `kdb_read_cached`, exposing no graph nodes and gated under the `kdb` feature. Added:

- A `//!` header on `cache/mod.rs` pointing at `kdb_read_cached` and summarising `CacheKey` / `CacheConfig` / `FileCache`.
- `cache/CLAUDE.md` documenting the SHA-256 key, self-documenting file format, LRU eviction, atomic writes, and the no-locks-on-the-graph-thread design — and explaining why the full adapter checklist (own feature flag, example, Python bindings, CI) deliberately does not apply.

## Verification

- `cargo check -p wingfoil --features kdb` passes (the new `//!` doc and intra-doc link to `kdb_read_cached` resolve).
- `cargo fmt --all` clean.
- Docs-only change — no behavioral impact.

https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX)_