### PR TITLE
Add kdb_sub real-time tickerplant subscription; simplify kdb read signatures

### DIFF
--- a/wingfoil-python/src/py_kdb.rs
+++ b/wingfoil-python/src/py_kdb.rs
@@ -143,7 +143,7 @@ pub fn py_kdb_read(
     chunk_size: u64,
 ) -> PyStream {
     let conn = KdbConnection::new(host, port);
-    let stream: Rc<dyn Stream<Burst<PyKdbRow>>> = kdb_read::<PyKdbRow, _>(
+    let stream: Rc<dyn Stream<Burst<PyKdbRow>>> = kdb_read::<PyKdbRow>(
         conn,
         std::time::Duration::from_secs(chunk_size),
         move |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/README.md
+++ b/wingfoil/examples/README.md
@@ -46,7 +46,7 @@ struct Price {
     mid: f64,
 }
 
-kdb_read::<Price, _>(
+kdb_read::<Price>(
     conn,
     Duration::from_secs(10),
     |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/read/README.md
+++ b/wingfoil/examples/kdb/read/README.md
@@ -49,7 +49,7 @@ impl KdbDeserialize for Price {
     }
 }
 
-kdb_read::<Price, _>(
+kdb_read::<Price>(
     conn,
     Duration::from_secs(10),
     |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/read/main.rs
+++ b/wingfoil/examples/kdb/read/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
     let conn = KdbConnection::new("localhost", 5000);
     let chunk = Duration::from_secs(10);
 
-    kdb_read::<Price, _>(
+    kdb_read::<Price>(
         conn,
         chunk,
         |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/read_cached/README.md
+++ b/wingfoil/examples/kdb/read_cached/README.md
@@ -59,7 +59,7 @@ impl KdbDeserialize for Price {
 // Use u64::MAX for an unbounded cache.
 let config = CacheConfig::new("/tmp/wingfoil-kdb-cache", 10 * 1024 * 1024);
 
-kdb_read_cached::<Price, _>(
+kdb_read_cached::<Price>(
     conn,
     Duration::from_secs(10),
     config,

--- a/wingfoil/examples/kdb/read_cached/main.rs
+++ b/wingfoil/examples/kdb/read_cached/main.rs
@@ -32,7 +32,7 @@ impl KdbDeserialize for Price {
 }
 
 fn run(conn: KdbConnection, config: CacheConfig) -> Result<()> {
-    kdb_read_cached::<Price, _>(
+    kdb_read_cached::<Price>(
         conn,
         Duration::from_secs(10),
         config,

--- a/wingfoil/examples/kdb/round_trip/README.md
+++ b/wingfoil/examples/kdb/round_trip/README.md
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
         .run(run_mode, run_for)?;
     let baseline = generate(num_rows);
     // Read
-    let read = kdb_read::<Trade, _>(
+    let read = kdb_read::<Trade>(
         conn,
         std::time::Duration::from_secs(86400),
         move |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/round_trip/main.rs
+++ b/wingfoil/examples/kdb/round_trip/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
         .run(run_mode, run_for)?;
     let baseline = generate(num_rows);
     // read — use kdb_read with time-slice filtering
-    let read = kdb_read::<Trade, _>(
+    let read = kdb_read::<Trade>(
         conn,
         std::time::Duration::from_secs(86400),
         move |(t0, t1), _date, _iter| {

--- a/wingfoil/src/adapters/cache/mod.rs
+++ b/wingfoil/src/adapters/cache/mod.rs
@@ -38,7 +38,7 @@ impl CacheKey {
 /// # Example
 /// ```ignore
 /// let config = CacheConfig::new("/tmp/my-backtest-cache", 512 * 1024 * 1024); // 512 MiB cap
-/// let stream = kdb_read_cached::<Trade, _>(conn, period, config, query_fn);
+/// let stream = kdb_read_cached::<Trade>(conn, period, config, query_fn);
 /// ```
 #[derive(Debug, Clone)]
 pub struct CacheConfig {

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -7,8 +7,9 @@ This directory contains the KDB+ adapter for wingfoil, enabling reading from and
 ```
 kdb/
   mod.rs               # Public API, connection types, error handling, Sym
-  read.rs              # kdb_read() and shared helpers (compute_time_slices, KdbExt, etc.)
+  read.rs              # kdb_read() and shared helpers (compute_time_slices, KdbExt, upd_payload_rows, etc.)
   read_cached.rs       # kdb_read_cached() — file-cached variant of kdb_read
+  sub.rs               # kdb_sub() — real-time tickerplant subscription
   write.rs             # kdb_write() - writing stream data to KDB+ tables
   integration_tests.rs # Integration tests (requires running KDB+ instance)
 ```
@@ -33,7 +34,20 @@ kdb/
   - `Sym` is fully supported — it serializes as a plain string (interning not restored on load)
   - If a cache file is corrupt, logs a warning and falls back to KDB, then overwrites the bad file
   - **Schema evolution:** `bincode` is not self-describing — delete the cache dir if `T` changes
-- `KdbDeserialize` trait - Convert KDB+ rows to `(NanoTime, T)` tuples
+- `kdb_sub()` - Real-time subscription to a tickerplant (the live counterpart to `kdb_read`)
+  - `kdb_sub(conn, table, symbols)` — `table` is the tickerplant table name (no backtick),
+    `symbols` a q symbol-list literal (`` "`" `` = all, `` "`AAPL`MSFT" `` to filter)
+  - Requires `RunMode::RealTime` (bails otherwise); `kdb_read` is for historical replay
+  - Sends `.u.sub[`table;syms]` synchronously (capturing the schema for column names),
+    then loops on `receive_message()`, decoding each pushed `(`upd; table; data)` message
+  - Genuinely push-based: unlike the postgres `LISTEN`/`NOTIFY` model, the tickerplant
+    pushes the rows themselves — no re-query, no cursor. The `upd` payload (a table or a
+    bare list of column vectors) is normalised via `upd_payload_rows` and decoded with the
+    same `KdbDeserialize` impl `kdb_read` uses
+  - Non-`upd` control messages (e.g. end-of-day `.u.end`) are ignored
+  - Tails from the moment of subscription — does **not** replay the tickerplant log / RDB
+    buffer, so rows published before the run started are not delivered
+  - `KdbDeserialize` trait - Convert KDB+ rows to `(NanoTime, T)` tuples
   - `from_kdb_row` returns `Result<(NanoTime, Self), KdbError>` — implementor owns time extraction
   - Use `row.get_timestamp(col)` to extract a KDB timestamp column as `NanoTime`
   - Your struct should only contain business data (sym, price, qty, etc.)
@@ -144,7 +158,7 @@ impl KdbSerialize for Trade {
 ```rust
 // Same query closure as kdb_read, plus a cache directory.
 // T must also implement serde::Serialize + serde::Deserialize + Sync.
-let stream = kdb_read_cached::<Trade, _>(
+let stream = kdb_read_cached::<Trade>(
     conn,
     std::time::Duration::from_secs(3600),
     "/tmp/my-backtest-cache",
@@ -162,7 +176,7 @@ let stream = kdb_read_cached::<Trade, _>(
 
 ```rust
 // Date-partitioned table: filter by date and time range in each slice
-let stream = kdb_read::<Trade, _>(
+let stream = kdb_read::<Trade>(
     conn,
     std::time::Duration::from_secs(3600), // 1-hour slices
     |(t0, t1), date, _| {

--- a/wingfoil/src/adapters/kdb/cache_integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/cache_integration_tests.rs
@@ -46,7 +46,7 @@ impl KdbDeserialize for TestTradeCached {
 
 /// Run `kdb_read_cached` over one day of `TABLE_NAME` and return the row count.
 fn run_cached(conn: KdbConnection, cache_dir: &std::path::Path) -> Result<usize> {
-    let stream = kdb_read_cached::<TestTradeCached, _>(
+    let stream = kdb_read_cached::<TestTradeCached>(
         conn,
         PERIOD,
         CacheConfig::new(cache_dir, u64::MAX),
@@ -160,7 +160,7 @@ fn test_kdb_read_cached_partial_cache() -> Result<()> {
     let half_day = std::time::Duration::from_secs(12 * 3600);
 
     let run = |conn: KdbConnection| -> Result<usize> {
-        let stream = kdb_read_cached::<TestTradeCached, _>(
+        let stream = kdb_read_cached::<TestTradeCached>(
             conn,
             half_day,
             CacheConfig::new(&cache_dir, u64::MAX),

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -286,7 +286,7 @@ fn test_kdb_sorted_data() -> Result<()> {
     let _ = env_logger::try_init();
     // 3 rows/day × 2 days = 6 rows total; one 24-hour slice per day.
     with_test_data(3, 2, true, |_n, conn| {
-        let stream = kdb_read::<TestTrade, _>(
+        let stream = kdb_read::<TestTrade>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
@@ -333,7 +333,7 @@ impl KdbDeserialize for BadTrade {
 fn test_kdb_bad_query() -> Result<()> {
     let _ = env_logger::try_init();
     let conn = TestDataBuilder::connection();
-    let stream = kdb_read::<TestTrade, _>(
+    let stream = kdb_read::<TestTrade>(
         conn,
         std::time::Duration::from_secs(24 * 3600),
         |_, _, _| "select from nonexistent_table_xyz".to_string(),
@@ -351,7 +351,7 @@ fn test_kdb_bad_query() -> Result<()> {
 fn test_kdb_deserialization_error() -> Result<()> {
     let _ = env_logger::try_init();
     let result = with_test_data(3, 1, true, |_n, conn| {
-        let stream = kdb_read::<BadTrade, _>(
+        let stream = kdb_read::<BadTrade>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
@@ -392,7 +392,7 @@ fn test_read_read_perf() -> Result<()> {
 
         for &period in &periods {
             let start = std::time::Instant::now();
-            let stream = kdb_read::<TestTrade, _>(conn.clone(), period, |within, date, _| {
+            let stream = kdb_read::<TestTrade>(conn.clone(), period, |within, date, _| {
                 slice_query(date, within.0, within.1)
             });
             let counter = stream.collapse().count();
@@ -412,7 +412,7 @@ fn test_read_read_perf() -> Result<()> {
 fn test_kdb_connection_refused() -> Result<()> {
     let _ = env_logger::try_init();
     let conn = KdbConnection::new("localhost", 59999);
-    let stream = kdb_read::<TestTrade, _>(
+    let stream = kdb_read::<TestTrade>(
         conn,
         std::time::Duration::from_secs(24 * 3600),
         |_, _, _| format!("select from {TABLE_NAME}"),
@@ -430,7 +430,7 @@ fn test_kdb_connection_refused() -> Result<()> {
 fn test_kdb_empty_table_returns_zero_rows() -> Result<()> {
     let _ = env_logger::try_init();
     with_empty_table(|conn| {
-        let stream = kdb_read::<TestTrade, _>(
+        let stream = kdb_read::<TestTrade>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
@@ -467,7 +467,7 @@ fn test_kdb_read_works() -> Result<()> {
     with_test_data(3, 2, true, |_n, conn| {
         let start = NanoTime::from_kdb_timestamp(0); // 2000.01.01D00:00:00
 
-        let stream = kdb_read::<TestTrade, _>(
+        let stream = kdb_read::<TestTrade>(
             conn,
             std::time::Duration::from_secs(12 * 3600), // 12-hour slices
             move |(slice_start, slice_end), date, _iteration| {
@@ -561,7 +561,7 @@ fn test_kdb_write_round_trip() -> Result<()> {
 
         // Verify data correctness by reading back via kdb_read.
         // The write table has no date column so we filter by time only.
-        let read_stream = kdb_read::<TestTradeWrite, _>(
+        let read_stream = kdb_read::<TestTradeWrite>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             move |(t0, t1), _, _| {

--- a/wingfoil/src/adapters/kdb/mod.rs
+++ b/wingfoil/src/adapters/kdb/mod.rs
@@ -1,7 +1,9 @@
 //! KDB+ database adapter for reading and writing data to q/kdb+ instances.
 //!
 //! This module provides async connectivity to KDB+ databases using the `kdbplus` crate,
-//! allowing query results to be streamed into wingfoil graphs.
+//! allowing query results to be streamed into wingfoil graphs. Historical reads
+//! (`kdb_read`), real-time tickerplant subscriptions (`kdb_sub`), and writes
+//! (`kdb_write`) are all supported.
 //!
 //! # Example
 //!
@@ -31,7 +33,7 @@
 //!     .with_credentials("user", "pass");
 //!
 //! // Read with time-sliced chunking, one slice per hour
-//! kdb_read::<Trade, _>(
+//! kdb_read::<Trade>(
 //!     conn,
 //!     std::time::Duration::from_secs(3600),
 //!     |(t0, t1), date, _| {
@@ -54,6 +56,7 @@
 
 mod read;
 mod read_cached;
+mod sub;
 mod write;
 
 #[cfg(all(test, feature = "kdb-integration-test"))]
@@ -64,6 +67,7 @@ mod integration_tests;
 pub use crate::adapters::cache::CacheConfig;
 pub use read::*;
 pub use read_cached::*;
+pub use sub::*;
 pub use write::*;
 
 /// Re-export kdbplus error type for convenience.

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -55,6 +55,16 @@ impl Rows {
         self.n_rows == 0
     }
 
+    /// Build a [`Rows`] accessor directly from a list of column vectors.
+    ///
+    /// A tickerplant `upd` payload is a bare list of per-column vectors rather
+    /// than a flipped table dictionary; this wraps that list so [`kdb_sub`](crate::kdb_sub)
+    /// can reuse the same indexed row access as [`kdb_read`].
+    pub(super) fn from_column_list(columns: Vec<K>) -> Self {
+        let n_rows = columns.first().map(K::len).unwrap_or(0);
+        Rows { columns, n_rows }
+    }
+
     /// Get a row by index.
     pub fn get(&self, index: usize) -> Option<Row<'_>> {
         if index < self.n_rows {
@@ -265,6 +275,29 @@ impl KdbExt for K {
     }
 }
 
+/// Turn a tickerplant `upd` payload into a [`Rows`] accessor.
+///
+/// The third element of a `(`upd; table; data)` message is either a table
+/// (qtype 98) or a bare list of column vectors, depending on the tickerplant.
+/// Both are normalised to [`Rows`] so [`kdb_sub`](crate::kdb_sub) can decode
+/// them with the same [`KdbDeserialize`] impls that [`kdb_read`] uses.
+pub(super) fn upd_payload_rows(data: &K) -> Result<Rows> {
+    if data.get_type() == qtype::TABLE {
+        data.rows()
+    } else {
+        let columns = data
+            .as_vec::<K>()
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "kdb_sub: upd payload is neither a table nor a list of columns (qtype {})",
+                    data.get_type()
+                )
+            })?
+            .clone();
+        Ok(Rows::from_column_list(columns))
+    }
+}
+
 /// Trait for deserializing KDB row data into Rust types.
 ///
 /// Implementors extract fields from the row using indexed column access and return
@@ -412,14 +445,13 @@ pub(crate) fn compute_time_slices(
 }
 
 #[must_use]
-pub fn kdb_read<T, F>(
+pub fn kdb_read<T>(
     connection: KdbConnection,
     period: std::time::Duration,
-    query_fn: F,
+    query_fn: impl FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 ) -> Rc<dyn Stream<Burst<T>>>
 where
     T: Element + Send + KdbDeserialize + 'static,
-    F: FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 {
     produce_async(move |ctx| {
         let start_time = ctx.start_time;

--- a/wingfoil/src/adapters/kdb/read_cached.rs
+++ b/wingfoil/src/adapters/kdb/read_cached.rs
@@ -39,7 +39,7 @@ use std::rc::Rc;
 /// # Example
 /// ```ignore
 /// let config = CacheConfig::new("/tmp/my-backtest-cache", 512 * 1024 * 1024);
-/// let stream = kdb_read_cached::<Trade, _>(
+/// let stream = kdb_read_cached::<Trade>(
 ///     KdbConnection::new("localhost", 5000),
 ///     Duration::from_secs(3600),
 ///     config,
@@ -51,11 +51,11 @@ use std::rc::Rc;
 /// );
 /// ```
 #[must_use]
-pub fn kdb_read_cached<T, F>(
+pub fn kdb_read_cached<T>(
     connection: KdbConnection,
     period: std::time::Duration,
     cache_config: CacheConfig,
-    query_fn: F,
+    query_fn: impl FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 ) -> Rc<dyn Stream<Burst<T>>>
 where
     T: Element
@@ -65,7 +65,6 @@ where
         + serde::Serialize
         + for<'de> serde::Deserialize<'de>
         + 'static,
-    F: FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 {
     produce_async(move |ctx| {
         let start_time = ctx.start_time;

--- a/wingfoil/src/adapters/kdb/sub.rs
+++ b/wingfoil/src/adapters/kdb/sub.rs
@@ -1,0 +1,189 @@
+//! KDB+ real-time subscription via a tickerplant.
+//!
+//! [`kdb_sub`] is the real-time counterpart to [`kdb_read`](super::kdb_read)
+//! (bounded historical replay): it subscribes to a q **tickerplant** and streams
+//! rows on-graph as they are published, using the same [`KdbDeserialize`] impls.
+
+use super::read::upd_payload_rows;
+use super::{KdbConnection, KdbDeserialize, KdbExt, SymbolInterner};
+use crate::RunMode;
+use crate::nodes::produce_async;
+use crate::types::*;
+use anyhow::Context;
+use kdb_plus_fixed::ipc::{ConnectionMethod, QStream};
+use kdb_plus_fixed::qtype;
+use log::info;
+use std::rc::Rc;
+
+/// Live-subscribe to a KDB+ tickerplant and stream published rows in real time.
+///
+/// Complements [`kdb_read`](super::kdb_read) (bounded historical replay) with an
+/// unbounded real-time source. Rows published to `table` while the graph runs are
+/// streamed on-graph as `Burst<T>`, decoded by the same [`KdbDeserialize`] impl
+/// `kdb_read` uses.
+///
+/// # How it works
+///
+/// A tickerplant is genuinely push-based (unlike the etcd/postgres LISTEN model,
+/// where the notification is only a wake-up and rows are re-queried):
+///
+/// 1. Opens a connection and sends `.u.sub[`table;syms]` **synchronously**. The
+///    reply carries the table schema, from which the column names are captured.
+/// 2. Loops on [`QStream::receive_message`], decoding each async
+///    `(`upd; table; data)` message the tickerplant pushes. The `data` payload —
+///    a table or a bare list of column vectors — is turned into rows and each is
+///    handed to `T::from_kdb_row`. Non-`upd` control messages (e.g. the
+///    end-of-day `.u.end`) are ignored.
+///
+/// # Subscription arguments
+///
+/// - `table` — the tickerplant table name (no leading backtick), e.g. `"trades"`.
+/// - `symbols` — a q symbol-list literal selecting which syms to receive:
+///   `` "`" `` for all, `` "`AAPL`MSFT" `` to filter. This is spliced into the
+///   `.u.sub` call, mirroring `kdb_read`'s caller-builds-the-query approach.
+///
+/// # Requirements
+///
+/// - `RunMode::RealTime` (use `kdb_read` for historical replay); bails otherwise.
+/// - `.u.sub` tails from the moment of subscription — it does **not** replay the
+///   tickerplant's log or the RDB's in-memory buffer, so rows published before the
+///   graph started are not delivered. Under `RunMode::RealTime` the on-graph time
+///   is the row's arrival (wall-clock) time; the timestamp column extracted by
+///   `from_kdb_row` is carried through but not used to order the real-time stream.
+#[must_use]
+pub fn kdb_sub<T>(
+    connection: KdbConnection,
+    table: impl Into<String>,
+    symbols: impl Into<String>,
+) -> Rc<dyn Stream<Burst<T>>>
+where
+    T: Element + Send + KdbDeserialize + 'static,
+{
+    let table = table.into();
+    let symbols = symbols.into();
+    produce_async(move |ctx| {
+        let run_mode = ctx.run_mode;
+        let connection = connection;
+        let table = table;
+        let symbols = symbols;
+
+        async move {
+            if !matches!(run_mode, RunMode::RealTime) {
+                anyhow::bail!(
+                    "kdb_sub requires RunMode::RealTime; use kdb_read for historical replay"
+                );
+            }
+
+            let creds = connection.credentials_string();
+            let mut socket = QStream::connect(
+                ConnectionMethod::TCP,
+                &connection.host,
+                connection.port,
+                &creds,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "kdb_sub: failed to connect to {}:{}",
+                    connection.host, connection.port
+                )
+            })?;
+
+            // Subscribe synchronously; the reply is `(`table; schema)`, from which
+            // we capture the column names for positional row decoding.
+            let sub_query = format!(".u.sub[`{table};{symbols}]");
+            info!("kdb_sub: {sub_query}");
+            let sub_reply = socket
+                .send_sync_message(&sub_query.as_str())
+                .await
+                .with_context(|| format!("kdb_sub: subscription `{sub_query}` failed"))?;
+            let columns: Vec<String> = sub_reply
+                .element_at(1)
+                .ok()
+                .and_then(|schema| schema.column_names().ok())
+                .unwrap_or_default();
+
+            Ok(async_stream::stream! {
+                let mut interner = SymbolInterner::default();
+                loop {
+                    let (_msg_type, msg) = match socket.receive_message().await {
+                        Ok(m) => m,
+                        Err(e) => {
+                            yield Err(anyhow::Error::new(e).context("kdb_sub: receive failed"));
+                            break;
+                        }
+                    };
+
+                    // A tickerplant update is `(`upd; `table; data)` — a 3-element
+                    // compound list whose first element is the symbol `upd`. Skip
+                    // anything else (heartbeats, `.u.end`, etc.).
+                    if msg.get_type() != qtype::COMPOUND_LIST || msg.len() < 3 {
+                        continue;
+                    }
+                    match msg.element_at(0).ok().as_ref().and_then(|f| f.get_symbol().ok()) {
+                        Some("upd") => {}
+                        _ => continue,
+                    }
+
+                    let data = match msg.element_at(2) {
+                        Ok(d) => d,
+                        Err(e) => {
+                            yield Err(anyhow::Error::new(e).context("kdb_sub: upd message has no data"));
+                            break;
+                        }
+                    };
+
+                    let rows = match upd_payload_rows(&data) {
+                        Ok(rows) => rows,
+                        Err(e) => { yield Err(e); break; }
+                    };
+
+                    for row in &rows {
+                        match T::from_kdb_row(row, &columns, &mut interner) {
+                            Ok((time, record)) => yield Ok((time, record)),
+                            Err(e) => { yield Err(anyhow::Error::new(e)); return; }
+                        }
+                    }
+                }
+            })
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::kdb::{KdbError, Row};
+    use crate::nodes::{NodeOperators, StreamOperators};
+    use crate::{RunFor, RunMode};
+
+    #[derive(Debug, Clone, Default)]
+    struct TestRow;
+
+    impl KdbDeserialize for TestRow {
+        fn from_kdb_row(
+            _row: Row<'_>,
+            _columns: &[String],
+            _interner: &mut SymbolInterner,
+        ) -> std::result::Result<(NanoTime, Self), KdbError> {
+            Ok((NanoTime::ZERO, TestRow))
+        }
+    }
+
+    #[test]
+    fn test_sub_rejects_historical_mode() {
+        // Bails on the run-mode guard before any connection is attempted.
+        let result = kdb_sub::<TestRow>(KdbConnection::new("127.0.0.1", 1), "trades", "`")
+            .collapse()
+            .collect()
+            .run(
+                RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
+                RunFor::Cycles(1),
+            );
+        let err = result.expect_err("historical mode must be rejected");
+        assert!(
+            format!("{err:#}").contains("requires RunMode::RealTime"),
+            "unexpected error: {err:#}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a real-time KDB+ read path and simplifies the historical read signatures.
Scope is **kdb only** — the PostgreSQL adapter lives in #411.

## `kdb_sub` — real-time tickerplant subscription

The live counterpart to `kdb_read` (bounded historical replay). It subscribes to a
q **tickerplant** via `.u.sub[`table;syms]` and streams published rows on-graph as
they arrive, decoded by the same `KdbDeserialize` impls `kdb_read` uses.

Unlike the postgres `LISTEN`/`NOTIFY` model — where the notification is only a
wake-up and rows are re-queried — a tickerplant is genuinely push-based: the
`(`upd; table; data)` message carries the rows themselves, so there is **no
re-query and no cursor**. The `upd` payload (a table or a bare list of column
vectors) is normalised by a new `upd_payload_rows` helper in `read.rs` and fed
through the existing `Rows`/`from_kdb_row` decode path.

- Requires `RunMode::RealTime` (bails otherwise); `kdb_read` stays historical.
- Captures column names from the synchronous `.u.sub` reply schema.
- Ignores non-`upd` control messages (e.g. end-of-day `.u.end`).
- Tails from subscription time; does **not** replay the tickerplant log / RDB buffer.
- Unit test covers the `RunMode::RealTime` guard (no live server needed).

## Read-signature simplification

Factors the query-closure generic `F` out of `kdb_read` and `kdb_read_cached`: it is
now an argument-position `impl FnMut(...)`, so callers write `kdb_read::<Trade>(…)`
instead of `kdb_read::<Trade, _>(…)`, matching the `csv_read` style. All kdb call
sites, examples, and docs updated.

## Testing note

The subscribe→receive→decode loop is **not** exercised against a live tickerplant
(none available in CI here); the wire path is covered by reuse of the existing,
tested `Rows`/`from_kdb_row` machinery, and the run-mode guard is unit-tested. A
`kdb-integration-test` against a real `tick.q` (plus an example and Python binding,
matching how `postgres_sub` shipped) is a sensible follow-up.

## Verification

- `cargo clippy` (kdb + integration-test features, `-D warnings`) — clean
- `cargo fmt --all --check` — clean
- 241 kdb lib unit tests pass (incl. the new guard test)
- `wingfoil-python` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cj5Jt9YcxAqSCPKuAVuDk

---
_Generated by [Claude Code](https://claude.ai/code/session_014Cj5Jt9YcxAqSCPKuAVuDk)_