### PR TITLE
Add augurs time-series adapter (ETS forecasting + MAD outlier detection)

### DIFF
--- a/.github/workflows/augurs-integration.yml
+++ b/.github/workflows/augurs-integration.yml
@@ -14,6 +14,7 @@ on:
       - 'wingfoil/examples/augurs/**'
       - 'wingfoil-python/src/py_augurs.rs'
       - 'wingfoil-python/tests/test_augurs.py'
+      - '.github/workflows/augurs-integration.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/augurs-integration.yml
+++ b/.github/workflows/augurs-integration.yml
@@ -47,6 +47,11 @@ jobs:
         run: cargo run -p wingfoil --example augurs --features augurs
 
       # --- Python bindings ---
+      - name: Install protoc
+        # wingfoil-python enables the etcd feature unconditionally, and
+        # etcd-client's build script needs protoc to compile its proto files.
+        run: sudo apt-get install -y protobuf-compiler
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/augurs-integration.yml
+++ b/.github/workflows/augurs-integration.yml
@@ -1,0 +1,65 @@
+name: test.integration.augurs
+
+# augurs is a pure-Rust compute library (no external service), so this workflow
+# runs the in-crate unit tests behind `--features augurs`, the example, and the
+# Python binding tests. There is no container to start and no `requires_*`
+# marker — the Python tests run by default.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'wingfoil/src/adapters/augurs/**'
+      - 'wingfoil/examples/augurs/**'
+      - 'wingfoil-python/src/py_augurs.rs'
+      - 'wingfoil-python/tests/test_augurs.py'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  augurs-integration:
+    name: augurs Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
+
+      - name: Run augurs unit tests
+        run: |
+          cargo test --features augurs -p wingfoil \
+            -- --nocapture adapters::augurs
+        env:
+          RUST_LOG: INFO
+
+      - name: Run augurs example
+        run: cargo run -p wingfoil --example augurs --features augurs
+
+      # --- Python bindings ---
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: wingfoil-python/pyproject.toml
+
+      - name: Install maturin and build Python bindings
+        run: |
+          python -m venv wingfoil-python/.venv
+          wingfoil-python/.venv/bin/pip install maturin pytest
+          cd wingfoil-python && .venv/bin/maturin develop
+
+      - name: Run Python augurs tests
+        run: |
+          cd wingfoil-python && .venv/bin/pytest tests/test_augurs.py -v

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,6 +50,11 @@ jobs:
     uses: ./.github/workflows/aeron-integration.yml
     secrets: inherit
 
+  augurs-integration:
+    name: augurs Integration Tests
+    uses: ./.github/workflows/augurs-integration.yml
+    secrets: inherit
+
   web-integration:
     name: Web Integration Tests
     uses: ./.github/workflows/web-integration.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arc-swap"
@@ -330,6 +345,60 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "augurs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fdc2e6862d3efa5152f15bacd0cb88fc0452a815cee31ac7999a3a080d871c0"
+dependencies = [
+ "augurs-core",
+ "augurs-ets",
+ "augurs-outlier",
+]
+
+[[package]]
+name = "augurs-core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304774394b274d23e2440648709efd47ccffa94e03ccc26fa4501cf69f52300c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "augurs-ets"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822469daf3558b05db63d14c54a13756753373ad92bccfa44912f40598d454e7"
+dependencies = [
+ "augurs-core",
+ "distrs",
+ "itertools 0.14.0",
+ "lstsq",
+ "nalgebra",
+ "rand 0.8.6",
+ "rand_distr",
+ "roots",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "augurs-outlier"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55e16ede4fdeaa3e2f42f95d279324876cd26879d9eddef9b1a9fd0c86e64b4"
+dependencies = [
+ "itertools 0.14.0",
+ "rand 0.8.6",
+ "roots",
+ "rustc-hash 2.1.2",
+ "rv",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+]
 
 [[package]]
 name = "autocfg"
@@ -649,6 +718,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -1387,6 +1462,18 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "distrs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2906d3628a885aa49a23b88e71f63e51ae8df41cd76652287f0a6179a11833a9"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "docker_credential"
@@ -2280,6 +2367,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,6 +2543,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -3322,6 +3519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,12 +3588,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lstsq"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ec6a3ba23bb2580ae4ea21f002edff262671a7bcc833f87728e2f8007a5ea2"
+dependencies = [
+ "nalgebra",
 ]
 
 [[package]]
@@ -3425,6 +3646,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "md-5"
@@ -3515,6 +3746,51 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nalgebra"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+dependencies = [
+ "approx",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "native-tls"
@@ -3668,6 +3944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4517,6 +4794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4524,6 +4811,12 @@ checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -4798,6 +5091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roots"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082f11ffa03bbef6c2c6ea6bea1acafaade2fd9050ae0234ab44a2153742b058"
+
+[[package]]
 name = "roxmltree"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,6 +5270,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rv"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fb66da6e2919c71fe2967b1e16a792f5d0191a9c580d5b9da1e0f4add31353"
+dependencies = [
+ "doc-comment",
+ "itertools 0.13.0",
+ "lru",
+ "num",
+ "num-traits",
+ "rand 0.8.6",
+ "rand_distr",
+ "special",
+]
+
+[[package]]
 name = "rxrust"
 version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4992,6 +5307,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -5341,6 +5665,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5388,6 +5725,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "special"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89cf0d71ae639fdd8097350bfac415a41aabf1d5ddd356295fdc95f09760382"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -6771,6 +7117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7033,6 +7389,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-stream",
+ "augurs",
  "axum",
  "axum-server",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +169,15 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -171,6 +192,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argmin"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897c18cfe995220bdd94a27455e5afedc7c688cbf62ad2be88ce7552452aa1b2"
+dependencies = [
+ "anyhow",
+ "argmin-math",
+ "bincode",
+ "instant",
+ "num-traits",
+ "paste",
+ "rand 0.8.6",
+ "rand_xoshiro",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-async",
+ "slog-json",
+ "slog-term",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "argmin-math"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8798ca7447753fcb3dd98d9095335b1564812a68c6e7c3d1926e1d5cf094e37"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "nalgebra 0.32.6",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rand 0.8.6",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -352,9 +412,37 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fdc2e6862d3efa5152f15bacd0cb88fc0452a815cee31ac7999a3a080d871c0"
 dependencies = [
+ "augurs-changepoint",
+ "augurs-clustering",
  "augurs-core",
+ "augurs-dtw",
  "augurs-ets",
+ "augurs-mstl",
  "augurs-outlier",
+ "augurs-seasons",
+]
+
+[[package]]
+name = "augurs-changepoint"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7471e5e48a5feb1887271686e3ecd4d0aa893c69c77efd575968207d7312705c"
+dependencies = [
+ "augurs-core",
+ "changepoint",
+ "distrs",
+ "itertools 0.14.0",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "augurs-clustering"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd05d22545099a3f3eda66117a3b5a6f636e2c5a259d89fcad4fca9f92f4a7e"
+dependencies = [
+ "augurs-core",
 ]
 
 [[package]]
@@ -367,19 +455,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "augurs-dtw"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aebefafb7b9b38882d3cb62cf6db96cc1f8c40a5698b5ae08953ae04a6b3058"
+dependencies = [
+ "augurs-core",
+ "tracing",
+]
+
+[[package]]
 name = "augurs-ets"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822469daf3558b05db63d14c54a13756753373ad92bccfa44912f40598d454e7"
 dependencies = [
  "augurs-core",
+ "augurs-mstl",
  "distrs",
  "itertools 0.14.0",
  "lstsq",
- "nalgebra",
+ "nalgebra 0.34.2",
  "rand 0.8.6",
  "rand_distr",
  "roots",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "augurs-mstl"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3f37da49fef8f960e99b7af346258ac8f5ed03821a008fdd9a5b34e83b1ce1"
+dependencies = [
+ "augurs-core",
+ "distrs",
+ "stlrs",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -394,10 +506,23 @@ dependencies = [
  "rand 0.8.6",
  "roots",
  "rustc-hash 2.1.2",
- "rv",
+ "rv 0.18.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tracing",
+]
+
+[[package]]
+name = "augurs-seasons"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd19353866ea5d344f116f9e1c3179f6addcd5dc2840919fa6d501c54bdf168"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+ "thiserror 2.0.18",
+ "tracing",
+ "welch-sde",
 ]
 
 [[package]]
@@ -819,6 +944,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "changepoint"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e436d00aacac4cab3b4036a12c3bc9dbf1e80e533848231ba5aa34b545070a7a"
+dependencies = [
+ "approx 0.5.1",
+ "derive_more 0.99.20",
+ "nalgebra 0.32.6",
+ "ndarray",
+ "num-traits",
+ "rand 0.8.6",
+ "rayon",
+ "rv 0.16.5",
+ "special",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1092,12 @@ checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -1340,6 +1488,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -1353,7 +1514,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1636,6 +1797,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -2528,7 +2698,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2536,6 +2706,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.12",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3589,6 +3768,15 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
@@ -3611,7 +3799,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ec6a3ba23bb2580ae4ea21f002edff262671a7bcc833f87728e2f8007a5ea2"
 dependencies = [
- "nalgebra",
+ "nalgebra 0.34.2",
 ]
 
 [[package]]
@@ -3654,7 +3842,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
+ "num_cpus",
+ "once_cell",
  "rawpointer",
+ "thread-tree",
 ]
 
 [[package]]
@@ -3749,11 +3940,28 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx 0.5.1",
+ "matrixmultiply",
+ "nalgebra-macros 0.2.2",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "serde",
+ "simba 0.8.1",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "glam 0.14.0",
  "glam 0.15.2",
  "glam 0.16.0",
@@ -3773,12 +3981,23 @@ dependencies = [
  "glam 0.31.1",
  "glam 0.32.1",
  "matrixmultiply",
- "nalgebra-macros",
+ "nalgebra-macros 0.3.0",
  "num-complex",
  "num-rational",
  "num-traits",
- "simba",
+ "simba 0.9.1",
  "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3807,6 +4026,22 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "approx 0.4.0",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+ "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -3898,6 +4133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3945,6 +4181,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4151,6 +4397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "order-stat"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa535d5117d3661134dbf1719b6f0ffe06f2375843b13935db186cd094105eb"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,6 +4530,30 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "peroxide"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703b5fbdc1f9018a66e2db8758633cec31d39ad3127bfd38c9b6ad510637519c"
+dependencies = [
+ "matrixmultiply",
+ "order-stat",
+ "peroxide-ad",
+ "puruspe",
+ "rand 0.8.6",
+ "rand_distr",
+]
+
+[[package]]
+name = "peroxide-ad"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fba8ff3f40b67996f7c745f699babaa3e57ef5c8178ec999daf7eedc51dc8c"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "petgraph"
@@ -4469,6 +4745,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "priority-queue"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4604,6 +4889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "puruspe"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3804877ffeba468c806c2ad9057bbbae92e4b2c410c2f108baaa0042f241fa4c"
+
+[[package]]
 name = "pyo3"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4726,6 +5017,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -4776,6 +5068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+ "serde",
 ]
 
 [[package]]
@@ -4801,6 +5094,16 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -5180,6 +5483,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,13 +5588,33 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rv"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07e0a3b756794c7ea2f05d93760ffb946ff4f94b255d92444d94c19fd71f4ab"
+dependencies = [
+ "argmin",
+ "argmin-math",
+ "doc-comment",
+ "lru 0.9.0",
+ "nalgebra 0.32.6",
+ "num",
+ "num-traits",
+ "peroxide",
+ "rand 0.8.6",
+ "rand_distr",
+ "serde",
+ "special",
+]
+
+[[package]]
+name = "rv"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05fb66da6e2919c71fe2967b1e16a792f5d0191a9c580d5b9da1e0f4add31353"
 dependencies = [
  "doc-comment",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "num",
  "num-traits",
  "rand 0.8.6",
@@ -5666,11 +6003,24 @@ dependencies = [
 
 [[package]]
 name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx 0.5.1",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
+name = "simba"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
- "approx",
+ "approx 0.5.1",
  "num-complex",
  "num-traits",
  "paste",
@@ -5694,6 +6044,56 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slog"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
+dependencies = [
+ "anyhow",
+ "erased-serde",
+ "rustversion",
+ "serde_core",
+]
+
+[[package]]
+name = "slog-async"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
+dependencies = [
+ "serde",
+ "serde_json",
+ "slog",
+ "time",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cb1fc680b38eed6fad4c02b3871c09d2c81db8c96aa4e9c0a34904c830f09b5"
+dependencies = [
+ "chrono",
+ "is-terminal",
+ "slog",
+ "term",
+ "thread_local",
+ "time",
+]
 
 [[package]]
 name = "smallvec"
@@ -5775,7 +6175,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c61941ccf5ddcada342cd59e3e5173b007c509e1e8e990dafc830294d9dc5"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
  "atoi",
  "base64 0.13.1",
  "bitflags 1.3.2",
@@ -5862,6 +6262,18 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stlrs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc437f5340cfad02b97cb7bba65a364f6121845a7a25aaf79f3d3dea46e6cf3"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "stringprep"
@@ -6031,6 +6443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6052,6 +6470,15 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -6140,6 +6567,15 @@ name = "thousands"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "thread-tree"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbd370cb847953a25954d9f63e14824a36113f8c72eecf6eccef5dc4b45d630"
+dependencies = [
+ "crossbeam-channel",
+]
 
 [[package]]
 name = "thread_local"
@@ -6670,6 +7106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7106,6 +7552,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "welch-sde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf9e00ede58031fc5fefd05329aeb93ffbc195ca5416e35144f1eff3c196067"
+dependencies = [
+ "num-complex",
+ "num-traits",
+ "rustfft",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7399,7 +7856,7 @@ dependencies = [
  "crossbeam",
  "csv",
  "derive-new",
- "derive_more",
+ "derive_more 2.1.1",
  "dhat",
  "env_logger 0.11.10",
  "etcd-client",
@@ -7469,7 +7926,7 @@ version = "6.0.5"
 dependencies = [
  "anyhow",
  "chrono",
- "derive_more",
+ "derive_more 2.1.1",
  "env_logger 0.11.10",
  "futures",
  "kdb-plus-fixed",

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Short code snippets for each adapter live in the [examples README](https://githu
 | [`aeron`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/aeron/) | Low-latency Aeron UDP/IPC transport — publish and subscribe to `i64` values with spin and threaded polling modes. |
 | [`web`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/web/) | WebSocket adapter streaming synthetic prices and receiving UI events. |
 | [`telemetry`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/telemetry/) | Metrics export via Prometheus scraping (pull) and OpenTelemetry OTLP (push). |
-| [`augurs`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/augurs/) | augurs time-series toolkit — on-graph ETS forecasting and MAD outlier detection over sliding windows. |
+| [`augurs`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/augurs/) | augurs time-series toolkit — on-graph forecasting (ETS/MSTL), outlier detection (MAD/DBSCAN), changepoint, seasonality, DTW and clustering over sliding windows. |
 
 ## Links
 - Checkout the [examples](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Short code snippets for each adapter live in the [examples README](https://githu
 | [`aeron`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/aeron/) | Low-latency Aeron UDP/IPC transport — publish and subscribe to `i64` values with spin and threaded polling modes. |
 | [`web`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/web/) | WebSocket adapter streaming synthetic prices and receiving UI events. |
 | [`telemetry`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/telemetry/) | Metrics export via Prometheus scraping (pull) and OpenTelemetry OTLP (push). |
+| [`augurs`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/augurs/) | augurs time-series toolkit — on-graph ETS forecasting and MAD outlier detection over sliding windows. |
 
 ## Links
 - Checkout the [examples](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples)

--- a/wingfoil-python/Cargo.toml
+++ b/wingfoil-python/Cargo.toml
@@ -27,7 +27,7 @@ aeron = ["wingfoil/aeron"]
 [dependencies]
 
 # parent
-wingfoil = { path = "../wingfoil", features = ["csv", "kdb", "zmq", "etcd", "fluvio", "prometheus", "otlp", "fix", "web", "kafka", "redis"] }
+wingfoil = { path = "../wingfoil", features = ["csv", "kdb", "zmq", "etcd", "fluvio", "prometheus", "otlp", "fix", "web", "kafka", "redis", "augurs"] }
 
 # workspace deps
 anyhow = {workspace = true}

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -1,6 +1,7 @@
 mod proxy_stream;
 #[cfg(feature = "aeron")]
 mod py_aeron;
+mod py_augurs;
 mod py_csv;
 mod py_element;
 #[cfg(feature = "etcd")]

--- a/wingfoil-python/src/py_augurs.rs
+++ b/wingfoil-python/src/py_augurs.rs
@@ -25,36 +25,41 @@ use wingfoil::{Stream, StreamOperators};
 
 use crate::py_element::PyElement;
 
-/// Map a `PyElement` stream to an `f64` stream, logging and substituting `NaN`
-/// on values that are not floats.
+/// Map a `PyElement` stream to an `f64` stream, failing the graph run with a
+/// contextual error on a value that is not a float. This mirrors
+/// [`PyStream::extract`] used by `.average()` / `.sum()`; substituting `NaN`
+/// instead would silently poison the model window and abort the run later with
+/// an augurs-internal message that never points back at the offending value.
 fn as_floats(stream: &Rc<dyn Stream<PyElement>>, op: &'static str) -> Rc<dyn Stream<f64>> {
-    stream.map(move |elem| {
+    stream.try_map(move |elem: PyElement| {
         Python::attach(|py| {
-            elem.as_ref().extract::<f64>(py).unwrap_or_else(|e| {
-                log::error!("{op}: expected a float input value: {e}");
-                f64::NAN
+            elem.as_ref().extract::<f64>(py).map_err(|e| {
+                anyhow::Error::new(e).context(format!("{op}: expected a float input value"))
             })
         })
     })
 }
 
 /// Map a `PyElement` stream to a `Vec<f64>` (per-series readings) stream,
-/// logging and substituting an empty vector on values that are not lists.
+/// failing the graph run with a contextual error on a value that is not a
+/// `list[float]`.
 fn as_series(stream: &Rc<dyn Stream<PyElement>>, op: &'static str) -> Rc<dyn Stream<Vec<f64>>> {
-    stream.map(move |elem| {
+    stream.try_map(move |elem: PyElement| {
         Python::attach(|py| {
-            elem.as_ref().extract::<Vec<f64>>(py).unwrap_or_else(|e| {
-                log::error!("{op}: expected a list[float] input value: {e}");
-                Vec::new()
+            elem.as_ref().extract::<Vec<f64>>(py).map_err(|e| {
+                anyhow::Error::new(e).context(format!("{op}: expected a list[float] input value"))
             })
         })
     })
 }
 
-fn metric_from_str(metric: &str) -> AugursDtwMetric {
+fn metric_from_str(metric: &str) -> PyResult<AugursDtwMetric> {
     match metric.to_ascii_lowercase().as_str() {
-        "manhattan" | "l1" => AugursDtwMetric::Manhattan,
-        _ => AugursDtwMetric::Euclidean,
+        "manhattan" | "l1" => Ok(AugursDtwMetric::Manhattan),
+        "euclidean" | "l2" => Ok(AugursDtwMetric::Euclidean),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unknown metric '{other}' (expected 'euclidean' or 'manhattan')"
+        ))),
     }
 }
 
@@ -95,14 +100,19 @@ pub fn py_augurs_outlier_inner(
     window: usize,
     sensitivity: f64,
     detector: &str,
-) -> Rc<dyn Stream<PyElement>> {
+) -> PyResult<Rc<dyn Stream<PyElement>>> {
     let series = as_series(stream, "augurs_outlier");
     let config = match detector.to_ascii_lowercase().as_str() {
         "dbscan" => AugursOutlierConfig::dbscan(window, sensitivity),
-        _ => AugursOutlierConfig::mad(window, sensitivity),
+        "mad" => AugursOutlierConfig::mad(window, sensitivity),
+        other => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "unknown detector '{other}' (expected 'mad' or 'dbscan')"
+            )));
+        }
     };
 
-    series.augurs_outlier(config).map(|outliers| {
+    Ok(series.augurs_outlier(config).map(|outliers| {
         Python::attach(|py| {
             let dict = PyDict::new(py);
             dict.set_item("outlying", outliers.outlying)
@@ -110,7 +120,7 @@ pub fn py_augurs_outlier_inner(
                 .expect("invariant: inserting list values into a dict cannot fail");
             PyElement::new(dict.into_any().unbind())
         })
-    })
+    }))
 }
 
 /// Inner implementation for the `.augurs_changepoint()` stream method.
@@ -148,9 +158,10 @@ pub fn py_augurs_seasons_inner(
     if let Some(min_points) = min_points {
         config = config.with_min_points(min_points);
     }
-    if let (Some(min_period), Some(max_period)) = (min_period, max_period) {
-        config = config.with_period_range(min_period, max_period);
-    }
+    // Apply each period bound independently — the Python signature documents
+    // them as separately optional, so passing only one must not be discarded.
+    config.min_period = min_period;
+    config.max_period = max_period;
 
     floats.augurs_seasons(config).map(|seasons| {
         Python::attach(|py| {
@@ -167,18 +178,18 @@ pub fn py_augurs_dtw_inner(
     stream: &Rc<dyn Stream<PyElement>>,
     window: usize,
     metric: &str,
-) -> Rc<dyn Stream<PyElement>> {
+) -> PyResult<Rc<dyn Stream<PyElement>>> {
     let series = as_series(stream, "augurs_dtw");
-    let config = AugursDtwConfig::new(window).with_metric(metric_from_str(metric));
+    let config = AugursDtwConfig::new(window).with_metric(metric_from_str(metric)?);
 
-    series.augurs_dtw(config).map(|matrix| {
+    Ok(series.augurs_dtw(config).map(|matrix| {
         Python::attach(|py| {
             let dict = PyDict::new(py);
             dict.set_item("rows", matrix.rows)
                 .expect("invariant: inserting a list into a dict cannot fail");
             PyElement::new(dict.into_any().unbind())
         })
-    })
+    }))
 }
 
 /// Inner implementation for the `.augurs_cluster()` stream method.
@@ -188,17 +199,17 @@ pub fn py_augurs_cluster_inner(
     epsilon: f64,
     min_cluster_size: usize,
     metric: &str,
-) -> Rc<dyn Stream<PyElement>> {
+) -> PyResult<Rc<dyn Stream<PyElement>>> {
     let series = as_series(stream, "augurs_cluster");
     let config = AugursClusterConfig::new(window, epsilon, min_cluster_size)
-        .with_metric(metric_from_str(metric));
+        .with_metric(metric_from_str(metric)?);
 
-    series.augurs_cluster(config).map(|clusters| {
+    Ok(series.augurs_cluster(config).map(|clusters| {
         Python::attach(|py| {
             let dict = PyDict::new(py);
             dict.set_item("labels", clusters.labels)
                 .expect("invariant: inserting a list into a dict cannot fail");
             PyElement::new(dict.into_any().unbind())
         })
-    })
+    }))
 }

--- a/wingfoil-python/src/py_augurs.rs
+++ b/wingfoil-python/src/py_augurs.rs
@@ -1,0 +1,82 @@
+//! Python bindings for the augurs adapter.
+//!
+//! augurs is a pure-Rust compute library, so both bindings are stream
+//! transforms exposed as methods on [`PyStream`] rather than source functions:
+//!
+//! - `.augurs_forecast(...)` consumes a stream of floats and yields a dict
+//!   `{"point": list[float], "lower": list[float], "upper": list[float]}`.
+//! - `.augurs_outlier(...)` consumes a stream of `list[float]` (one value per
+//!   series per tick) and yields `{"outlying": list[int], "scores": list[float]}`.
+
+use std::rc::Rc;
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use wingfoil::adapters::augurs::{
+    AugursForecastConfig, AugursForecastOperators, AugursOutlierConfig, AugursOutlierOperators,
+};
+use wingfoil::{Stream, StreamOperators};
+
+use crate::py_element::PyElement;
+
+/// Inner implementation for the `.augurs_forecast()` stream method.
+pub fn py_augurs_forecast_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    window: usize,
+    horizon: usize,
+    level: Option<f64>,
+    min_points: usize,
+) -> Rc<dyn Stream<PyElement>> {
+    let floats: Rc<dyn Stream<f64>> = stream.map(|elem| {
+        Python::attach(|py| {
+            elem.as_ref().extract::<f64>(py).unwrap_or_else(|e| {
+                log::error!("augurs_forecast: expected a float input value: {e}");
+                f64::NAN
+            })
+        })
+    });
+
+    let mut config = AugursForecastConfig::new(window, horizon).with_min_points(min_points);
+    if let Some(level) = level {
+        config = config.with_level(level);
+    }
+
+    floats.augurs_forecast(config).map(|forecast| {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("point", forecast.point)
+                .and_then(|()| dict.set_item("lower", forecast.lower))
+                .and_then(|()| dict.set_item("upper", forecast.upper))
+                .expect("invariant: inserting list values into a dict cannot fail");
+            PyElement::new(dict.into_any().unbind())
+        })
+    })
+}
+
+/// Inner implementation for the `.augurs_outlier()` stream method.
+pub fn py_augurs_outlier_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    window: usize,
+    sensitivity: f64,
+) -> Rc<dyn Stream<PyElement>> {
+    let series: Rc<dyn Stream<Vec<f64>>> = stream.map(|elem| {
+        Python::attach(|py| {
+            elem.as_ref().extract::<Vec<f64>>(py).unwrap_or_else(|e| {
+                log::error!("augurs_outlier: expected a list[float] input value: {e}");
+                Vec::new()
+            })
+        })
+    });
+
+    series
+        .augurs_outlier(AugursOutlierConfig::new(window, sensitivity))
+        .map(|outliers| {
+            Python::attach(|py| {
+                let dict = PyDict::new(py);
+                dict.set_item("outlying", outliers.outlying)
+                    .and_then(|()| dict.set_item("scores", outliers.scores))
+                    .expect("invariant: inserting list values into a dict cannot fail");
+                PyElement::new(dict.into_any().unbind())
+            })
+        })
+}

--- a/wingfoil-python/src/py_augurs.rs
+++ b/wingfoil-python/src/py_augurs.rs
@@ -1,23 +1,62 @@
 //! Python bindings for the augurs adapter.
 //!
-//! augurs is a pure-Rust compute library, so both bindings are stream
-//! transforms exposed as methods on [`PyStream`] rather than source functions:
+//! augurs is a pure-Rust compute library, so all bindings are stream transforms
+//! exposed as methods on [`PyStream`] rather than source functions. Each yields
+//! a dict per tick:
 //!
-//! - `.augurs_forecast(...)` consumes a stream of floats and yields a dict
-//!   `{"point": list[float], "lower": list[float], "upper": list[float]}`.
-//! - `.augurs_outlier(...)` consumes a stream of `list[float]` (one value per
-//!   series per tick) and yields `{"outlying": list[int], "scores": list[float]}`.
+//! - `.augurs_forecast(...)` — floats in → `{"point", "lower", "upper"}`.
+//! - `.augurs_outlier(...)` — `list[float]` in → `{"outlying", "scores"}`.
+//! - `.augurs_changepoint(...)` — floats in → `{"indices"}`.
+//! - `.augurs_seasons(...)` — floats in → `{"periods"}`.
+//! - `.augurs_dtw(...)` — `list[float]` in → `{"rows"}` (distance matrix).
+//! - `.augurs_cluster(...)` — `list[float]` in → `{"labels"}`.
 
 use std::rc::Rc;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use wingfoil::adapters::augurs::{
+    AugursChangepointConfig, AugursChangepointOperators, AugursClusterConfig,
+    AugursClusterOperators, AugursDtwConfig, AugursDtwMetric, AugursDtwOperators,
     AugursForecastConfig, AugursForecastOperators, AugursOutlierConfig, AugursOutlierOperators,
+    AugursSeasonsConfig, AugursSeasonsOperators,
 };
 use wingfoil::{Stream, StreamOperators};
 
 use crate::py_element::PyElement;
+
+/// Map a `PyElement` stream to an `f64` stream, logging and substituting `NaN`
+/// on values that are not floats.
+fn as_floats(stream: &Rc<dyn Stream<PyElement>>, op: &'static str) -> Rc<dyn Stream<f64>> {
+    stream.map(move |elem| {
+        Python::attach(|py| {
+            elem.as_ref().extract::<f64>(py).unwrap_or_else(|e| {
+                log::error!("{op}: expected a float input value: {e}");
+                f64::NAN
+            })
+        })
+    })
+}
+
+/// Map a `PyElement` stream to a `Vec<f64>` (per-series readings) stream,
+/// logging and substituting an empty vector on values that are not lists.
+fn as_series(stream: &Rc<dyn Stream<PyElement>>, op: &'static str) -> Rc<dyn Stream<Vec<f64>>> {
+    stream.map(move |elem| {
+        Python::attach(|py| {
+            elem.as_ref().extract::<Vec<f64>>(py).unwrap_or_else(|e| {
+                log::error!("{op}: expected a list[float] input value: {e}");
+                Vec::new()
+            })
+        })
+    })
+}
+
+fn metric_from_str(metric: &str) -> AugursDtwMetric {
+    match metric.to_ascii_lowercase().as_str() {
+        "manhattan" | "l1" => AugursDtwMetric::Manhattan,
+        _ => AugursDtwMetric::Euclidean,
+    }
+}
 
 /// Inner implementation for the `.augurs_forecast()` stream method.
 pub fn py_augurs_forecast_inner(
@@ -26,19 +65,16 @@ pub fn py_augurs_forecast_inner(
     horizon: usize,
     level: Option<f64>,
     min_points: usize,
+    periods: Option<Vec<usize>>,
 ) -> Rc<dyn Stream<PyElement>> {
-    let floats: Rc<dyn Stream<f64>> = stream.map(|elem| {
-        Python::attach(|py| {
-            elem.as_ref().extract::<f64>(py).unwrap_or_else(|e| {
-                log::error!("augurs_forecast: expected a float input value: {e}");
-                f64::NAN
-            })
-        })
-    });
+    let floats = as_floats(stream, "augurs_forecast");
 
     let mut config = AugursForecastConfig::new(window, horizon).with_min_points(min_points);
     if let Some(level) = level {
         config = config.with_level(level);
+    }
+    if let Some(periods) = periods.filter(|p| !p.is_empty()) {
+        config = config.mstl(periods);
     }
 
     floats.augurs_forecast(config).map(|forecast| {
@@ -58,25 +94,111 @@ pub fn py_augurs_outlier_inner(
     stream: &Rc<dyn Stream<PyElement>>,
     window: usize,
     sensitivity: f64,
+    detector: &str,
 ) -> Rc<dyn Stream<PyElement>> {
-    let series: Rc<dyn Stream<Vec<f64>>> = stream.map(|elem| {
-        Python::attach(|py| {
-            elem.as_ref().extract::<Vec<f64>>(py).unwrap_or_else(|e| {
-                log::error!("augurs_outlier: expected a list[float] input value: {e}");
-                Vec::new()
-            })
-        })
-    });
+    let series = as_series(stream, "augurs_outlier");
+    let config = match detector.to_ascii_lowercase().as_str() {
+        "dbscan" => AugursOutlierConfig::dbscan(window, sensitivity),
+        _ => AugursOutlierConfig::mad(window, sensitivity),
+    };
 
-    series
-        .augurs_outlier(AugursOutlierConfig::new(window, sensitivity))
-        .map(|outliers| {
-            Python::attach(|py| {
-                let dict = PyDict::new(py);
-                dict.set_item("outlying", outliers.outlying)
-                    .and_then(|()| dict.set_item("scores", outliers.scores))
-                    .expect("invariant: inserting list values into a dict cannot fail");
-                PyElement::new(dict.into_any().unbind())
-            })
+    series.augurs_outlier(config).map(|outliers| {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("outlying", outliers.outlying)
+                .and_then(|()| dict.set_item("scores", outliers.scores))
+                .expect("invariant: inserting list values into a dict cannot fail");
+            PyElement::new(dict.into_any().unbind())
         })
+    })
+}
+
+/// Inner implementation for the `.augurs_changepoint()` stream method.
+pub fn py_augurs_changepoint_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    window: usize,
+    min_points: usize,
+    hazard: f64,
+) -> Rc<dyn Stream<PyElement>> {
+    let floats = as_floats(stream, "augurs_changepoint");
+    let config = AugursChangepointConfig::new(window)
+        .with_min_points(min_points)
+        .with_hazard(hazard);
+
+    floats.augurs_changepoint(config).map(|changes| {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("indices", changes.indices)
+                .expect("invariant: inserting a list into a dict cannot fail");
+            PyElement::new(dict.into_any().unbind())
+        })
+    })
+}
+
+/// Inner implementation for the `.augurs_seasons()` stream method.
+pub fn py_augurs_seasons_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    window: usize,
+    min_points: Option<usize>,
+    min_period: Option<u32>,
+    max_period: Option<u32>,
+) -> Rc<dyn Stream<PyElement>> {
+    let floats = as_floats(stream, "augurs_seasons");
+    let mut config = AugursSeasonsConfig::new(window);
+    if let Some(min_points) = min_points {
+        config = config.with_min_points(min_points);
+    }
+    if let (Some(min_period), Some(max_period)) = (min_period, max_period) {
+        config = config.with_period_range(min_period, max_period);
+    }
+
+    floats.augurs_seasons(config).map(|seasons| {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("periods", seasons.periods)
+                .expect("invariant: inserting a list into a dict cannot fail");
+            PyElement::new(dict.into_any().unbind())
+        })
+    })
+}
+
+/// Inner implementation for the `.augurs_dtw()` stream method.
+pub fn py_augurs_dtw_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    window: usize,
+    metric: &str,
+) -> Rc<dyn Stream<PyElement>> {
+    let series = as_series(stream, "augurs_dtw");
+    let config = AugursDtwConfig::new(window).with_metric(metric_from_str(metric));
+
+    series.augurs_dtw(config).map(|matrix| {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("rows", matrix.rows)
+                .expect("invariant: inserting a list into a dict cannot fail");
+            PyElement::new(dict.into_any().unbind())
+        })
+    })
+}
+
+/// Inner implementation for the `.augurs_cluster()` stream method.
+pub fn py_augurs_cluster_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    window: usize,
+    epsilon: f64,
+    min_cluster_size: usize,
+    metric: &str,
+) -> Rc<dyn Stream<PyElement>> {
+    let series = as_series(stream, "augurs_cluster");
+    let config = AugursClusterConfig::new(window, epsilon, min_cluster_size)
+        .with_metric(metric_from_str(metric));
+
+    series.augurs_cluster(config).map(|clusters| {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("labels", clusters.labels)
+                .expect("invariant: inserting a list into a dict cannot fail");
+            PyElement::new(dict.into_any().unbind())
+        })
+    })
 }

--- a/wingfoil-python/src/py_augurs.rs
+++ b/wingfoil-python/src/py_augurs.rs
@@ -71,18 +71,32 @@ pub fn py_augurs_forecast_inner(
     level: Option<f64>,
     min_points: usize,
     periods: Option<Vec<usize>>,
-) -> Rc<dyn Stream<PyElement>> {
+) -> PyResult<Rc<dyn Stream<PyElement>>> {
     let floats = as_floats(stream, "augurs_forecast");
 
     let mut config = AugursForecastConfig::new(window, horizon).with_min_points(min_points);
     if let Some(level) = level {
+        // Validate up front so a bad level raises a clean `ValueError` rather
+        // than silently producing `inf`/`NaN` interval bounds downstream.
+        if !(level > 0.0 && level < 1.0) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "augurs_forecast: level must be strictly between 0 and 1, got {level}"
+            )));
+        }
         config = config.with_level(level);
     }
     if let Some(periods) = periods.filter(|p| !p.is_empty()) {
+        // STL cannot decompose a period below 2; reject it here so the caller
+        // gets a clear error at construction rather than a fit failure later.
+        if periods.iter().any(|&p| p < 2) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "augurs_forecast: MSTL periods must each be >= 2, got {periods:?}"
+            )));
+        }
         config = config.mstl(periods);
     }
 
-    floats.augurs_forecast(config).map(|forecast| {
+    Ok(floats.augurs_forecast(config).map(|forecast| {
         Python::attach(|py| {
             let dict = PyDict::new(py);
             dict.set_item("point", forecast.point)
@@ -91,7 +105,7 @@ pub fn py_augurs_forecast_inner(
                 .expect("invariant: inserting list values into a dict cannot fail");
             PyElement::new(dict.into_any().unbind())
         })
-    })
+    }))
 }
 
 /// Inner implementation for the `.augurs_outlier()` stream method.
@@ -102,6 +116,14 @@ pub fn py_augurs_outlier_inner(
     detector: &str,
 ) -> PyResult<Rc<dyn Stream<PyElement>>> {
     let series = as_series(stream, "augurs_outlier");
+    // Validate up front so an out-of-range value raises a clean `ValueError`
+    // rather than panicking across the FFI boundary (augurs' detector
+    // constructor panics on a sensitivity outside `(0, 1)`).
+    if !(sensitivity > 0.0 && sensitivity < 1.0) {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "augurs_outlier: sensitivity must be strictly between 0 and 1, got {sensitivity}"
+        )));
+    }
     let config = match detector.to_ascii_lowercase().as_str() {
         "dbscan" => AugursOutlierConfig::dbscan(window, sensitivity),
         "mad" => AugursOutlierConfig::mad(window, sensitivity),

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -415,13 +415,18 @@ impl PyStream {
     ///     sensitivity: Detector sensitivity, strictly between 0 and 1.
     ///     detector: "mad" (default) or "dbscan". DBSCAN needs >= 3 series.
     #[pyo3(signature = (window, sensitivity, detector="mad"))]
-    fn augurs_outlier(&self, window: usize, sensitivity: f64, detector: &str) -> PyStream {
-        PyStream(crate::py_augurs::py_augurs_outlier_inner(
+    fn augurs_outlier(
+        &self,
+        window: usize,
+        sensitivity: f64,
+        detector: &str,
+    ) -> PyResult<PyStream> {
+        Ok(PyStream(crate::py_augurs::py_augurs_outlier_inner(
             &self.0,
             window,
             sensitivity,
             detector,
-        ))
+        )?))
     }
 
     /// Detect changepoints in this stream of floats (Bayesian online
@@ -474,10 +479,10 @@ impl PyStream {
     ///     window: Number of recent samples compared per series.
     ///     metric: "euclidean" (default) or "manhattan".
     #[pyo3(signature = (window, metric="euclidean"))]
-    fn augurs_dtw(&self, window: usize, metric: &str) -> PyStream {
-        PyStream(crate::py_augurs::py_augurs_dtw_inner(
+    fn augurs_dtw(&self, window: usize, metric: &str) -> PyResult<PyStream> {
+        Ok(PyStream(crate::py_augurs::py_augurs_dtw_inner(
             &self.0, window, metric,
-        ))
+        )?))
     }
 
     /// Cluster the series in a window of per-series readings via DBSCAN over
@@ -499,14 +504,14 @@ impl PyStream {
         epsilon: f64,
         min_cluster_size: usize,
         metric: &str,
-    ) -> PyStream {
-        PyStream(crate::py_augurs::py_augurs_cluster_inner(
+    ) -> PyResult<PyStream> {
+        Ok(PyStream(crate::py_augurs::py_augurs_cluster_inner(
             &self.0,
             window,
             epsilon,
             min_cluster_size,
             metric,
-        ))
+        )?))
     }
 
     /// Write this stream to a KDB+ table.

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -374,6 +374,48 @@ impl PyStream {
         Ok(PyNode::new(node))
     }
 
+    /// Forecast this stream of floats with the augurs ETS model.
+    ///
+    /// Buffers a sliding window of the last `window` values and, once
+    /// `min_points` have arrived, emits a dict each tick:
+    /// `{"point": list[float], "lower": list[float], "upper": list[float]}`.
+    /// `lower`/`upper` are empty unless a `level` (0..1) is requested.
+    ///
+    /// Args:
+    ///     window: Maximum number of recent points retained as history.
+    ///     horizon: Number of steps to forecast ahead.
+    ///     level: Confidence level for prediction intervals (0..1), or None.
+    ///     min_points: Minimum points before fitting begins (floored at 12).
+    #[pyo3(signature = (window, horizon, level=None, min_points=12))]
+    fn augurs_forecast(
+        &self,
+        window: usize,
+        horizon: usize,
+        level: Option<f64>,
+        min_points: usize,
+    ) -> PyStream {
+        PyStream(crate::py_augurs::py_augurs_forecast_inner(
+            &self.0, window, horizon, level, min_points,
+        ))
+    }
+
+    /// Detect outlying series in this stream of per-series readings.
+    ///
+    /// Each value must be a `list[float]` carrying one reading per series.
+    /// Buffers the last `window` ticks and emits a dict each tick:
+    /// `{"outlying": list[int], "scores": list[float]}`.
+    ///
+    /// Args:
+    ///     window: Number of recent samples in the detection window.
+    ///     sensitivity: MAD sensitivity, strictly between 0 and 1.
+    fn augurs_outlier(&self, window: usize, sensitivity: f64) -> PyStream {
+        PyStream(crate::py_augurs::py_augurs_outlier_inner(
+            &self.0,
+            window,
+            sensitivity,
+        ))
+    }
+
     /// Write this stream to a KDB+ table.
     ///
     /// Args:

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -374,28 +374,33 @@ impl PyStream {
         Ok(PyNode::new(node))
     }
 
-    /// Forecast this stream of floats with the augurs ETS model.
+    /// Forecast this stream of floats with an augurs model.
     ///
     /// Buffers a sliding window of the last `window` values and, once
     /// `min_points` have arrived, emits a dict each tick:
     /// `{"point": list[float], "lower": list[float], "upper": list[float]}`.
     /// `lower`/`upper` are empty unless a `level` (0..1) is requested.
     ///
+    /// Uses non-seasonal ETS by default. Pass `periods` (a list of seasonal
+    /// period lengths, e.g. `[24]`) to fit an MSTL seasonal model instead.
+    ///
     /// Args:
     ///     window: Maximum number of recent points retained as history.
     ///     horizon: Number of steps to forecast ahead.
     ///     level: Confidence level for prediction intervals (0..1), or None.
     ///     min_points: Minimum points before fitting begins (floored at 12).
-    #[pyo3(signature = (window, horizon, level=None, min_points=12))]
+    ///     periods: Seasonal period lengths for MSTL, or None for ETS.
+    #[pyo3(signature = (window, horizon, level=None, min_points=12, periods=None))]
     fn augurs_forecast(
         &self,
         window: usize,
         horizon: usize,
         level: Option<f64>,
         min_points: usize,
+        periods: Option<Vec<usize>>,
     ) -> PyStream {
         PyStream(crate::py_augurs::py_augurs_forecast_inner(
-            &self.0, window, horizon, level, min_points,
+            &self.0, window, horizon, level, min_points, periods,
         ))
     }
 
@@ -407,12 +412,100 @@ impl PyStream {
     ///
     /// Args:
     ///     window: Number of recent samples in the detection window.
-    ///     sensitivity: MAD sensitivity, strictly between 0 and 1.
-    fn augurs_outlier(&self, window: usize, sensitivity: f64) -> PyStream {
+    ///     sensitivity: Detector sensitivity, strictly between 0 and 1.
+    ///     detector: "mad" (default) or "dbscan". DBSCAN needs >= 3 series.
+    #[pyo3(signature = (window, sensitivity, detector="mad"))]
+    fn augurs_outlier(&self, window: usize, sensitivity: f64, detector: &str) -> PyStream {
         PyStream(crate::py_augurs::py_augurs_outlier_inner(
             &self.0,
             window,
             sensitivity,
+            detector,
+        ))
+    }
+
+    /// Detect changepoints in this stream of floats (Bayesian online
+    /// changepoint detection over a sliding window).
+    ///
+    /// Emits `{"indices": list[int]}` each tick once `min_points` have arrived:
+    /// the indices, within the window, of detected regime changes.
+    ///
+    /// Args:
+    ///     window: Number of recent points in the detection window.
+    ///     min_points: Minimum points before detection begins.
+    ///     hazard: Prior expected run length between changepoints.
+    #[pyo3(signature = (window, min_points=8, hazard=250.0))]
+    fn augurs_changepoint(&self, window: usize, min_points: usize, hazard: f64) -> PyStream {
+        PyStream(crate::py_augurs::py_augurs_changepoint_inner(
+            &self.0, window, min_points, hazard,
+        ))
+    }
+
+    /// Detect seasonal periods in this stream of floats (periodogram over a
+    /// sliding window).
+    ///
+    /// Emits `{"periods": list[int]}` each tick once enough points have arrived.
+    ///
+    /// Args:
+    ///     window: Number of recent points in the detection window.
+    ///     min_points: Minimum points before detection begins, or None.
+    ///     min_period: Shortest period to consider, or None.
+    ///     max_period: Longest period to consider, or None.
+    #[pyo3(signature = (window, min_points=None, min_period=None, max_period=None))]
+    fn augurs_seasons(
+        &self,
+        window: usize,
+        min_points: Option<usize>,
+        min_period: Option<u32>,
+        max_period: Option<u32>,
+    ) -> PyStream {
+        PyStream(crate::py_augurs::py_augurs_seasons_inner(
+            &self.0, window, min_points, min_period, max_period,
+        ))
+    }
+
+    /// Compute the pairwise dynamic time warping distance matrix over a window
+    /// of per-series readings.
+    ///
+    /// Each value must be a `list[float]` (one reading per series). Emits
+    /// `{"rows": list[list[float]]}` each tick, an `n x n` distance matrix.
+    ///
+    /// Args:
+    ///     window: Number of recent samples compared per series.
+    ///     metric: "euclidean" (default) or "manhattan".
+    #[pyo3(signature = (window, metric="euclidean"))]
+    fn augurs_dtw(&self, window: usize, metric: &str) -> PyStream {
+        PyStream(crate::py_augurs::py_augurs_dtw_inner(
+            &self.0, window, metric,
+        ))
+    }
+
+    /// Cluster the series in a window of per-series readings via DBSCAN over
+    /// their pairwise DTW distances.
+    ///
+    /// Each value must be a `list[float]` (one reading per series). Emits
+    /// `{"labels": list[int]}` each tick — a cluster label per series
+    /// (`-1` = noise).
+    ///
+    /// Args:
+    ///     window: Number of recent samples compared per series.
+    ///     epsilon: DBSCAN neighbourhood radius (max DTW distance).
+    ///     min_cluster_size: DBSCAN minimum core-point neighbourhood size.
+    ///     metric: "euclidean" (default) or "manhattan".
+    #[pyo3(signature = (window, epsilon, min_cluster_size, metric="euclidean"))]
+    fn augurs_cluster(
+        &self,
+        window: usize,
+        epsilon: f64,
+        min_cluster_size: usize,
+        metric: &str,
+    ) -> PyStream {
+        PyStream(crate::py_augurs::py_augurs_cluster_inner(
+            &self.0,
+            window,
+            epsilon,
+            min_cluster_size,
+            metric,
         ))
     }
 

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -388,8 +388,14 @@ impl PyStream {
     ///     window: Maximum number of recent points retained as history.
     ///     horizon: Number of steps to forecast ahead.
     ///     level: Confidence level for prediction intervals (0..1), or None.
-    ///     min_points: Minimum points before fitting begins (floored at 12).
+    ///     min_points: Minimum points before fitting begins. Raised to the
+    ///         model's warm-up floor: 12 for ETS, or `2 * max(periods) + 1`
+    ///         for MSTL (STL needs two full seasonal periods).
     ///     periods: Seasonal period lengths for MSTL, or None for ETS.
+    ///
+    /// Raises:
+    ///     ValueError: if `level` is not in `(0, 1)`, or any `periods` entry
+    ///         is below 2.
     #[pyo3(signature = (window, horizon, level=None, min_points=12, periods=None))]
     fn augurs_forecast(
         &self,
@@ -398,10 +404,10 @@ impl PyStream {
         level: Option<f64>,
         min_points: usize,
         periods: Option<Vec<usize>>,
-    ) -> PyStream {
-        PyStream(crate::py_augurs::py_augurs_forecast_inner(
+    ) -> PyResult<PyStream> {
+        Ok(PyStream(crate::py_augurs::py_augurs_forecast_inner(
             &self.0, window, horizon, level, min_points, periods,
-        ))
+        )?))
     }
 
     /// Detect outlying series in this stream of per-series readings.
@@ -414,6 +420,10 @@ impl PyStream {
     ///     window: Number of recent samples in the detection window.
     ///     sensitivity: Detector sensitivity, strictly between 0 and 1.
     ///     detector: "mad" (default) or "dbscan". DBSCAN needs >= 3 series.
+    ///
+    /// Raises:
+    ///     ValueError: if `sensitivity` is not in `(0, 1)`, or `detector` is
+    ///         not "mad" or "dbscan".
     #[pyo3(signature = (window, sensitivity, detector="mad"))]
     fn augurs_outlier(
         &self,

--- a/wingfoil-python/tests/test_augurs.py
+++ b/wingfoil-python/tests/test_augurs.py
@@ -1,0 +1,91 @@
+"""Tests for the augurs Python bindings (stream.augurs_forecast / augurs_outlier).
+
+augurs is a pure-Rust compute library with no external service, so these tests
+run by default — there is no `requires_*` marker to gate. They exercise the
+pyo3 marshaling glue end to end against deterministic historical-mode runs.
+"""
+
+import unittest
+
+from wingfoil import ticker
+
+
+def _ramp():
+    """A rising stream of floats: n + sin(n/2)."""
+    import math
+
+    return ticker(1.0).count().map(lambda n: float(n) + math.sin(n * 0.5))
+
+
+def _series():
+    """Four readings per tick; series 3 diverges after tick 15."""
+    import math
+
+    def reading(n):
+        base = 100.0 + math.sin(n * 0.4)
+        diverging = base + 80.0 if n > 15 else base + 0.2
+        return [base, base + 0.1, base - 0.1, diverging]
+
+    return ticker(1.0).count().map(reading)
+
+
+class TestForecast(unittest.TestCase):
+    def test_forecast_shape(self):
+        forecast = _ramp().augurs_forecast(48, 3)
+        captured = forecast.collect()
+        captured.run(realtime=False, cycles=30)
+        last = captured.peek_value()[-1]
+        self.assertIsInstance(last, dict)
+        self.assertEqual(len(last["point"]), 3)
+
+    def test_forecast_with_intervals(self):
+        forecast = _ramp().augurs_forecast(48, 2, level=0.9)
+        captured = forecast.collect()
+        captured.run(realtime=False, cycles=30)
+        last = captured.peek_value()[-1]
+        self.assertEqual(len(last["lower"]), 2)
+        self.assertEqual(len(last["upper"]), 2)
+        for i in range(2):
+            self.assertLessEqual(last["lower"][i], last["point"][i])
+            self.assertGreaterEqual(last["upper"][i], last["point"][i])
+
+    def test_forecast_waits_for_min_points(self):
+        forecast = _ramp().augurs_forecast(64, 1, min_points=20)
+        captured = forecast.collect()
+        captured.run(realtime=False, cycles=10)
+        # 10 cycles < 20 min_points → never ticked, so the collected stream
+        # has no value (peeks as None rather than an empty list).
+        self.assertFalse(captured.peek_value())
+
+
+class TestOutlier(unittest.TestCase):
+    def test_flags_diverging_series(self):
+        outliers = _series().augurs_outlier(30, 0.5)
+        captured = outliers.collect()
+        captured.run(realtime=False, cycles=30)
+        last = captured.peek_value()[-1]
+        self.assertIn(3, last["outlying"])
+        self.assertEqual(len(last["scores"]), 4)
+
+    def test_aligned_series_quiet(self):
+        aligned = ticker(1.0).count().map(lambda n: [50.0, 50.05, 49.95])
+        outliers = aligned.augurs_outlier(20, 0.5)
+        captured = outliers.collect()
+        captured.run(realtime=False, cycles=20)
+        self.assertEqual(captured.peek_value()[-1]["outlying"], [])
+
+
+class TestConstruction(unittest.TestCase):
+    """Construction-only: exercise argument parsing without depending on output."""
+
+    def test_forecast_constructs(self):
+        stream = _ramp().augurs_forecast(32, 2)
+        self.assertIsNotNone(stream)
+
+    def test_outlier_constructs(self):
+        stream = _series().augurs_outlier(16, 0.25)
+        self.assertIsNotNone(stream)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wingfoil-python/tests/test_augurs.py
+++ b/wingfoil-python/tests/test_augurs.py
@@ -197,5 +197,29 @@ class TestConstruction(unittest.TestCase):
         self.assertIsNotNone(_series().augurs_cluster(16, 1.0, 2))
 
 
+class TestValidation(unittest.TestCase):
+    """Invalid arguments are rejected loudly rather than silently coerced."""
+
+    def test_unknown_detector_raises(self):
+        with self.assertRaises(ValueError):
+            _series().augurs_outlier(30, 0.5, detector="dbscann")
+
+    def test_unknown_metric_raises(self):
+        with self.assertRaises(ValueError):
+            _series().augurs_dtw(30, metric="manhatten")
+
+    def test_unknown_cluster_metric_raises(self):
+        with self.assertRaises(ValueError):
+            _series().augurs_cluster(30, 1.0, 2, metric="chebyshev")
+
+    def test_non_float_input_fails_fast(self):
+        # A non-float value is a hard error (like .average()/.sum()), not a
+        # silently substituted NaN that would poison the model window.
+        bad = ticker(1.0).count().map(lambda n: "not a float")
+        captured = bad.augurs_forecast(16, 1).collect()
+        with self.assertRaises(Exception):
+            captured.run(realtime=False, cycles=20)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/wingfoil-python/tests/test_augurs.py
+++ b/wingfoil-python/tests/test_augurs.py
@@ -124,6 +124,15 @@ class TestChangepoint(unittest.TestCase):
         captured.run(realtime=False, cycles=40)
         self.assertEqual(captured.peek_value()[-1]["indices"], [])
 
+    def test_hazard_and_min_points_marshal(self):
+        # Exercise the hazard/min_points optionals end to end: a level shift
+        # is still detected with a non-default hazard and min_points.
+        series = ticker(1.0).count().map(lambda n: 50.0 if n > 20 else 0.0)
+        changes = series.augurs_changepoint(60, min_points=12, hazard=100.0)
+        captured = changes.collect()
+        captured.run(realtime=False, cycles=50)
+        self.assertTrue(captured.peek_value()[-1]["indices"])
+
 
 class TestSeasons(unittest.TestCase):
     def test_detects_period(self):
@@ -132,6 +141,24 @@ class TestSeasons(unittest.TestCase):
         captured.run(realtime=False, cycles=96)
         periods = captured.peek_value()[-1]["periods"]
         self.assertTrue(any(10 <= p <= 14 for p in periods), periods)
+
+    def test_period_range_and_min_points_marshal(self):
+        # Exercise the min_period/max_period/min_points optionals: a bracket
+        # around 12 must still surface the period, and min_points must gate.
+        seasons = _sine(12).augurs_seasons(
+            96, min_points=40, min_period=8, max_period=16
+        )
+        captured = seasons.collect()
+        captured.run(realtime=False, cycles=96)
+        periods = captured.peek_value()[-1]["periods"]
+        self.assertTrue(any(8 <= p <= 16 for p in periods), periods)
+
+    def test_min_points_gates(self):
+        seasons = _sine(12).augurs_seasons(96, min_points=50)
+        captured = seasons.collect()
+        captured.run(realtime=False, cycles=20)
+        # 20 cycles < 50 min_points → never ticked.
+        self.assertFalse(captured.peek_value())
 
 
 class TestDtw(unittest.TestCase):
@@ -211,6 +238,24 @@ class TestValidation(unittest.TestCase):
     def test_unknown_cluster_metric_raises(self):
         with self.assertRaises(ValueError):
             _series().augurs_cluster(30, 1.0, 2, metric="chebyshev")
+
+    def test_out_of_range_sensitivity_raises(self):
+        # A sensitivity outside (0, 1) raises ValueError at construction rather
+        # than panicking across the FFI boundary.
+        for bad in (0.0, 1.0, 1.5, -0.1):
+            with self.assertRaises(ValueError):
+                _series().augurs_outlier(30, bad)
+
+    def test_out_of_range_level_raises(self):
+        for bad in (0.0, 1.0, 1.5):
+            with self.assertRaises(ValueError):
+                _ramp().augurs_forecast(48, 2, level=bad)
+
+    def test_invalid_mstl_period_raises(self):
+        # STL cannot decompose a period below 2; caught at construction.
+        for bad in ([1], [0], [12, 1]):
+            with self.assertRaises(ValueError):
+                _ramp().augurs_forecast(64, 4, periods=bad)
 
     def test_non_float_input_fails_fast(self):
         # A non-float value is a hard error (like .average()/.sum()), not a

--- a/wingfoil-python/tests/test_augurs.py
+++ b/wingfoil-python/tests/test_augurs.py
@@ -29,6 +29,13 @@ def _series():
     return ticker(1.0).count().map(reading)
 
 
+def _sine(period=12):
+    """A clean sine wave with the given period."""
+    import math
+
+    return ticker(1.0).count().map(lambda n: math.sin(n * math.tau / period))
+
+
 class TestForecast(unittest.TestCase):
     def test_forecast_shape(self):
         forecast = _ramp().augurs_forecast(48, 3)
@@ -75,6 +82,99 @@ class TestOutlier(unittest.TestCase):
         self.assertEqual(captured.peek_value()[-1]["outlying"], [])
 
 
+class TestForecastMstl(unittest.TestCase):
+    def test_mstl_forecast_swings(self):
+        import math
+
+        seasonal = ticker(1.0).count().map(
+            lambda n: 0.1 * n + 5.0 * math.sin(n * math.tau / 12.0)
+        )
+        forecast = seasonal.augurs_forecast(120, 12, periods=[12])
+        captured = forecast.collect()
+        captured.run(realtime=False, cycles=80)
+        point = captured.peek_value()[-1]["point"]
+        self.assertEqual(len(point), 12)
+        self.assertGreater(max(point) - min(point), 2.0)
+
+
+class TestOutlierDbscan(unittest.TestCase):
+    def test_dbscan_flags_diverging(self):
+        outliers = _series().augurs_outlier(40, 0.5, detector="dbscan")
+        captured = outliers.collect()
+        captured.run(realtime=False, cycles=30)
+        self.assertIn(3, captured.peek_value()[-1]["outlying"])
+
+
+class TestChangepoint(unittest.TestCase):
+    def test_detects_level_shift(self):
+        series = ticker(1.0).count().map(lambda n: 50.0 if n > 20 else 0.0)
+        changes = series.augurs_changepoint(60)
+        captured = changes.collect()
+        captured.run(realtime=False, cycles=50)
+        indices = captured.peek_value()[-1]["indices"]
+        self.assertTrue(indices, "expected a changepoint after the shift")
+        self.assertTrue(any(i >= 10 for i in indices))
+
+    def test_quiet_when_steady(self):
+        import math
+
+        series = ticker(1.0).count().map(lambda n: 10.0 + 0.1 * math.sin(n * 0.5))
+        changes = series.augurs_changepoint(40)
+        captured = changes.collect()
+        captured.run(realtime=False, cycles=40)
+        self.assertEqual(captured.peek_value()[-1]["indices"], [])
+
+
+class TestSeasons(unittest.TestCase):
+    def test_detects_period(self):
+        seasons = _sine(12).augurs_seasons(96)
+        captured = seasons.collect()
+        captured.run(realtime=False, cycles=96)
+        periods = captured.peek_value()[-1]["periods"]
+        self.assertTrue(any(10 <= p <= 14 for p in periods), periods)
+
+
+class TestDtw(unittest.TestCase):
+    def test_distance_matrix_shape_and_order(self):
+        import math
+
+        readings = ticker(1.0).count().map(
+            lambda n: [
+                math.sin(n * 0.3),
+                math.sin(n * 0.3) + 0.02,
+                5.0 * math.sin(n * 0.3) + 10.0,
+            ]
+        )
+        dists = readings.augurs_dtw(30)
+        captured = dists.collect()
+        captured.run(realtime=False, cycles=30)
+        rows = captured.peek_value()[-1]["rows"]
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(len(rows[0]), 3)
+        self.assertLess(rows[0][0], 1e-9)
+        self.assertGreater(rows[0][2], rows[0][1])
+
+
+class TestCluster(unittest.TestCase):
+    def test_groups_series(self):
+        import math
+
+        def reading(n):
+            low = math.sin(n * 0.3)
+            high = math.sin(n * 0.3) + 20.0
+            return [low, low + 0.02, high, high + 0.02, 50.0 * math.cos(n * 0.9) + 100.0]
+
+        clusters = ticker(1.0).count().map(reading).augurs_cluster(30, 1.0, 2)
+        captured = clusters.collect()
+        captured.run(realtime=False, cycles=30)
+        labels = captured.peek_value()[-1]["labels"]
+        self.assertEqual(len(labels), 5)
+        self.assertEqual(labels[0], labels[1])
+        self.assertEqual(labels[2], labels[3])
+        self.assertNotEqual(labels[0], labels[2])
+        self.assertEqual(labels[4], -1)
+
+
 class TestConstruction(unittest.TestCase):
     """Construction-only: exercise argument parsing without depending on output."""
 
@@ -82,9 +182,19 @@ class TestConstruction(unittest.TestCase):
         stream = _ramp().augurs_forecast(32, 2)
         self.assertIsNotNone(stream)
 
+    def test_forecast_mstl_constructs(self):
+        stream = _ramp().augurs_forecast(48, 4, periods=[12])
+        self.assertIsNotNone(stream)
+
     def test_outlier_constructs(self):
         stream = _series().augurs_outlier(16, 0.25)
         self.assertIsNotNone(stream)
+
+    def test_new_ops_construct(self):
+        self.assertIsNotNone(_ramp().augurs_changepoint(32))
+        self.assertIsNotNone(_ramp().augurs_seasons(48))
+        self.assertIsNotNone(_series().augurs_dtw(16))
+        self.assertIsNotNone(_series().augurs_cluster(16, 1.0, 2))
 
 
 if __name__ == "__main__":

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -1,6 +1,6 @@
 [features]
 default = ["async"]
-full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2", "prometheus", "otlp", "fix", "web", "web-tls", "kafka", "redis", "aeron"]
+full = ["async", "csv", "kdb", "zmq", "etcd", "fluvio", "dynamic-graph-beta", "instrument-default", "iceoryx2", "prometheus", "otlp", "fix", "web", "web-tls", "kafka", "redis", "aeron", "augurs"]
 # Exposes the `bencher` helper (`add_bench`, used by the criterion benches).
 # Off by default so consumers don't pull in criterion's dependency tree.
 bench = ["dep:criterion"]
@@ -24,6 +24,10 @@ kafka = ["dep:rdkafka", "async"]
 kafka-integration-test = ["kafka", "dep:testcontainers"]
 redis = ["dep:redis", "async"]
 redis-integration-test = ["redis", "dep:testcontainers"]
+# augurs is a pure-Rust time-series toolkit (no external service), so there is
+# no `*-integration-test` feature — the adapter is covered by in-crate unit
+# tests behind `--features augurs`.
+augurs = ["dep:augurs"]
 tracing = []
 instrument-run = ["tracing"]
 instrument-cycle = ["tracing"]
@@ -121,6 +125,10 @@ zmq = { version = "0.10.0", optional = true }
 etcd-client = { version = "0.18", optional = true }
 rdkafka = { version = "0.37", optional = true }
 redis = { version = "0.27", features = ["tokio-comp", "aio", "streams"], optional = true }
+# augurs time-series toolkit — ETS forecasting and MAD outlier detection.
+# Pure-Rust compute (no network/async), so only the `ets` and `outlier`
+# sub-features are pulled in.
+augurs = { version = "0.10.2", default-features = false, features = ["ets", "outlier"], optional = true }
 testcontainers = { version = "0.27", features = ["blocking"], optional = true }
 tracing = { workspace = true, features = ["log", "attributes"] }
 fluvio = { version = "0.50.1", optional = true }
@@ -352,6 +360,11 @@ required-features = ["kafka"]
 name = "redis"
 path = "examples/redis/main.rs"
 required-features = ["redis"]
+
+[[example]]
+name = "augurs"
+path = "examples/augurs/main.rs"
+required-features = ["augurs"]
 
 [[example]]
 name = "latency_e2e_ws_server"

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -125,9 +125,11 @@ zmq = { version = "0.10.0", optional = true }
 etcd-client = { version = "0.18", optional = true }
 rdkafka = { version = "0.37", optional = true }
 redis = { version = "0.27", features = ["tokio-comp", "aio", "streams"], optional = true }
-# augurs time-series toolkit — ETS forecasting and MAD outlier detection.
-# Pure-Rust compute (no network/async), so only the `ets` and `outlier`
-# sub-features are pulled in.
+# augurs time-series toolkit — forecasting, outlier/changepoint/season
+# detection, DTW and clustering. Pure-Rust compute (no network/async), so
+# `default-features = false` and only the compute sub-features the adapter uses
+# are enabled (Prophet is deliberately excluded — it needs a bundled Stan
+# toolchain).
 augurs = { version = "0.10.2", default-features = false, features = ["ets", "mstl", "outlier", "changepoint", "seasons", "dtw", "clustering"], optional = true }
 testcontainers = { version = "0.27", features = ["blocking"], optional = true }
 tracing = { workspace = true, features = ["log", "attributes"] }

--- a/wingfoil/Cargo.toml
+++ b/wingfoil/Cargo.toml
@@ -128,7 +128,7 @@ redis = { version = "0.27", features = ["tokio-comp", "aio", "streams"], optiona
 # augurs time-series toolkit — ETS forecasting and MAD outlier detection.
 # Pure-Rust compute (no network/async), so only the `ets` and `outlier`
 # sub-features are pulled in.
-augurs = { version = "0.10.2", default-features = false, features = ["ets", "outlier"], optional = true }
+augurs = { version = "0.10.2", default-features = false, features = ["ets", "mstl", "outlier", "changepoint", "seasons", "dtw", "clustering"], optional = true }
 testcontainers = { version = "0.27", features = ["blocking"], optional = true }
 tracing = { workspace = true, features = ["log", "attributes"] }
 fluvio = { version = "0.50.1", optional = true }

--- a/wingfoil/examples/README.md
+++ b/wingfoil/examples/README.md
@@ -30,7 +30,7 @@ A guide to the examples in this directory. Each one is runnable — see its own 
 | [`aeron`](aeron/) | Low-latency Aeron UDP/IPC transport — publish and subscribe to `i64` values with spin and threaded polling modes. |
 | [`web`](web/) | WebSocket adapter streaming synthetic prices and receiving UI events. |
 | [`telemetry`](telemetry/) | Metrics export: [`prometheus`](telemetry/prometheus/) (pull-based scrape) and [`otlp`](telemetry/otlp/) (push to Grafana Alloy, Datadog, Honeycomb, etc.). |
-| [`augurs`](augurs/) | augurs time-series toolkit — on-graph ETS forecasting and MAD outlier detection over sliding windows. |
+| [`augurs`](augurs/) | augurs time-series toolkit — on-graph forecasting (ETS/MSTL), outlier detection (MAD/DBSCAN), changepoint, seasonality, DTW and clustering over sliding windows. |
 
 ## Snippets
 
@@ -305,13 +305,14 @@ Graph::new(vec![prometheus_node, otlp_node], RunMode::RealTime, RunFor::Forever)
 
 ### augurs
 
-On-graph time-series analysis with the [augurs](https://docs.rs/augurs) toolkit — no external service. Buffer a sliding window of a stream and forecast it with ETS, or detect outliers across a group of series with MAD:
+On-graph time-series analysis with the [augurs](https://docs.rs/augurs) toolkit — no external service. Six windowed operators: `augurs_forecast` (ETS or MSTL), `augurs_outlier` (MAD or DBSCAN), `augurs_changepoint`, `augurs_seasons`, `augurs_dtw` and `augurs_cluster`:
 
 ```rust,ignore
 use wingfoil::adapters::augurs::*;
 use wingfoil::*;
 
-// Forecast a noisy upward ramp 5 steps ahead with 90% prediction intervals.
+// Forecast a noisy upward ramp 5 steps ahead with 90% prediction intervals
+// (add `.mstl(vec![24])` to the config for a seasonal MSTL model instead).
 ticker(Duration::from_secs(1))
     .count()
     .map(|n| n as f64 + (n as f64 * 0.5).sin())
@@ -321,9 +322,13 @@ ticker(Duration::from_secs(1))
 
 // Flag the series that diverges from the group (one Vec<f64> per tick).
 readings // Rc<dyn Stream<Vec<f64>>>
-    .augurs_outlier(AugursOutlierConfig::new(40, 0.5))
+    .augurs_outlier(AugursOutlierConfig::mad(40, 0.5))
     .for_each(|o, _| println!("outlying: {:?}", o.outlying))
     .run(RunMode::RealTime, RunFor::Forever)?;
+
+// Detect regime changes and seasonal periods in a single series.
+prices.augurs_changepoint(AugursChangepointConfig::new(120));
+prices.augurs_seasons(AugursSeasonsConfig::new(240));
 ```
 
 [Full example.](augurs/)

--- a/wingfoil/examples/README.md
+++ b/wingfoil/examples/README.md
@@ -30,6 +30,7 @@ A guide to the examples in this directory. Each one is runnable — see its own 
 | [`aeron`](aeron/) | Low-latency Aeron UDP/IPC transport — publish and subscribe to `i64` values with spin and threaded polling modes. |
 | [`web`](web/) | WebSocket adapter streaming synthetic prices and receiving UI events. |
 | [`telemetry`](telemetry/) | Metrics export: [`prometheus`](telemetry/prometheus/) (pull-based scrape) and [`otlp`](telemetry/otlp/) (push to Grafana Alloy, Datadog, Honeycomb, etc.). |
+| [`augurs`](augurs/) | augurs time-series toolkit — on-graph ETS forecasting and MAD outlier detection over sliding windows. |
 
 ## Snippets
 
@@ -301,3 +302,28 @@ Graph::new(vec![prometheus_node, otlp_node], RunMode::RealTime, RunFor::Forever)
 ```
 
 [Full example.](telemetry/)
+
+### augurs
+
+On-graph time-series analysis with the [augurs](https://docs.rs/augurs) toolkit — no external service. Buffer a sliding window of a stream and forecast it with ETS, or detect outliers across a group of series with MAD:
+
+```rust,ignore
+use wingfoil::adapters::augurs::*;
+use wingfoil::*;
+
+// Forecast a noisy upward ramp 5 steps ahead with 90% prediction intervals.
+ticker(Duration::from_secs(1))
+    .count()
+    .map(|n| n as f64 + (n as f64 * 0.5).sin())
+    .augurs_forecast(AugursForecastConfig::new(48, 5).with_level(0.90))
+    .for_each(|f, _| println!("next 5: {:?}", f.point))
+    .run(RunMode::RealTime, RunFor::Forever)?;
+
+// Flag the series that diverges from the group (one Vec<f64> per tick).
+readings // Rc<dyn Stream<Vec<f64>>>
+    .augurs_outlier(AugursOutlierConfig::new(40, 0.5))
+    .for_each(|o, _| println!("outlying: {:?}", o.outlying))
+    .run(RunMode::RealTime, RunFor::Forever)?;
+```
+
+[Full example.](augurs/)

--- a/wingfoil/examples/augurs/README.md
+++ b/wingfoil/examples/augurs/README.md
@@ -1,0 +1,42 @@
+# augurs Adapter Example
+
+Demonstrates on-graph time-series analysis with the
+[`augurs`](https://docs.rs/augurs) adapter. augurs is a pure-Rust toolkit, so
+there is nothing to install or run — the example drives two synthetic streams:
+
+1. **forecasting** — a noisy upward ramp is fed to `augurs_forecast`, which
+   buffers a sliding window, fits an ETS model and emits a 5-step-ahead forecast
+   with a 90% prediction interval each tick.
+2. **outlier detection** — four monitored series (three moving together, one
+   that diverges half-way through) are fed to `augurs_outlier`, which flags the
+   diverging series via the MAD detector.
+
+## Setup
+
+None — augurs runs in-process.
+
+## Run
+
+```sh
+cargo run --example augurs --features augurs
+```
+
+## Code
+
+See `main.rs` for the full source.
+
+## Output
+
+```
+== forecasting (ETS, 5 steps ahead, 90% interval) ==
+  11000000000  next 5: [12.8, 13.9, 15.0, 16.1, 17.1]
+  12000000000  next 5: [14.2, 15.2, 16.1, 17.1, 18.1]
+  ...
+  35000000000  next 5: [36.2, 37.2, 38.1, 39.1, 40.1]
+
+== outlier detection (MAD over 4 series) ==
+  20000000000  outlying series: [3]
+  21000000000  outlying series: [3]
+  ...
+  35000000000  outlying series: [3]
+```

--- a/wingfoil/examples/augurs/README.md
+++ b/wingfoil/examples/augurs/README.md
@@ -2,7 +2,8 @@
 
 Demonstrates on-graph time-series analysis with the
 [`augurs`](https://docs.rs/augurs) adapter. augurs is a pure-Rust toolkit, so
-there is nothing to install or run — the example drives two synthetic streams:
+there is nothing to install or run — the example drives synthetic streams
+through four of the adapter's operators:
 
 1. **forecasting** — a noisy upward ramp is fed to `augurs_forecast`, which
    buffers a sliding window, fits an ETS model and emits a 5-step-ahead forecast
@@ -10,6 +11,14 @@ there is nothing to install or run — the example drives two synthetic streams:
 2. **outlier detection** — four monitored series (three moving together, one
    that diverges half-way through) are fed to `augurs_outlier`, which flags the
    diverging series via the MAD detector.
+3. **seasonality detection** — a period-24 sine wave is fed to `augurs_seasons`,
+   which reports the dominant seasonal period.
+4. **changepoint detection** — a series that jumps regime is fed to
+   `augurs_changepoint`, which reports where the change occurs.
+
+The adapter also provides `augurs_dtw` (dynamic time warping distance matrix)
+and `augurs_cluster` (DBSCAN clustering of series), plus MSTL seasonal
+forecasting and DBSCAN outlier detection — see the module docs.
 
 ## Setup
 
@@ -30,13 +39,23 @@ See `main.rs` for the full source.
 ```
 == forecasting (ETS, 5 steps ahead, 90% interval) ==
   11000000000  next 5: [12.8, 13.9, 15.0, 16.1, 17.1]
-  12000000000  next 5: [14.2, 15.2, 16.1, 17.1, 18.1]
   ...
   35000000000  next 5: [36.2, 37.2, 38.1, 39.1, 40.1]
 
 == outlier detection (MAD over 4 series) ==
   20000000000  outlying series: [3]
-  21000000000  outlying series: [3]
   ...
   35000000000  outlying series: [3]
+
+== seasonality detection (periodogram) ==
+  ...
+  119000000000  seasonal period ~= 30 samples (true 24)
+
+== changepoint detection (BOCPD) ==
+  30000000000  changepoint at window index [29]
+  ...
+  49000000000  changepoint at window index [29]
 ```
+
+(The periodogram gives a coarse period estimate — `~=30` for a true period of
+24 — so it flags the presence and rough scale of a season, not the exact value.)

--- a/wingfoil/examples/augurs/main.rs
+++ b/wingfoil/examples/augurs/main.rs
@@ -7,13 +7,18 @@
 //! ```
 //!
 //! augurs is a pure-Rust time-series toolkit, so there is no service to start.
-//! This example drives two synthetic streams through the adapter:
+//! This example drives synthetic streams through four of the adapter's
+//! operators:
 //!
-//! 1. a noisy upward ramp fed to [`augurs_forecast`], printing the 5-step-ahead
-//!    forecast and its 90% prediction interval each tick; and
+//! 1. a noisy upward ramp fed to `augurs_forecast`, printing the 5-step-ahead
+//!    forecast and its 90% prediction interval each tick;
 //! 2. four monitored series — three moving together and one that diverges
-//!    half-way through — fed to [`augurs_outlier`], printing which series the
-//!    MAD detector flags.
+//!    half-way through — fed to `augurs_outlier`, printing which series the MAD
+//!    detector flags;
+//! 3. a seasonal signal fed to `augurs_seasons`, printing the detected period;
+//!    and
+//! 4. a series with a regime shift fed to `augurs_changepoint`, printing where
+//!    the changepoint lands.
 
 use std::time::Duration;
 
@@ -57,8 +62,48 @@ fn outlier_detection() {
         .unwrap();
 }
 
+fn seasonality() {
+    println!("\n== seasonality detection (periodogram) ==");
+
+    // A period-24 sine wave. The periodogram gives a coarse (approximate)
+    // estimate, so it reports the season is present at roughly this scale.
+    ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| (n as f64 * std::f64::consts::TAU / 24.0).sin())
+        .augurs_seasons(AugursSeasonsConfig::new(120))
+        .for_each(|seasons, time| {
+            if let Some(period) = seasons.dominant() {
+                println!("  {time}  seasonal period ~= {period} samples (true 24)");
+            }
+        })
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(120))
+        .unwrap();
+}
+
+fn changepoints() {
+    println!("\n== changepoint detection (BOCPD) ==");
+
+    // A series that jumps from ~0 to ~50 after tick 30.
+    ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| if n > 30 { 50.0 } else { 0.0 })
+        .augurs_changepoint(AugursChangepointConfig::new(60))
+        .for_each(|changes, time| {
+            if changes.any() {
+                println!(
+                    "  {time}  changepoint at window index {:?}",
+                    changes.indices
+                );
+            }
+        })
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(50))
+        .unwrap();
+}
+
 fn main() {
     env_logger::init();
     forecasting();
     outlier_detection();
+    seasonality();
+    changepoints();
 }

--- a/wingfoil/examples/augurs/main.rs
+++ b/wingfoil/examples/augurs/main.rs
@@ -1,0 +1,64 @@
+//! augurs adapter example — on-graph forecasting and outlier detection.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example augurs --features augurs
+//! ```
+//!
+//! augurs is a pure-Rust time-series toolkit, so there is no service to start.
+//! This example drives two synthetic streams through the adapter:
+//!
+//! 1. a noisy upward ramp fed to [`augurs_forecast`], printing the 5-step-ahead
+//!    forecast and its 90% prediction interval each tick; and
+//! 2. four monitored series — three moving together and one that diverges
+//!    half-way through — fed to [`augurs_outlier`], printing which series the
+//!    MAD detector flags.
+
+use std::time::Duration;
+
+use wingfoil::adapters::augurs::*;
+use wingfoil::*;
+
+fn forecasting() {
+    println!("== forecasting (ETS, 5 steps ahead, 90% interval) ==");
+
+    // A rising series with mild seasonality: n + sin(n/2).
+    ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| n as f64 + (n as f64 * 0.5).sin())
+        .augurs_forecast(AugursForecastConfig::new(48, 5).with_level(0.90))
+        .for_each(|forecast, time| {
+            let point: Vec<String> = forecast.point.iter().map(|v| format!("{v:.1}")).collect();
+            println!("  {time}  next 5: [{}]", point.join(", "));
+        })
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(36))
+        .unwrap();
+}
+
+fn outlier_detection() {
+    println!("\n== outlier detection (MAD over 4 series) ==");
+
+    // Per tick: four readings. Series 3 jumps away from the pack after tick 20.
+    ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| {
+            let base = 100.0 + (n as f64 * 0.4).sin();
+            let diverging = if n > 20 { base + 75.0 } else { base + 0.3 };
+            vec![base, base + 0.1, base - 0.1, diverging]
+        })
+        .augurs_outlier(AugursOutlierConfig::new(40, 0.5))
+        .for_each(|outliers, time| {
+            if !outliers.outlying.is_empty() {
+                println!("  {time}  outlying series: {:?}", outliers.outlying);
+            }
+        })
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(36))
+        .unwrap();
+}
+
+fn main() {
+    env_logger::init();
+    forecasting();
+    outlier_detection();
+}

--- a/wingfoil/src/adapters/augurs/CLAUDE.md
+++ b/wingfoil/src/adapters/augurs/CLAUDE.md
@@ -1,0 +1,69 @@
+# augurs Adapter
+
+On-graph time-series analysis backed by the [`augurs`](https://docs.rs/augurs)
+toolkit. Provides two transform operators:
+
+- `augurs_forecast` — ETS forecasting over a sliding window of an `f64` stream.
+- `augurs_outlier` — MAD outlier detection over a sliding window of a
+  `Vec<f64>` stream (one value per series per tick).
+
+## Module Structure
+
+```
+augurs/
+  mod.rs        # Module doc, AugursForecast / AugursOutliers value types
+  forecast.rs   # AugursForecastConfig, AugursForecastNode, AugursForecastOperators, tests
+  outlier.rs    # AugursOutlierConfig, AugursOutlierNode, AugursOutlierOperators, tests
+  CLAUDE.md     # This file
+```
+
+## Key Design Decisions
+
+- **Not a service adapter.** augurs is a pure-Rust compute library — there is no
+  endpoint, no Docker container, and no `async`. Consequently there is **no
+  `augurs-integration-test` feature**; coverage lives in `#[cfg(test)]` blocks
+  in `forecast.rs` / `outlier.rs` and runs under `--features augurs`. This is the
+  skill's "Option C" (no external service).
+
+- **Transform, not pub/sub.** The skill's `_sub` / `_pub` verbs do not fit a
+  computation library, so the adapter exposes fluent stream operators
+  (`.augurs_forecast(...)`, `.augurs_outlier(...)`) instead, mirroring core
+  operators like `.window(...)` and `.fold(...)`.
+
+- **Models are fitted inside `cycle()`.** This is pure CPU work on the
+  single-threaded graph engine — no locks, no I/O, so it does not violate the
+  "no locks on the graph path" invariant. It is, however, not free: `AutoETS`
+  searches a small model space and the MAD detector recomputes medians each
+  cycle. If a fresh fit every tick is too expensive, throttle the input with
+  `.sample(...)` / `.throttle(...)` upstream — the idiomatic wingfoil answer
+  rather than baking an interval into the node.
+
+- **Forecast warm-up.** `AutoETS` requires more than ~8 points, so the forecast
+  node does not tick until `min_points` (floored at 12) samples have arrived.
+
+- **Outlier transpose.** Each tick of the input carries one reading per series;
+  the node buffers the last `window` ticks and transposes them into aligned
+  per-series columns before calling MAD. Short samples are forward-filled so the
+  columns stay equal length. MAD needs ≥2 timestamps before it emits.
+
+- **augurs error types are not `Send + Sync`.** `augurs::outlier::Error` cannot
+  flow through `anyhow::Context`, so the outlier node renders it with
+  `anyhow::anyhow!("...: {e}")`. The ETS error *is* `Send + Sync` and uses
+  `.context(...)`.
+
+## Gotchas
+
+- Pinned to `augurs = "0.10.2"` with only the `ets` and `outlier` sub-features
+  (`default-features = false`). Bumping the version may move the ETS / MAD APIs.
+- MAD divides by the per-series median, so series whose median is `0.0` will
+  surface a "division by zero" error from augurs. Feed it positive-scale data.
+- `sensitivity` must be in `(0, 1)`; an out-of-range value panics at wiring time
+  (in the operator, before the graph starts), which is acceptable for a factory.
+
+## Pre-Commit Requirements
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features
+cargo test -p wingfoil --features augurs adapters::augurs
+```

--- a/wingfoil/src/adapters/augurs/CLAUDE.md
+++ b/wingfoil/src/adapters/augurs/CLAUDE.md
@@ -49,7 +49,9 @@ augurs/
 - **Multi-series transpose.** The `Vec<f64>` operators buffer the last `window`
   ticks and transpose them into aligned per-series columns via the shared
   `transpose_window()` helper in `mod.rs`. Short samples are forward-filled so
-  columns stay equal length.
+  columns stay equal length; a series that first appears part-way through the
+  window has its leading gap back-filled with its own first value (never a
+  fabricated `0.0`, which the detectors would read as a large deviation).
 
 - **Model / detector choice via config, not new operators.** `augurs_forecast`
   takes an `AugursForecastModel` (`Ets` | `Mstl{periods}`) and `augurs_outlier`
@@ -59,7 +61,11 @@ augurs/
 
 - **Warm-up floors.** ETS needs >~8 points (floored at 12). MSTL/STL cannot
   decompose fewer than **two full seasonal periods**, so the forecast floor
-  becomes `2 * max_period + 1` for MSTL. Multi-series operators need ≥2 series.
+  becomes `2 * max_period + 1` for MSTL. When the requested `window` is below a
+  model's floor the node grows its effective window to the floor so it still
+  warms up and emits (rather than silently never ticking). `augurs_dtw` /
+  `augurs_cluster` need ≥2 series for a distance matrix; `augurs_outlier` (MAD)
+  runs with a single series.
 
 - **BOCPD index 0 is dropped.** Bayesian online changepoint detection always
   reports index 0 (the window start) as a changepoint; the node filters it out

--- a/wingfoil/src/adapters/augurs/CLAUDE.md
+++ b/wingfoil/src/adapters/augurs/CLAUDE.md
@@ -1,62 +1,86 @@
 # augurs Adapter
 
 On-graph time-series analysis backed by the [`augurs`](https://docs.rs/augurs)
-toolkit. Provides two transform operators:
+toolkit. Provides six transform operators over sliding windows:
 
-- `augurs_forecast` — ETS forecasting over a sliding window of an `f64` stream.
-- `augurs_outlier` — MAD outlier detection over a sliding window of a
-  `Vec<f64>` stream (one value per series per tick).
+| Operator | Input stream | Emits |
+|---|---|---|
+| `augurs_forecast` | `f64` | `AugursForecast` (point + intervals); ETS or MSTL |
+| `augurs_outlier` | `Vec<f64>` | `AugursOutliers`; MAD or DBSCAN detector |
+| `augurs_changepoint` | `f64` | `AugursChangepoints` (BOCPD indices) |
+| `augurs_seasons` | `f64` | `AugursSeasons` (periodogram periods) |
+| `augurs_dtw` | `Vec<f64>` | `AugursDistanceMatrix` (pairwise DTW) |
+| `augurs_cluster` | `Vec<f64>` | `AugursClusters` (DBSCAN labels via DTW) |
+
+The `Vec<f64>` operators take one reading per series per tick.
 
 ## Module Structure
 
 ```
 augurs/
-  mod.rs        # Module doc, AugursForecast / AugursOutliers value types
-  forecast.rs   # AugursForecastConfig, AugursForecastNode, AugursForecastOperators, tests
-  outlier.rs    # AugursOutlierConfig, AugursOutlierNode, AugursOutlierOperators, tests
-  CLAUDE.md     # This file
+  mod.rs         # Module doc, value types, transpose_window() helper
+  forecast.rs    # ETS + MSTL forecasting
+  outlier.rs     # MAD + DBSCAN outlier detection
+  changepoint.rs # Bayesian online changepoint detection
+  seasons.rs     # periodogram seasonality detection
+  dtw.rs         # dynamic time warping distance matrix
+  cluster.rs     # DBSCAN clustering over the DTW distance matrix
+  CLAUDE.md      # This file
 ```
 
 ## Key Design Decisions
 
 - **Not a service adapter.** augurs is a pure-Rust compute library — there is no
   endpoint, no Docker container, and no `async`. Consequently there is **no
-  `augurs-integration-test` feature**; coverage lives in `#[cfg(test)]` blocks
-  in `forecast.rs` / `outlier.rs` and runs under `--features augurs`. This is the
-  skill's "Option C" (no external service).
+  `augurs-integration-test` feature**; coverage lives in `#[cfg(test)]` blocks in
+  each file and runs under `--features augurs`. This is the skill's "Option C".
 
 - **Transform, not pub/sub.** The skill's `_sub` / `_pub` verbs do not fit a
-  computation library, so the adapter exposes fluent stream operators
-  (`.augurs_forecast(...)`, `.augurs_outlier(...)`) instead, mirroring core
-  operators like `.window(...)` and `.fold(...)`.
+  computation library, so the adapter exposes fluent stream operators mirroring
+  core operators like `.window(...)` and `.fold(...)`.
 
-- **Models are fitted inside `cycle()`.** This is pure CPU work on the
-  single-threaded graph engine — no locks, no I/O, so it does not violate the
-  "no locks on the graph path" invariant. It is, however, not free: `AutoETS`
-  searches a small model space and the MAD detector recomputes medians each
-  cycle. If a fresh fit every tick is too expensive, throttle the input with
-  `.sample(...)` / `.throttle(...)` upstream — the idiomatic wingfoil answer
-  rather than baking an interval into the node.
+- **Models are fitted inside `cycle()`.** Pure CPU work on the single-threaded
+  graph engine — no locks, no I/O, so the "no locks on the graph path" invariant
+  holds. It is not free, though: each cycle refits/recomputes over the whole
+  window (ETS model search, DTW is `O(n² · window²)`, BOCPD re-scans the window).
+  Throttle the input with `.sample(...)` / `.throttle(...)` upstream if a fresh
+  result every tick is too expensive.
 
-- **Forecast warm-up.** `AutoETS` requires more than ~8 points, so the forecast
-  node does not tick until `min_points` (floored at 12) samples have arrived.
+- **Multi-series transpose.** The `Vec<f64>` operators buffer the last `window`
+  ticks and transpose them into aligned per-series columns via the shared
+  `transpose_window()` helper in `mod.rs`. Short samples are forward-filled so
+  columns stay equal length.
 
-- **Outlier transpose.** Each tick of the input carries one reading per series;
-  the node buffers the last `window` ticks and transposes them into aligned
-  per-series columns before calling MAD. Short samples are forward-filled so the
-  columns stay equal length. MAD needs ≥2 timestamps before it emits.
+- **Model / detector choice via config, not new operators.** `augurs_forecast`
+  takes an `AugursForecastModel` (`Ets` | `Mstl{periods}`) and `augurs_outlier`
+  an `AugursOutlierDetector` (`Mad` | `Dbscan`), keeping one operator per
+  concern. `AugursForecastConfig::mstl(periods)` and
+  `AugursOutlierConfig::dbscan(...)` are the ergonomic constructors.
 
-- **augurs error types are not `Send + Sync`.** `augurs::outlier::Error` cannot
-  flow through `anyhow::Context`, so the outlier node renders it with
-  `anyhow::anyhow!("...: {e}")`. The ETS error *is* `Send + Sync` and uses
+- **Warm-up floors.** ETS needs >~8 points (floored at 12). MSTL/STL cannot
+  decompose fewer than **two full seasonal periods**, so the forecast floor
+  becomes `2 * max_period + 1` for MSTL. Multi-series operators need ≥2 series.
+
+- **BOCPD index 0 is dropped.** Bayesian online changepoint detection always
+  reports index 0 (the window start) as a changepoint; the node filters it out
+  so only genuine internal regime changes are emitted.
+
+- **augurs error types are not all `Send + Sync`.** `augurs::outlier::Error`
+  cannot flow through `anyhow::Context`, so the outlier node renders it with
+  `anyhow::anyhow!("...: {e}")`. The ETS/MSTL errors *are* `Send + Sync` and use
   `.context(...)`.
 
 ## Gotchas
 
-- Pinned to `augurs = "0.10.2"` with only the `ets` and `outlier` sub-features
-  (`default-features = false`). Bumping the version may move the ETS / MAD APIs.
-- MAD divides by the per-series median, so series whose median is `0.0` will
-  surface a "division by zero" error from augurs. Feed it positive-scale data.
+- Pinned to `augurs = "0.10.2"` with `default-features = false` and the sub-
+  features `ets, mstl, outlier, changepoint, seasons, dtw, clustering`. Bumping
+  the version may move these APIs. **Prophet is deliberately excluded** — it
+  needs a bundled Stan toolchain (cmdstan/wasmstan), a heavy external build that
+  does not fit a lightweight pure-Rust adapter.
+- MAD divides by the per-series median, so series whose median is `0.0` surface a
+  "division by zero" error from augurs. Feed it positive-scale data.
+- DBSCAN outlier detection needs **at least three** series to form a cluster;
+  with fewer it reports nothing.
 - `sensitivity` must be in `(0, 1)`; an out-of-range value panics at wiring time
   (in the operator, before the graph starts), which is acceptable for a factory.
 

--- a/wingfoil/src/adapters/augurs/changepoint.rs
+++ b/wingfoil/src/adapters/augurs/changepoint.rs
@@ -57,17 +57,22 @@ impl From<usize> for AugursChangepointConfig {
 pub(crate) struct AugursChangepointNode {
     upstream: Rc<dyn Stream<f64>>,
     config: AugursChangepointConfig,
+    /// Effective window: the configured `window` grown to at least `min_points`
+    /// so a `window` below the warm-up floor still lets the node fill up and
+    /// emit rather than never ticking.
+    window: usize,
     buffer: VecDeque<f64>,
     value: AugursChangepoints,
 }
 
 impl AugursChangepointNode {
     fn new(upstream: Rc<dyn Stream<f64>>, config: AugursChangepointConfig) -> Self {
-        let cap = config.window.max(config.min_points);
+        let window = config.window.max(config.min_points);
         Self {
             upstream,
             config,
-            buffer: VecDeque::with_capacity(cap),
+            window,
+            buffer: VecDeque::with_capacity(window),
             value: AugursChangepoints::default(),
         }
     }
@@ -77,7 +82,7 @@ impl AugursChangepointNode {
 impl MutableNode for AugursChangepointNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
         self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.config.window {
+        while self.buffer.len() > self.window {
             self.buffer.pop_front();
         }
         if self.buffer.len() < self.config.min_points {

--- a/wingfoil/src/adapters/augurs/changepoint.rs
+++ b/wingfoil/src/adapters/augurs/changepoint.rs
@@ -1,0 +1,184 @@
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use augurs::changepoint::{Detector, NormalGammaDetector, dist::NormalGamma};
+
+use super::AugursChangepoints;
+use crate::types::*;
+
+/// Configuration for [`AugursChangepointOperators::augurs_changepoint`].
+#[derive(Debug, Clone)]
+pub struct AugursChangepointConfig {
+    /// Number of recent points retained as the detection window.
+    pub window: usize,
+    /// Minimum number of buffered points before detection runs. Until this many
+    /// points have arrived the node does not tick.
+    pub min_points: usize,
+    /// Hazard rate for the Bayesian online changepoint detector: the prior
+    /// expected run length between changepoints. Larger values make the
+    /// detector more conservative (fewer changepoints). Defaults to `250`.
+    pub hazard_lambda: f64,
+}
+
+impl AugursChangepointConfig {
+    /// Detect changepoints over the last `window` points with the default
+    /// hazard rate.
+    #[must_use]
+    pub fn new(window: usize) -> Self {
+        Self {
+            window,
+            min_points: 8,
+            hazard_lambda: 250.0,
+        }
+    }
+
+    /// Set the hazard rate (prior expected run length between changepoints).
+    #[must_use]
+    pub fn with_hazard(mut self, hazard_lambda: f64) -> Self {
+        self.hazard_lambda = hazard_lambda;
+        self
+    }
+
+    /// Set the minimum number of points required before detection begins.
+    #[must_use]
+    pub fn with_min_points(mut self, min_points: usize) -> Self {
+        self.min_points = min_points;
+        self
+    }
+}
+
+impl From<usize> for AugursChangepointConfig {
+    /// `window`, with default hazard rate.
+    fn from(window: usize) -> Self {
+        Self::new(window)
+    }
+}
+
+pub(crate) struct AugursChangepointNode {
+    upstream: Rc<dyn Stream<f64>>,
+    config: AugursChangepointConfig,
+    buffer: VecDeque<f64>,
+    value: AugursChangepoints,
+}
+
+impl AugursChangepointNode {
+    fn new(upstream: Rc<dyn Stream<f64>>, config: AugursChangepointConfig) -> Self {
+        let cap = config.window.max(config.min_points);
+        Self {
+            upstream,
+            config,
+            buffer: VecDeque::with_capacity(cap),
+            value: AugursChangepoints::default(),
+        }
+    }
+}
+
+#[node(active = [upstream], output = value: AugursChangepoints)]
+impl MutableNode for AugursChangepointNode {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.buffer.push_back(self.upstream.peek_value());
+        while self.buffer.len() > self.config.window {
+            self.buffer.pop_front();
+        }
+        if self.buffer.len() < self.config.min_points {
+            return Ok(false);
+        }
+
+        let data: Vec<f64> = self.buffer.iter().copied().collect();
+        // BOCPD is stateful (it steps through the series), so build a fresh
+        // detector each cycle and re-scan the current window.
+        let mut detector = NormalGammaDetector::normal_gamma(
+            self.config.hazard_lambda,
+            NormalGamma::new_unchecked(0.0, 1.0, 1.0, 1.0),
+        );
+        // BOCPD always reports index 0 (the start of the first run) as a
+        // changepoint; it is an artifact of the window start, not a real
+        // regime change, so drop it.
+        let indices = detector
+            .detect_changepoints(&data)
+            .into_iter()
+            .filter(|&i| i != 0)
+            .collect();
+        self.value = AugursChangepoints { indices };
+        Ok(true)
+    }
+}
+
+/// Adds the [`augurs_changepoint`](AugursChangepointOperators::augurs_changepoint)
+/// operator to `f64` streams.
+pub trait AugursChangepointOperators {
+    /// Maintain a sliding window of this stream and, once `min_points` have
+    /// arrived, emit an [`AugursChangepoints`] each tick with the indices,
+    /// within the window, at which Bayesian online changepoint detection found a
+    /// changepoint. The window-start index (`0`), which BOCPD always reports, is
+    /// excluded — only genuine internal regime changes are returned.
+    #[must_use]
+    fn augurs_changepoint(
+        self: &Rc<Self>,
+        config: impl Into<AugursChangepointConfig>,
+    ) -> Rc<dyn Stream<AugursChangepoints>>;
+}
+
+impl AugursChangepointOperators for dyn Stream<f64> {
+    fn augurs_changepoint(
+        self: &Rc<Self>,
+        config: impl Into<AugursChangepointConfig>,
+    ) -> Rc<dyn Stream<AugursChangepoints>> {
+        AugursChangepointNode::new(self.clone(), config.into()).into_stream()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::*;
+    use crate::nodes::*;
+    use std::time::Duration;
+
+    /// A series that jumps from a low mean to a high mean partway through should
+    /// produce a changepoint somewhere after the jump.
+    #[test]
+    fn changepoint_detects_level_shift() {
+        // First ~20 samples near 0, then a jump to near 50.
+        let series = ticker(Duration::from_secs(1)).count().map(|n| {
+            let noise = (n as f64 * 0.7).sin() * 0.5;
+            if n > 20 { 50.0 + noise } else { noise }
+        });
+        let changes = series.augurs_changepoint(AugursChangepointConfig::new(60));
+        let captured = changes.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(50))
+            .unwrap();
+
+        let last = changes.peek_value();
+        assert!(
+            last.any(),
+            "expected a changepoint after the level shift, got {last:?}"
+        );
+        // The shift happens around window index 20; a detected changepoint
+        // should land after the first few points.
+        assert!(
+            last.indices.iter().any(|&i| i >= 10),
+            "expected a changepoint past the initial regime, got {:?}",
+            last.indices
+        );
+    }
+
+    /// A perfectly steady series yields no changepoints.
+    #[test]
+    fn changepoint_quiet_when_steady() {
+        let series = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| 10.0 + (n as f64 * 0.5).sin() * 0.1);
+        let changes = series.augurs_changepoint(40);
+        let captured = changes.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+            .unwrap();
+        assert!(
+            !changes.peek_value().any(),
+            "steady series should have no changepoints, got {:?}",
+            changes.peek_value().indices
+        );
+    }
+}

--- a/wingfoil/src/adapters/augurs/changepoint.rs
+++ b/wingfoil/src/adapters/augurs/changepoint.rs
@@ -81,10 +81,7 @@ impl AugursChangepointNode {
 #[node(active = [upstream], output = value: AugursChangepoints)]
 impl MutableNode for AugursChangepointNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.window {
-            self.buffer.pop_front();
-        }
+        super::push_windowed(&mut self.buffer, self.upstream.peek_value(), self.window);
         if self.buffer.len() < self.config.min_points {
             return Ok(false);
         }

--- a/wingfoil/src/adapters/augurs/cluster.rs
+++ b/wingfoil/src/adapters/augurs/cluster.rs
@@ -44,6 +44,13 @@ impl AugursClusterConfig {
     }
 }
 
+impl From<(usize, f64, usize)> for AugursClusterConfig {
+    /// `(window, epsilon, min_cluster_size)` using the Euclidean metric.
+    fn from((window, epsilon, min_cluster_size): (usize, f64, usize)) -> Self {
+        Self::new(window, epsilon, min_cluster_size)
+    }
+}
+
 pub(crate) struct AugursClusterNode {
     upstream: Rc<dyn Stream<Vec<f64>>>,
     config: AugursClusterConfig,
@@ -66,9 +73,15 @@ impl AugursClusterNode {
 #[node(active = [upstream], output = value: AugursClusters)]
 impl MutableNode for AugursClusterNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.config.window {
-            self.buffer.pop_front();
+        super::push_windowed(
+            &mut self.buffer,
+            self.upstream.peek_value(),
+            self.config.window,
+        );
+        // Warm up: clustering over length-1 columns compares single points, not
+        // windowed histories, so wait for at least two samples before emitting.
+        if self.buffer.len() < 2 {
+            return Ok(false);
         }
 
         let series = transpose_window(&self.buffer);
@@ -98,16 +111,16 @@ pub trait AugursClusterOperators {
     #[must_use]
     fn augurs_cluster(
         self: &Rc<Self>,
-        config: AugursClusterConfig,
+        config: impl Into<AugursClusterConfig>,
     ) -> Rc<dyn Stream<AugursClusters>>;
 }
 
 impl AugursClusterOperators for dyn Stream<Vec<f64>> {
     fn augurs_cluster(
         self: &Rc<Self>,
-        config: AugursClusterConfig,
+        config: impl Into<AugursClusterConfig>,
     ) -> Rc<dyn Stream<AugursClusters>> {
-        AugursClusterNode::new(self.clone(), config).into_stream()
+        AugursClusterNode::new(self.clone(), config.into()).into_stream()
     }
 }
 
@@ -165,5 +178,37 @@ mod tests {
             .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10))
             .unwrap();
         assert!(captured.peek_value().is_empty());
+    }
+
+    /// With two series but only a single sample, the node stays silent —
+    /// clustering length-1 columns compares single points, not histories.
+    #[test]
+    fn cluster_waits_for_two_samples() {
+        let readings = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| vec![n as f64, n as f64 + 1.0]);
+        let clusters = readings.augurs_cluster(AugursClusterConfig::new(8, 1.0, 2));
+        let captured = clusters.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+            .unwrap();
+        assert!(captured.peek_value().is_empty());
+    }
+
+    /// `(window, epsilon, min_cluster_size)` tuples convert into a config, so
+    /// `augurs_cluster` reads like the rest of the operator family.
+    #[test]
+    fn cluster_accepts_tuple_config() {
+        let readings = ticker(Duration::from_secs(1)).count().map(|n| {
+            let t = n as f64;
+            let low = (t * 0.3).sin();
+            vec![low, low + 0.02, low + 20.0, low + 20.02]
+        });
+        let clusters = readings.augurs_cluster((30, 1.0, 2));
+        let captured = clusters.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+            .unwrap();
+        assert_eq!(clusters.peek_value().labels.len(), 4);
     }
 }

--- a/wingfoil/src/adapters/augurs/cluster.rs
+++ b/wingfoil/src/adapters/augurs/cluster.rs
@@ -1,0 +1,169 @@
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use augurs::clustering::DbscanClusterer;
+
+use super::dtw::{AugursDtwMetric, distance_matrix};
+use super::{AugursClusters, transpose_window};
+use crate::types::*;
+
+/// Configuration for [`AugursClusterOperators::augurs_cluster`].
+#[derive(Debug, Clone)]
+pub struct AugursClusterConfig {
+    /// Number of recent samples retained as the window over which each series'
+    /// history is compared.
+    pub window: usize,
+    /// DBSCAN neighbourhood radius: the maximum DTW distance between two series
+    /// for them to be considered neighbours.
+    pub epsilon: f64,
+    /// DBSCAN minimum cluster size: the number of neighbours (including itself)
+    /// a series needs to be a core point.
+    pub min_cluster_size: usize,
+    /// Pointwise distance metric used inside the DTW alignment.
+    pub metric: AugursDtwMetric,
+}
+
+impl AugursClusterConfig {
+    /// Cluster the series over the last `window` samples with the given DBSCAN
+    /// `epsilon` radius and `min_cluster_size`, using DTW/Euclidean distances.
+    #[must_use]
+    pub fn new(window: usize, epsilon: f64, min_cluster_size: usize) -> Self {
+        Self {
+            window,
+            epsilon,
+            min_cluster_size,
+            metric: AugursDtwMetric::Euclidean,
+        }
+    }
+
+    /// Use the given pointwise distance metric inside DTW.
+    #[must_use]
+    pub fn with_metric(mut self, metric: AugursDtwMetric) -> Self {
+        self.metric = metric;
+        self
+    }
+}
+
+pub(crate) struct AugursClusterNode {
+    upstream: Rc<dyn Stream<Vec<f64>>>,
+    config: AugursClusterConfig,
+    buffer: VecDeque<Vec<f64>>,
+    value: AugursClusters,
+}
+
+impl AugursClusterNode {
+    fn new(upstream: Rc<dyn Stream<Vec<f64>>>, config: AugursClusterConfig) -> Self {
+        let cap = config.window.max(2);
+        Self {
+            upstream,
+            config,
+            buffer: VecDeque::with_capacity(cap),
+            value: AugursClusters::default(),
+        }
+    }
+}
+
+#[node(active = [upstream], output = value: AugursClusters)]
+impl MutableNode for AugursClusterNode {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.buffer.push_back(self.upstream.peek_value());
+        while self.buffer.len() > self.config.window {
+            self.buffer.pop_front();
+        }
+
+        let series = transpose_window(&self.buffer);
+        // Need at least two series to cluster.
+        if series.len() < 2 {
+            return Ok(false);
+        }
+        let refs: Vec<&[f64]> = series.iter().map(Vec::as_slice).collect();
+        let matrix = distance_matrix(self.config.metric, &refs);
+        let clusters =
+            DbscanClusterer::new(self.config.epsilon, self.config.min_cluster_size).fit(&matrix);
+
+        self.value = AugursClusters {
+            labels: clusters.iter().map(|c| c.as_i32()).collect(),
+        };
+        Ok(true)
+    }
+}
+
+/// Adds the [`augurs_cluster`](AugursClusterOperators::augurs_cluster) operator
+/// to streams of per-series readings.
+pub trait AugursClusterOperators {
+    /// Maintain a sliding window of per-series readings (one `f64` per series
+    /// per tick) and emit an [`AugursClusters`] each tick: a DBSCAN cluster
+    /// label per series (`-1` = noise), computed from the pairwise DTW distances
+    /// between the series' windowed histories.
+    #[must_use]
+    fn augurs_cluster(
+        self: &Rc<Self>,
+        config: AugursClusterConfig,
+    ) -> Rc<dyn Stream<AugursClusters>>;
+}
+
+impl AugursClusterOperators for dyn Stream<Vec<f64>> {
+    fn augurs_cluster(
+        self: &Rc<Self>,
+        config: AugursClusterConfig,
+    ) -> Rc<dyn Stream<AugursClusters>> {
+        AugursClusterNode::new(self.clone(), config).into_stream()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::*;
+    use crate::nodes::*;
+    use std::time::Duration;
+
+    /// Two tight groups of series plus one outlier should form two clusters,
+    /// with the outlier labelled as noise.
+    #[test]
+    fn cluster_groups_similar_series() {
+        // series 0,1 near a low sine; series 2,3 near a high sine; series 4 wild.
+        let readings = ticker(Duration::from_secs(1)).count().map(|n| {
+            let t = n as f64;
+            let low = (t * 0.3).sin();
+            let high = (t * 0.3).sin() + 20.0;
+            vec![
+                low,
+                low + 0.02,
+                high,
+                high + 0.02,
+                50.0 * (t * 0.9).cos() + 100.0,
+            ]
+        });
+        let clusters = readings.augurs_cluster(AugursClusterConfig::new(30, 1.0, 2));
+        let captured = clusters.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+            .unwrap();
+
+        let last = clusters.peek_value();
+        assert_eq!(last.labels.len(), 5, "one label per series");
+        // series 0 and 1 belong to the same (non-noise) cluster.
+        assert!(last.labels[0] >= 0 && last.labels[0] == last.labels[1]);
+        // series 2 and 3 belong to the same cluster, distinct from 0/1.
+        assert!(last.labels[2] >= 0 && last.labels[2] == last.labels[3]);
+        assert_ne!(last.labels[0], last.labels[2]);
+        assert_eq!(last.cluster_count(), 2, "expected two clusters");
+        // the wild series is noise.
+        assert_eq!(last.labels[4], -1);
+    }
+
+    /// The node stays silent until it has at least two series.
+    #[test]
+    fn cluster_waits_for_two_series() {
+        let readings = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| vec![n as f64]);
+        let clusters = readings.augurs_cluster(AugursClusterConfig::new(8, 1.0, 2));
+        let captured = clusters.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10))
+            .unwrap();
+        assert!(captured.peek_value().is_empty());
+    }
+}

--- a/wingfoil/src/adapters/augurs/dtw.rs
+++ b/wingfoil/src/adapters/augurs/dtw.rs
@@ -1,0 +1,180 @@
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use augurs::dtw::Dtw;
+
+use super::AugursDistanceMatrix;
+use crate::types::*;
+
+/// The pointwise distance metric used by [`Dtw`] when warping two series.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AugursDtwMetric {
+    /// Euclidean (L2) distance between aligned points.
+    #[default]
+    Euclidean,
+    /// Manhattan (L1) distance between aligned points.
+    Manhattan,
+}
+
+/// Configuration for [`AugursDtwOperators::augurs_dtw`].
+#[derive(Debug, Clone)]
+pub struct AugursDtwConfig {
+    /// Number of recent samples retained as the window over which each series'
+    /// history is compared.
+    pub window: usize,
+    /// Pointwise distance metric used inside the DTW alignment.
+    pub metric: AugursDtwMetric,
+}
+
+impl AugursDtwConfig {
+    /// Compute the DTW distance matrix over the last `window` samples using the
+    /// Euclidean metric.
+    #[must_use]
+    pub fn new(window: usize) -> Self {
+        Self {
+            window,
+            metric: AugursDtwMetric::Euclidean,
+        }
+    }
+
+    /// Use the given pointwise distance metric.
+    #[must_use]
+    pub fn with_metric(mut self, metric: AugursDtwMetric) -> Self {
+        self.metric = metric;
+        self
+    }
+}
+
+impl From<usize> for AugursDtwConfig {
+    /// `window`, with the Euclidean metric.
+    fn from(window: usize) -> Self {
+        Self::new(window)
+    }
+}
+
+/// Compute the DTW distance matrix for `series` using `metric`. Returned as the
+/// augurs [`DistanceMatrix`](augurs::DistanceMatrix) so callers that need the
+/// raw rows can call [`into_inner`](augurs::DistanceMatrix::into_inner) and
+/// those feeding clustering can pass it straight through.
+pub(crate) fn distance_matrix(
+    metric: AugursDtwMetric,
+    series: &[&[f64]],
+) -> augurs::DistanceMatrix {
+    match metric {
+        AugursDtwMetric::Euclidean => Dtw::euclidean().distance_matrix(series),
+        AugursDtwMetric::Manhattan => Dtw::manhattan().distance_matrix(series),
+    }
+}
+
+pub(crate) struct AugursDtwNode {
+    upstream: Rc<dyn Stream<Vec<f64>>>,
+    metric: AugursDtwMetric,
+    window: usize,
+    buffer: VecDeque<Vec<f64>>,
+    value: AugursDistanceMatrix,
+}
+
+impl AugursDtwNode {
+    fn new(upstream: Rc<dyn Stream<Vec<f64>>>, config: AugursDtwConfig) -> Self {
+        Self {
+            upstream,
+            metric: config.metric,
+            window: config.window.max(2),
+            buffer: VecDeque::with_capacity(config.window.max(2)),
+            value: AugursDistanceMatrix::default(),
+        }
+    }
+}
+
+#[node(active = [upstream], output = value: AugursDistanceMatrix)]
+impl MutableNode for AugursDtwNode {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.buffer.push_back(self.upstream.peek_value());
+        while self.buffer.len() > self.window {
+            self.buffer.pop_front();
+        }
+
+        let series = super::transpose_window(&self.buffer);
+        // Need at least two series for a distance matrix to be meaningful.
+        if series.len() < 2 {
+            return Ok(false);
+        }
+        let refs: Vec<&[f64]> = series.iter().map(Vec::as_slice).collect();
+        self.value = AugursDistanceMatrix {
+            rows: distance_matrix(self.metric, &refs).into_inner(),
+        };
+        Ok(true)
+    }
+}
+
+/// Adds the [`augurs_dtw`](AugursDtwOperators::augurs_dtw) operator to streams
+/// of per-series readings.
+pub trait AugursDtwOperators {
+    /// Maintain a sliding window of per-series readings (one `f64` per series
+    /// per tick) and emit an [`AugursDistanceMatrix`] each tick with the
+    /// pairwise dynamic time warping distances between the series' windowed
+    /// histories.
+    #[must_use]
+    fn augurs_dtw(
+        self: &Rc<Self>,
+        config: impl Into<AugursDtwConfig>,
+    ) -> Rc<dyn Stream<AugursDistanceMatrix>>;
+}
+
+impl AugursDtwOperators for dyn Stream<Vec<f64>> {
+    fn augurs_dtw(
+        self: &Rc<Self>,
+        config: impl Into<AugursDtwConfig>,
+    ) -> Rc<dyn Stream<AugursDistanceMatrix>> {
+        AugursDtwNode::new(self.clone(), config.into()).into_stream()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::*;
+    use crate::nodes::*;
+    use std::time::Duration;
+
+    /// Two similar series and one dissimilar one: the distance from the odd
+    /// series out should exceed the distance between the similar pair.
+    #[test]
+    fn dtw_distances_reflect_similarity() {
+        // series 0 and 1 track each other; series 2 is scaled up and offset.
+        let readings = ticker(Duration::from_secs(1)).count().map(|n| {
+            let t = n as f64;
+            let a = (t * 0.3).sin();
+            vec![a, a + 0.02, 5.0 * (t * 0.3).sin() + 10.0]
+        });
+        let dists = readings.augurs_dtw(AugursDtwConfig::new(30));
+        let captured = dists.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+            .unwrap();
+
+        let m = dists.peek_value();
+        assert_eq!(m.rows.len(), 3, "3x3 distance matrix");
+        let d01 = m.get(0, 1).unwrap();
+        let d02 = m.get(0, 2).unwrap();
+        assert!(m.get(0, 0).unwrap() < 1e-9, "self-distance is zero");
+        assert!(
+            d02 > d01,
+            "dissimilar series should be farther: d02={d02}, d01={d01}"
+        );
+    }
+
+    /// The node stays silent until it has at least two series.
+    #[test]
+    fn dtw_waits_for_two_series() {
+        let readings = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| vec![n as f64]);
+        let dists = readings.augurs_dtw(8);
+        let captured = dists.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10))
+            .unwrap();
+        assert!(captured.peek_value().is_empty());
+    }
+}

--- a/wingfoil/src/adapters/augurs/dtw.rs
+++ b/wingfoil/src/adapters/augurs/dtw.rs
@@ -89,9 +89,12 @@ impl AugursDtwNode {
 #[node(active = [upstream], output = value: AugursDistanceMatrix)]
 impl MutableNode for AugursDtwNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.window {
-            self.buffer.pop_front();
+        super::push_windowed(&mut self.buffer, self.upstream.peek_value(), self.window);
+        // Warm up: a DTW distance over length-1 columns is just |x - y|, not a
+        // windowed-history distance, so wait for at least two samples before
+        // emitting.
+        if self.buffer.len() < 2 {
+            return Ok(false);
         }
 
         let series = super::transpose_window(&self.buffer);
@@ -162,6 +165,21 @@ mod tests {
             d02 > d01,
             "dissimilar series should be farther: d02={d02}, d01={d01}"
         );
+    }
+
+    /// With two series but only a single sample, the node stays silent — a DTW
+    /// distance over length-1 columns is not a windowed-history distance.
+    #[test]
+    fn dtw_waits_for_two_samples() {
+        let readings = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| vec![n as f64, n as f64 + 1.0]);
+        let dists = readings.augurs_dtw(8);
+        let captured = dists.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+            .unwrap();
+        assert!(captured.peek_value().is_empty());
     }
 
     /// The node stays silent until it has at least two series.

--- a/wingfoil/src/adapters/augurs/forecast.rs
+++ b/wingfoil/src/adapters/augurs/forecast.rs
@@ -143,10 +143,7 @@ impl AugursForecastNode {
 #[node(active = [upstream], output = value: AugursForecast)]
 impl MutableNode for AugursForecastNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.window {
-            self.buffer.pop_front();
-        }
+        super::push_windowed(&mut self.buffer, self.upstream.peek_value(), self.window);
         if self.buffer.len() < self.min_points {
             return Ok(false);
         }
@@ -162,6 +159,14 @@ impl MutableNode for AugursForecastNode {
                     .context("augurs_forecast: ETS predict failed")?
             }
             AugursForecastModel::Mstl { periods } => {
+                // STL cannot decompose an empty period set or a period below 2;
+                // catch it here with a clear message rather than letting augurs
+                // fail deep inside the fit with an opaque error.
+                if periods.is_empty() || periods.iter().any(|&p| p < 2) {
+                    anyhow::bail!(
+                        "augurs_forecast: MSTL periods must be non-empty and each >= 2, got {periods:?}"
+                    );
+                }
                 let trend = AutoETSTrendModel::from(AutoETS::non_seasonal());
                 let fitted = MSTLModel::new(periods.clone(), trend)
                     .fit(&data)
@@ -305,6 +310,21 @@ mod tests {
             forecast.peek_value().point.len(),
             2,
             "should emit despite window < floor"
+        );
+    }
+
+    /// An MSTL period below 2 (or an empty period set) is rejected with a clear
+    /// error at run time rather than an opaque augurs-internal fit failure.
+    #[test]
+    fn forecast_mstl_rejects_invalid_period() {
+        let source = ticker(Duration::from_secs(1)).count().map(|n| n as f64);
+        let forecast = source.augurs_forecast(AugursForecastConfig::new(64, 2).mstl(vec![1]));
+        let captured = forecast.clone().collect();
+        let result = captured.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30));
+        let err = result.expect_err("period < 2 should fail the run");
+        assert!(
+            format!("{err:#}").contains("MSTL periods"),
+            "expected a clear MSTL period error, got {err:#}"
         );
     }
 

--- a/wingfoil/src/adapters/augurs/forecast.rs
+++ b/wingfoil/src/adapters/augurs/forecast.rs
@@ -3,10 +3,30 @@ use std::rc::Rc;
 
 use anyhow::Context;
 use augurs::ets::AutoETS;
+use augurs::ets::trend::AutoETSTrendModel;
+use augurs::mstl::MSTLModel;
 use augurs::{Fit, Predict};
 
 use super::AugursForecast;
 use crate::types::*;
+
+/// The forecasting model used by [`AugursForecastOperators::augurs_forecast`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum AugursForecastModel {
+    /// Non-seasonal [`AutoETS`]. Fast and a good default for data without a
+    /// fixed seasonal period.
+    #[default]
+    Ets,
+    /// [MSTL](augurs::mstl) seasonal-trend decomposition with an [`AutoETS`]
+    /// trend, using the given seasonal `periods` (in samples). Choose this when
+    /// the data has one or more known seasonalities (e.g. `[24]` for hourly
+    /// data with a daily cycle). Needs a window of at least a couple of full
+    /// periods.
+    Mstl {
+        /// Seasonal period lengths, in samples.
+        periods: Vec<usize>,
+    },
+}
 
 /// Configuration for [`AugursForecastOperators::augurs_forecast`].
 #[derive(Debug, Clone)]
@@ -23,6 +43,8 @@ pub struct AugursForecastConfig {
     /// Confidence level for prediction intervals (between 0 and 1). When `None`,
     /// only point forecasts are produced and `lower`/`upper` stay empty.
     pub level: Option<f64>,
+    /// Which forecasting model to fit each cycle.
+    pub model: AugursForecastModel,
 }
 
 impl AugursForecastConfig {
@@ -35,6 +57,7 @@ impl AugursForecastConfig {
             min_points: 12,
             horizon,
             level: None,
+            model: AugursForecastModel::Ets,
         }
     }
 
@@ -45,6 +68,21 @@ impl AugursForecastConfig {
         self
     }
 
+    /// Use MSTL seasonal-trend forecasting with the given seasonal `periods`
+    /// (in samples) instead of the default non-seasonal ETS model.
+    #[must_use]
+    pub fn mstl(mut self, periods: Vec<usize>) -> Self {
+        self.model = AugursForecastModel::Mstl { periods };
+        self
+    }
+
+    /// Select the forecasting model explicitly.
+    #[must_use]
+    pub fn with_model(mut self, model: AugursForecastModel) -> Self {
+        self.model = model;
+        self
+    }
+
     /// Set the minimum number of points required before fitting begins.
     #[must_use]
     pub fn with_min_points(mut self, min_points: usize) -> Self {
@@ -52,9 +90,18 @@ impl AugursForecastConfig {
         self
     }
 
-    /// The effective minimum, never below the `AutoETS` floor.
+    /// The effective minimum. Never below the `AutoETS` floor (~12 points), and
+    /// for MSTL never below two full seasonal periods (STL cannot decompose
+    /// fewer than two periods).
     fn effective_min_points(&self) -> usize {
-        self.min_points.max(12)
+        let floor = match &self.model {
+            AugursForecastModel::Ets => 12,
+            AugursForecastModel::Mstl { periods } => {
+                let max_period = periods.iter().copied().max().unwrap_or(1);
+                (2 * max_period + 1).max(12)
+            }
+        };
+        self.min_points.max(floor)
     }
 }
 
@@ -96,12 +143,25 @@ impl MutableNode for AugursForecastNode {
         }
 
         let data: Vec<f64> = self.buffer.iter().copied().collect();
-        let fitted = AutoETS::non_seasonal()
-            .fit(&data)
-            .context("augurs_forecast: ETS fit failed")?;
-        let forecast = fitted
-            .predict(self.config.horizon, self.config.level)
-            .context("augurs_forecast: ETS predict failed")?;
+        let forecast = match &self.config.model {
+            AugursForecastModel::Ets => {
+                let fitted = AutoETS::non_seasonal()
+                    .fit(&data)
+                    .context("augurs_forecast: ETS fit failed")?;
+                fitted
+                    .predict(self.config.horizon, self.config.level)
+                    .context("augurs_forecast: ETS predict failed")?
+            }
+            AugursForecastModel::Mstl { periods } => {
+                let trend = AutoETSTrendModel::from(AutoETS::non_seasonal());
+                let fitted = MSTLModel::new(periods.clone(), trend)
+                    .fit(&data)
+                    .context("augurs_forecast: MSTL fit failed")?;
+                fitted
+                    .predict(self.config.horizon, self.config.level)
+                    .context("augurs_forecast: MSTL predict failed")?
+            }
+        };
 
         let (lower, upper) = match forecast.intervals {
             Some(intervals) => (intervals.lower, intervals.upper),
@@ -187,6 +247,35 @@ mod tests {
             .unwrap();
         // 15 cycles < 20 min_points → never ticked.
         assert!(captured.peek_value().is_empty());
+    }
+
+    /// MSTL with a seasonal period forecasts a strongly seasonal series and
+    /// reproduces its seasonal swing rather than a flat line.
+    #[test]
+    fn forecast_mstl_captures_season() {
+        // Period-12 sine wave riding on a gentle ramp.
+        let source = ticker(Duration::from_secs(1)).count().map(|n| {
+            let t = n as f64;
+            0.1 * t + 5.0 * (t * std::f64::consts::TAU / 12.0).sin()
+        });
+        let forecast = source.augurs_forecast(AugursForecastConfig::new(120, 12).mstl(vec![12]));
+        let captured = forecast.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(80))
+            .unwrap();
+
+        let last = forecast.peek_value();
+        assert_eq!(last.point.len(), 12, "horizon == 12 point forecasts");
+        // A seasonal forecast should swing: max and min of the 12-step forecast
+        // must differ by a meaningful fraction of the amplitude (10.0 pk-pk).
+        let max = last.point.iter().cloned().fold(f64::MIN, f64::max);
+        let min = last.point.iter().cloned().fold(f64::MAX, f64::min);
+        assert!(
+            max - min > 2.0,
+            "expected a seasonal swing, got range {:.3} for {:?}",
+            max - min,
+            last.point
+        );
     }
 
     /// `(window, horizon)` tuples convert into a config.

--- a/wingfoil/src/adapters/augurs/forecast.rs
+++ b/wingfoil/src/adapters/augurs/forecast.rs
@@ -1,0 +1,203 @@
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use anyhow::Context;
+use augurs::ets::AutoETS;
+use augurs::{Fit, Predict};
+
+use super::AugursForecast;
+use crate::types::*;
+
+/// Configuration for [`AugursForecastOperators::augurs_forecast`].
+#[derive(Debug, Clone)]
+pub struct AugursForecastConfig {
+    /// Maximum number of recent points retained as training history. Older
+    /// points are dropped once the window is full.
+    pub window: usize,
+    /// Minimum number of buffered points before the model is fitted. Until this
+    /// many points have arrived the node does not tick. `AutoETS` needs more
+    /// than ~8 points, so values below `12` are raised to `12`.
+    pub min_points: usize,
+    /// Number of steps to forecast ahead.
+    pub horizon: usize,
+    /// Confidence level for prediction intervals (between 0 and 1). When `None`,
+    /// only point forecasts are produced and `lower`/`upper` stay empty.
+    pub level: Option<f64>,
+}
+
+impl AugursForecastConfig {
+    /// A config that keeps the last `window` points and forecasts `horizon`
+    /// steps ahead with no prediction intervals.
+    #[must_use]
+    pub fn new(window: usize, horizon: usize) -> Self {
+        Self {
+            window,
+            min_points: 12,
+            horizon,
+            level: None,
+        }
+    }
+
+    /// Request prediction intervals at the given confidence `level` (0..1).
+    #[must_use]
+    pub fn with_level(mut self, level: f64) -> Self {
+        self.level = Some(level);
+        self
+    }
+
+    /// Set the minimum number of points required before fitting begins.
+    #[must_use]
+    pub fn with_min_points(mut self, min_points: usize) -> Self {
+        self.min_points = min_points;
+        self
+    }
+
+    /// The effective minimum, never below the `AutoETS` floor.
+    fn effective_min_points(&self) -> usize {
+        self.min_points.max(12)
+    }
+}
+
+impl From<(usize, usize)> for AugursForecastConfig {
+    /// `(window, horizon)`.
+    fn from((window, horizon): (usize, usize)) -> Self {
+        Self::new(window, horizon)
+    }
+}
+
+pub(crate) struct AugursForecastNode {
+    upstream: Rc<dyn Stream<f64>>,
+    config: AugursForecastConfig,
+    buffer: VecDeque<f64>,
+    value: AugursForecast,
+}
+
+impl AugursForecastNode {
+    fn new(upstream: Rc<dyn Stream<f64>>, config: AugursForecastConfig) -> Self {
+        let window = config.window.max(config.effective_min_points());
+        Self {
+            upstream,
+            config,
+            buffer: VecDeque::with_capacity(window),
+            value: AugursForecast::default(),
+        }
+    }
+}
+
+#[node(active = [upstream], output = value: AugursForecast)]
+impl MutableNode for AugursForecastNode {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.buffer.push_back(self.upstream.peek_value());
+        while self.buffer.len() > self.config.window {
+            self.buffer.pop_front();
+        }
+        if self.buffer.len() < self.config.effective_min_points() {
+            return Ok(false);
+        }
+
+        let data: Vec<f64> = self.buffer.iter().copied().collect();
+        let fitted = AutoETS::non_seasonal()
+            .fit(&data)
+            .context("augurs_forecast: ETS fit failed")?;
+        let forecast = fitted
+            .predict(self.config.horizon, self.config.level)
+            .context("augurs_forecast: ETS predict failed")?;
+
+        let (lower, upper) = match forecast.intervals {
+            Some(intervals) => (intervals.lower, intervals.upper),
+            None => (Vec::new(), Vec::new()),
+        };
+        self.value = AugursForecast {
+            point: forecast.point,
+            lower,
+            upper,
+        };
+        Ok(true)
+    }
+}
+
+/// Adds the [`augurs_forecast`](AugursForecastOperators::augurs_forecast)
+/// operator to `f64` streams.
+pub trait AugursForecastOperators {
+    /// Maintain a sliding window of this stream and, once `min_points` have
+    /// arrived, emit an [`AugursForecast`] each tick by fitting an `AutoETS`
+    /// model and predicting `horizon` steps ahead.
+    #[must_use]
+    fn augurs_forecast(
+        self: &Rc<Self>,
+        config: impl Into<AugursForecastConfig>,
+    ) -> Rc<dyn Stream<AugursForecast>>;
+}
+
+impl AugursForecastOperators for dyn Stream<f64> {
+    fn augurs_forecast(
+        self: &Rc<Self>,
+        config: impl Into<AugursForecastConfig>,
+    ) -> Rc<dyn Stream<AugursForecast>> {
+        AugursForecastNode::new(self.clone(), config.into()).into_stream()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::*;
+    use crate::nodes::*;
+    use std::time::Duration;
+
+    /// A clean upward ramp with mild seasonality should forecast values above
+    /// the last observed point, and intervals should bracket the point forecast.
+    #[test]
+    fn forecast_ramp_predicts_ahead() {
+        let source = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| n as f64 + (n as f64 * 0.5).sin());
+        let forecast = source.augurs_forecast(AugursForecastConfig::new(48, 3).with_level(0.9));
+        let captured = forecast.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+            .unwrap();
+
+        let last = forecast.peek_value();
+        assert_eq!(last.point.len(), 3, "horizon == 3 point forecasts");
+        assert_eq!(last.lower.len(), 3);
+        assert_eq!(last.upper.len(), 3);
+        // The ramp is still rising, so the next forecast should exceed the
+        // ~40th observed value (which is around 40).
+        assert!(
+            last.next().unwrap() > 30.0,
+            "expected forecast to continue the ramp, got {:?}",
+            last.point
+        );
+        // Intervals must bracket the point forecast.
+        for i in 0..3 {
+            assert!(last.lower[i] <= last.point[i]);
+            assert!(last.upper[i] >= last.point[i]);
+        }
+    }
+
+    /// The node stays silent until `min_points` have arrived.
+    #[test]
+    fn forecast_waits_for_min_points() {
+        let source = ticker(Duration::from_secs(1)).count().map(|n| n as f64);
+        let forecast = source.augurs_forecast(AugursForecastConfig::new(64, 1).with_min_points(20));
+        let captured = forecast.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(15))
+            .unwrap();
+        // 15 cycles < 20 min_points → never ticked.
+        assert!(captured.peek_value().is_empty());
+    }
+
+    /// `(window, horizon)` tuples convert into a config.
+    #[test]
+    fn forecast_accepts_tuple_config() {
+        let source = ticker(Duration::from_secs(1)).count().map(|n| n as f64);
+        let forecast = source.augurs_forecast((32, 2));
+        let captured = forecast.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+            .unwrap();
+        assert_eq!(forecast.peek_value().point.len(), 2);
+    }
+}

--- a/wingfoil/src/adapters/augurs/forecast.rs
+++ b/wingfoil/src/adapters/augurs/forecast.rs
@@ -115,16 +115,25 @@ impl From<(usize, usize)> for AugursForecastConfig {
 pub(crate) struct AugursForecastNode {
     upstream: Rc<dyn Stream<f64>>,
     config: AugursForecastConfig,
+    /// Effective window: the configured `window` grown to the model's warm-up
+    /// floor so a `window` smaller than the floor still lets the node fill up
+    /// and emit rather than never ticking.
+    window: usize,
+    /// Resolved warm-up floor, computed once (`effective_min_points`).
+    min_points: usize,
     buffer: VecDeque<f64>,
     value: AugursForecast,
 }
 
 impl AugursForecastNode {
     fn new(upstream: Rc<dyn Stream<f64>>, config: AugursForecastConfig) -> Self {
-        let window = config.window.max(config.effective_min_points());
+        let min_points = config.effective_min_points();
+        let window = config.window.max(min_points);
         Self {
             upstream,
             config,
+            window,
+            min_points,
             buffer: VecDeque::with_capacity(window),
             value: AugursForecast::default(),
         }
@@ -135,10 +144,10 @@ impl AugursForecastNode {
 impl MutableNode for AugursForecastNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
         self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.config.window {
+        while self.buffer.len() > self.window {
             self.buffer.pop_front();
         }
-        if self.buffer.len() < self.config.effective_min_points() {
+        if self.buffer.len() < self.min_points {
             return Ok(false);
         }
 
@@ -275,6 +284,27 @@ mod tests {
             "expected a seasonal swing, got range {:.3} for {:?}",
             max - min,
             last.point
+        );
+    }
+
+    /// A `window` smaller than the model's warm-up floor still warms up and
+    /// emits — the effective window grows to the floor — rather than silently
+    /// never ticking.
+    #[test]
+    fn forecast_window_below_floor_still_emits() {
+        let source = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| n as f64 + (n as f64 * 0.5).sin());
+        // window 10 is below the ETS floor of 12.
+        let forecast = source.augurs_forecast(AugursForecastConfig::new(10, 2));
+        let captured = forecast.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+            .unwrap();
+        assert_eq!(
+            forecast.peek_value().point.len(),
+            2,
+            "should emit despite window < floor"
         );
     }
 

--- a/wingfoil/src/adapters/augurs/mod.rs
+++ b/wingfoil/src/adapters/augurs/mod.rs
@@ -1,5 +1,5 @@
 //! augurs adapter — on-graph time-series analysis powered by the
-//! [`augurs`](https://docs.rs/augurs) toolkit (forecasting and outlier detection).
+//! [`augurs`](https://docs.rs/augurs) toolkit.
 //!
 //! Unlike the messaging adapters in this crate, augurs is a pure-Rust compute
 //! library rather than an external service — there is nothing to connect to and
@@ -8,14 +8,28 @@
 //! the graph thread each cycle:
 //!
 //! - [`AugursForecastOperators::augurs_forecast`] — buffers a window of an
-//!   `f64` stream, fits an [`AutoETS`](augurs::ets::AutoETS) model and emits an
-//!   [`AugursForecast`] (point forecast + optional prediction intervals).
+//!   `f64` stream, fits a forecasting model ([`AutoETS`](augurs::ets::AutoETS)
+//!   or [MSTL](augurs::mstl)) and emits an [`AugursForecast`] (point forecast +
+//!   optional prediction intervals).
 //! - [`AugursOutlierOperators::augurs_outlier`] — buffers a window of a
-//!   `Vec<f64>` stream (one value per series per tick), runs the
-//!   [`MADDetector`](augurs::outlier::MADDetector) and emits an
-//!   [`AugursOutliers`] (which series are outlying + their latest scores).
+//!   `Vec<f64>` stream (one value per series per tick), runs an outlier detector
+//!   ([MAD](augurs::outlier::MADDetector) or
+//!   [DBSCAN](augurs::outlier::DbscanDetector)) and emits an [`AugursOutliers`]
+//!   (which series are outlying + their latest scores).
+//! - [`AugursChangepointOperators::augurs_changepoint`] — Bayesian online
+//!   changepoint detection over a window of an `f64` stream, emitting the
+//!   [`AugursChangepoints`] indices within the window.
+//! - [`AugursSeasonsOperators::augurs_seasons`] — periodogram seasonality
+//!   detection over a window of an `f64` stream, emitting the detected
+//!   [`AugursSeasons`] period lengths.
+//! - [`AugursDtwOperators::augurs_dtw`] — dynamic time warping distance matrix
+//!   over a window of a `Vec<f64>` (multi-series) stream, emitting an
+//!   [`AugursDistanceMatrix`].
+//! - [`AugursClusterOperators::augurs_cluster`] — DBSCAN clustering of the
+//!   series in a `Vec<f64>` window using their DTW distances, emitting the
+//!   per-series [`AugursClusters`] labels.
 //!
-//! Both models are fitted inside `cycle()`. This is pure CPU work on the
+//! Models are fitted inside `cycle()`. This is pure CPU work on the
 //! single-threaded graph engine (no locks, no I/O), but refitting is not free —
 //! throttle the input with [`sample`](crate::StreamOperators) /
 //! [`throttle`](crate::StreamOperators) upstream if you do not need a fresh fit
@@ -35,6 +49,12 @@
 //!     .for_each(|f, _| println!("next 5: {:?}", f.point))
 //!     .run(RunMode::RealTime, RunFor::Forever)
 //!     .unwrap();
+//!
+//! // Seasonal data: fit MSTL with a period-24 season instead of plain ETS.
+//! # use wingfoil::adapters::augurs::*;
+//! # use wingfoil::*;
+//! # let hourly: std::rc::Rc<dyn Stream<f64>> = constant(0.0);
+//! hourly.augurs_forecast(AugursForecastConfig::new(240, 24).mstl(vec![24]));
 //! ```
 //!
 //! # Outlier detection
@@ -45,17 +65,46 @@
 //!
 //! // Each tick carries one reading per monitored series.
 //! some_stream_of_readings // Rc<dyn Stream<Vec<f64>>>
-//!     .augurs_outlier(AugursOutlierConfig::new(32, 0.5))
+//!     .augurs_outlier(AugursOutlierConfig::mad(32, 0.5))
 //!     .for_each(|o, _| println!("outlying series: {:?}", o.outlying))
 //!     .run(RunMode::RealTime, RunFor::Forever)
 //!     .unwrap();
 //! ```
 
+mod changepoint;
+mod cluster;
+mod dtw;
 mod forecast;
 mod outlier;
+mod seasons;
 
+pub use changepoint::*;
+pub use cluster::*;
+pub use dtw::*;
 pub use forecast::*;
 pub use outlier::*;
+pub use seasons::*;
+
+use std::collections::VecDeque;
+
+/// Transpose a window of per-tick multi-series samples (one value per series per
+/// tick) into aligned per-series columns of equal length. Short samples are
+/// forward-filled with the series' previous value (or `0.0` before any value
+/// exists) so every column spans the full window.
+///
+/// Shared by the multi-series operators ([`augurs_outlier`](AugursOutlierOperators),
+/// [`augurs_dtw`](AugursDtwOperators), [`augurs_cluster`](AugursClusterOperators)).
+pub(crate) fn transpose_window(buffer: &VecDeque<Vec<f64>>) -> Vec<Vec<f64>> {
+    let n_series = buffer.iter().map(Vec::len).max().unwrap_or(0);
+    let mut series: Vec<Vec<f64>> = vec![Vec::with_capacity(buffer.len()); n_series];
+    for sample in buffer {
+        for (j, col) in series.iter_mut().enumerate() {
+            let value = sample.get(j).copied().or_else(|| col.last().copied());
+            col.push(value.unwrap_or(0.0));
+        }
+    }
+    series
+}
 
 /// A forecast produced by [`AugursForecastOperators::augurs_forecast`].
 ///
@@ -94,5 +143,75 @@ impl AugursOutliers {
     #[must_use]
     pub fn is_outlier(&self, index: usize) -> bool {
         self.outlying.contains(&index)
+    }
+}
+
+/// The result of [`AugursChangepointOperators::augurs_changepoint`] for one
+/// cycle — the indices, within the current window, at which a changepoint was
+/// detected.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursChangepoints {
+    /// Changepoint indices relative to the start of the current window.
+    pub indices: Vec<usize>,
+}
+
+impl AugursChangepoints {
+    /// Whether any changepoint was detected in the current window.
+    #[must_use]
+    pub fn any(&self) -> bool {
+        !self.indices.is_empty()
+    }
+}
+
+/// The result of [`AugursSeasonsOperators::augurs_seasons`] for one cycle — the
+/// seasonal period lengths (in samples) detected in the current window.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursSeasons {
+    /// Detected seasonal period lengths, longest signal first.
+    pub periods: Vec<u32>,
+}
+
+impl AugursSeasons {
+    /// The dominant (first-reported) seasonal period, if any.
+    #[must_use]
+    pub fn dominant(&self) -> Option<u32> {
+        self.periods.first().copied()
+    }
+}
+
+/// A row-major square distance matrix produced by
+/// [`AugursDtwOperators::augurs_dtw`]. `rows[i][j]` is the DTW distance between
+/// series `i` and series `j` over the current window.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursDistanceMatrix {
+    /// Row-major `n × n` distances, where `n` is the number of series.
+    pub rows: Vec<Vec<f64>>,
+}
+
+impl AugursDistanceMatrix {
+    /// The distance between series `i` and series `j`, if both are in range.
+    #[must_use]
+    pub fn get(&self, i: usize, j: usize) -> Option<f64> {
+        self.rows.get(i).and_then(|row| row.get(j)).copied()
+    }
+}
+
+/// The result of [`AugursClusterOperators::augurs_cluster`] for one cycle — a
+/// cluster label per series. A label of `-1` marks a noise point (unclustered);
+/// non-negative labels group series into clusters.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursClusters {
+    /// Cluster label for each series (`-1` = noise).
+    pub labels: Vec<i32>,
+}
+
+impl AugursClusters {
+    /// The number of distinct (non-noise) clusters found.
+    #[must_use]
+    pub fn cluster_count(&self) -> usize {
+        let mut seen: Vec<i32> = self.labels.iter().copied().filter(|&l| l >= 0).collect();
+        seen.sort_unstable();
+        seen.dedup();
+        seen.len()
     }
 }

--- a/wingfoil/src/adapters/augurs/mod.rs
+++ b/wingfoil/src/adapters/augurs/mod.rs
@@ -1,0 +1,98 @@
+//! augurs adapter — on-graph time-series analysis powered by the
+//! [`augurs`](https://docs.rs/augurs) toolkit (forecasting and outlier detection).
+//!
+//! Unlike the messaging adapters in this crate, augurs is a pure-Rust compute
+//! library rather than an external service — there is nothing to connect to and
+//! no Docker container to run. The adapter therefore exposes **transform nodes**
+//! that maintain a sliding window of an input stream and apply augurs models on
+//! the graph thread each cycle:
+//!
+//! - [`AugursForecastOperators::augurs_forecast`] — buffers a window of an
+//!   `f64` stream, fits an [`AutoETS`](augurs::ets::AutoETS) model and emits an
+//!   [`AugursForecast`] (point forecast + optional prediction intervals).
+//! - [`AugursOutlierOperators::augurs_outlier`] — buffers a window of a
+//!   `Vec<f64>` stream (one value per series per tick), runs the
+//!   [`MADDetector`](augurs::outlier::MADDetector) and emits an
+//!   [`AugursOutliers`] (which series are outlying + their latest scores).
+//!
+//! Both models are fitted inside `cycle()`. This is pure CPU work on the
+//! single-threaded graph engine (no locks, no I/O), but refitting is not free —
+//! throttle the input with [`sample`](crate::StreamOperators) /
+//! [`throttle`](crate::StreamOperators) upstream if you do not need a fresh fit
+//! on every tick.
+//!
+//! # Forecasting
+//!
+//! ```ignore
+//! use wingfoil::adapters::augurs::*;
+//! use wingfoil::*;
+//!
+//! // A noisy upward ramp; forecast 5 steps ahead with 95% intervals.
+//! ticker(std::time::Duration::from_secs(1))
+//!     .count()
+//!     .map(|n| n as f64 + (n as f64 * 0.3).sin())
+//!     .augurs_forecast(AugursForecastConfig::new(64, 5).with_level(0.95))
+//!     .for_each(|f, _| println!("next 5: {:?}", f.point))
+//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .unwrap();
+//! ```
+//!
+//! # Outlier detection
+//!
+//! ```ignore
+//! use wingfoil::adapters::augurs::*;
+//! use wingfoil::*;
+//!
+//! // Each tick carries one reading per monitored series.
+//! some_stream_of_readings // Rc<dyn Stream<Vec<f64>>>
+//!     .augurs_outlier(AugursOutlierConfig::new(32, 0.5))
+//!     .for_each(|o, _| println!("outlying series: {:?}", o.outlying))
+//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .unwrap();
+//! ```
+
+mod forecast;
+mod outlier;
+
+pub use forecast::*;
+pub use outlier::*;
+
+/// A forecast produced by [`AugursForecastOperators::augurs_forecast`].
+///
+/// `point` holds the n-ahead point forecasts (length = `horizon`). `lower` /
+/// `upper` hold the prediction-interval bounds when a confidence level was
+/// requested, and are empty otherwise.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursForecast {
+    /// Point forecasts, one per step of the horizon.
+    pub point: Vec<f64>,
+    /// Lower prediction-interval bounds (empty when no level was requested).
+    pub lower: Vec<f64>,
+    /// Upper prediction-interval bounds (empty when no level was requested).
+    pub upper: Vec<f64>,
+}
+
+impl AugursForecast {
+    /// The one-step-ahead point forecast, if any.
+    #[must_use]
+    pub fn next(&self) -> Option<f64> {
+        self.point.first().copied()
+    }
+}
+
+/// The result of [`AugursOutlierOperators::augurs_outlier`] for one cycle.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursOutliers {
+    /// Indices of the series flagged as outlying over the current window.
+    pub outlying: Vec<usize>,
+    /// The most recent outlier score for each series (higher = more outlying).
+    pub scores: Vec<f64>,
+}
+
+impl AugursOutliers {
+    /// Whether the series at `index` is currently flagged as an outlier.
+    #[must_use]
+    pub fn is_outlier(&self, index: usize) -> bool {
+        self.outlying.contains(&index)
+    }
+}

--- a/wingfoil/src/adapters/augurs/mod.rs
+++ b/wingfoil/src/adapters/augurs/mod.rs
@@ -89,21 +89,36 @@ use std::collections::VecDeque;
 
 /// Transpose a window of per-tick multi-series samples (one value per series per
 /// tick) into aligned per-series columns of equal length. Short samples are
-/// forward-filled with the series' previous value (or `0.0` before any value
-/// exists) so every column spans the full window.
+/// forward-filled with the series' previous value so every column spans the full
+/// window. A series that first appears part-way through the window has its
+/// leading gap back-filled with its own first observed value — never a
+/// fabricated `0.0`, which would read as a large deviation to the outlier / DTW
+/// operators for the rest of the window.
 ///
 /// Shared by the multi-series operators ([`augurs_outlier`](AugursOutlierOperators),
 /// [`augurs_dtw`](AugursDtwOperators), [`augurs_cluster`](AugursClusterOperators)).
 pub(crate) fn transpose_window(buffer: &VecDeque<Vec<f64>>) -> Vec<Vec<f64>> {
     let n_series = buffer.iter().map(Vec::len).max().unwrap_or(0);
-    let mut series: Vec<Vec<f64>> = vec![Vec::with_capacity(buffer.len()); n_series];
+    let mut series: Vec<Vec<Option<f64>>> = vec![Vec::with_capacity(buffer.len()); n_series];
     for sample in buffer {
         for (j, col) in series.iter_mut().enumerate() {
-            let value = sample.get(j).copied().or_else(|| col.last().copied());
-            col.push(value.unwrap_or(0.0));
+            // Forward-fill a short sample from the series' previous value; a
+            // series that has not appeared yet stays `None` and is back-filled
+            // below.
+            let value = sample
+                .get(j)
+                .copied()
+                .or_else(|| col.last().copied().flatten());
+            col.push(value);
         }
     }
     series
+        .into_iter()
+        .map(|col| {
+            let first = col.iter().copied().flatten().next().unwrap_or(0.0);
+            col.into_iter().map(|v| v.unwrap_or(first)).collect()
+        })
+        .collect()
 }
 
 /// A forecast produced by [`AugursForecastOperators::augurs_forecast`].
@@ -213,5 +228,40 @@ impl AugursClusters {
         seen.sort_unstable();
         seen.dedup();
         seen.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A series that only appears part-way through the window has its leading
+    /// gap back-filled with its own first value, not a fabricated `0.0` (which
+    /// would read as a large deviation to the outlier / DTW operators).
+    #[test]
+    fn transpose_backfills_late_series_with_first_value() {
+        let mut buffer = VecDeque::new();
+        buffer.push_back(vec![1.0, 2.0]);
+        buffer.push_back(vec![1.0, 2.0]);
+        buffer.push_back(vec![1.0, 2.0, 3.0]);
+        let cols = transpose_window(&buffer);
+        assert_eq!(
+            cols,
+            vec![
+                vec![1.0, 1.0, 1.0],
+                vec![2.0, 2.0, 2.0],
+                vec![3.0, 3.0, 3.0],
+            ]
+        );
+    }
+
+    /// A short sample forward-fills each missing series from its previous value.
+    #[test]
+    fn transpose_forward_fills_short_samples() {
+        let mut buffer = VecDeque::new();
+        buffer.push_back(vec![1.0, 2.0]);
+        buffer.push_back(vec![5.0]);
+        let cols = transpose_window(&buffer);
+        assert_eq!(cols, vec![vec![1.0, 5.0], vec![2.0, 2.0]]);
     }
 }

--- a/wingfoil/src/adapters/augurs/mod.rs
+++ b/wingfoil/src/adapters/augurs/mod.rs
@@ -87,6 +87,16 @@ pub use seasons::*;
 
 use std::collections::VecDeque;
 
+/// Push `value` onto a sliding-window buffer, evicting the oldest samples until
+/// at most `window` remain. Shared by every augurs node's `cycle()` so the
+/// ring-buffer maintenance lives in one place.
+pub(crate) fn push_windowed<T>(buffer: &mut VecDeque<T>, value: T, window: usize) {
+    buffer.push_back(value);
+    while buffer.len() > window {
+        buffer.pop_front();
+    }
+}
+
 /// Transpose a window of per-tick multi-series samples (one value per series per
 /// tick) into aligned per-series columns of equal length. Short samples are
 /// forward-filled with the series' previous value so every column spans the full

--- a/wingfoil/src/adapters/augurs/outlier.rs
+++ b/wingfoil/src/adapters/augurs/outlier.rs
@@ -1,50 +1,119 @@
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use augurs::outlier::{MADDetector, OutlierDetector};
+use augurs::outlier::{DbscanDetector, MADDetector, OutlierDetector, OutlierOutput};
 
 use super::AugursOutliers;
 use crate::types::*;
+
+/// Which outlier-detection algorithm [`AugursOutlierOperators::augurs_outlier`]
+/// uses.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AugursOutlierDetector {
+    /// Median absolute deviation. Flags series whose values sit far from the
+    /// rolling median of the group. Works with any number of series (including
+    /// one) and is robust to a few out-of-sync members.
+    #[default]
+    Mad,
+    /// DBSCAN density clustering. Flags series that fall outside the main
+    /// cluster of similarly-behaving series. Needs **at least three** series to
+    /// form a cluster; with fewer it reports nothing.
+    Dbscan,
+}
 
 /// Configuration for [`AugursOutlierOperators::augurs_outlier`].
 #[derive(Debug, Clone)]
 pub struct AugursOutlierConfig {
     /// Number of recent samples retained as the detection window.
     pub window: usize,
-    /// MAD sensitivity, strictly between 0 and 1. Higher is more sensitive.
-    /// Used to derive a detection threshold from the scale of the data.
+    /// Detector sensitivity, strictly between 0 and 1. Higher is more
+    /// sensitive. Used to derive a detection threshold from the scale of the
+    /// data.
     pub sensitivity: f64,
+    /// Which detector to run.
+    pub detector: AugursOutlierDetector,
 }
 
 impl AugursOutlierConfig {
-    /// Detect over the last `window` samples at the given MAD `sensitivity`
-    /// (must be in `(0, 1)`).
+    /// Detect over the last `window` samples at the given `sensitivity` (must be
+    /// in `(0, 1)`) using the default [MAD](AugursOutlierDetector::Mad)
+    /// detector.
     #[must_use]
     pub fn new(window: usize, sensitivity: f64) -> Self {
         Self {
             window,
             sensitivity,
+            detector: AugursOutlierDetector::Mad,
+        }
+    }
+
+    /// A MAD-detector config (same as [`new`](Self::new); reads clearer at call
+    /// sites that also use [`dbscan`](Self::dbscan)).
+    #[must_use]
+    pub fn mad(window: usize, sensitivity: f64) -> Self {
+        Self::new(window, sensitivity)
+    }
+
+    /// A [DBSCAN](AugursOutlierDetector::Dbscan)-detector config. Needs at least
+    /// three series to report anything.
+    #[must_use]
+    pub fn dbscan(window: usize, sensitivity: f64) -> Self {
+        Self {
+            window,
+            sensitivity,
+            detector: AugursOutlierDetector::Dbscan,
         }
     }
 }
 
 impl From<(usize, f64)> for AugursOutlierConfig {
-    /// `(window, sensitivity)`.
+    /// `(window, sensitivity)` using the default MAD detector.
     fn from((window, sensitivity): (usize, f64)) -> Self {
         Self::new(window, sensitivity)
     }
 }
 
+/// A constructed detector. `OutlierDetector` has an associated `PreprocessedData`
+/// type so it is not object-safe; this enum dispatches over the two concrete
+/// implementations instead.
+enum Detector {
+    Mad(MADDetector),
+    Dbscan(DbscanDetector),
+}
+
+impl Detector {
+    fn run(&self, series: &[&[f64]]) -> anyhow::Result<OutlierOutput> {
+        // augurs' outlier `Error` is not `Send + Sync`, so it cannot flow
+        // through `anyhow::Context`; render it into an `anyhow::Error` instead.
+        match self {
+            Detector::Mad(d) => {
+                let pre = d
+                    .preprocess(series)
+                    .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD preprocess failed: {e}"))?;
+                d.detect(&pre)
+                    .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD detect failed: {e}"))
+            }
+            Detector::Dbscan(d) => {
+                let pre = d.preprocess(series).map_err(|e| {
+                    anyhow::anyhow!("augurs_outlier: DBSCAN preprocess failed: {e}")
+                })?;
+                d.detect(&pre)
+                    .map_err(|e| anyhow::anyhow!("augurs_outlier: DBSCAN detect failed: {e}"))
+            }
+        }
+    }
+}
+
 pub(crate) struct AugursOutlierNode {
     upstream: Rc<dyn Stream<Vec<f64>>>,
-    detector: MADDetector,
+    detector: Detector,
     window: usize,
     buffer: VecDeque<Vec<f64>>,
     value: AugursOutliers,
 }
 
 impl AugursOutlierNode {
-    fn new(upstream: Rc<dyn Stream<Vec<f64>>>, detector: MADDetector, window: usize) -> Self {
+    fn new(upstream: Rc<dyn Stream<Vec<f64>>>, detector: Detector, window: usize) -> Self {
         Self {
             upstream,
             detector,
@@ -62,37 +131,19 @@ impl MutableNode for AugursOutlierNode {
         while self.buffer.len() > self.window {
             self.buffer.pop_front();
         }
-        // MAD needs at least two timestamps to have any spread to measure.
+        // Need at least two timestamps to have any spread to measure.
         if self.buffer.len() < 2 {
             return Ok(false);
         }
 
         // Transpose the buffered samples (one value per series per tick) into
-        // aligned per-series time series. Missing entries are filled forward
-        // with the series' previous value so the columns stay the same length.
-        let n_series = self.buffer.iter().map(Vec::len).max().unwrap_or(0);
-        if n_series == 0 {
+        // aligned per-series time series.
+        let series = super::transpose_window(&self.buffer);
+        if series.is_empty() {
             return Ok(false);
         }
-        let mut series: Vec<Vec<f64>> = vec![Vec::with_capacity(self.buffer.len()); n_series];
-        for sample in &self.buffer {
-            for (j, col) in series.iter_mut().enumerate() {
-                let value = sample.get(j).copied().or_else(|| col.last().copied());
-                col.push(value.unwrap_or(0.0));
-            }
-        }
-
         let refs: Vec<&[f64]> = series.iter().map(Vec::as_slice).collect();
-        // augurs' outlier `Error` is not `Send + Sync`, so it cannot flow
-        // through `anyhow::Context`; render it into an `anyhow::Error` instead.
-        let preprocessed = self
-            .detector
-            .preprocess(&refs)
-            .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD preprocess failed: {e}"))?;
-        let output = self
-            .detector
-            .detect(&preprocessed)
-            .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD detect failed: {e}"))?;
+        let output = self.detector.run(&refs)?;
 
         self.value = AugursOutliers {
             outlying: output.outlying_series.iter().copied().collect(),
@@ -111,8 +162,8 @@ impl MutableNode for AugursOutlierNode {
 pub trait AugursOutlierOperators {
     /// Maintain a sliding window of per-series readings (one `f64` per series
     /// per tick) and emit an [`AugursOutliers`] each tick once at least two
-    /// samples have arrived, flagging series that deviate from the group via
-    /// the MAD detector.
+    /// samples have arrived, flagging series that deviate from the group via the
+    /// configured detector.
     ///
     /// # Panics
     ///
@@ -130,12 +181,24 @@ impl AugursOutlierOperators for dyn Stream<Vec<f64>> {
         config: impl Into<AugursOutlierConfig>,
     ) -> Rc<dyn Stream<AugursOutliers>> {
         let config = config.into();
-        let detector = MADDetector::with_sensitivity(config.sensitivity).unwrap_or_else(|e| {
-            panic!(
-                "augurs_outlier: invalid sensitivity {}: {e}",
-                config.sensitivity
-            )
-        });
+        let detector = match config.detector {
+            AugursOutlierDetector::Mad => Detector::Mad(
+                MADDetector::with_sensitivity(config.sensitivity).unwrap_or_else(|e| {
+                    panic!(
+                        "augurs_outlier: invalid sensitivity {}: {e}",
+                        config.sensitivity
+                    )
+                }),
+            ),
+            AugursOutlierDetector::Dbscan => Detector::Dbscan(
+                DbscanDetector::with_sensitivity(config.sensitivity).unwrap_or_else(|e| {
+                    panic!(
+                        "augurs_outlier: invalid sensitivity {}: {e}",
+                        config.sensitivity
+                    )
+                }),
+            ),
+        };
         AugursOutlierNode::new(self.clone(), detector, config.window).into_stream()
     }
 }
@@ -148,9 +211,9 @@ mod tests {
     use std::time::Duration;
 
     /// Three series move together except one, which jumps away part-way
-    /// through. The diverging series should be flagged as an outlier.
+    /// through. The diverging series should be flagged by MAD.
     #[test]
-    fn outlier_flags_diverging_series() {
+    fn outlier_mad_flags_diverging_series() {
         // Per tick: [series0, series1, series2]. Series 2 spikes after a while.
         let readings = ticker(Duration::from_secs(1)).count().map(|n| {
             let base = 100.0 + (n as f64 * 0.4).sin();
@@ -171,6 +234,29 @@ mod tests {
         );
         assert!(!last.is_outlier(0));
         assert!(!last.is_outlier(1));
+    }
+
+    /// DBSCAN flags a series diverging from a cluster of similar series.
+    #[test]
+    fn outlier_dbscan_flags_diverging_series() {
+        // Four series: three cluster together, series 3 diverges.
+        let readings = ticker(Duration::from_secs(1)).count().map(|n| {
+            let base = 100.0 + (n as f64 * 0.4).sin();
+            let series3 = if n > 15 { base + 90.0 } else { base + 0.3 };
+            vec![base, base + 0.1, base - 0.1, series3]
+        });
+        let outliers = readings.augurs_outlier(AugursOutlierConfig::dbscan(40, 0.5));
+        let captured = outliers.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+            .unwrap();
+
+        let last = outliers.peek_value();
+        assert_eq!(last.scores.len(), 4);
+        assert!(
+            last.is_outlier(3),
+            "series 3 diverged and should be flagged by DBSCAN, got {last:?}"
+        );
     }
 
     /// With all series moving together, nothing is flagged.

--- a/wingfoil/src/adapters/augurs/outlier.rs
+++ b/wingfoil/src/adapters/augurs/outlier.rs
@@ -127,10 +127,7 @@ impl AugursOutlierNode {
 #[node(active = [upstream], output = value: AugursOutliers)]
 impl MutableNode for AugursOutlierNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.window {
-            self.buffer.pop_front();
-        }
+        super::push_windowed(&mut self.buffer, self.upstream.peek_value(), self.window);
         // Need at least two timestamps to have any spread to measure.
         if self.buffer.len() < 2 {
             return Ok(false);

--- a/wingfoil/src/adapters/augurs/outlier.rs
+++ b/wingfoil/src/adapters/augurs/outlier.rs
@@ -1,0 +1,208 @@
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use augurs::outlier::{MADDetector, OutlierDetector};
+
+use super::AugursOutliers;
+use crate::types::*;
+
+/// Configuration for [`AugursOutlierOperators::augurs_outlier`].
+#[derive(Debug, Clone)]
+pub struct AugursOutlierConfig {
+    /// Number of recent samples retained as the detection window.
+    pub window: usize,
+    /// MAD sensitivity, strictly between 0 and 1. Higher is more sensitive.
+    /// Used to derive a detection threshold from the scale of the data.
+    pub sensitivity: f64,
+}
+
+impl AugursOutlierConfig {
+    /// Detect over the last `window` samples at the given MAD `sensitivity`
+    /// (must be in `(0, 1)`).
+    #[must_use]
+    pub fn new(window: usize, sensitivity: f64) -> Self {
+        Self {
+            window,
+            sensitivity,
+        }
+    }
+}
+
+impl From<(usize, f64)> for AugursOutlierConfig {
+    /// `(window, sensitivity)`.
+    fn from((window, sensitivity): (usize, f64)) -> Self {
+        Self::new(window, sensitivity)
+    }
+}
+
+pub(crate) struct AugursOutlierNode {
+    upstream: Rc<dyn Stream<Vec<f64>>>,
+    detector: MADDetector,
+    window: usize,
+    buffer: VecDeque<Vec<f64>>,
+    value: AugursOutliers,
+}
+
+impl AugursOutlierNode {
+    fn new(upstream: Rc<dyn Stream<Vec<f64>>>, detector: MADDetector, window: usize) -> Self {
+        Self {
+            upstream,
+            detector,
+            window: window.max(2),
+            buffer: VecDeque::with_capacity(window.max(2)),
+            value: AugursOutliers::default(),
+        }
+    }
+}
+
+#[node(active = [upstream], output = value: AugursOutliers)]
+impl MutableNode for AugursOutlierNode {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.buffer.push_back(self.upstream.peek_value());
+        while self.buffer.len() > self.window {
+            self.buffer.pop_front();
+        }
+        // MAD needs at least two timestamps to have any spread to measure.
+        if self.buffer.len() < 2 {
+            return Ok(false);
+        }
+
+        // Transpose the buffered samples (one value per series per tick) into
+        // aligned per-series time series. Missing entries are filled forward
+        // with the series' previous value so the columns stay the same length.
+        let n_series = self.buffer.iter().map(Vec::len).max().unwrap_or(0);
+        if n_series == 0 {
+            return Ok(false);
+        }
+        let mut series: Vec<Vec<f64>> = vec![Vec::with_capacity(self.buffer.len()); n_series];
+        for sample in &self.buffer {
+            for (j, col) in series.iter_mut().enumerate() {
+                let value = sample.get(j).copied().or_else(|| col.last().copied());
+                col.push(value.unwrap_or(0.0));
+            }
+        }
+
+        let refs: Vec<&[f64]> = series.iter().map(Vec::as_slice).collect();
+        // augurs' outlier `Error` is not `Send + Sync`, so it cannot flow
+        // through `anyhow::Context`; render it into an `anyhow::Error` instead.
+        let preprocessed = self
+            .detector
+            .preprocess(&refs)
+            .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD preprocess failed: {e}"))?;
+        let output = self
+            .detector
+            .detect(&preprocessed)
+            .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD detect failed: {e}"))?;
+
+        self.value = AugursOutliers {
+            outlying: output.outlying_series.iter().copied().collect(),
+            scores: output
+                .series_results
+                .iter()
+                .map(|s| s.scores.last().copied().unwrap_or(0.0))
+                .collect(),
+        };
+        Ok(true)
+    }
+}
+
+/// Adds the [`augurs_outlier`](AugursOutlierOperators::augurs_outlier) operator
+/// to streams of per-series readings.
+pub trait AugursOutlierOperators {
+    /// Maintain a sliding window of per-series readings (one `f64` per series
+    /// per tick) and emit an [`AugursOutliers`] each tick once at least two
+    /// samples have arrived, flagging series that deviate from the group via
+    /// the MAD detector.
+    ///
+    /// # Panics
+    ///
+    /// Panics at wiring time if `sensitivity` is not in `(0, 1)`.
+    #[must_use]
+    fn augurs_outlier(
+        self: &Rc<Self>,
+        config: impl Into<AugursOutlierConfig>,
+    ) -> Rc<dyn Stream<AugursOutliers>>;
+}
+
+impl AugursOutlierOperators for dyn Stream<Vec<f64>> {
+    fn augurs_outlier(
+        self: &Rc<Self>,
+        config: impl Into<AugursOutlierConfig>,
+    ) -> Rc<dyn Stream<AugursOutliers>> {
+        let config = config.into();
+        let detector = MADDetector::with_sensitivity(config.sensitivity).unwrap_or_else(|e| {
+            panic!(
+                "augurs_outlier: invalid sensitivity {}: {e}",
+                config.sensitivity
+            )
+        });
+        AugursOutlierNode::new(self.clone(), detector, config.window).into_stream()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::*;
+    use crate::nodes::*;
+    use std::time::Duration;
+
+    /// Three series move together except one, which jumps away part-way
+    /// through. The diverging series should be flagged as an outlier.
+    #[test]
+    fn outlier_flags_diverging_series() {
+        // Per tick: [series0, series1, series2]. Series 2 spikes after a while.
+        let readings = ticker(Duration::from_secs(1)).count().map(|n| {
+            let base = 100.0 + (n as f64 * 0.4).sin();
+            let series2 = if n > 20 { base + 80.0 } else { base + 0.2 };
+            vec![base, base + 0.1, series2]
+        });
+        let outliers = readings.augurs_outlier(AugursOutlierConfig::new(40, 0.5));
+        let captured = outliers.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+            .unwrap();
+
+        let last = outliers.peek_value();
+        assert_eq!(last.scores.len(), 3, "one score per series");
+        assert!(
+            last.is_outlier(2),
+            "series 2 diverged and should be flagged, got {last:?}"
+        );
+        assert!(!last.is_outlier(0));
+        assert!(!last.is_outlier(1));
+    }
+
+    /// With all series moving together, nothing is flagged.
+    #[test]
+    fn outlier_quiet_when_aligned() {
+        let readings = ticker(Duration::from_secs(1)).count().map(|n| {
+            let base = 50.0 + (n as f64 * 0.3).sin();
+            vec![base, base + 0.05, base - 0.05]
+        });
+        let outliers = readings.augurs_outlier((30, 0.5));
+        let captured = outliers.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+            .unwrap();
+        assert!(
+            outliers.peek_value().outlying.is_empty(),
+            "aligned series should produce no outliers, got {:?}",
+            outliers.peek_value()
+        );
+    }
+
+    /// The node stays silent until it has at least two samples.
+    #[test]
+    fn outlier_waits_for_two_samples() {
+        let readings = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| vec![n as f64, n as f64 + 1.0]);
+        let outliers = readings.augurs_outlier((8, 0.5));
+        let captured = outliers.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+            .unwrap();
+        assert!(captured.peek_value().is_empty());
+    }
+}

--- a/wingfoil/src/adapters/augurs/seasons.rs
+++ b/wingfoil/src/adapters/augurs/seasons.rs
@@ -93,10 +93,7 @@ impl AugursSeasonsNode {
 #[node(active = [upstream], output = value: AugursSeasons)]
 impl MutableNode for AugursSeasonsNode {
     fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
-        self.buffer.push_back(self.upstream.peek_value());
-        while self.buffer.len() > self.window {
-            self.buffer.pop_front();
-        }
+        super::push_windowed(&mut self.buffer, self.upstream.peek_value(), self.window);
         if self.buffer.len() < self.min_points {
             return Ok(false);
         }

--- a/wingfoil/src/adapters/augurs/seasons.rs
+++ b/wingfoil/src/adapters/augurs/seasons.rs
@@ -1,0 +1,179 @@
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use augurs::seasons::{Detector, PeriodogramDetector};
+
+use super::AugursSeasons;
+use crate::types::*;
+
+/// Configuration for [`AugursSeasonsOperators::augurs_seasons`].
+#[derive(Debug, Clone)]
+pub struct AugursSeasonsConfig {
+    /// Number of recent points retained as the detection window.
+    pub window: usize,
+    /// Minimum number of buffered points before detection runs.
+    pub min_points: usize,
+    /// Shortest seasonal period to consider (in samples). `None` uses the
+    /// augurs default.
+    pub min_period: Option<u32>,
+    /// Longest seasonal period to consider (in samples). `None` uses the augurs
+    /// default (derived from the window length).
+    pub max_period: Option<u32>,
+}
+
+impl AugursSeasonsConfig {
+    /// Detect seasonal periods over the last `window` points using the default
+    /// period bounds.
+    #[must_use]
+    pub fn new(window: usize) -> Self {
+        Self {
+            window,
+            min_points: (window / 2).max(16),
+            min_period: None,
+            max_period: None,
+        }
+    }
+
+    /// Restrict detection to periods within `[min_period, max_period]` samples.
+    #[must_use]
+    pub fn with_period_range(mut self, min_period: u32, max_period: u32) -> Self {
+        self.min_period = Some(min_period);
+        self.max_period = Some(max_period);
+        self
+    }
+
+    /// Set the minimum number of points required before detection begins.
+    #[must_use]
+    pub fn with_min_points(mut self, min_points: usize) -> Self {
+        self.min_points = min_points;
+        self
+    }
+}
+
+impl From<usize> for AugursSeasonsConfig {
+    /// `window`, with default period bounds.
+    fn from(window: usize) -> Self {
+        Self::new(window)
+    }
+}
+
+pub(crate) struct AugursSeasonsNode {
+    upstream: Rc<dyn Stream<f64>>,
+    detector: PeriodogramDetector,
+    window: usize,
+    min_points: usize,
+    buffer: VecDeque<f64>,
+    value: AugursSeasons,
+}
+
+impl AugursSeasonsNode {
+    fn new(upstream: Rc<dyn Stream<f64>>, config: AugursSeasonsConfig) -> Self {
+        let mut builder = PeriodogramDetector::builder();
+        if let Some(min_period) = config.min_period {
+            builder = builder.min_period(min_period);
+        }
+        if let Some(max_period) = config.max_period {
+            builder = builder.max_period(max_period);
+        }
+        let cap = config.window.max(config.min_points);
+        Self {
+            upstream,
+            detector: builder.build(),
+            window: config.window,
+            min_points: config.min_points,
+            buffer: VecDeque::with_capacity(cap),
+            value: AugursSeasons::default(),
+        }
+    }
+}
+
+#[node(active = [upstream], output = value: AugursSeasons)]
+impl MutableNode for AugursSeasonsNode {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.buffer.push_back(self.upstream.peek_value());
+        while self.buffer.len() > self.window {
+            self.buffer.pop_front();
+        }
+        if self.buffer.len() < self.min_points {
+            return Ok(false);
+        }
+
+        let data: Vec<f64> = self.buffer.iter().copied().collect();
+        self.value = AugursSeasons {
+            periods: self.detector.detect(&data),
+        };
+        Ok(true)
+    }
+}
+
+/// Adds the [`augurs_seasons`](AugursSeasonsOperators::augurs_seasons) operator
+/// to `f64` streams.
+pub trait AugursSeasonsOperators {
+    /// Maintain a sliding window of this stream and, once `min_points` have
+    /// arrived, emit an [`AugursSeasons`] each tick with the seasonal period
+    /// lengths detected by a periodogram.
+    ///
+    /// augurs estimates periods with a Welch periodogram over power-of-two FFT
+    /// segments, so the reported lengths are **approximate** (coarsely binned) —
+    /// good for spotting *that* a season exists and its rough scale, not for
+    /// exact period recovery.
+    #[must_use]
+    fn augurs_seasons(
+        self: &Rc<Self>,
+        config: impl Into<AugursSeasonsConfig>,
+    ) -> Rc<dyn Stream<AugursSeasons>>;
+}
+
+impl AugursSeasonsOperators for dyn Stream<f64> {
+    fn augurs_seasons(
+        self: &Rc<Self>,
+        config: impl Into<AugursSeasonsConfig>,
+    ) -> Rc<dyn Stream<AugursSeasons>> {
+        AugursSeasonsNode::new(self.clone(), config.into()).into_stream()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::*;
+    use crate::nodes::*;
+    use std::time::Duration;
+
+    /// A clean period-12 sine wave should be detected as having a ~12-sample
+    /// season.
+    #[test]
+    fn seasons_detects_known_period() {
+        let series = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| (n as f64 * std::f64::consts::TAU / 12.0).sin());
+        let seasons = series.augurs_seasons(AugursSeasonsConfig::new(96));
+        let captured = seasons.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(96))
+            .unwrap();
+
+        let last = seasons.peek_value();
+        assert!(
+            last.periods.iter().any(|&p| (10..=14).contains(&p)),
+            "expected a period near 12, got {:?}",
+            last.periods
+        );
+        let dominant = last.dominant().unwrap();
+        assert!((10..=14).contains(&dominant), "dominant was {dominant}");
+    }
+
+    /// The node stays silent until `min_points` have arrived.
+    #[test]
+    fn seasons_waits_for_min_points() {
+        let series = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| (n as f64 * std::f64::consts::TAU / 12.0).sin());
+        let seasons = series.augurs_seasons(AugursSeasonsConfig::new(96).with_min_points(50));
+        let captured = seasons.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(20))
+            .unwrap();
+        assert!(captured.peek_value().is_empty());
+    }
+}

--- a/wingfoil/src/adapters/augurs/seasons.rs
+++ b/wingfoil/src/adapters/augurs/seasons.rs
@@ -75,13 +75,16 @@ impl AugursSeasonsNode {
         if let Some(max_period) = config.max_period {
             builder = builder.max_period(max_period);
         }
-        let cap = config.window.max(config.min_points);
+        // Grow the window to at least `min_points` so a `window` below the
+        // warm-up floor still lets the node fill up and emit rather than never
+        // ticking.
+        let window = config.window.max(config.min_points);
         Self {
             upstream,
             detector: builder.build(),
-            window: config.window,
+            window,
             min_points: config.min_points,
-            buffer: VecDeque::with_capacity(cap),
+            buffer: VecDeque::with_capacity(window),
             value: AugursSeasons::default(),
         }
     }
@@ -161,6 +164,25 @@ mod tests {
         );
         let dominant = last.dominant().unwrap();
         assert!((10..=14).contains(&dominant), "dominant was {dominant}");
+    }
+
+    /// A `window` below the default `min_points` floor still warms up and emits
+    /// rather than never ticking (the effective window grows to the floor).
+    #[test]
+    fn seasons_window_below_floor_still_emits() {
+        let series = ticker(Duration::from_secs(1))
+            .count()
+            .map(|n| (n as f64 * std::f64::consts::TAU / 6.0).sin());
+        // window 12 is below the default min_points floor of 16.
+        let seasons = series.augurs_seasons(AugursSeasonsConfig::new(12));
+        let captured = seasons.clone().collect();
+        captured
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+            .unwrap();
+        assert!(
+            !captured.peek_value().is_empty(),
+            "should emit despite window < floor"
+        );
     }
 
     /// The node stays silent until `min_points` have arrived.

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -2,6 +2,8 @@
 
 #[cfg(any(feature = "aeron", feature = "aeron-rs-beta"))]
 pub mod aeron;
+#[cfg(feature = "augurs")]
+pub mod augurs;
 #[cfg(feature = "kdb")]
 pub mod cache;
 #[cfg(feature = "csv")]


### PR DESCRIPTION
augurs (grafana/augurs) is a pure-Rust time-series toolkit rather than a
network service, so this adapter exposes on-graph transform nodes that buffer a
sliding window of an input stream and apply augurs models on the graph thread:

- `augurs_forecast` — fits an AutoETS model over a window of an `f64` stream and
  emits point forecasts with optional prediction intervals.
- `augurs_outlier` — runs the MAD detector over a window of `Vec<f64>` readings
  (one value per series per tick) and flags outlying series.

Because there is no external service this follows the new-adapter skill's
"Option C": a single `augurs` feature (no integration-test feature/containers),
with coverage in `#[cfg(test)]` unit tests run under `--features augurs`.

Includes: Cargo feature + dep, module registration, runnable example with
README, adapter CLAUDE.md, README index tables + snippet, a containerless CI
workflow wired into the integration-tests hub, and Python bindings
(`.augurs_forecast()` / `.augurs_outlier()` PyStream methods) with tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNVUiX5S1JKMZUvduFqNsp