### PR TITLE
docs(adapters): fix stale CLAUDE.md details in kdb, otlp, prometheus

### DIFF
--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -25,9 +25,11 @@ kdb/
   - Caller constructs the full query — date/time filters, partition hints, etc.
   - Terminates automatically when all slices are exhausted
 - `kdb_read_cached()` - Cached variant of `kdb_read`
-  - Same signature as `kdb_read` plus a `cache_dir: impl Into<PathBuf>` parameter
-  - Checks `<cache_dir>/<hash>.cache` before each slice query; writes on miss
-  - Cache files persist until manually deleted — no TTL, no eviction
+  - Same signature as `kdb_read` plus a `cache_config: CacheConfig` parameter
+  - Checks `<folder>/<hash>.cache` before each slice query; writes on miss
+  - LRU eviction once the total on-disk size would exceed `CacheConfig::max_size_bytes`
+    (use `u64::MAX` for an unbounded cache). Each `.cache` file is self-documenting —
+    the producing query is written as a header line. See `../cache/CLAUDE.md`.
   - Lazy TCP connection: if all slices are cache hits, no KDB connection is opened
   - `T` must additionally implement `serde::Serialize + serde::Deserialize`; `Sync` is also required
   - `Sym` is fully supported — it serializes as a plain string (interning not restored on load)
@@ -142,12 +144,12 @@ impl KdbSerialize for Trade {
 ### Reading with kdb_read_cached
 
 ```rust
-// Same query closure as kdb_read, plus a cache directory.
+// Same query closure as kdb_read, plus a CacheConfig (folder + LRU size cap).
 // T must also implement serde::Serialize + serde::Deserialize + Sync.
 let stream = kdb_read_cached::<Trade, _>(
     conn,
     std::time::Duration::from_secs(3600),
-    "/tmp/my-backtest-cache",
+    CacheConfig::new("/tmp/my-backtest-cache", 512 * 1024 * 1024), // 512 MiB cap
     |(t0, t1), date, _| {
         format!(
             "select from trades where date=2000.01.01+{}, \

--- a/wingfoil/src/adapters/otlp/CLAUDE.md
+++ b/wingfoil/src/adapters/otlp/CLAUDE.md
@@ -74,5 +74,5 @@ automatically — no manual Docker setup required. The container is stopped when
   short-running tests. Decrease if tests become flaky; increase if the backend is slow.
 - Non-numeric stream values are parsed as f64 via `.to_string().parse()`. Values that fail
   parsing are recorded as `0.0` and a warning is logged.
-- The collector image version is pinned (`0.116.0`) to avoid unexpected API changes.
+- The collector image version is pinned (`0.149.0`) to avoid unexpected API changes.
   Update the pin deliberately and re-run integration tests.

--- a/wingfoil/src/adapters/prometheus/CLAUDE.md
+++ b/wingfoil/src/adapters/prometheus/CLAUDE.md
@@ -20,8 +20,9 @@ prometheus/
 - `PrometheusExporter` spawns its own OS thread (same pattern as the ZMQ publisher).
   `serve()` binds synchronously so bind errors surface before the graph starts.
 - Metric nodes are regular `MutableNode` sinks; they read `peek_value()` each tick and publish the
-  stringified value into a per-metric `Arc<ArcSwap<String>>` slot with a lock-free atomic pointer
-  swap. The exporter holds a `Mutex<Vec<(name, slot)>>` registry that is locked only at
+  stringified value into a per-metric `Arc<ArcSwapOption<String>>` slot with a lock-free atomic
+  pointer swap (the `None` state is a never-ticked sentinel, skipped on scrape). The exporter holds
+  a `Mutex<Vec<(name, slot)>>` registry that is locked only at
   `register()` time and once per HTTP scrape (off the graph thread) — never from `cycle()`. On
   scrape the HTTP thread snapshots the registry, drops the lock, then `.load()`s each slot to
   render the response.


### PR DESCRIPTION
Part 4 of 4 from the adapter compliance review — low-severity doc drift where CLAUDE.md comments describe behavior the code no longer matches.

- **kdb** — `kdb_read_cached` takes a `cache_config: CacheConfig` (folder + LRU size cap), not a `cache_dir: impl Into<PathBuf>`, and the cache **does** evict (LRU by `max_size_bytes`) rather than "persist until manually deleted — no TTL, no eviction". Updated the API description and the example snippet (now passes `CacheConfig::new(...)`). The mod.rs docs and example READMEs already described this correctly — only the adapter CLAUDE.md was stale.

- **otlp** — the integration-test collector image is pinned to `0.149.0` (`integration_tests.rs:26`, `mod.rs:9`), not the `0.116.0` the Gotchas section claimed.

- **prometheus** — the per-metric slot is `Arc<ArcSwapOption<String>>` (`exporter.rs`), not `Arc<ArcSwap<String>>`; noted the `None` never-ticked sentinel that's skipped on scrape.

Docs only — no code or behavior change. Verified no other occurrences of the stale strings remain in each adapter directory.

https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLqvwSW8V4xPpvxV1vwXuX)_