### PR TITLE
fix(async): deliver same-timestamp historical bursts as one atomic message

### DIFF
--- a/wingfoil/src/channel/kanal_chan.rs
+++ b/wingfoil/src/channel/kanal_chan.rs
@@ -128,12 +128,16 @@ mod tests {
     }
 
     #[test]
-    fn send_historical_batch() {
+    fn send_in_historical_mode_wraps_value_in_single_burst() {
+        let state = historical_state();
         let (tx, rx) = channel_pair::<u64>(None);
-        let batch = vec![ValueAt::new(1, NanoTime::new(1))];
-        tx.send_historical_batch(batch).unwrap();
-        let msg = rx.try_recv().unwrap();
-        assert!(matches!(msg, Message::HistoricalBatch(_)));
+        tx.send(&state, 7).unwrap();
+        match rx.try_recv().unwrap() {
+            Message::HistoricalValue(value_at) => {
+                assert_eq!(value_at.value.as_slice(), &[7]);
+            }
+            other => panic!("expected HistoricalValue, got {other:?}"),
+        }
     }
 
     #[test]
@@ -206,7 +210,7 @@ impl<T: Element + Send> ChannelSender<T> {
     pub fn send(&self, state: &GraphState, value: T) -> SendResult {
         let message = match state.run_mode() {
             RunMode::HistoricalFrom(_) => {
-                let value_at = ValueAt::new(value, state.time());
+                let value_at = ValueAt::new(crate::burst![value], state.time());
                 Message::HistoricalValue(value_at)
             }
             RunMode::RealTime => Message::RealtimeValue(value),
@@ -216,12 +220,6 @@ impl<T: Element + Send> ChannelSender<T> {
 
     pub fn send_checkpoint(&self, state: &GraphState) -> SendResult {
         let message = Message::CheckPoint(state.time());
-        self.send_message(message)
-    }
-
-    #[allow(dead_code)]
-    pub fn send_historical_batch(&self, batch: Vec<ValueAt<T>>) -> SendResult {
-        let message = Message::HistoricalBatch(batch.into_boxed_slice());
         self.send_message(message)
     }
 
@@ -288,7 +286,7 @@ impl<T: Element + Send> AsyncChannelSender<T> {
     pub async fn send(&self, run_mode: RunMode, time: NanoTime, value: T) {
         let message = match run_mode {
             RunMode::HistoricalFrom(_) => {
-                let value_at = ValueAt::new(value, time);
+                let value_at = ValueAt::new(crate::burst![value], time);
                 Message::HistoricalValue(value_at)
             }
             RunMode::RealTime => Message::RealtimeValue(value),
@@ -299,12 +297,6 @@ impl<T: Element + Send> AsyncChannelSender<T> {
     #[allow(dead_code)]
     pub async fn send_checkpoint(&self, time: NanoTime) {
         let message = Message::CheckPoint(time);
-        self.send_message(message).await;
-    }
-
-    #[allow(dead_code)]
-    pub async fn send_historical_batch(&self, batch: Vec<ValueAt<T>>) {
-        let message = Message::HistoricalBatch(batch.into_boxed_slice());
         self.send_message(message).await;
     }
 

--- a/wingfoil/src/channel/message.rs
+++ b/wingfoil/src/channel/message.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::queue::ValueAt;
 use crate::time::NanoTime;
-use crate::types::Element;
+use crate::types::{Burst, Element};
 #[cfg(feature = "zmq")]
 use crate::{GraphState, RunMode};
 
@@ -23,17 +23,38 @@ pub(crate) enum Message<T: Element + Send> {
     /// Tells the receiving node that there are no messages
     /// so it can shutdown cleanly.
     EndOfStream,
-    /// Used in [RunMode::HistoricalFrom].  A value and its
-    /// associated time.
-    HistoricalValue(ValueAt<T>),
+    /// Used in [RunMode::HistoricalFrom]. A burst of values sharing one
+    /// timestamp, delivered atomically so a same-time group can never be split
+    /// across the graph's strictly-monotonic clock.
+    HistoricalValue(#[serde(with = "burst_value_at_serde")] ValueAt<Burst<T>>),
     /// Sent in [RunMode::RealTime].  Just a value.
     RealtimeValue(T),
-    /// Used in [RunMode::HistoricalFrom] for bulk data transfer.
-    /// Contains multiple values with their timestamps.
-    HistoricalBatch(Box<[ValueAt<T>]>),
     /// Error message that can be propagated through channels.
     /// When received, the receiver will immediately return the error.
     Error(#[serde(with = "arc_error_serde")] Arc<anyhow::Error>),
+}
+
+// Serialize the burst as a plain slice/`Vec` so we don't need tinyvec's `serde`
+// feature: enabling it would make `Burst<T>: Serialize`, which makes
+// `Stream<Burst<T>>` satisfy both the `Stream<T>` and `Stream<Burst<T>>`
+// operator impls (e.g. `CsvOperators`) and breaks inference across the crate.
+mod burst_value_at_serde {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer, T: Element + Send + Serialize>(
+        value_at: &ValueAt<Burst<T>>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
+        (value_at.time, value_at.value.as_slice()).serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>, T: Element + Send + Deserialize<'de>>(
+        d: D,
+    ) -> Result<ValueAt<Burst<T>>, D::Error> {
+        let (time, values): (NanoTime, Vec<T>) = Deserialize::deserialize(d)?;
+        Ok(ValueAt::new(values.into_iter().collect(), time))
+    }
 }
 
 mod arc_error_serde {
@@ -57,7 +78,6 @@ impl<T: Element + Send + PartialEq> PartialEq for Message<T> {
             (Message::EndOfStream, Message::EndOfStream) => true,
             (Message::HistoricalValue(v1), Message::HistoricalValue(v2)) => v1 == v2,
             (Message::RealtimeValue(v1), Message::RealtimeValue(v2)) => v1 == v2,
-            (Message::HistoricalBatch(b1), Message::HistoricalBatch(b2)) => b1 == b2,
             (Message::Error(_), Message::Error(_)) => false,
             _ => false,
         }
@@ -76,7 +96,7 @@ impl<T: Element + Send> Message<T> {
         match graph_state.run_mode() {
             RunMode::RealTime => Message::RealtimeValue(value),
             RunMode::HistoricalFrom(_) => {
-                Message::HistoricalValue(ValueAt::new(value, graph_state.time()))
+                Message::HistoricalValue(ValueAt::new(crate::burst![value], graph_state.time()))
             }
         }
     }
@@ -109,9 +129,9 @@ mod tests {
 
     #[test]
     fn historical_value_eq() {
-        let v1 = ValueAt::new(1u64, NanoTime::new(10));
-        let v2 = ValueAt::new(1u64, NanoTime::new(10));
-        let v3 = ValueAt::new(2u64, NanoTime::new(10));
+        let v1 = ValueAt::new(crate::burst![1u64], NanoTime::new(10));
+        let v2 = ValueAt::new(crate::burst![1u64], NanoTime::new(10));
+        let v3 = ValueAt::new(crate::burst![2u64], NanoTime::new(10));
         assert_eq!(
             Message::HistoricalValue(v1.clone()),
             Message::HistoricalValue(v2)
@@ -126,10 +146,16 @@ mod tests {
     }
 
     #[test]
-    fn historical_batch_eq() {
-        let b1: Box<[ValueAt<u64>]> = vec![ValueAt::new(1, NanoTime::new(1))].into_boxed_slice();
-        let b2: Box<[ValueAt<u64>]> = vec![ValueAt::new(1, NanoTime::new(1))].into_boxed_slice();
-        assert_eq!(Message::HistoricalBatch(b1), Message::HistoricalBatch(b2));
+    fn historical_value_burst_eq() {
+        // A multi-value same-time burst compares by its contained values.
+        let b1 = ValueAt::new(crate::burst![1u64, 2], NanoTime::new(1));
+        let b2 = ValueAt::new(crate::burst![1u64, 2], NanoTime::new(1));
+        let b3 = ValueAt::new(crate::burst![1u64, 3], NanoTime::new(1));
+        assert_eq!(
+            Message::HistoricalValue(b1.clone()),
+            Message::HistoricalValue(b2)
+        );
+        assert_ne!(Message::HistoricalValue(b1), Message::HistoricalValue(b3));
     }
 
     #[test]
@@ -165,7 +191,16 @@ mod tests {
 
     #[test]
     fn serde_roundtrip_historical_value() {
-        let msg = Message::HistoricalValue(ValueAt::new(42u64, NanoTime::new(5)));
+        let msg = Message::HistoricalValue(ValueAt::new(crate::burst![42u64], NanoTime::new(5)));
+        let json = serde_json::to_string(&msg).unwrap();
+        let decoded: Message<u64> = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn serde_roundtrip_historical_value_multi() {
+        let msg =
+            Message::HistoricalValue(ValueAt::new(crate::burst![1u64, 2, 3], NanoTime::new(7)));
         let json = serde_json::to_string(&msg).unwrap();
         let decoded: Message<u64> = serde_json::from_str(&json).unwrap();
         assert_eq!(msg, decoded);
@@ -174,19 +209,6 @@ mod tests {
     #[test]
     fn serde_roundtrip_realtime_value() {
         let msg = Message::RealtimeValue(99u64);
-        let json = serde_json::to_string(&msg).unwrap();
-        let decoded: Message<u64> = serde_json::from_str(&json).unwrap();
-        assert_eq!(msg, decoded);
-    }
-
-    #[test]
-    fn serde_roundtrip_historical_batch() {
-        let batch: Box<[ValueAt<u64>]> = vec![
-            ValueAt::new(1, NanoTime::new(1)),
-            ValueAt::new(2, NanoTime::new(2)),
-        ]
-        .into_boxed_slice();
-        let msg = Message::HistoricalBatch(batch);
         let json = serde_json::to_string(&msg).unwrap();
         let decoded: Message<u64> = serde_json::from_str(&json).unwrap();
         assert_eq!(msg, decoded);

--- a/wingfoil/src/nodes/async_io.rs
+++ b/wingfoil/src/nodes/async_io.rs
@@ -321,16 +321,35 @@ where
     fn to_message_stream(self, run_mode: RunMode) -> impl futures::Stream<Item = Message<T>> {
         async_stream::stream! {
             let mut source = Box::pin(self);
+            // Group consecutive same-time values into one atomic `HistoricalValue`
+            // message so a slow producer can't split a timestamp across the
+            // receiver's monotonic clock. The source is time-ordered, so a change
+            // in `time` marks the previous group complete.
+            let mut pending: Option<ValueAt<Burst<T>>> = None;
             while let Some(result) = source.next().await {
                 match result {
                     Ok((time, value)) => match run_mode {
                         RunMode::RealTime => yield Message::RealtimeValue(value),
-                        RunMode::HistoricalFrom(_) => yield Message::HistoricalValue(ValueAt::new(value, time)),
+                        RunMode::HistoricalFrom(_) => match &mut pending {
+                            Some(group) if group.time == time => group.value.push(value),
+                            _ => {
+                                if let Some(group) = pending.take() {
+                                    yield Message::HistoricalValue(group);
+                                }
+                                pending = Some(ValueAt::new(crate::burst![value], time));
+                            }
+                        },
                     },
                     Err(e) => {
+                        if let Some(group) = pending.take() {
+                            yield Message::HistoricalValue(group);
+                        }
                         yield Message::Error(std::sync::Arc::new(e));
                     }
                 }
+            }
+            if let Some(group) = pending.take() {
+                yield Message::HistoricalValue(group);
             }
             yield Message::EndOfStream;
         }
@@ -368,12 +387,6 @@ where
                     Message::CheckPoint(t) => {
                         time = *t;
                     },
-                    Message::HistoricalBatch(batch) => {
-                        // Update time to earliest timestamp in batch
-                        if let Some(value_at) = batch.first() {
-                            time = value_at.time;
-                        }
-                    }
                     Message::EndOfStream => {
                         finished = true;
                     },
@@ -400,15 +413,11 @@ where
                         yield (NanoTime::now(), value)
                     }
                     Message::HistoricalValue(value_at) => {
-                        yield (value_at.time, value_at.value)
-                    },
-                    Message::HistoricalBatch(batch) => {
-                        // Convert to Vec to own the data and avoid holding reference across await
-                        let batch_vec = batch.into_vec();
-                        for value_at in batch_vec {
-                            yield (value_at.time, value_at.value)
+                        let time = value_at.time;
+                        for value in value_at.value {
+                            yield (time, value)
                         }
-                    }
+                    },
                     Message::CheckPoint(_) => {},
                     Message::EndOfStream => {},
                     Message::Error(err) => {
@@ -431,48 +440,19 @@ mod tests {
     use std::pin::Pin;
     use std::time::Duration;
 
-    /// Regression repro for the client's async/historical KDB defect.
-    ///
-    /// `kdb_read` streams rows through `produce_async`: a background tokio task
-    /// reads rows and sends one `HistoricalValue` per row over the channel, while
-    /// the graph pulls them out via `ChannelReceiverStream`. A KDB table routinely
-    /// holds several rows stamped at the *same* timestamp (multiple events in the
-    /// same nanosecond bucket), and a live query streams them with arbitrary
-    /// latency between rows.
-    ///
-    /// The same-timestamp fix in #397 drains every same-time message that is
-    /// *already buffered* on the channel before yielding. That is sufficient when
-    /// the whole burst is produced up front (the in-process channel test in
-    /// `nodes/channel.rs`), but NOT for an async producer: if the next same-time
-    /// row has not been sent yet when the receiver drains, the non-blocking
-    /// `try_recv` returns `None`, the receiver yields, and the graph's strict
-    /// monotonic clock advances by 1ns. When the straggler row — still stamped at
-    /// the old time — finally lands, the receiver reads a timestamp now behind
-    /// engine time and aborts the run with:
-    ///   "received Historical message but with time less than graph time, 100 < 101".
-    ///
-    /// The `sleep` between the two same-time rows makes the background producer
-    /// reliably lag the receiver, reproducing the timing the client hits against a
-    /// live KDB instance without needing a running KDB+ server.
-    ///
-    /// Asserts the correct behaviour (both rows delivered at their real time) and
-    /// is marked `#[ignore]` so CI stays green until the receiver is fixed; run it
-    /// with `--ignored` to observe the failure.
+    /// An async producer that emits same-time values with latency between them
+    /// must not drive engine time backwards. The `sleep` makes the producer lag
+    /// the receiver, so without producer-side grouping the second value lands
+    /// behind engine time and aborts with "time less than graph time".
     #[test]
-    #[ignore]
     fn async_same_time_burst_breaks_monotonic_engine_time() {
         let _ = env_logger::try_init();
 
-        // Two rows stamped at the *same* time (t=100), streamed by a background
-        // task with latency between them — exactly what a live KDB query produces
-        // when several events share a timestamp.
         let producer = move |_ctx: RunParams| async move {
             Ok(async_stream::stream! {
                 yield Ok((NanoTime::new(100), 1u32));
-                // The straggler: arrives only after the receiver has already
-                // drained the first row, yielded, and let engine time advance
-                // past t=100. The non-blocking drain in the receiver cannot see
-                // it because it has not been sent yet.
+                // Lands after the receiver has drained the first value and let
+                // engine time advance past t=100.
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 yield Ok((NanoTime::new(100), 2u32));
             })
@@ -484,19 +464,16 @@ mod tests {
             .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
             .expect("async same-time burst must not drive engine time backwards");
 
-        // Flatten every burst the receiver emitted, pairing each value with the
-        // engine time it was delivered at.
         let delivered: Vec<(u32, NanoTime)> = collected
             .peek_value()
             .iter()
             .flat_map(|burst| burst.value.iter().map(|v| (*v, burst.time)))
             .collect();
 
-        // Both rows must be delivered, and both at t=100 (their real time).
         assert_eq!(
             delivered,
             vec![(1, NanoTime::new(100)), (2, NanoTime::new(100))],
-            "expected both same-time rows delivered at t=100, got {delivered:?}"
+            "expected both same-time values delivered at t=100, got {delivered:?}"
         );
     }
 

--- a/wingfoil/src/nodes/async_io.rs
+++ b/wingfoil/src/nodes/async_io.rs
@@ -431,6 +431,75 @@ mod tests {
     use std::pin::Pin;
     use std::time::Duration;
 
+    /// Regression repro for the client's async/historical KDB defect.
+    ///
+    /// `kdb_read` streams rows through `produce_async`: a background tokio task
+    /// reads rows and sends one `HistoricalValue` per row over the channel, while
+    /// the graph pulls them out via `ChannelReceiverStream`. A KDB table routinely
+    /// holds several rows stamped at the *same* timestamp (multiple events in the
+    /// same nanosecond bucket), and a live query streams them with arbitrary
+    /// latency between rows.
+    ///
+    /// The same-timestamp fix in #397 drains every same-time message that is
+    /// *already buffered* on the channel before yielding. That is sufficient when
+    /// the whole burst is produced up front (the in-process channel test in
+    /// `nodes/channel.rs`), but NOT for an async producer: if the next same-time
+    /// row has not been sent yet when the receiver drains, the non-blocking
+    /// `try_recv` returns `None`, the receiver yields, and the graph's strict
+    /// monotonic clock advances by 1ns. When the straggler row — still stamped at
+    /// the old time — finally lands, the receiver reads a timestamp now behind
+    /// engine time and aborts the run with:
+    ///   "received Historical message but with time less than graph time, 100 < 101".
+    ///
+    /// The `sleep` between the two same-time rows makes the background producer
+    /// reliably lag the receiver, reproducing the timing the client hits against a
+    /// live KDB instance without needing a running KDB+ server.
+    ///
+    /// Asserts the correct behaviour (both rows delivered at their real time) and
+    /// is marked `#[ignore]` so CI stays green until the receiver is fixed; run it
+    /// with `--ignored` to observe the failure.
+    #[test]
+    #[ignore]
+    fn async_same_time_burst_breaks_monotonic_engine_time() {
+        let _ = env_logger::try_init();
+
+        // Two rows stamped at the *same* time (t=100), streamed by a background
+        // task with latency between them — exactly what a live KDB query produces
+        // when several events share a timestamp.
+        let producer = move |_ctx: RunParams| async move {
+            Ok(async_stream::stream! {
+                yield Ok((NanoTime::new(100), 1u32));
+                // The straggler: arrives only after the receiver has already
+                // drained the first row, yielded, and let engine time advance
+                // past t=100. The non-blocking drain in the receiver cannot see
+                // it because it has not been sent yet.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                yield Ok((NanoTime::new(100), 2u32));
+            })
+        };
+
+        let collected = produce_async(producer).collect();
+
+        collected
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+            .expect("async same-time burst must not drive engine time backwards");
+
+        // Flatten every burst the receiver emitted, pairing each value with the
+        // engine time it was delivered at.
+        let delivered: Vec<(u32, NanoTime)> = collected
+            .peek_value()
+            .iter()
+            .flat_map(|burst| burst.value.iter().map(|v| (*v, burst.time)))
+            .collect();
+
+        // Both rows must be delivered, and both at t=100 (their real time).
+        assert_eq!(
+            delivered,
+            vec![(1, NanoTime::new(100)), (2, NanoTime::new(100))],
+            "expected both same-time rows delivered at t=100, got {delivered:?}"
+        );
+    }
+
     #[test]
     fn produce_async_mid_stream_error() {
         let _ = env_logger::try_init();

--- a/wingfoil/src/nodes/channel.rs
+++ b/wingfoil/src/nodes/channel.rs
@@ -96,7 +96,7 @@ pub struct ChannelReceiverStream<T: Element + Send> {
     #[new(default)]
     message_time: Option<NanoTime>,
     #[new(default)]
-    queue: VecDeque<ValueAt<T>>,
+    queue: VecDeque<ValueAt<Burst<T>>>,
 }
 
 // `finished` is only read by `ReceiverStream`, which is itself gated behind the
@@ -136,12 +136,7 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
                                     values.push(value);
                                 }
                                 Message::HistoricalValue(value_at) => {
-                                    values.push(value_at.value);
-                                }
-                                Message::HistoricalBatch(_) => {
-                                    return Err(anyhow!(
-                                        "received HistoricalBatch but RunMode is RealTime"
-                                    ));
+                                    values.extend(value_at.value);
                                 }
                                 Message::EndOfStream => self.finished = true,
                                 Message::CheckPoint(_) => {}
@@ -214,34 +209,6 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
                             self.message_time = Some(value_at.time);
                             self.queue.push_back(value_at);
                         }
-                        Message::HistoricalBatch(batch) => {
-                            if batch.is_empty() {
-                                continue;
-                            }
-
-                            // Validate: all timestamps must be >= current graph time
-                            // (batch is non-empty per the `is_empty()` check above).
-                            let min_time = batch
-                                .iter()
-                                .map(|va| va.time)
-                                .min()
-                                .expect("batch is non-empty");
-                            if min_time < state.time() {
-                                return Err(anyhow!(
-                                    "received HistoricalBatch with timestamp less than graph time, {} < {}",
-                                    min_time,
-                                    state.time()
-                                ));
-                            }
-
-                            // Set message_time to earliest timestamp
-                            self.message_time = Some(min_time);
-
-                            // Unpack all values into queue
-                            for value_at in batch.iter() {
-                                self.queue.push_back(value_at.clone());
-                            }
-                        }
                         Message::EndOfStream => self.finished = true,
                         Message::CheckPoint(check_point) => {
                             self.message_time = Some(check_point);
@@ -255,7 +222,7 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
                     if value_at.time <= state.time() {
                         // front() returned Some, so pop_front is guaranteed.
                         let popped = self.queue.pop_front().expect("front() just returned Some");
-                        values.push(popped.value);
+                        values.extend(popped.value);
                     } else {
                         break;
                     }
@@ -340,13 +307,13 @@ mod tests {
         // messages onto the channel.
         sender
             .send_message(Message::HistoricalValue(ValueAt::new(
-                1u64,
+                burst![1u64],
                 NanoTime::new(100),
             )))
             .unwrap();
         sender
             .send_message(Message::HistoricalValue(ValueAt::new(
-                2u64,
+                burst![2u64],
                 NanoTime::new(100),
             )))
             .unwrap();


### PR DESCRIPTION
## Problem

A client reading KDB data in async historical mode still hit the
non-monotonic-engine-time abort that #397 was meant to fix:

```
received Historical message but with time less than graph time, 100 < 101
```

#397 made the receiver drain same-time messages **already buffered** on the
channel before yielding. That holds when the whole burst is produced up front
(the in-process channel test), but **not** for an async producer like
`kdb_read`, which streams one value per row from a background tokio task. A KDB
table routinely has several rows stamped at the same timestamp, streamed with
latency between them.

The race:

1. Receiver reads the first row at `t=100`, sees the channel momentarily empty
   (the next same-time row hasn't been sent), so the non-blocking `try_recv`
   returns `None` and it yields.
2. The graph's strict monotonic clock advances `100 → 101`.
3. The straggler row — still stamped `t=100` — lands behind engine time and
   aborts the run.

The receiver *can't* simply block for the next row: an untriggered receiver may
be fed one value per engine step (the graph-map round-trip), and blocking would
deadlock it.

## Fix

Group same-timestamp values into one atomic message **at the producer**
(`to_message_stream`), which runs in the background task where awaiting the next
row is free and cannot deadlock the graph. `Message::HistoricalValue` now
carries `ValueAt<Burst<T>>`, so a timestamp crosses the channel as a single
message and can never be split across the monotonic-clock boundary.

The receiver queue is `Burst`-typed end to end, which also drops the old
per-value unpack-and-clone. The unused `HistoricalBatch` variant and its dead
`send_historical_batch` helpers are removed.

### Why the burst is serialized as a slice

`Message` derives `Serialize`/`Deserialize` for zmq/aeron transport. Enabling
tinyvec's `serde` feature to get `Burst<T>: Serialize` would make
`Stream<Burst<T>>` satisfy **both** the `Stream<T>` and `Stream<Burst<T>>`
operator impls (e.g. `CsvOperators`) and break type inference across the crate.
Instead, the one `HistoricalValue` field gets a custom serde that writes the
burst as a plain slice — tinyvec's serde feature stays off.

### The `SenderNode` / graph-map path is unaffected

It keeps sending one 1-element burst per tick (no look-ahead, no deadlock). Its
same-time multi-ticks are produced back-to-back into the channel before the main
graph cycles, so the receiver's existing non-blocking drain still groups them —
covered by the retained `same_time_burst_does_not_break_monotonic_engine_time`
test.

## Changes

- `channel/message.rs` — `HistoricalValue(ValueAt<Burst<T>>)`; remove dead
  `HistoricalBatch`; slice-based custom serde for the burst field.
- `channel/kanal_chan.rs` — sends wrap their value in a 1-element burst; remove
  dead `send_historical_batch` (sync + async).
- `nodes/async_io.rs` — producer-side same-time grouping (the fix); update
  `limit`/`to_stream`; un-ignore the async repro test.
- `nodes/channel.rs` — `Burst`-typed receiver queue; `extend` on drain; drop the
  `HistoricalBatch` handling.

## Testing

- The async repro test (added in the first commit, `#[ignore]`d) now **passes**
  and runs in normal CI.
- `cargo test -p wingfoil` (214 + 14) and `--features kdb` (240 + 14) green.
- `cargo fmt --all`, `cargo lint`, and full `cargo lint-all` all clean.

https://claude.ai/code/session_01H1PsZzKdYLqXAYu5kGfvPo

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1PsZzKdYLqXAYu5kGfvPo)_