### PR TITLE
Add Redis I/O adapter (Pub/Sub + Streams)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,11 @@ jobs:
     uses: ./.github/workflows/etcd-integration.yml
     secrets: inherit
 
+  redis-integration:
+    name: redis Integration Tests
+    uses: ./.github/workflows/redis-integration.yml
+    secrets: inherit
+
   prometheus-integration:
     name: Prometheus Integration Tests
     uses: ./.github/workflows/prometheus-integration.yml

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -1,0 +1,87 @@
+name: test.integration.redis
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'wingfoil/src/adapters/redis/**'
+      - 'wingfoil-python/src/py_redis.rs'
+      - 'wingfoil-python/tests/test_redis.py'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  redis-integration:
+    name: redis Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
+
+      - name: Pre-pull redis image
+        # testcontainers pulls the image lazily on first use, which is
+        # vulnerable to transient registry flakes. Pull once up front with
+        # retries so every test reuses the cached image.
+        run: |
+          for i in 1 2 3; do
+            docker pull redis:7-alpine && exit 0
+            echo "pull attempt $i failed, retrying..."
+            sleep 5
+          done
+          echo "failed to pull redis image after 3 attempts" && exit 1
+
+      - name: Run redis integration tests
+        run: |
+          cargo test --features redis-integration-test -p wingfoil \
+            -- --test-threads=1 --nocapture redis::integration_tests
+        env:
+          RUST_LOG: INFO
+
+      - name: Start redis container for Python tests
+        run: |
+          docker run -d --name redis-py -p 6379:6379 redis:7-alpine
+          for i in $(seq 1 30); do
+            nc -z localhost 6379 && echo "redis ready" && break
+            echo "Waiting... ($i/30)"
+            sleep 1
+          done
+          nc -z localhost 6379 || (echo "redis never became ready" && exit 1)
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: wingfoil-python/pyproject.toml
+
+      - name: Install maturin and build Python bindings
+        run: |
+          python -m venv wingfoil-python/.venv
+          wingfoil-python/.venv/bin/pip install maturin pytest
+          cd wingfoil-python && .venv/bin/maturin develop
+
+      - name: Run Python redis integration tests
+        run: |
+          cd wingfoil-python && .venv/bin/pytest -m requires_redis tests/test_redis.py -v
+        env:
+          RUST_LOG: INFO
+
+      - name: Dump redis logs on failure
+        if: failure()
+        run: docker logs redis-py
+
+      - name: Stop redis container
+        if: always()
+        run: docker stop redis-py && docker rm redis-py

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -66,6 +66,11 @@ jobs:
           cache: "pip"
           cache-dependency-path: wingfoil-python/pyproject.toml
 
+      - name: Install protoc
+        # Building the Python bindings compiles wingfoil-python, which enables the
+        # `etcd` feature; etcd-client's build script requires protoc.
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Install maturin and build Python bindings
         run: |
           python -m venv wingfoil-python/.venv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.18",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4585,6 +4599,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itertools 0.13.0",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util 0.7.18",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7030,6 +7068,7 @@ dependencies = [
  "quanta",
  "rcgen",
  "rdkafka",
+ "redis",
  "reqwest",
  "rusteron-client",
  "rusteron-media-driver",

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Short code snippets for each adapter live in the [examples README](https://githu
 | [`fix`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/fix/) | FIX 4.4 protocol: self-contained loopback, client, echo server, and live LMAX market data over TLS. |
 | [`zmq`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/zmq/) | ZeroMQ pub/sub with direct addressing or etcd-based service discovery. |
 | [`etcd`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/etcd/) | etcd key-value store adapter for sub/pub with transformation. |
+| [`redis`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/redis/) | Redis adapter — Pub/Sub channels (subscribe, transform, republish) and persistent Streams (snapshot + tail). |
 | [`iceoryx2`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/iceoryx2/) | Zero-copy IPC over shared memory (spin, threaded, signaled polling modes). |
 | [`aeron`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/aeron/) | Low-latency Aeron UDP/IPC transport — publish and subscribe to `i64` values with spin and threaded polling modes. |
 | [`web`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/web/) | WebSocket adapter streaming synthetic prices and receiving UI events. |

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -27,7 +27,7 @@ aeron = ["wingfoil/aeron"]
 [dependencies]
 
 # parent
-wingfoil = { path = "../wingfoil", features = ["csv", "kdb", "zmq", "etcd", "fluvio", "prometheus", "otlp", "fix", "web", "kafka"] }
+wingfoil = { path = "../wingfoil", features = ["csv", "kdb", "zmq", "etcd", "fluvio", "prometheus", "otlp", "fix", "web", "kafka", "redis"] }
 
 # workspace deps
 anyhow = {workspace = true}

--- a/wingfoil-python/pyproject.toml
+++ b/wingfoil-python/pyproject.toml
@@ -51,6 +51,7 @@ markers = [
     "requires_iceoryx2: needs wingfoil built with --features iceoryx2",
     "requires_web: needs a wingfoil web server (runs in-process)",
     "requires_kafka: needs a Kafka-compatible broker on localhost:9092",
+    "requires_redis: needs Redis on localhost:6379",
     "requires_aeron: needs an Aeron media driver (and wingfoil built with --features aeron)",
 ]
-addopts = "-m 'not requires_etcd and not requires_kdb and not requires_otel and not requires_iceoryx2 and not requires_web and not requires_kafka and not requires_aeron'"
+addopts = "-m 'not requires_etcd and not requires_kdb and not requires_otel and not requires_iceoryx2 and not requires_web and not requires_kafka and not requires_redis and not requires_aeron'"

--- a/wingfoil-python/python/wingfoil/__init__.py
+++ b/wingfoil-python/python/wingfoil/__init__.py
@@ -34,6 +34,10 @@ fluvio_sub = _ext.py_fluvio_sub
 # User-friendly aliases for Kafka functions
 kafka_sub = _ext.py_kafka_sub
 
+# User-friendly aliases for Redis functions
+redis_sub = _ext.py_redis_sub
+redis_stream_read = _ext.py_redis_stream_read
+
 # User-friendly aliases for KDB+ functions
 kdb_read = _ext.py_kdb_read
 kdb_write = _ext.py_kdb_write

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -14,6 +14,7 @@ mod py_kdb;
 mod py_latency;
 mod py_otlp;
 mod py_prometheus;
+mod py_redis;
 mod py_stream;
 mod py_web;
 mod py_zmq;
@@ -199,6 +200,8 @@ fn _wingfoil(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(py_etcd::py_etcd_sub, module)?)?;
     module.add_function(wrap_pyfunction!(py_fluvio::py_fluvio_sub, module)?)?;
     module.add_function(wrap_pyfunction!(py_kafka::py_kafka_sub, module)?)?;
+    module.add_function(wrap_pyfunction!(py_redis::py_redis_sub, module)?)?;
+    module.add_function(wrap_pyfunction!(py_redis::py_redis_stream_read, module)?)?;
     module.add_function(wrap_pyfunction!(py_kdb::py_kdb_read, module)?)?;
     module.add_function(wrap_pyfunction!(py_kdb::py_kdb_write, module)?)?;
     module.add_function(wrap_pyfunction!(py_zmq::py_zmq_sub, module)?)?;

--- a/wingfoil-python/src/py_redis.rs
+++ b/wingfoil-python/src/py_redis.rs
@@ -1,0 +1,221 @@
+//! Python bindings for the Redis adapter.
+
+use crate::py_element::PyElement;
+use crate::py_stream::PyStream;
+use crate::types::{DICT_INSERT_INFALLIBLE, LIST_NEW_INFALLIBLE};
+
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict, PyList};
+use std::rc::Rc;
+use wingfoil::adapters::redis::{
+    RedisConnection, RedisEntry, RedisStreamRecord, redis_pub, redis_stream_read,
+    redis_stream_write, redis_sub,
+};
+use wingfoil::{Burst, Node, Stream, StreamOperators};
+
+/// Subscribe to a Redis Pub/Sub channel.
+///
+/// Each tick yields a `list` of event dicts:
+/// `{"channel": str, "payload": bytes}`
+///
+/// Redis Pub/Sub is fire-and-forget: only messages published after the
+/// subscription is registered are delivered.
+///
+/// Args:
+///     url: Redis URL, e.g. `"redis://127.0.0.1:6379"`
+///     channel: channel to subscribe to
+#[pyfunction]
+pub fn py_redis_sub(url: String, channel: String) -> PyStream {
+    let conn = RedisConnection::new(url);
+    let stream = redis_sub(conn, channel);
+
+    let py_stream = stream.map(|burst| {
+        Python::attach(|py| {
+            let items: Vec<Py<PyAny>> = burst
+                .into_iter()
+                .map(|event| {
+                    let dict = PyDict::new(py);
+                    dict.set_item("channel", &event.channel)
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.set_item("payload", PyBytes::new(py, &event.payload))
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.into_any().unbind()
+                })
+                .collect();
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
+        })
+    });
+
+    PyStream(py_stream)
+}
+
+/// Inner implementation for the `.redis_pub()` stream method.
+///
+/// The stream must yield either:
+/// - a single `dict` with `"channel"` (str) and `"payload"` (bytes), or
+/// - a `list` of such dicts for multiple messages per tick.
+///
+/// Dicts that omit `"channel"` fall back to `default_channel`.
+pub fn py_redis_pub_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    url: String,
+    channel: String,
+) -> Rc<dyn Node> {
+    let conn = RedisConnection::new(url);
+    let default_channel = channel;
+
+    let burst_stream: Rc<dyn Stream<Burst<RedisEntry>>> = stream.map(move |elem| {
+        let default_channel = default_channel.clone();
+        Python::attach(|py| {
+            let obj = elem.as_ref().bind(py);
+            if let Ok(dict) = obj.cast_exact::<PyDict>() {
+                std::iter::once(dict_to_entry(dict, &default_channel)).collect()
+            } else if let Ok(list) = obj.cast_exact::<PyList>() {
+                list.iter()
+                    .filter_map(|item| {
+                        item.cast_exact::<PyDict>()
+                            .ok()
+                            .map(|d| dict_to_entry(d, &default_channel))
+                    })
+                    .collect()
+            } else {
+                log::error!("redis_pub: stream value must be a dict or list of dicts");
+                Burst::new()
+            }
+        })
+    });
+
+    redis_pub(conn, &burst_stream)
+}
+
+fn dict_to_entry(dict: &Bound<'_, PyDict>, default_channel: &str) -> RedisEntry {
+    let channel = dict
+        .get_item("channel")
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<String>().ok())
+        .unwrap_or_else(|| default_channel.to_string());
+    let payload = dict
+        .get_item("payload")
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<Vec<u8>>().ok())
+        .unwrap_or_default();
+    RedisEntry { channel, payload }
+}
+
+/// Read a Redis stream: snapshot of existing entries, then live appends.
+///
+/// Each tick yields a `list` of event dicts:
+/// `{"key": str, "id": str, "fields": {name: bytes}}`
+///
+/// Args:
+///     url: Redis URL, e.g. `"redis://127.0.0.1:6379"`
+///     key: stream key to read
+#[pyfunction]
+pub fn py_redis_stream_read(url: String, key: String) -> PyStream {
+    let conn = RedisConnection::new(url);
+    let stream = redis_stream_read(conn, key);
+
+    let py_stream = stream.map(|burst| {
+        Python::attach(|py| {
+            let items: Vec<Py<PyAny>> = burst
+                .into_iter()
+                .map(|event| {
+                    let dict = PyDict::new(py);
+                    dict.set_item("key", &event.key)
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.set_item("id", &event.id)
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    let fields = PyDict::new(py);
+                    for (name, value) in &event.fields {
+                        fields
+                            .set_item(name, PyBytes::new(py, value))
+                            .expect(DICT_INSERT_INFALLIBLE);
+                    }
+                    dict.set_item("fields", fields)
+                        .expect(DICT_INSERT_INFALLIBLE);
+                    dict.into_any().unbind()
+                })
+                .collect();
+            PyElement::new(
+                PyList::new(py, items)
+                    .expect(LIST_NEW_INFALLIBLE)
+                    .into_any()
+                    .unbind(),
+            )
+        })
+    });
+
+    PyStream(py_stream)
+}
+
+/// Inner implementation for the `.redis_stream_write()` stream method.
+///
+/// The stream must yield either:
+/// - a single `dict` with optional `"key"` (str) and `"fields"` (dict of `name -> bytes`), or
+/// - a `list` of such dicts for multiple entries per tick.
+///
+/// Dicts that omit `"key"` fall back to `default_key`.
+pub fn py_redis_stream_write_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    url: String,
+    key: String,
+) -> Rc<dyn Node> {
+    let conn = RedisConnection::new(url);
+    let default_key = key;
+
+    let burst_stream: Rc<dyn Stream<Burst<RedisStreamRecord>>> = stream.map(move |elem| {
+        let default_key = default_key.clone();
+        Python::attach(|py| {
+            let obj = elem.as_ref().bind(py);
+            if let Ok(dict) = obj.cast_exact::<PyDict>() {
+                std::iter::once(dict_to_record(dict, &default_key)).collect()
+            } else if let Ok(list) = obj.cast_exact::<PyList>() {
+                list.iter()
+                    .filter_map(|item| {
+                        item.cast_exact::<PyDict>()
+                            .ok()
+                            .map(|d| dict_to_record(d, &default_key))
+                    })
+                    .collect()
+            } else {
+                log::error!("redis_stream_write: stream value must be a dict or list of dicts");
+                Burst::new()
+            }
+        })
+    });
+
+    redis_stream_write(conn, &burst_stream)
+}
+
+fn dict_to_record(dict: &Bound<'_, PyDict>, default_key: &str) -> RedisStreamRecord {
+    let key = dict
+        .get_item("key")
+        .ok()
+        .flatten()
+        .and_then(|v| v.extract::<String>().ok())
+        .unwrap_or_else(|| default_key.to_string());
+    let fields = dict
+        .get_item("fields")
+        .ok()
+        .flatten()
+        .and_then(|v| v.cast_into::<PyDict>().ok())
+        .map(|fields| {
+            fields
+                .iter()
+                .filter_map(|(name, value)| {
+                    let name = name.extract::<String>().ok()?;
+                    let value = value.extract::<Vec<u8>>().ok()?;
+                    Some((name, value))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    RedisStreamRecord { key, fields }
+}

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -454,6 +454,38 @@ impl PyStream {
         PyNode::new(crate::py_kafka::py_kafka_pub_inner(&self.0, brokers, topic))
     }
 
+    /// Publish this stream of dicts to Redis via `PUBLISH`.
+    ///
+    /// Stream values must be dicts with `"payload"` (bytes) and optionally
+    /// `"channel"` (str), or lists of such dicts for multi-message writes per tick.
+    ///
+    /// Args:
+    ///     url: Redis URL, e.g. `"redis://127.0.0.1:6379"`
+    ///     channel: default channel for dicts that don't specify one
+    ///
+    /// Returns:
+    ///     A Node that drives the publish operation.
+    fn redis_pub(&self, url: String, channel: String) -> PyNode {
+        PyNode::new(crate::py_redis::py_redis_pub_inner(&self.0, url, channel))
+    }
+
+    /// Append this stream of dicts to a Redis stream via `XADD`.
+    ///
+    /// Stream values must be dicts with `"fields"` (dict of `name -> bytes`) and
+    /// optionally `"key"` (str), or lists of such dicts for multi-entry writes per tick.
+    ///
+    /// Args:
+    ///     url: Redis URL, e.g. `"redis://127.0.0.1:6379"`
+    ///     key: default stream key for dicts that don't specify one
+    ///
+    /// Returns:
+    ///     A Node that drives the append operation.
+    fn redis_stream_write(&self, url: String, key: String) -> PyNode {
+        PyNode::new(crate::py_redis::py_redis_stream_write_inner(
+            &self.0, url, key,
+        ))
+    }
+
     /// Publish this stream of bytes to a ZMQ PUB socket bound on the given port.
     ///
     /// The stream values must be `bytes` objects. Only supported in real-time mode.

--- a/wingfoil-python/tests/test_redis.py
+++ b/wingfoil-python/tests/test_redis.py
@@ -1,0 +1,189 @@
+"""Tests for the Redis Pub/Sub Python bindings.
+
+Two groups:
+
+- Unit-level construction / marshaling tests (no marker): run by default, with no
+  live service. They keep the binding module visible in coverage and exercise the
+  pyo3 marshaling glue.
+- Integration tests (``@pytest.mark.requires_redis``): deselected by default. The
+  Redis integration workflow opts in with ``-m requires_redis``; without Redis on
+  localhost:6379 they fail loudly with a real connection error rather than skipping.
+
+Local setup:
+    docker run --rm -p 6379:6379 redis:7-alpine
+"""
+
+import threading
+import time
+import unittest
+
+import pytest
+
+ENDPOINT = "redis://localhost:6379"
+# Loopback port 1 is reserved and never hosts a service: connect is rejected.
+UNREACHABLE_ENDPOINT = "redis://127.0.0.1:1"
+CHANNEL_PREFIX = "wingfoil_pytest_"
+
+
+# ---- Unit-level coverage (no live Redis) ----
+
+
+class TestRedisConstruction(unittest.TestCase):
+    def test_sub_constructs_stream(self):
+        from wingfoil import redis_sub
+
+        stream = redis_sub(UNREACHABLE_ENDPOINT, "ch")
+        self.assertIsNotNone(stream)
+
+    def test_pub_method_constructs_node(self):
+        from wingfoil import constant
+
+        node = constant({"channel": "ch", "payload": b"v"}).redis_pub(
+            UNREACHABLE_ENDPOINT, "ch"
+        )
+        self.assertIsNotNone(node)
+
+
+class TestRedisUnreachable(unittest.TestCase):
+    def test_pub_single_dict_marshals_then_errors(self):
+        # dict_to_entry runs on the upstream tick; connect then fails.
+        from wingfoil import constant
+
+        node = constant({"channel": "ch", "payload": b"v"}).redis_pub(
+            UNREACHABLE_ENDPOINT, "ch"
+        )
+        with self.assertRaises(Exception):
+            node.run(realtime=True, cycles=1)
+
+    def test_pub_list_of_dicts_marshals_then_errors(self):
+        from wingfoil import constant
+
+        records = [{"channel": "ch", "payload": b"v"}, {"payload": b"v2"}]  # channel-less path
+        node = constant(records).redis_pub(UNREACHABLE_ENDPOINT, "ch")
+        with self.assertRaises(Exception):
+            node.run(realtime=True, cycles=1)
+
+    def test_pub_bad_value_type_marshals_empty_burst(self):
+        # Fallthrough branch: neither dict nor list. Logs an error and emits an
+        # empty burst; the run still fails at connect time.
+        from wingfoil import constant
+
+        node = constant("not a dict").redis_pub(UNREACHABLE_ENDPOINT, "ch")
+        with self.assertRaises(Exception):
+            node.run(realtime=True, cycles=1)
+
+    def test_sub_unreachable_errors(self):
+        from wingfoil import redis_sub
+
+        stream = redis_sub(UNREACHABLE_ENDPOINT, "ch").collect()
+        with self.assertRaises(Exception):
+            stream.run(realtime=True, cycles=1)
+
+    def test_stream_read_constructs_stream(self):
+        from wingfoil import redis_stream_read
+
+        stream = redis_stream_read(UNREACHABLE_ENDPOINT, "events")
+        self.assertIsNotNone(stream)
+
+    def test_stream_write_marshals_then_errors(self):
+        # dict_to_record runs on the upstream tick; connect then fails.
+        from wingfoil import constant
+
+        node = constant({"key": "events", "fields": {"kind": b"login"}}).redis_stream_write(
+            UNREACHABLE_ENDPOINT, "events"
+        )
+        with self.assertRaises(Exception):
+            node.run(realtime=True, cycles=1)
+
+    def test_stream_write_list_marshals_then_errors(self):
+        from wingfoil import constant
+
+        records = [
+            {"key": "events", "fields": {"kind": b"login"}},
+            {"fields": {"kind": b"logout"}},  # key-less path
+        ]
+        node = constant(records).redis_stream_write(UNREACHABLE_ENDPOINT, "events")
+        with self.assertRaises(Exception):
+            node.run(realtime=True, cycles=1)
+
+
+# ---- Integration tests (require live Redis) ----
+
+
+@pytest.mark.requires_redis
+class TestRedisSub(unittest.TestCase):
+    def test_sub_returns_expected_shape(self):
+        from wingfoil import redis_sub
+
+        channel = f"{CHANNEL_PREFIX}sub_shape"
+        stream = redis_sub(ENDPOINT, channel).collect()
+        stream.run(realtime=True, duration=2.0)
+        result = stream.peek_value()
+        # Nobody publishes here, so the upstream may never tick: None or list.
+        self.assertTrue(result is None or isinstance(result, list))
+
+
+@pytest.mark.requires_redis
+class TestRedisPub(unittest.TestCase):
+    def test_pub_to_no_subscriber_succeeds(self):
+        # PUBLISH with no subscribers returns 0 receivers, not an error; this
+        # proves the pub path connects to a live Redis.
+        from wingfoil import constant
+
+        channel = f"{CHANNEL_PREFIX}pub_noop"
+        constant({"channel": channel, "payload": b"v"}).redis_pub(
+            ENDPOINT, channel
+        ).run(realtime=True, cycles=1)
+
+    def test_pub_sub_round_trip(self):
+        from wingfoil import constant, redis_sub
+
+        channel = f"{CHANNEL_PREFIX}round_trip"
+        received = []
+
+        def subscriber():
+            stream = redis_sub(ENDPOINT, channel).collect()
+            stream.run(realtime=True, duration=3.0)
+            for tick in stream.peek_value() or []:
+                for event in tick:
+                    received.append(event["payload"])
+
+        t = threading.Thread(target=subscriber)
+        t.start()
+        # Let the subscriber register before publishing (fire-and-forget).
+        time.sleep(0.8)
+        constant({"channel": channel, "payload": b"hello_from_python"}).redis_pub(
+            ENDPOINT, channel
+        ).run(realtime=True, cycles=1)
+        t.join()
+
+        self.assertIn(b"hello_from_python", received)
+
+
+@pytest.mark.requires_redis
+class TestRedisStreams(unittest.TestCase):
+    def test_stream_write_and_read_snapshot(self):
+        from wingfoil import constant, redis_stream_read
+
+        key = f"{CHANNEL_PREFIX}stream_snapshot"
+        constant(
+            [
+                {"key": key, "fields": {"kind": b"login"}},
+                {"key": key, "fields": {"kind": b"logout"}},
+            ]
+        ).redis_stream_write(ENDPOINT, key).run(realtime=True, cycles=1)
+
+        stream = redis_stream_read(ENDPOINT, key).collect()
+        stream.run(realtime=True, cycles=1)
+        events = [e for tick in (stream.peek_value() or []) for e in tick]
+        kinds = [e["fields"]["kind"] for e in events]
+        self.assertIn(b"login", kinds)
+        self.assertIn(b"logout", kinds)
+        for e in events:
+            self.assertIn("key", e)
+            self.assertIn("id", e)
+            self.assertIsInstance(e["fields"], dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -1,6 +1,6 @@
 [features]
 default = ["async"]
-full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2", "prometheus", "otlp", "fix", "web", "web-tls", "kafka", "aeron"]
+full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2", "prometheus", "otlp", "fix", "web", "web-tls", "kafka", "redis", "aeron"]
 # Exposes the `bencher` helper (`add_bench`, used by the criterion benches).
 # Off by default so consumers don't pull in criterion's dependency tree.
 bench = ["dep:criterion"]
@@ -22,6 +22,8 @@ etcd = ["dep:etcd-client", "async"]
 etcd-integration-test = ["etcd", "dep:testcontainers"]
 kafka = ["dep:rdkafka", "async"]
 kafka-integration-test = ["kafka", "dep:testcontainers"]
+redis = ["dep:redis", "async"]
+redis-integration-test = ["redis", "dep:testcontainers"]
 tracing = []
 instrument-run = ["tracing"]
 instrument-cycle = ["tracing"]
@@ -118,6 +120,7 @@ kdb-plus-fixed = { version = "0.5.0", features = ["ipc"], optional = true }
 zmq = { version = "0.10.0", optional = true }
 etcd-client = { version = "0.18", optional = true }
 rdkafka = { version = "0.37", optional = true }
+redis = { version = "0.27", features = ["tokio-comp", "aio", "streams"], optional = true }
 testcontainers = { version = "0.27", features = ["blocking"], optional = true }
 tracing = { workspace = true, features = ["log", "attributes"] }
 fluvio = { version = "0.50.1", optional = true }
@@ -344,6 +347,11 @@ required-features = ["fluvio"]
 name = "kafka"
 path = "examples/kafka/main.rs"
 required-features = ["kafka"]
+
+[[example]]
+name = "redis"
+path = "examples/redis/main.rs"
+required-features = ["redis"]
 
 [[example]]
 name = "latency_e2e_ws_server"

--- a/wingfoil/examples/README.md
+++ b/wingfoil/examples/README.md
@@ -25,6 +25,7 @@ A guide to the examples in this directory. Each one is runnable — see its own 
 | [`fix`](fix/) | FIX 4.4 protocol: [`fix_loopback`](fix/fix_loopback.rs) (self-contained), [`fix_client`](fix/fix_client.rs), [`fix_echo_server`](fix/fix_echo_server.rs), [`lmax_demo`](fix/lmax_demo.rs) (live LMAX market data over TLS), [`lmax_instruments`](fix/lmax_instruments.rs). |
 | [`zmq`](zmq/) | ZeroMQ pub/sub: [`direct`](zmq/direct/) (direct addressing) and [`etcd`](zmq/etcd/) (service discovery via etcd). |
 | [`etcd`](etcd/) | etcd key-value store adapter for sub/pub with transformation. |
+| [`redis`](redis/) | Redis adapter — Pub/Sub channels (subscribe, transform, republish) and persistent Streams (snapshot + tail). |
 | [`iceoryx2`](iceoryx2/) | Zero-copy IPC over shared memory (spin, threaded, signaled polling modes). |
 | [`aeron`](aeron/) | Low-latency Aeron UDP/IPC transport — publish and subscribe to `i64` values with spin and threaded polling modes. |
 | [`web`](web/) | WebSocket adapter streaming synthetic prices and receiving UI events. |
@@ -140,6 +141,35 @@ round_trip.run(RunMode::RealTime, RunFor::Cycles(10)).unwrap();
 ```
 
 [Full example.](kafka/)
+
+### Redis
+
+Subscribe to a Redis Pub/Sub channel, uppercase each payload, and republish to another channel. Redis Pub/Sub is fire-and-forget, so subscribers must be live before a message is published:
+
+```rust,ignore
+use wingfoil::adapters::redis::*;
+use wingfoil::*;
+
+let conn = RedisConnection::new("redis://127.0.0.1:6379");
+
+let processor = redis_sub(conn.clone(), "source")
+    .map(|burst| {
+        burst.into_iter().map(|event| {
+            let upper = event.payload_str().unwrap_or("").to_uppercase().into_bytes();
+            RedisEntry { channel: "dest".into(), payload: upper }
+        })
+        .collect::<Burst<RedisEntry>>()
+    })
+    .redis_pub(conn);
+
+processor.run(RunMode::RealTime, RunFor::Forever).unwrap();
+```
+
+The adapter also supports Redis **Streams** for a persistent, replayable log:
+`redis_stream_write` appends entries via `XADD`, and `redis_stream_read` replays
+existing entries (`XRANGE`) before tailing live appends (`XREAD BLOCK`).
+
+[Full example.](redis/)
 
 ### ZeroMQ
 

--- a/wingfoil/examples/redis/README.md
+++ b/wingfoil/examples/redis/README.md
@@ -1,0 +1,33 @@
+# Redis Adapter Example
+
+Demonstrates a full Pub/Sub round-trip with the Redis adapter. Because Redis
+Pub/Sub is fire-and-forget (only live subscribers receive a message), the three
+roles run as separate graphs and the subscribers start before anything is published:
+
+1. **processor** — subscribes to `example-source` with `redis_sub`, uppercases each
+   payload, and republishes to `example-dest` with `redis_pub`
+2. **verifier** — subscribes to `example-dest` and prints what it receives
+3. **publisher** — publishes `hello` and `world` to `example-source`
+
+## Setup
+
+```sh
+docker run --rm -p 6379:6379 redis:7-alpine
+```
+
+## Run
+
+```sh
+cargo run --example redis --features redis
+```
+
+## Code
+
+See `main.rs` for the full source.
+
+## Output
+
+```
+  example-dest -> HELLO
+  example-dest -> WORLD
+```

--- a/wingfoil/examples/redis/main.rs
+++ b/wingfoil/examples/redis/main.rs
@@ -1,0 +1,96 @@
+//! Redis Pub/Sub adapter example — publish, subscribe, transform, republish.
+//!
+//! Redis Pub/Sub is fire-and-forget: a subscriber only sees messages published
+//! after its `SUBSCRIBE` completes. This example therefore wires three roles as
+//! separate graphs and starts the subscribers before the publisher sends anything:
+//!
+//! - **processor** — subscribes to `source`, uppercases each payload, republishes to `dest`
+//! - **verifier**  — subscribes to `dest` and prints what it receives
+//! - **publisher** — publishes two messages to `source`
+//!
+//! # Prerequisites
+//!
+//! A running Redis:
+//! ```sh
+//! docker run --rm -p 6379:6379 redis:7-alpine
+//! ```
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run --example redis --features redis
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::adapters::redis::*;
+use wingfoil::*;
+
+const URL: &str = "redis://127.0.0.1:6379";
+const SOURCE: &str = "example-source";
+const DEST: &str = "example-dest";
+
+fn main() -> anyhow::Result<()> {
+    let conn = RedisConnection::new(URL);
+
+    // processor: source -> uppercase -> dest
+    let processor_conn = conn.clone();
+    let processor = std::thread::spawn(move || -> anyhow::Result<()> {
+        redis_sub(processor_conn.clone(), SOURCE)
+            .map(|burst| {
+                burst
+                    .into_iter()
+                    .map(|event| {
+                        let upper = event
+                            .payload_str()
+                            .unwrap_or("")
+                            .to_uppercase()
+                            .into_bytes();
+                        RedisEntry {
+                            channel: DEST.to_string(),
+                            payload: upper,
+                        }
+                    })
+                    .collect::<Burst<RedisEntry>>()
+            })
+            .redis_pub(processor_conn)
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+        Ok(())
+    });
+
+    // verifier: print everything that lands on dest
+    let verifier_conn = conn.clone();
+    let verifier = std::thread::spawn(move || -> anyhow::Result<()> {
+        redis_sub(verifier_conn, DEST)
+            .collapse()
+            .for_each(|event, _| {
+                println!(
+                    "  {} -> {}",
+                    event.channel,
+                    event.payload_str().unwrap_or("?")
+                );
+            })
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+        Ok(())
+    });
+
+    // Give both subscribers time to register before publishing.
+    std::thread::sleep(Duration::from_millis(500));
+
+    constant(burst![
+        RedisEntry {
+            channel: SOURCE.into(),
+            payload: b"hello".to_vec()
+        },
+        RedisEntry {
+            channel: SOURCE.into(),
+            payload: b"world".to_vec()
+        },
+    ])
+    .redis_pub(conn)
+    .run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    processor.join().expect("processor thread panicked")?;
+    verifier.join().expect("verifier thread panicked")?;
+    Ok(())
+}

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -24,6 +24,8 @@ pub mod kdb;
 pub mod otlp;
 #[cfg(feature = "prometheus")]
 pub mod prometheus;
+#[cfg(feature = "redis")]
+pub mod redis;
 #[cfg(feature = "web")]
 pub mod web;
 #[cfg(feature = "zmq")]

--- a/wingfoil/src/adapters/redis/CLAUDE.md
+++ b/wingfoil/src/adapters/redis/CLAUDE.md
@@ -1,0 +1,146 @@
+# Redis Adapter
+
+Two transports:
+
+- **Pub/Sub** — subscribe to a channel (`redis_sub`) and publish messages (`redis_pub`)
+- **Streams** — snapshot+tail read of a stream (`redis_stream_read`) and append (`redis_stream_write`)
+
+`HSET`/key-value operations are intentionally out of scope.
+
+## Module Structure
+
+```
+redis/
+  mod.rs               # RedisConnection + Pub/Sub types (RedisEntry, RedisEvent)
+                       #   + Stream types (RedisStreamRecord, RedisStreamEvent), re-exports
+  read.rs              # redis_sub() producer (SUBSCRIBE)
+  write.rs             # redis_pub() consumer (PUBLISH), RedisPubOperators trait
+  stream.rs            # redis_stream_read() + redis_stream_write(), RedisStreamOperators trait
+  integration_tests.rs # Integration tests (requires Docker, gated by feature)
+  CLAUDE.md            # This file
+```
+
+## Key Components
+
+### Reading from Redis — `redis_sub`
+
+- `redis_sub(conn, channel)` — produces `Burst<RedisEvent>`
+  - Connects and issues `SUBSCRIBE channel` once at startup
+  - Emits each incoming message as a `RedisEvent { channel, payload }`
+  - Built on `produce_async`: the async pub/sub stream runs on the tokio runtime
+    and marshals messages into the graph
+
+### Writing to Redis — `redis_pub`
+
+- `redis_pub(conn, upstream)` — consumes `Burst<RedisEntry>`, issues one `PUBLISH`
+  per entry to the channel the entry names
+- `RedisPubOperators::redis_pub(conn)` — fluent API on both
+  `Rc<dyn Stream<Burst<RedisEntry>>>` and `Rc<dyn Stream<RedisEntry>>`
+- Built on `consume_async`: connects once via a multiplexed async connection
+
+### Reading from a stream — `redis_stream_read`
+
+- `redis_stream_read(conn, key)` — produces `Burst<RedisStreamEvent>`
+  - **Phase 1 (snapshot):** `XRANGE key - +` replays all existing entries; the last
+    entry ID is captured (or `"0"` if the stream is empty)
+  - **Phase 2 (tail):** `XREAD BLOCK 0 STREAMS key <last_id>` returns only entries with
+    an ID strictly greater than `last_id`, so the snapshot→tail handoff misses nothing
+    and never duplicates
+
+### Writing to a stream — `redis_stream_write`
+
+- `redis_stream_write(conn, upstream)` — consumes `Burst<RedisStreamRecord>`, issues one
+  `XADD key *` per record (Redis assigns the entry ID)
+- `RedisStreamOperators::redis_stream_write(conn)` — fluent API on both
+  `Rc<dyn Stream<Burst<RedisStreamRecord>>>` and `Rc<dyn Stream<RedisStreamRecord>>`
+
+### Types
+
+- `RedisConnection::new(url)` — Redis URL (e.g. `"redis://127.0.0.1:6379"`);
+  `From<&str>` / `From<String>` so factories accept `impl Into<RedisConnection>`
+- `RedisEntry { channel, payload }` — Pub/Sub message to publish; `.payload_str()` for UTF-8
+- `RedisEvent { channel, payload }` — received Pub/Sub message; `.payload_str()` for UTF-8
+- `RedisStreamRecord { key, fields: Vec<(String, Vec<u8>)> }` — entry to `XADD`;
+  `::single(key, field, value)` for the common one-field case
+- `RedisStreamEvent { key, id, fields }` — entry read from a stream; `.field(name)` lookup
+
+## Pub/Sub: fire-and-forget (no snapshot)
+
+Redis Pub/Sub has **no backlog, replay, or offsets**. A subscriber only receives
+messages published *after* its `SUBSCRIBE` completes, so there is no snapshot phase.
+
+The Pub/Sub integration tests order subscribe-before-publish explicitly: the publisher
+either retries until the graph subscriber has captured a message, or waits for a `ready`
+flag the subscriber sets only after `SUBSCRIBE` returns.
+
+## Streams: snapshot → tail handoff (race prevention)
+
+```
+XRANGE key - +  ──→ capture last_id ──→ emit snapshot ──→ XREAD BLOCK STREAMS key last_id
+                                                            (only ids > last_id)
+```
+
+Because the tail reads from the exact snapshot boundary ID, any entry appended between
+the `XRANGE` and the first `XREAD` is returned by `XREAD` (its ID is greater) — never
+missed — and no snapshot entry is re-delivered. This mirrors `etcd_sub`'s
+watch-before-GET guarantee, but with stream IDs instead of etcd revisions. Streams
+persist, so unlike Pub/Sub the integration tests need no subscribe-before-write ordering.
+
+## Pre-Commit Requirements
+
+1. **Run integration tests (requires Docker):**
+
+   ```bash
+   cargo test --features redis-integration-test -p wingfoil \
+     -- --test-threads=1 redis::integration_tests
+   ```
+
+2. **Run standard checks:**
+
+   ```bash
+   cargo fmt --all
+   cargo clippy --workspace --all-targets --all-features
+   cargo test -p wingfoil
+   ```
+
+## Integration Test Details
+
+Tests use `testcontainers` (`SyncRunner`) to start a `redis:7-alpine` container per
+test. Docker must be running. No environment variables required.
+
+Feature flag: `redis-integration-test` (implies `redis`).
+
+Tests must be run with `--test-threads=1` to avoid port conflicts between containers.
+
+### Test coverage
+
+| Test | What it proves |
+|------|----------------|
+| `test_connection_refused` | Error propagates when Redis is unreachable |
+| `test_sub_live_message` | A message published while subscribed arrives as a `RedisEvent` |
+| `test_pub_round_trip` | `redis_pub` writes are received by a direct subscriber |
+| `test_pub_multiple_entries_in_burst` | All entries in a single burst are published |
+| `test_redis_entry_payload_str` | UTF-8 payload interpretation works |
+| `test_stream_write_and_read_snapshot` | `redis_stream_write` entries replay via the snapshot phase |
+| `test_stream_read_live_tail` | An entry appended after the snapshot arrives via the `XREAD` tail |
+| `test_stream_record_single` | `RedisStreamRecord::single` builds the expected record |
+
+## Notes
+
+- `redis` is pinned to `"0.27"` with the `tokio-comp` + `aio` + `streams` features.
+- `get_async_pubsub()` (async PubSub), `get_multiplexed_async_connection()` (publishing /
+  XADD / XREAD), and the typed `redis::streams` replies (`StreamRangeReply`,
+  `StreamReadReply`) are all stable in 0.27.
+- The stream tail uses `XREAD BLOCK 0` on a dedicated connection used only for reading,
+  so blocking that connection indefinitely is safe.
+- We use `GenericImage` with the official `redis:7-alpine` image directly rather than a
+  `testcontainers-modules` helper, matching the etcd/kafka adapters.
+- `redis_sub` is designed for `RunMode::RealTime`. Using it in `HistoricalFrom` mode is
+  technically valid but timestamps will be wall-clock `NanoTime::now()`, not historical.
+
+## Python bindings
+
+- Binding module: `wingfoil-python/src/py_redis.rs` (`py_redis_sub` + `py_redis_pub_inner`).
+- Integration tests live in `wingfoil-python/tests/test_redis.py`, gated by the
+  `requires_redis` pytest marker (registered in `pyproject.toml` and deselected by
+  default). Unit-level construction/marshaling tests in the same file run by default.

--- a/wingfoil/src/adapters/redis/integration_tests.rs
+++ b/wingfoil/src/adapters/redis/integration_tests.rs
@@ -1,0 +1,286 @@
+//! Integration tests for the Redis adapter.
+//!
+//! Requires Docker. Run with:
+//! ```sh
+//! cargo test --features redis-integration-test -p wingfoil \
+//!   -- --test-threads=1 redis::integration_tests
+//! ```
+
+use super::*;
+use crate::nodes::{NodeOperators, StreamOperators, constant};
+use crate::types::Burst;
+use crate::{RunFor, RunMode, burst};
+use futures::StreamExt;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+use testcontainers::{GenericImage, core::WaitFor, runners::SyncRunner};
+
+const REDIS_PORT: u16 = 6379;
+const REDIS_IMAGE: &str = "redis";
+const REDIS_TAG: &str = "7-alpine";
+
+/// Start a Redis container and return the connection URL.
+/// The returned container must be kept alive for the duration of the test.
+fn start_redis() -> anyhow::Result<(impl Drop, String)> {
+    let container = GenericImage::new(REDIS_IMAGE, REDIS_TAG)
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()?;
+    let port = container.get_host_port_ipv4(REDIS_PORT)?;
+    let url = format!("redis://127.0.0.1:{port}");
+    Ok((container, url))
+}
+
+/// Spawn a background thread that repeatedly publishes `payload` to `channel`
+/// until the returned flag is set. Redis Pub/Sub drops messages with no live
+/// subscriber, so the publisher keeps retrying until the graph has captured one.
+fn spawn_publisher(
+    url: &str,
+    channel: &str,
+    payload: &[u8],
+) -> (Arc<AtomicBool>, std::thread::JoinHandle<()>) {
+    let done = Arc::new(AtomicBool::new(false));
+    let done_thread = done.clone();
+    let url = url.to_string();
+    let channel = channel.to_string();
+    let payload = payload.to_vec();
+    let handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let client = redis::Client::open(url.as_str()).unwrap();
+            let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+            while !done_thread.load(Ordering::Relaxed) {
+                let _: i64 = redis::cmd("PUBLISH")
+                    .arg(channel.as_str())
+                    .arg(payload.as_slice())
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap_or(0);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        });
+    });
+    (done, handle)
+}
+
+/// Subscribe to `channel` on a dedicated thread, set `ready` once the subscription
+/// is registered server-side, then collect up to `n` payloads (with a timeout).
+fn spawn_subscriber(
+    url: &str,
+    channel: &str,
+    n: usize,
+    ready: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<anyhow::Result<Vec<Vec<u8>>>> {
+    let url = url.to_string();
+    let channel = channel.to_string();
+    std::thread::spawn(move || -> anyhow::Result<Vec<Vec<u8>>> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let client = redis::Client::open(url.as_str())?;
+            let mut pubsub = client.get_async_pubsub().await?;
+            pubsub.subscribe(channel.as_str()).await?;
+            // Subscription is now active server-side.
+            ready.store(true, Ordering::Relaxed);
+            let mut messages = pubsub.on_message();
+            let mut out = Vec::new();
+            while out.len() < n {
+                match tokio::time::timeout(Duration::from_secs(10), messages.next()).await {
+                    Ok(Some(msg)) => out.push(msg.get_payload_bytes().to_vec()),
+                    _ => break,
+                }
+            }
+            Ok(out)
+        })
+    })
+}
+
+// ---- Tests ----
+
+#[test]
+fn test_connection_refused() {
+    // Error propagates correctly without a running Redis.
+    let conn = RedisConnection::new("redis://127.0.0.1:59999");
+    let result = redis_sub(conn, "ch")
+        .collapse()
+        .collect()
+        .run(RunMode::RealTime, RunFor::Cycles(1));
+    assert!(result.is_err(), "expected connection error");
+}
+
+#[test]
+fn test_sub_live_message() -> anyhow::Result<()> {
+    // A message published while the graph is subscribed arrives as a RedisEvent.
+    let (_container, url) = start_redis()?;
+    let conn = RedisConnection::new(&url);
+
+    let (done, publisher) = spawn_publisher(&url, "live", b"hello");
+
+    let collected = redis_sub(conn, "live").collapse().collect();
+    collected
+        .clone()
+        .run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    done.store(true, Ordering::Relaxed);
+    publisher.join().unwrap();
+
+    let events = collected.peek_value();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].value.channel, "live");
+    assert_eq!(events[0].value.payload, b"hello");
+    Ok(())
+}
+
+#[test]
+fn test_pub_round_trip() -> anyhow::Result<()> {
+    // redis_pub publishes a message; a direct subscriber receives it.
+    let (_container, url) = start_redis()?;
+    let conn = RedisConnection::new(&url);
+
+    let ready = Arc::new(AtomicBool::new(false));
+    let subscriber = spawn_subscriber(&url, "rt", 1, ready.clone());
+
+    // Wait until the subscriber's SUBSCRIBE has been registered server-side so the
+    // fire-and-forget PUBLISH is guaranteed to reach it.
+    while !ready.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let source = constant(burst![RedisEntry {
+        channel: "rt".to_string(),
+        payload: b"value1".to_vec(),
+    }]);
+    redis_pub(conn, &source).run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let payloads = subscriber.join().unwrap()?;
+    assert_eq!(payloads, vec![b"value1".to_vec()]);
+    Ok(())
+}
+
+#[test]
+fn test_pub_multiple_entries_in_burst() -> anyhow::Result<()> {
+    // Multiple entries in a single burst are all published.
+    let (_container, url) = start_redis()?;
+    let conn = RedisConnection::new(&url);
+
+    let ready = Arc::new(AtomicBool::new(false));
+    let subscriber = spawn_subscriber(&url, "multi", 3, ready.clone());
+
+    while !ready.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let source: Rc<dyn crate::Stream<Burst<RedisEntry>>> = constant(burst![
+        RedisEntry {
+            channel: "multi".to_string(),
+            payload: b"a".to_vec()
+        },
+        RedisEntry {
+            channel: "multi".to_string(),
+            payload: b"b".to_vec()
+        },
+        RedisEntry {
+            channel: "multi".to_string(),
+            payload: b"c".to_vec()
+        },
+    ]);
+    redis_pub(conn, &source).run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let mut payloads = subscriber.join().unwrap()?;
+    payloads.sort();
+    assert_eq!(payloads, vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]);
+    Ok(())
+}
+
+#[test]
+fn test_redis_entry_payload_str() {
+    let entry = RedisEntry {
+        channel: "ch".to_string(),
+        payload: b"bar".to_vec(),
+    };
+    assert_eq!(entry.payload_str().unwrap(), "bar");
+}
+
+// ---- Streams ----
+
+/// Append a single-field entry directly to a stream via the client.
+fn xadd(url: &str, key: &str, field: &str, value: &[u8]) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let client = redis::Client::open(url)?;
+        let mut conn = client.get_multiplexed_async_connection().await?;
+        redis::cmd("XADD")
+            .arg(key)
+            .arg("*")
+            .arg(field)
+            .arg(value)
+            .query_async::<String>(&mut conn)
+            .await?;
+        Ok(())
+    })
+}
+
+#[test]
+fn test_stream_write_and_read_snapshot() -> anyhow::Result<()> {
+    // redis_stream_write appends entries; redis_stream_read replays them as a snapshot.
+    let (_container, url) = start_redis()?;
+    let conn = RedisConnection::new(&url);
+
+    let source: Rc<dyn crate::Stream<Burst<RedisStreamRecord>>> = constant(burst![
+        RedisStreamRecord::single("events", "kind", b"login".to_vec()),
+        RedisStreamRecord::single("events", "kind", b"logout".to_vec()),
+    ]);
+    redis_stream_write(conn.clone(), &source).run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let collected = redis_stream_read(conn, "events").collect();
+    collected
+        .clone()
+        .run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let events: Vec<RedisStreamEvent> = collected
+        .peek_value()
+        .into_iter()
+        .flat_map(|v| v.value.into_iter())
+        .collect();
+    assert_eq!(events.len(), 2);
+    let kinds: Vec<Vec<u8>> = events
+        .iter()
+        .map(|e| e.field("kind").unwrap_or_default().to_vec())
+        .collect();
+    assert_eq!(kinds, vec![b"login".to_vec(), b"logout".to_vec()]);
+    // Redis assigns monotonically increasing IDs.
+    assert!(events[0].id < events[1].id);
+    Ok(())
+}
+
+#[test]
+fn test_stream_read_live_tail() -> anyhow::Result<()> {
+    // An entry appended after the (empty) snapshot arrives via the XREAD tail.
+    let (_container, url) = start_redis()?;
+    let conn = RedisConnection::new(&url);
+
+    let url_writer = url.clone();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(300));
+        xadd(&url_writer, "tail", "msg", b"live").unwrap();
+    });
+
+    let collected = redis_stream_read(conn, "tail").collapse().collect();
+    collected
+        .clone()
+        .run(RunMode::RealTime, RunFor::Cycles(1))?;
+    writer.join().unwrap();
+
+    let events = collected.peek_value();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].value.key, "tail");
+    assert_eq!(events[0].value.field("msg"), Some(b"live".as_ref()));
+    Ok(())
+}
+
+#[test]
+fn test_stream_record_single() {
+    let record = RedisStreamRecord::single("k", "f", b"v".to_vec());
+    assert_eq!(record.key, "k");
+    assert_eq!(record.fields, vec![("f".to_string(), b"v".to_vec())]);
+}

--- a/wingfoil/src/adapters/redis/mod.rs
+++ b/wingfoil/src/adapters/redis/mod.rs
@@ -1,0 +1,216 @@
+//! Redis adapter — streaming Pub/Sub reads (`SUBSCRIBE`) and writes (`PUBLISH`).
+//!
+//! Provides two transports, each with a producer and a consumer:
+//!
+//! **Pub/Sub** (fire-and-forget channels):
+//! - [`redis_sub`] — producer that subscribes to a channel and emits each message as an event
+//! - [`redis_pub`] — consumer that publishes messages to Redis channels
+//!
+//! **Streams** (a persistent, replayable log):
+//! - [`redis_stream_read`] — producer that emits a snapshot of existing entries
+//!   followed by live entries as they are appended
+//! - [`redis_stream_write`] — consumer that appends entries to a stream via `XADD`
+//!
+//! Redis Pub/Sub is **fire-and-forget**: messages are delivered only to clients
+//! subscribed at the moment of publication. There is no backlog, no replay, and no
+//! offsets — a subscriber sees only what is published after its `SUBSCRIBE` completes.
+//! Redis Streams, by contrast, persist entries with monotonic IDs, so
+//! [`redis_stream_read`] can replay history before tailing live appends.
+//!
+//! # Setup
+//!
+//! ## Local (Docker)
+//!
+//! ```sh
+//! docker run --rm -p 6379:6379 redis:7-alpine
+//! ```
+//!
+//! # Subscribing to a channel
+//!
+//! [`redis_sub`] subscribes to a single channel and streams every message published to it
+//! as a [`RedisEvent`].
+//!
+//! ```ignore
+//! use wingfoil::adapters::redis::*;
+//! use wingfoil::*;
+//!
+//! let conn = RedisConnection::new("redis://127.0.0.1:6379");
+//!
+//! redis_sub(conn, "prices")
+//!     .collapse()
+//!     .for_each(|event, _| {
+//!         println!("{}: {:?}", event.channel, event.payload_str())
+//!     })
+//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .unwrap();
+//! ```
+//!
+//! # Publishing messages
+//!
+//! [`redis_pub`] (or the fluent `.redis_pub()` method) consumes a `Burst<RedisEntry>`
+//! stream and publishes each entry to the channel it names.
+//!
+//! ```ignore
+//! use wingfoil::adapters::redis::*;
+//! use wingfoil::*;
+//!
+//! let conn = RedisConnection::new("redis://127.0.0.1:6379");
+//!
+//! constant(burst![
+//!     RedisEntry { channel: "prices".into(), payload: b"42".to_vec() },
+//! ])
+//! .redis_pub(conn)
+//! .run(RunMode::RealTime, RunFor::Cycles(1))
+//! .unwrap();
+//! ```
+//!
+//! # Reading and writing streams
+//!
+//! [`redis_stream_read`] first emits all existing entries under the stream key
+//! (via `XRANGE`), capturing the last entry ID, then tails live appends (via
+//! `XREAD BLOCK` from that ID) so no entry is missed in the handoff.
+//!
+//! ```ignore
+//! use wingfoil::adapters::redis::*;
+//! use wingfoil::*;
+//!
+//! let conn = RedisConnection::new("redis://127.0.0.1:6379");
+//!
+//! // Append an entry.
+//! constant(burst![RedisStreamRecord::single("events", "kind", b"login".to_vec())])
+//!     .redis_stream_write(conn.clone())
+//!     .run(RunMode::RealTime, RunFor::Cycles(1))
+//!     .unwrap();
+//!
+//! // Replay history, then tail live entries.
+//! redis_stream_read(conn, "events")
+//!     .collapse()
+//!     .for_each(|event, _| println!("{} {:?}", event.id, event.fields))
+//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .unwrap();
+//! ```
+//!
+//! # Round-trip example
+//!
+//! See [`examples/redis`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/redis)
+//! for a full working example that publishes messages, subscribes to them, transforms
+//! the payloads, and republishes the results to a second channel.
+
+mod read;
+mod stream;
+mod write;
+
+#[cfg(all(test, feature = "redis-integration-test"))]
+mod integration_tests;
+
+pub use read::*;
+pub use stream::*;
+pub use write::*;
+
+/// Connection configuration for Redis.
+#[derive(Debug, Clone)]
+pub struct RedisConnection {
+    /// Redis connection URL, e.g. `"redis://127.0.0.1:6379"`.
+    ///
+    /// Supports the standard `redis://`/`rediss://` URL scheme, including an
+    /// optional password and database index: `"redis://:pass@host:6379/0"`.
+    pub url: String,
+}
+
+impl RedisConnection {
+    /// Create a connection config from a Redis URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+impl From<&str> for RedisConnection {
+    fn from(url: &str) -> Self {
+        Self::new(url)
+    }
+}
+
+impl From<String> for RedisConnection {
+    fn from(url: String) -> Self {
+        Self::new(url)
+    }
+}
+
+/// A message to publish to a Redis channel.
+#[derive(Debug, Clone, Default)]
+pub struct RedisEntry {
+    /// The target channel.
+    pub channel: String,
+    /// The message payload.
+    pub payload: Vec<u8>,
+}
+
+impl RedisEntry {
+    /// Interpret the payload as a UTF-8 string.
+    pub fn payload_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.payload)
+    }
+}
+
+/// A message received from a subscribed Redis channel.
+#[derive(Debug, Clone, Default)]
+pub struct RedisEvent {
+    /// The channel the message was published to.
+    pub channel: String,
+    /// The message payload.
+    pub payload: Vec<u8>,
+}
+
+impl RedisEvent {
+    /// Interpret the payload as a UTF-8 string.
+    pub fn payload_str(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.payload)
+    }
+}
+
+/// A record to append to a Redis stream via `XADD`.
+///
+/// A Redis stream entry is an ordered map of field → value pairs. The entry ID is
+/// assigned by Redis (`XADD key *`), so it is not part of the record.
+#[derive(Debug, Clone, Default)]
+pub struct RedisStreamRecord {
+    /// The target stream key.
+    pub key: String,
+    /// The entry's field → value pairs, in insertion order.
+    pub fields: Vec<(String, Vec<u8>)>,
+}
+
+impl RedisStreamRecord {
+    /// Build a single-field record (`field` → `value`) for stream `key`.
+    pub fn single(
+        key: impl Into<String>,
+        field: impl Into<String>,
+        value: impl Into<Vec<u8>>,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            fields: vec![(field.into(), value.into())],
+        }
+    }
+}
+
+/// An entry read from a Redis stream via `XRANGE` (snapshot) or `XREAD` (tail).
+#[derive(Debug, Clone, Default)]
+pub struct RedisStreamEvent {
+    /// The source stream key.
+    pub key: String,
+    /// The Redis-assigned entry ID, e.g. `"1526919030474-0"`.
+    pub id: String,
+    /// The entry's field → value pairs.
+    pub fields: Vec<(String, Vec<u8>)>,
+}
+
+impl RedisStreamEvent {
+    /// Look up a field's value by name.
+    pub fn field(&self, name: &str) -> Option<&[u8]> {
+        self.fields
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_slice())
+    }
+}

--- a/wingfoil/src/adapters/redis/read.rs
+++ b/wingfoil/src/adapters/redis/read.rs
@@ -1,0 +1,52 @@
+//! Redis Pub/Sub producer — subscribes to a channel and streams messages.
+
+use super::{RedisConnection, RedisEvent};
+use crate::nodes::{RunParams, produce_async};
+use crate::types::*;
+use futures::StreamExt;
+use std::rc::Rc;
+
+/// Subscribe to a Redis `channel` and stream every message published to it as a [`RedisEvent`].
+///
+/// Connects and issues `SUBSCRIBE` once at startup, then emits each incoming message.
+/// Redis Pub/Sub has no backlog: only messages published *after* the subscription is
+/// registered are delivered. Any connection or subscribe error terminates the producer
+/// and propagates to the graph.
+///
+/// Emits `Burst<RedisEvent>`. Use `.collapse()` for single-event processing.
+///
+/// Designed for `RunMode::RealTime`. In `HistoricalFrom` mode timestamps are wall-clock
+/// `NanoTime::now()` rather than historical, since messages arrive live off the wire.
+#[must_use]
+pub fn redis_sub(
+    connection: impl Into<RedisConnection>,
+    channel: impl Into<String>,
+) -> Rc<dyn Stream<Burst<RedisEvent>>> {
+    let connection = connection.into();
+    let channel = channel.into();
+    produce_async(move |_ctx: RunParams| async move {
+        let client = redis::Client::open(connection.url.as_str())
+            .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
+        let mut pubsub = client
+            .get_async_pubsub()
+            .await
+            .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
+        pubsub
+            .subscribe(channel.as_str())
+            .await
+            .map_err(|e| anyhow::anyhow!("redis subscribe to {channel:?} failed: {e}"))?;
+
+        Ok(async_stream::stream! {
+            let mut messages = pubsub.on_message();
+            while let Some(msg) = messages.next().await {
+                let event = RedisEvent {
+                    channel: msg.get_channel_name().to_string(),
+                    payload: msg.get_payload_bytes().to_vec(),
+                };
+                yield Ok((NanoTime::now(), event));
+            }
+            // `on_message` ends only when the connection drops.
+            yield Err(anyhow::anyhow!("redis subscription stream closed unexpectedly"));
+        })
+    })
+}

--- a/wingfoil/src/adapters/redis/stream.rs
+++ b/wingfoil/src/adapters/redis/stream.rs
@@ -1,0 +1,162 @@
+//! Redis Streams adapter — snapshot + tail reads (`XRANGE`/`XREAD`) and appends (`XADD`).
+
+use super::{RedisConnection, RedisStreamEvent, RedisStreamRecord};
+use crate::burst;
+use crate::nodes::{FutStream, RunParams, StreamOperators, produce_async};
+use crate::types::*;
+use futures::StreamExt;
+use redis::AsyncCommands;
+use redis::streams::{StreamId, StreamRangeReply, StreamReadOptions, StreamReadReply};
+use std::pin::Pin;
+use std::rc::Rc;
+
+/// Convert a redis `StreamId` (id + field map) into a [`RedisStreamEvent`].
+fn to_event(key: &str, id: &StreamId) -> RedisStreamEvent {
+    let fields = id
+        .map
+        .iter()
+        .filter_map(|(name, value)| {
+            redis::from_redis_value::<Vec<u8>>(value)
+                .ok()
+                .map(|bytes| (name.clone(), bytes))
+        })
+        .collect();
+    RedisStreamEvent {
+        key: key.to_string(),
+        id: id.id.clone(),
+        fields,
+    }
+}
+
+/// Read a Redis stream `key`: emit a snapshot of all existing entries, then tail
+/// live appends as [`RedisStreamEvent`]s.
+///
+/// The snapshot is read with `XRANGE key - +` and its last entry ID is captured;
+/// the tail then issues `XREAD BLOCK 0 STREAMS key <last_id>`, which only returns
+/// entries with an ID strictly greater than `last_id`. Because the tail reads from
+/// the exact snapshot boundary, no entry is missed or duplicated in the handoff.
+///
+/// Emits `Burst<RedisStreamEvent>`. Use `.collapse()` for single-event processing.
+///
+/// Designed for `RunMode::RealTime`. In `HistoricalFrom` mode timestamps are wall-clock
+/// `NanoTime::now()` rather than historical.
+#[must_use]
+pub fn redis_stream_read(
+    connection: impl Into<RedisConnection>,
+    key: impl Into<String>,
+) -> Rc<dyn Stream<Burst<RedisStreamEvent>>> {
+    let connection = connection.into();
+    let key = key.into();
+    produce_async(move |_ctx: RunParams| async move {
+        let client = redis::Client::open(connection.url.as_str())
+            .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
+        let mut conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
+
+        // 1. Snapshot all existing entries and capture the last ID.
+        let snapshot: StreamRangeReply = conn
+            .xrange(&key, "-", "+")
+            .await
+            .map_err(|e| anyhow::anyhow!("redis xrange on {key:?} failed: {e}"))?;
+        // "0" means "from the beginning" — used when the stream is empty so the tail
+        // picks up the very first appended entry.
+        let mut last_id = snapshot
+            .ids
+            .last()
+            .map(|id| id.id.clone())
+            .unwrap_or_else(|| "0".to_string());
+        let snapshot_events: Vec<RedisStreamEvent> =
+            snapshot.ids.iter().map(|id| to_event(&key, id)).collect();
+
+        Ok(async_stream::stream! {
+            // Phase 1: emit the snapshot.
+            for event in snapshot_events {
+                yield Ok((NanoTime::now(), event));
+            }
+
+            // Phase 2: tail live appends from the snapshot boundary.
+            let opts = StreamReadOptions::default().block(0);
+            loop {
+                let reply: redis::RedisResult<StreamReadReply> =
+                    conn.xread_options(&[&key], &[&last_id], &opts).await;
+                match reply {
+                    Ok(reply) => {
+                        for stream_key in &reply.keys {
+                            for id in &stream_key.ids {
+                                last_id = id.id.clone();
+                                yield Ok((NanoTime::now(), to_event(&stream_key.key, id)));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        yield Err(anyhow::anyhow!("redis xread on {key:?} failed: {e}"));
+                        break;
+                    }
+                }
+            }
+        })
+    })
+}
+
+/// Append a `Burst<RedisStreamRecord>` stream to Redis via `XADD`.
+///
+/// Connects once at startup and issues one `XADD <key> *` per [`RedisStreamRecord`]
+/// in each burst, letting Redis assign the entry ID. Any append error terminates the
+/// consumer and propagates to the graph.
+#[must_use]
+pub fn redis_stream_write(
+    connection: impl Into<RedisConnection>,
+    upstream: &Rc<dyn Stream<Burst<RedisStreamRecord>>>,
+) -> Rc<dyn Node> {
+    let connection = connection.into();
+    upstream.consume_async(Box::new(
+        move |_ctx: RunParams,
+              mut source: Pin<Box<dyn FutStream<Burst<RedisStreamRecord>>>>| async move {
+            let client = redis::Client::open(connection.url.as_str())
+                .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
+            let mut conn = client
+                .get_multiplexed_async_connection()
+                .await
+                .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
+
+            while let Some((_time, burst)) = source.next().await {
+                for record in burst {
+                    let mut cmd = redis::cmd("XADD");
+                    cmd.arg(record.key.as_str()).arg("*");
+                    for (field, value) in &record.fields {
+                        cmd.arg(field.as_str()).arg(value.as_slice());
+                    }
+                    cmd.query_async::<String>(&mut conn).await.map_err(|e| {
+                        anyhow::anyhow!("redis xadd to {:?} failed: {e}", record.key)
+                    })?;
+                }
+            }
+            Ok(())
+        },
+    ))
+}
+
+/// Extension trait providing a fluent API for appending streams to Redis streams.
+///
+/// Implemented for both `Burst<RedisStreamRecord>` (multi-item) and `RedisStreamRecord`
+/// (single-item) streams, so burst wrapping is never required in user code.
+pub trait RedisStreamOperators {
+    /// Append this stream to a Redis stream via `XADD`.
+    #[must_use]
+    fn redis_stream_write(self: &Rc<Self>, conn: impl Into<RedisConnection>) -> Rc<dyn Node>;
+}
+
+impl RedisStreamOperators for dyn Stream<Burst<RedisStreamRecord>> {
+    fn redis_stream_write(self: &Rc<Self>, conn: impl Into<RedisConnection>) -> Rc<dyn Node> {
+        redis_stream_write(conn, self)
+    }
+}
+
+impl RedisStreamOperators for dyn Stream<RedisStreamRecord> {
+    fn redis_stream_write(self: &Rc<Self>, conn: impl Into<RedisConnection>) -> Rc<dyn Node> {
+        let burst_stream = self.map(|record| burst![record]);
+        redis_stream_write(conn, &burst_stream)
+    }
+}

--- a/wingfoil/src/adapters/redis/write.rs
+++ b/wingfoil/src/adapters/redis/write.rs
@@ -1,0 +1,73 @@
+//! Redis Pub/Sub consumer — publishes upstream messages via `PUBLISH`.
+
+use super::{RedisConnection, RedisEntry};
+use crate::burst;
+use crate::nodes::{FutStream, RunParams, StreamOperators};
+use crate::types::*;
+use futures::StreamExt;
+use std::pin::Pin;
+use std::rc::Rc;
+
+/// Publish a `Burst<RedisEntry>` stream to Redis via `PUBLISH`.
+///
+/// Connects once at startup and issues one `PUBLISH` per [`RedisEntry`] in each burst,
+/// to the channel each entry names. Any publish error terminates the consumer and
+/// propagates to the graph.
+///
+/// Redis Pub/Sub is fire-and-forget: a published message reaches only the clients that
+/// are subscribed at the moment of publication. `PUBLISH` returns the number of clients
+/// that received the message (which may be zero); this count is not surfaced.
+#[must_use]
+pub fn redis_pub(
+    connection: impl Into<RedisConnection>,
+    upstream: &Rc<dyn Stream<Burst<RedisEntry>>>,
+) -> Rc<dyn Node> {
+    let connection = connection.into();
+    upstream.consume_async(Box::new(
+        move |_ctx: RunParams, mut source: Pin<Box<dyn FutStream<Burst<RedisEntry>>>>| async move {
+            let client = redis::Client::open(connection.url.as_str())
+                .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
+            let mut conn = client
+                .get_multiplexed_async_connection()
+                .await
+                .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
+
+            while let Some((_time, burst)) = source.next().await {
+                for entry in burst {
+                    redis::cmd("PUBLISH")
+                        .arg(entry.channel.as_str())
+                        .arg(entry.payload.as_slice())
+                        .query_async::<i64>(&mut conn)
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!("redis publish to {:?} failed: {e}", entry.channel)
+                        })?;
+                }
+            }
+            Ok(())
+        },
+    ))
+}
+
+/// Extension trait providing a fluent API for publishing streams to Redis.
+///
+/// Implemented for both `Burst<RedisEntry>` (multi-item) and `RedisEntry` (single-item)
+/// streams, so burst wrapping is never required in user code.
+pub trait RedisPubOperators {
+    /// Publish this stream to Redis via `PUBLISH`.
+    #[must_use]
+    fn redis_pub(self: &Rc<Self>, conn: impl Into<RedisConnection>) -> Rc<dyn Node>;
+}
+
+impl RedisPubOperators for dyn Stream<Burst<RedisEntry>> {
+    fn redis_pub(self: &Rc<Self>, conn: impl Into<RedisConnection>) -> Rc<dyn Node> {
+        redis_pub(conn, self)
+    }
+}
+
+impl RedisPubOperators for dyn Stream<RedisEntry> {
+    fn redis_pub(self: &Rc<Self>, conn: impl Into<RedisConnection>) -> Rc<dyn Node> {
+        let burst_stream = self.map(|entry| burst![entry]);
+        redis_pub(conn, &burst_stream)
+    }
+}


### PR DESCRIPTION
Implements a new `redis` adapter with two transports:

- Pub/Sub: `redis_sub` (SUBSCRIBE) / `redis_pub` (PUBLISH), fire-and-forget channels
- Streams: `redis_stream_read` (XRANGE snapshot + XREAD tail) /
  `redis_stream_write` (XADD), a persistent, replayable log

The stream reader replays existing entries then tails live appends from the
exact snapshot boundary ID, so the handoff misses nothing and never duplicates
(mirrors etcd_sub's watch-before-GET guarantee, using stream IDs). HSET/key-value
operations are intentionally out of scope.

Includes:
- Feature flags `redis` and `redis-integration-test`; redis 0.27 (tokio-comp,
  aio, streams)
- testcontainers-based integration tests (redis:7-alpine), gated by feature
- Example (examples/redis) + README entries and snippet in both README tables
- Adapter CLAUDE.md documenting the snapshot/tail race prevention
- Standalone CI workflow + registration in the integration-tests hub
- Python bindings: py_redis_sub, py_redis_stream_read, .redis_pub() /
  .redis_stream_write() stream methods, aliases, requires_redis marker, and
  unit + integration tests

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UxZDZgMMeRZkez2bGgJx2L