### PR TITLE
Add kdb_sub for real-time tickerplant subscriptions

### DIFF
--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -63,9 +63,8 @@ for (time, record) in rows {
 filter.finish();                          // one summary warn! if anything was dropped
 ```
 
-`adapters::common` is feature-gated in `wingfoil/src/adapters/mod.rs` (currently
-`#[cfg(feature = "kdb")]`); add your adapter's feature to that gate when you
-become the first non-kdb consumer. Reference implementation: `kdb_read` /
+`adapters::common` is always compiled (no feature gate), so it's available to
+every adapter out of the box. Reference implementation: `kdb_read` /
 `kdb_read_cached` in `wingfoil/src/adapters/kdb/`.
 
 ## 1. Branch

--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -35,6 +35,39 @@ stream of deltas), `arc_swap::ArcSwap<T>` gives a lock-free atomic pointer swap
 in `cycle()` that the reader can `.load()` off-thread — see
 `wingfoil/src/adapters/prometheus/exporter.rs` for the per-slot pattern.
 
+### Historical reads: clamp emitted rows to the run window
+
+Applies to any adapter that replays historical data (`RunMode::HistoricalFrom`)
+from a caller-parameterised range — time-sliced queries, cursor/offset replays,
+file scans. Real-time sources (`RunMode::RealTime`) stamp arrival time and do
+**not** need this.
+
+The graph clock is strictly monotonic and bounded to the run's
+`[start_time, end_time)`. Delivering a historical value earlier than the clock
+aborts the run (`received Historical message but with time less than graph time`)
+and can underflow `NanoTime` subtraction in debug builds. Callers build their own
+filters and boundaries rarely align perfectly to `start`/`end`, so a source can
+legitimately return rows outside the requested window. Filter every emitted row
+through the shared [`WindowFilter`] before yielding it — do **not** re-implement
+the check per adapter:
+
+```rust
+use crate::adapters::common::{TimeWindow, WindowFilter};
+
+// once per slice/batch:
+let mut filter = WindowFilter::new("$ARGUMENTS_read", TimeWindow::clamp(t0, t1, start, end));
+for (time, record) in rows {
+    if !filter.keep(time) { continue; }   // drops rows outside [max(t0,start), min(t1,end))
+    yield Ok((time, record));
+}
+filter.finish();                          // one summary warn! if anything was dropped
+```
+
+`adapters::common` is feature-gated in `wingfoil/src/adapters/mod.rs` (currently
+`#[cfg(feature = "kdb")]`); add your adapter's feature to that gate when you
+become the first non-kdb consumer. Reference implementation: `kdb_read` /
+`kdb_read_cached` in `wingfoil/src/adapters/kdb/`.
+
 ## 1. Branch
 
 ```bash

--- a/wingfoil-python/src/py_kdb.rs
+++ b/wingfoil-python/src/py_kdb.rs
@@ -143,7 +143,7 @@ pub fn py_kdb_read(
     chunk_size: u64,
 ) -> PyStream {
     let conn = KdbConnection::new(host, port);
-    let stream: Rc<dyn Stream<Burst<PyKdbRow>>> = kdb_read::<PyKdbRow, _>(
+    let stream: Rc<dyn Stream<Burst<PyKdbRow>>> = kdb_read::<PyKdbRow>(
         conn,
         std::time::Duration::from_secs(chunk_size),
         move |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/README.md
+++ b/wingfoil/examples/README.md
@@ -46,7 +46,7 @@ struct Price {
     mid: f64,
 }
 
-kdb_read::<Price, _>(
+kdb_read::<Price>(
     conn,
     Duration::from_secs(10),
     |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/read/README.md
+++ b/wingfoil/examples/kdb/read/README.md
@@ -49,7 +49,7 @@ impl KdbDeserialize for Price {
     }
 }
 
-kdb_read::<Price, _>(
+kdb_read::<Price>(
     conn,
     Duration::from_secs(10),
     |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/read/main.rs
+++ b/wingfoil/examples/kdb/read/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
     let conn = KdbConnection::new("localhost", 5000);
     let chunk = Duration::from_secs(10);
 
-    kdb_read::<Price, _>(
+    kdb_read::<Price>(
         conn,
         chunk,
         |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/read_cached/README.md
+++ b/wingfoil/examples/kdb/read_cached/README.md
@@ -59,7 +59,7 @@ impl KdbDeserialize for Price {
 // Use u64::MAX for an unbounded cache.
 let config = CacheConfig::new("/tmp/wingfoil-kdb-cache", 10 * 1024 * 1024);
 
-kdb_read_cached::<Price, _>(
+kdb_read_cached::<Price>(
     conn,
     Duration::from_secs(10),
     config,

--- a/wingfoil/examples/kdb/read_cached/main.rs
+++ b/wingfoil/examples/kdb/read_cached/main.rs
@@ -32,7 +32,7 @@ impl KdbDeserialize for Price {
 }
 
 fn run(conn: KdbConnection, config: CacheConfig) -> Result<()> {
-    kdb_read_cached::<Price, _>(
+    kdb_read_cached::<Price>(
         conn,
         Duration::from_secs(10),
         config,

--- a/wingfoil/examples/kdb/round_trip/README.md
+++ b/wingfoil/examples/kdb/round_trip/README.md
@@ -104,7 +104,7 @@ fn main() -> Result<()> {
         .run(run_mode, run_for)?;
     let baseline = generate(num_rows);
     // Read
-    let read = kdb_read::<Trade, _>(
+    let read = kdb_read::<Trade>(
         conn,
         std::time::Duration::from_secs(86400),
         move |(t0, t1), _date, _iter| {

--- a/wingfoil/examples/kdb/round_trip/main.rs
+++ b/wingfoil/examples/kdb/round_trip/main.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
         .run(run_mode, run_for)?;
     let baseline = generate(num_rows);
     // read — use kdb_read with time-slice filtering
-    let read = kdb_read::<Trade, _>(
+    let read = kdb_read::<Trade>(
         conn,
         std::time::Duration::from_secs(86400),
         move |(t0, t1), _date, _iter| {

--- a/wingfoil/src/adapters/cache/mod.rs
+++ b/wingfoil/src/adapters/cache/mod.rs
@@ -38,7 +38,7 @@ impl CacheKey {
 /// # Example
 /// ```ignore
 /// let config = CacheConfig::new("/tmp/my-backtest-cache", 512 * 1024 * 1024); // 512 MiB cap
-/// let stream = kdb_read_cached::<Trade, _>(conn, period, config, query_fn);
+/// let stream = kdb_read_cached::<Trade>(conn, period, config, query_fn);
 /// ```
 #[derive(Debug, Clone)]
 pub struct CacheConfig {

--- a/wingfoil/src/adapters/common.rs
+++ b/wingfoil/src/adapters/common.rs
@@ -1,0 +1,94 @@
+//! Helpers shared across I/O adapters.
+//!
+//! Currently this is the out-of-window row filter used by historical/replay
+//! sources. The graph clock is strictly monotonic and bounded to the run's
+//! `[start_time, end_time)`: delivering a value before the clock aborts the run
+//! ("received Historical message but with time less than graph time"), and can
+//! even underflow `NanoTime` subtraction in debug builds. Any adapter that
+//! replays a caller-parameterised range (time-sliced queries, cursor replays,
+//! etc.) can over-read its bounds, so it should pass each emitted row through a
+//! [`WindowFilter`] first.
+
+use crate::time::NanoTime;
+
+/// A half-open on-graph time window `[lo, hi)`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TimeWindow {
+    lo: NanoTime,
+    hi: NanoTime,
+}
+
+impl TimeWindow {
+    /// Clamp a candidate range `[t0, t1)` to the run bounds `[start, end)`.
+    ///
+    /// Use when a source's natural boundaries (`t0`, `t1`) may fall outside the
+    /// requested range — e.g. period-aligned query slices whose first `t0`
+    /// precedes `start`, or a final slice whose `t1` overshoots `end`.
+    pub(crate) fn clamp(t0: NanoTime, t1: NanoTime, start: NanoTime, end: NanoTime) -> Self {
+        Self {
+            lo: t0.max(start),
+            hi: t1.min(end),
+        }
+    }
+
+    /// True if `time` is within `[lo, hi)`.
+    pub(crate) fn contains(&self, time: NanoTime) -> bool {
+        self.lo <= time && time < self.hi
+    }
+}
+
+/// Filters rows to a [`TimeWindow`], counting discards and emitting a single
+/// summary warning.
+///
+/// Create one per slice/batch, call [`WindowFilter::keep`] for each row before
+/// emitting it, and [`WindowFilter::finish`] once when the batch is drained:
+///
+/// ```ignore
+/// let mut filter = WindowFilter::new("my_adapter", TimeWindow::clamp(t0, t1, start, end));
+/// for (time, record) in rows {
+///     if !filter.keep(time) { continue; }
+///     yield Ok((time, record));
+/// }
+/// filter.finish();
+/// ```
+pub(crate) struct WindowFilter {
+    label: &'static str,
+    window: TimeWindow,
+    dropped: usize,
+}
+
+impl WindowFilter {
+    pub(crate) fn new(label: &'static str, window: TimeWindow) -> Self {
+        Self {
+            label,
+            window,
+            dropped: 0,
+        }
+    }
+
+    /// Returns `true` if the row at `time` should be emitted; otherwise records
+    /// a discard.
+    pub(crate) fn keep(&mut self, time: NanoTime) -> bool {
+        if self.window.contains(time) {
+            true
+        } else {
+            self.dropped += 1;
+            false
+        }
+    }
+
+    /// Emit a single summary warning if any rows were discarded. Consumes `self`
+    /// so it is called exactly once per batch.
+    pub(crate) fn finish(self) {
+        if self.dropped > 0 {
+            log::warn!(
+                "{}: dropped {} row(s) outside the requested window [{:?}, {:?}); \
+                the source returned data beyond the range it was asked for",
+                self.label,
+                self.dropped,
+                self.window.lo,
+                self.window.hi,
+            );
+        }
+    }
+}

--- a/wingfoil/src/adapters/common.rs
+++ b/wingfoil/src/adapters/common.rs
@@ -13,7 +13,7 @@ use crate::time::NanoTime;
 
 /// A half-open on-graph time window `[lo, hi)`.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TimeWindow {
+pub struct TimeWindow {
     lo: NanoTime,
     hi: NanoTime,
 }
@@ -24,7 +24,7 @@ impl TimeWindow {
     /// Use when a source's natural boundaries (`t0`, `t1`) may fall outside the
     /// requested range — e.g. period-aligned query slices whose first `t0`
     /// precedes `start`, or a final slice whose `t1` overshoots `end`.
-    pub(crate) fn clamp(t0: NanoTime, t1: NanoTime, start: NanoTime, end: NanoTime) -> Self {
+    pub fn clamp(t0: NanoTime, t1: NanoTime, start: NanoTime, end: NanoTime) -> Self {
         Self {
             lo: t0.max(start),
             hi: t1.min(end),
@@ -32,7 +32,7 @@ impl TimeWindow {
     }
 
     /// True if `time` is within `[lo, hi)`.
-    pub(crate) fn contains(&self, time: NanoTime) -> bool {
+    pub fn contains(&self, time: NanoTime) -> bool {
         self.lo <= time && time < self.hi
     }
 }
@@ -51,14 +51,14 @@ impl TimeWindow {
 /// }
 /// filter.finish();
 /// ```
-pub(crate) struct WindowFilter {
+pub struct WindowFilter {
     label: &'static str,
     window: TimeWindow,
     dropped: usize,
 }
 
 impl WindowFilter {
-    pub(crate) fn new(label: &'static str, window: TimeWindow) -> Self {
+    pub fn new(label: &'static str, window: TimeWindow) -> Self {
         Self {
             label,
             window,
@@ -68,7 +68,7 @@ impl WindowFilter {
 
     /// Returns `true` if the row at `time` should be emitted; otherwise records
     /// a discard.
-    pub(crate) fn keep(&mut self, time: NanoTime) -> bool {
+    pub fn keep(&mut self, time: NanoTime) -> bool {
         if self.window.contains(time) {
             true
         } else {
@@ -79,7 +79,7 @@ impl WindowFilter {
 
     /// Emit a single summary warning if any rows were discarded. Consumes `self`
     /// so it is called exactly once per batch.
-    pub(crate) fn finish(self) {
+    pub fn finish(self) {
         if self.dropped > 0 {
             log::warn!(
                 "{}: dropped {} row(s) outside the requested window [{:?}, {:?}); \

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -52,6 +52,10 @@ kdb/
   - Non-`upd` control messages (e.g. end-of-day `.u.end`) are ignored
   - Tails from the moment of subscription — does **not** replay the tickerplant log / RDB
     buffer, so rows published before the run started are not delivered
+  - A single `upd` can carry many rows; in real time they surface as one on-graph
+    `Burst<T>` (or a few, depending on timing). Consume with `.collect()` or by
+    iterating the burst — `.collapse()` keeps only the **last** row of each burst
+    and would silently drop the rest
   - `KdbDeserialize` trait - Convert KDB+ rows to `(NanoTime, T)` tuples
   - `from_kdb_row` returns `Result<(NanoTime, Self), KdbError>` — implementor owns time extraction
   - Use `row.get_timestamp(col)` to extract a KDB timestamp column as `NanoTime`

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -29,6 +29,9 @@ kdb/
     the first slice starts at the period boundary at/before `start_time`, so a
     `time >= t0j` filter can legitimately return rows before `start_time`; emitting
     them would drive the monotonic graph clock backwards and abort the run
+  - Emits `Burst<T>` (rows sharing a timestamp are grouped into one tick); iterate the
+    burst to process every row. `.collapse()` keeps only the **last** row per tick, so
+    avoid it when multiple rows can share a timestamp
   - Terminates automatically when all slices are exhausted
 - `kdb_read_cached()` - Cached variant of `kdb_read`
   - Same signature as `kdb_read` plus a `cache_dir: impl Into<PathBuf>` parameter
@@ -200,7 +203,13 @@ let stream = kdb_read::<Trade>(
     },
 );
 stream
-    .collapse()
+    // Each tick is a `Burst<Trade>` (all trades at one timestamp). Iterate the
+    // burst to process every row — `.collapse()` keeps only the last per tick.
+    .for_each(|trades, _| {
+        for trade in &trades {
+            println!("{}", trade.price);
+        }
+    })
     .run(
         RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(start_kdb)),
         RunFor::Duration(std::time::Duration::from_secs(86400)),

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -24,6 +24,11 @@ kdb/
   - Use `time >= t0j, time < t1j` in the q filter for clean round-number boundaries
   - Requires `RunMode::HistoricalFrom` (non-zero start) and `RunFor::Duration`
   - Caller constructs the full query — date/time filters, partition hints, etc.
+  - Rows a query returns outside the run window `[start_time, end_time)` are
+    dropped (with a per-slice warning), not emitted on-graph. This matters because
+    the first slice starts at the period boundary at/before `start_time`, so a
+    `time >= t0j` filter can legitimately return rows before `start_time`; emitting
+    them would drive the monotonic graph clock backwards and abort the run
   - Terminates automatically when all slices are exhausted
 - `kdb_read_cached()` - Cached variant of `kdb_read`
   - Same signature as `kdb_read` plus a `cache_dir: impl Into<PathBuf>` parameter

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -7,8 +7,9 @@ This directory contains the KDB+ adapter for wingfoil, enabling reading from and
 ```
 kdb/
   mod.rs               # Public API, connection types, error handling, Sym
-  read.rs              # kdb_read() and shared helpers (compute_time_slices, KdbExt, etc.)
+  read.rs              # kdb_read() and shared helpers (compute_time_slices, KdbExt, upd_payload_rows, etc.)
   read_cached.rs       # kdb_read_cached() — file-cached variant of kdb_read
+  sub.rs               # kdb_sub() — real-time tickerplant subscription
   write.rs             # kdb_write() - writing stream data to KDB+ tables
   integration_tests.rs # Integration tests (requires running KDB+ instance)
 ```
@@ -33,7 +34,20 @@ kdb/
   - `Sym` is fully supported — it serializes as a plain string (interning not restored on load)
   - If a cache file is corrupt, logs a warning and falls back to KDB, then overwrites the bad file
   - **Schema evolution:** `bincode` is not self-describing — delete the cache dir if `T` changes
-- `KdbDeserialize` trait - Convert KDB+ rows to `(NanoTime, T)` tuples
+- `kdb_sub()` - Real-time subscription to a tickerplant (the live counterpart to `kdb_read`)
+  - `kdb_sub(conn, table, symbols)` — `table` is the tickerplant table name (no backtick),
+    `symbols` a q symbol-list literal (`` "`" `` = all, `` "`AAPL`MSFT" `` to filter)
+  - Requires `RunMode::RealTime` (bails otherwise); `kdb_read` is for historical replay
+  - Sends `.u.sub[`table;syms]` synchronously (capturing the schema for column names),
+    then loops on `receive_message()`, decoding each pushed `(`upd; table; data)` message
+  - Genuinely push-based: unlike the postgres `LISTEN`/`NOTIFY` model, the tickerplant
+    pushes the rows themselves — no re-query, no cursor. The `upd` payload (a table or a
+    bare list of column vectors) is normalised via `upd_payload_rows` and decoded with the
+    same `KdbDeserialize` impl `kdb_read` uses
+  - Non-`upd` control messages (e.g. end-of-day `.u.end`) are ignored
+  - Tails from the moment of subscription — does **not** replay the tickerplant log / RDB
+    buffer, so rows published before the run started are not delivered
+  - `KdbDeserialize` trait - Convert KDB+ rows to `(NanoTime, T)` tuples
   - `from_kdb_row` returns `Result<(NanoTime, Self), KdbError>` — implementor owns time extraction
   - Use `row.get_timestamp(col)` to extract a KDB timestamp column as `NanoTime`
   - Your struct should only contain business data (sym, price, qty, etc.)
@@ -144,7 +158,7 @@ impl KdbSerialize for Trade {
 ```rust
 // Same query closure as kdb_read, plus a cache directory.
 // T must also implement serde::Serialize + serde::Deserialize + Sync.
-let stream = kdb_read_cached::<Trade, _>(
+let stream = kdb_read_cached::<Trade>(
     conn,
     std::time::Duration::from_secs(3600),
     "/tmp/my-backtest-cache",
@@ -162,7 +176,7 @@ let stream = kdb_read_cached::<Trade, _>(
 
 ```rust
 // Date-partitioned table: filter by date and time range in each slice
-let stream = kdb_read::<Trade, _>(
+let stream = kdb_read::<Trade>(
     conn,
     std::time::Duration::from_secs(3600), // 1-hour slices
     |(t0, t1), date, _| {

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -38,6 +38,9 @@ kdb/
   - `T` must additionally implement `serde::Serialize + serde::Deserialize`; `Sync` is also required
   - `Sym` is fully supported — it serializes as a plain string (interning not restored on load)
   - If a cache file is corrupt, logs a warning and falls back to KDB, then overwrites the bad file
+  - Drops rows outside the run window `[start_time, end_time)` like `kdb_read`, but the
+    **cache stores the full `[t0, t1)` slice** (the key is the query string, which does not
+    encode start/end); the clamp is applied on emit, on both cache hits and misses
   - **Schema evolution:** `bincode` is not self-describing — delete the cache dir if `T` changes
 - `kdb_sub()` - Real-time subscription to a tickerplant (the live counterpart to `kdb_read`)
   - `kdb_sub(conn, table, symbols)` — `table` is the tickerplant table name (no backtick),

--- a/wingfoil/src/adapters/kdb/cache_integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/cache_integration_tests.rs
@@ -46,7 +46,7 @@ impl KdbDeserialize for TestTradeCached {
 
 /// Run `kdb_read_cached` over one day of `TABLE_NAME` and return the row count.
 fn run_cached(conn: KdbConnection, cache_dir: &std::path::Path) -> Result<usize> {
-    let stream = kdb_read_cached::<TestTradeCached, _>(
+    let stream = kdb_read_cached::<TestTradeCached>(
         conn,
         PERIOD,
         CacheConfig::new(cache_dir, u64::MAX),
@@ -160,7 +160,7 @@ fn test_kdb_read_cached_partial_cache() -> Result<()> {
     let half_day = std::time::Duration::from_secs(12 * 3600);
 
     let run = |conn: KdbConnection| -> Result<usize> {
-        let stream = kdb_read_cached::<TestTradeCached, _>(
+        let stream = kdb_read_cached::<TestTradeCached>(
             conn,
             half_day,
             CacheConfig::new(&cache_dir, u64::MAX),

--- a/wingfoil/src/adapters/kdb/cache_integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/cache_integration_tests.rs
@@ -102,6 +102,146 @@ fn test_kdb_read_cached_populates_and_hits() -> Result<()> {
     Ok(())
 }
 
+/// Serde record for the out-of-window test: (time, sym, price, qty), no date.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct TickCached {
+    sym: Sym,
+    price: f64,
+    qty: i64,
+}
+
+impl KdbDeserialize for TickCached {
+    fn from_kdb_row(
+        row: Row<'_>,
+        _columns: &[String],
+        interner: &mut SymbolInterner,
+    ) -> Result<(NanoTime, Self), KdbError> {
+        let time = row.get_timestamp(0)?; // col 0: time
+        Ok((
+            time,
+            TickCached {
+                sym: row.get_sym(1, interner)?,
+                price: row.get(2)?.get_float()?,
+                qty: row.get(3)?.get_long()?,
+            },
+        ))
+    }
+}
+
+/// Regression: `kdb_read_cached` must drop rows outside the run's
+/// `[start_time, end_time)` window — on both the cache-miss and cache-hit paths —
+/// while the cache still stores the *full* slice result.
+///
+/// Seeds a pre-start row (75s) plus in-window rows (90/150/210s) and runs with an
+/// unaligned start (90s, 60s period), so the first slice `[60s, 120s)` fetches the
+/// 75s row. Three runs:
+///  1. cache miss → fetch + cache full slice, drop 75s at emit;
+///  2. closed port, same window → cache hit, drop 75s at emit;
+///  3. closed port, *wider* window (start 70s) → cache hit surfaces the 75s row,
+///     proving the cache stored the full slice and the clamp is per-run window.
+#[test]
+fn test_kdb_read_cached_drops_rows_outside_window() -> Result<()> {
+    let _ = env_logger::try_init();
+    let conn = super::integration_tests::test_connection();
+    let cache_dir =
+        std::env::temp_dir().join(format!("wingfoil_cache_window_{}", std::process::id()));
+    std::fs::remove_dir_all(&cache_dir).ok();
+
+    const CTBL: &str = "cached_window_trades";
+    let rt = tokio::runtime::Runtime::new()?;
+
+    // Seed rows at 75s (pre-start), 90s, 150s, 210s past the KDB epoch.
+    rt.block_on(async {
+        let mut s = super::integration_tests::connect(&conn).await?;
+        super::integration_tests::q_exec(
+            &mut s,
+            &format!("{CTBL}:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())"),
+        )
+        .await?;
+        super::integration_tests::q_exec(
+            &mut s,
+            &format!(
+                "insert[`{CTBL};(2000.01.01D00:00:00+1000000000*75 90 150 210;\
+                 `EARLY`AAPL`GOOG`MSFT;100 101 102 103f;10 20 30 40j)]"
+            ),
+        )
+        .await?;
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    let period = std::time::Duration::from_secs(60);
+    let run = |conn: KdbConnection, start: NanoTime, dur_secs: u64| -> Result<Vec<(String, i64)>> {
+        let stream = kdb_read_cached::<TickCached>(
+            conn,
+            period,
+            CacheConfig::new(&cache_dir, u64::MAX),
+            move |(t0, t1), _, _| {
+                format!(
+                    "select from {CTBL} where time >= (`timestamp$){}j, time < (`timestamp$){}j",
+                    t0.to_kdb_timestamp(),
+                    t1.to_kdb_timestamp(),
+                )
+            },
+        );
+        // Collect the raw bursts (not `.collapse()`, which would drop rows).
+        let collected = stream.collect();
+        collected.clone().run(
+            RunMode::HistoricalFrom(start),
+            RunFor::Duration(std::time::Duration::from_secs(dur_secs)),
+        )?;
+        Ok(collected
+            .peek_value()
+            .iter()
+            .flat_map(|va| va.value.iter())
+            .map(|t| (t.sym.to_string(), t.qty))
+            .collect())
+    };
+
+    let start_90 = NanoTime::from_kdb_timestamp(90 * 1_000_000_000);
+    let start_70 = NanoTime::from_kdb_timestamp(70 * 1_000_000_000);
+    let closed = KdbConnection::new("localhost", 59999);
+
+    // 1. Cache miss: populates cache with the full slice, drops the 75s row at emit.
+    let first = run(conn.clone(), start_90, 180)?;
+    // 2. Cache hit (closed port): still drops the 75s row at emit.
+    let second = run(closed.clone(), start_90, 180)?;
+    // 3. Cache hit, wider window starting at 70s: the 75s row now surfaces,
+    //    proving the cache stored the full slice.
+    let third = run(closed, start_70, 180)?;
+
+    rt.block_on(async {
+        let mut s = super::integration_tests::connect(&conn).await?;
+        super::integration_tests::q_exec(&mut s, &format!("delete {CTBL} from `.")).await?;
+        Ok::<(), anyhow::Error>(())
+    })?;
+    std::fs::remove_dir_all(&cache_dir).ok();
+
+    let in_window = vec![
+        ("AAPL".to_string(), 20),
+        ("GOOG".to_string(), 30),
+        ("MSFT".to_string(), 40),
+    ];
+    assert_eq!(
+        first, in_window,
+        "cache-miss path must drop the pre-start row"
+    );
+    assert_eq!(
+        second, in_window,
+        "cache-hit path must also drop the pre-start row"
+    );
+    assert_eq!(
+        third,
+        vec![
+            ("EARLY".to_string(), 10),
+            ("AAPL".to_string(), 20),
+            ("GOOG".to_string(), 30),
+            ("MSFT".to_string(), 40),
+        ],
+        "cache stored the full slice: a wider window surfaces the 75s row from cache"
+    );
+    Ok(())
+}
+
 /// After cache population, corrupt one cache file with invalid bincode. The
 /// next run should log a warning, fall back to KDB, overwrite the bad file,
 /// and return the correct rows. A subsequent run with a closed port confirms

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -286,7 +286,7 @@ fn test_kdb_sorted_data() -> Result<()> {
     let _ = env_logger::try_init();
     // 3 rows/day × 2 days = 6 rows total; one 24-hour slice per day.
     with_test_data(3, 2, true, |_n, conn| {
-        let stream = kdb_read::<TestTrade, _>(
+        let stream = kdb_read::<TestTrade>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
@@ -333,7 +333,7 @@ impl KdbDeserialize for BadTrade {
 fn test_kdb_bad_query() -> Result<()> {
     let _ = env_logger::try_init();
     let conn = TestDataBuilder::connection();
-    let stream = kdb_read::<TestTrade, _>(
+    let stream = kdb_read::<TestTrade>(
         conn,
         std::time::Duration::from_secs(24 * 3600),
         |_, _, _| "select from nonexistent_table_xyz".to_string(),
@@ -351,7 +351,7 @@ fn test_kdb_bad_query() -> Result<()> {
 fn test_kdb_deserialization_error() -> Result<()> {
     let _ = env_logger::try_init();
     let result = with_test_data(3, 1, true, |_n, conn| {
-        let stream = kdb_read::<BadTrade, _>(
+        let stream = kdb_read::<BadTrade>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
@@ -392,7 +392,7 @@ fn test_read_read_perf() -> Result<()> {
 
         for &period in &periods {
             let start = std::time::Instant::now();
-            let stream = kdb_read::<TestTrade, _>(conn.clone(), period, |within, date, _| {
+            let stream = kdb_read::<TestTrade>(conn.clone(), period, |within, date, _| {
                 slice_query(date, within.0, within.1)
             });
             let counter = stream.collapse().count();
@@ -412,7 +412,7 @@ fn test_read_read_perf() -> Result<()> {
 fn test_kdb_connection_refused() -> Result<()> {
     let _ = env_logger::try_init();
     let conn = KdbConnection::new("localhost", 59999);
-    let stream = kdb_read::<TestTrade, _>(
+    let stream = kdb_read::<TestTrade>(
         conn,
         std::time::Duration::from_secs(24 * 3600),
         |_, _, _| format!("select from {TABLE_NAME}"),
@@ -430,7 +430,7 @@ fn test_kdb_connection_refused() -> Result<()> {
 fn test_kdb_empty_table_returns_zero_rows() -> Result<()> {
     let _ = env_logger::try_init();
     with_empty_table(|conn| {
-        let stream = kdb_read::<TestTrade, _>(
+        let stream = kdb_read::<TestTrade>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
@@ -467,7 +467,7 @@ fn test_kdb_read_works() -> Result<()> {
     with_test_data(3, 2, true, |_n, conn| {
         let start = NanoTime::from_kdb_timestamp(0); // 2000.01.01D00:00:00
 
-        let stream = kdb_read::<TestTrade, _>(
+        let stream = kdb_read::<TestTrade>(
             conn,
             std::time::Duration::from_secs(12 * 3600), // 12-hour slices
             move |(slice_start, slice_end), date, _iteration| {
@@ -561,7 +561,7 @@ fn test_kdb_write_round_trip() -> Result<()> {
 
         // Verify data correctness by reading back via kdb_read.
         // The write table has no date column so we filter by time only.
-        let read_stream = kdb_read::<TestTradeWrite, _>(
+        let read_stream = kdb_read::<TestTradeWrite>(
             conn,
             std::time::Duration::from_secs(24 * 3600),
             move |(t0, t1), _, _| {

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -838,3 +838,80 @@ fn test_kdb_sub_realtime_receives_published_rows() -> Result<()> {
     );
     Ok(())
 }
+
+// --- kdb_read out-of-window row handling ---
+
+/// Regression: `kdb_read` must drop rows the query returns outside the run's
+/// `[start_time, end_time)` window rather than aborting the run.
+///
+/// When `start_time` is not aligned to `period`, the first slice begins at the
+/// period boundary *before* `start_time` (for clean round-number queries), so a
+/// `time >= t0` filter returns rows earlier than `start_time`. Those rows have
+/// on-graph time before the graph clock; emitting them would abort the run. This
+/// test seeds one pre-start row plus three in-window rows and asserts the run
+/// succeeds with only the three in-window rows delivered.
+#[test]
+fn test_kdb_read_drops_rows_outside_window() -> Result<()> {
+    let _ = env_logger::try_init();
+    let conn = TestDataBuilder::connection();
+    let rt = tokio::runtime::Runtime::new()?;
+
+    const TBL: &str = "read_window_trades";
+
+    // Table (time, sym, price, qty) with rows at 75s, 90s, 150s, 210s past the
+    // KDB epoch. Start at 90s with a 60s period, so the first slice is
+    // [60s, 120s) — its `time >= 60s` filter also returns the 75s row, which is
+    // before start_time and must be dropped.
+    rt.block_on(async {
+        let mut s = connect(&conn).await?;
+        q_exec(
+            &mut s,
+            &format!("{TBL}:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())"),
+        )
+        .await?;
+        q_exec(
+            &mut s,
+            &format!(
+                "insert[`{TBL};(2000.01.01D00:00:00+1000000000*75 90 150 210;\
+                 `EARLY`AAPL`GOOG`MSFT;100 101 102 103f;10 20 30 40j)]"
+            ),
+        )
+        .await?;
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    // 90s past the epoch — deliberately NOT aligned to the 60s period.
+    let start = NanoTime::from_kdb_timestamp(90 * 1_000_000_000);
+    let period = std::time::Duration::from_secs(60);
+    let stream = kdb_read::<TestTick>(conn.clone(), period, move |(t0, t1), _date, _| {
+        format!(
+            "select from {TBL} where time >= (`timestamp$){}j, time < (`timestamp$){}j",
+            t0.to_kdb_timestamp(),
+            t1.to_kdb_timestamp(),
+        )
+    });
+    let collected = stream.collapse().collect();
+    // Run through 270s (start + 180s), covering the 90s/150s/210s rows.
+    let run_result = collected.clone().run(
+        RunMode::HistoricalFrom(start),
+        RunFor::Duration(std::time::Duration::from_secs(180)),
+    );
+
+    let teardown_result = rt.block_on(async {
+        let mut s = connect(&conn).await?;
+        q_exec(&mut s, &format!("delete {TBL} from `.")).await?;
+        Ok::<(), anyhow::Error>(())
+    });
+
+    run_result?; // must NOT throw despite the pre-start (75s) row
+    teardown_result?;
+
+    let rows = collected.peek_value();
+    let syms: Vec<String> = rows.iter().map(|v| v.value.sym.to_string()).collect();
+    assert_eq!(
+        syms,
+        vec!["AAPL", "GOOG", "MSFT"],
+        "the pre-start `EARLY` row must be dropped; got {syms:?}"
+    );
+    Ok(())
+}

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -794,8 +794,13 @@ fn test_kdb_sub_realtime_receives_published_rows() -> Result<()> {
 
     // 3. Subscribe on-graph in real time and collect for a bounded window. The
     //    run terminates at the duration bound even though kdb_sub never ends.
+    //
+    //    Collect the raw `Burst<T>` stream (not `.collapse()`): in real time the
+    //    receiver drains every row that arrives together into a single burst, and
+    //    `collapse()` keeps only the *last* element of each burst — which would
+    //    silently drop rows from a multi-row `upd`. Flatten the bursts instead.
     let stream = kdb_sub::<TestTick>(conn.clone(), SUB_TABLE_NAME, "`");
-    let collected = stream.collapse().collect();
+    let collected = stream.collect();
     let run_result = collected.clone().run(
         RunMode::RealTime,
         RunFor::Duration(std::time::Duration::from_secs(5)),
@@ -819,11 +824,15 @@ fn test_kdb_sub_realtime_receives_published_rows() -> Result<()> {
     publish_result?;
     teardown_result?;
 
-    // 5. Verify every published row was streamed on-graph, in order.
+    // 5. Verify every published row was streamed on-graph, in order. Flatten the
+    //    per-cycle bursts: a multi-row `upd` may arrive as one burst of many rows
+    //    or several single-row bursts depending on timing; either way order and
+    //    count are preserved.
     let rows = collected.peek_value();
     let got: Vec<(String, f64, i64)> = rows
         .iter()
-        .map(|v| (v.value.sym.to_string(), v.value.price, v.value.qty))
+        .flat_map(|va| va.value.iter())
+        .map(|t| (t.sym.to_string(), t.price, t.qty))
         .collect();
     let expected = vec![
         ("AAPL".to_string(), 100.0, 10),

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -650,3 +650,191 @@ fn test_kdb_write_append() -> Result<()> {
     teardown_result?;
     Ok(())
 }
+
+// --- Real-time subscription (kdb_sub) integration test ---
+
+/// Subscription test table: (time, sym, price, qty) — no date column, as a
+/// tickerplant streams live rows rather than date-partitioned history.
+const SUB_TABLE_NAME: &str = "sub_trades";
+
+/// Business record for the tickerplant stream, matching `SUB_TABLE_NAME`'s
+/// column order (time, sym, price, qty).
+#[derive(Debug, Clone, Default)]
+struct TestTick {
+    sym: Sym,
+    price: f64,
+    qty: i64,
+}
+
+impl KdbDeserialize for TestTick {
+    fn from_kdb_row(
+        row: Row<'_>,
+        _columns: &[String],
+        interner: &mut SymbolInterner,
+    ) -> Result<(NanoTime, Self), KdbError> {
+        let time = row.get_timestamp(0)?; // col 0: time
+        Ok((
+            time,
+            TestTick {
+                sym: row.get_sym(1, interner)?,
+                price: row.get(2)?.get_float()?,
+                qty: row.get(3)?.get_long()?,
+            },
+        ))
+    }
+}
+
+/// A minimal in-process tickerplant defined over IPC, so the standard
+/// `q -p 5000` test instance can act as a tickerplant without loading
+/// `tick/u.q`. Defines the table schema plus `.u.sub` / `.u.pub` / `.u.nsub`:
+///
+/// - `.u.sub[t;s]` registers the caller's handle (`.z.w`) as a subscriber and
+///   returns `(t; 0#value t)` — the empty-table schema `kdb_sub` reads column
+///   names from, mirroring a real tickerplant's synchronous subscribe reply.
+/// - `.u.pub[t;x]` pushes `(`upd; t; x)` asynchronously to every subscriber.
+/// - `.u.nsub[t]` reports the subscriber count (so the publisher can wait until
+///   `kdb_sub` has actually subscribed before pushing rows).
+///
+/// `.u.w` is reset here on every setup so a subscriber handle left over from a
+/// previous run cannot cause `.u.pub` to send to a closed handle.
+const TICKERPLANT_INIT: &str = "\
+sub_trades:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$());\
+.u.w:()!();\
+.u.sub:{[t;s].u.w[t]:$[t in key .u.w;.u.w[t];()],enlist(.z.w;s);(t;0#value t)};\
+.u.pub:{[t;x]{[t;x;ws]neg[ws 0](`upd;t;x)}[t;x]each .u.w[t]};\
+.u.nsub:{$[x in key .u.w;count .u.w[x];0]}";
+
+/// Send a q expression synchronously, erroring on a q error object (type -128).
+async fn q_exec(socket: &mut QStream, query: &str) -> Result<K> {
+    let result = socket
+        .send_sync_message(&query)
+        .await
+        .with_context(|| format!("failed to send `{query}`"))?;
+    if result.get_type() == -128 {
+        anyhow::bail!("KDB+ query error for `{query}`: {result:?}");
+    }
+    Ok(result)
+}
+
+async fn connect(conn: &KdbConnection) -> Result<QStream> {
+    let creds = conn.credentials_string();
+    QStream::connect(ConnectionMethod::TCP, &conn.host, conn.port, &creds)
+        .await
+        .context("Failed to connect to KDB+")
+}
+
+/// End-to-end test of the `kdb_sub` subscribe → receive → decode path against a
+/// live q instance acting as a tickerplant (see `TICKERPLANT_INIT`).
+///
+/// Flow:
+/// 1. Define the tickerplant (`.u.*`) and table schema over IPC.
+/// 2. Spawn a publisher thread that waits for `kdb_sub` to register, then pushes
+///    5 rows — a 3-row batch in one `upd` (exercises multi-row `from_column_list`)
+///    plus two single-row `upd` messages (exercises the receive loop across
+///    messages).
+/// 3. Subscribe on-graph with `kdb_sub` in `RunMode::RealTime`, collecting for a
+///    bounded window, and assert the decoded rows match what was published.
+#[test]
+fn test_kdb_sub_realtime_receives_published_rows() -> Result<()> {
+    let _ = env_logger::try_init();
+    let conn = TestDataBuilder::connection();
+    let rt = tokio::runtime::Runtime::new()?;
+
+    // 1. Set up the in-process tickerplant on the test instance.
+    rt.block_on(async {
+        let mut socket = connect(&conn).await?;
+        q_exec(&mut socket, TICKERPLANT_INIT).await?;
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    // 2. Publisher thread: wait for the subscription, then publish 5 rows.
+    let pub_conn = conn.clone();
+    let publisher = std::thread::spawn(move || -> Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async move {
+            let mut socket = connect(&pub_conn).await?;
+
+            // Wait until kdb_sub has registered (up to ~5s) so no rows are
+            // published before the subscription exists (the TP does not replay).
+            let mut registered = false;
+            for _ in 0..250 {
+                let n = q_exec(&mut socket, &format!(".u.nsub[`{SUB_TABLE_NAME}]")).await?;
+                if n.get_long().unwrap_or(0) > 0 {
+                    registered = true;
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+            if !registered {
+                anyhow::bail!("kdb_sub never registered as a subscriber");
+            }
+
+            // 3-row batch in a single `upd` (multi-row column vectors).
+            q_exec(
+                &mut socket,
+                &format!(
+                    ".u.pub[`{SUB_TABLE_NAME};(`timestamp$3#.z.p;`AAPL`GOOG`MSFT;100 101 102f;10 20 30j)]"
+                ),
+            )
+            .await?;
+            // Two single-row `upd` messages.
+            q_exec(
+                &mut socket,
+                &format!(".u.pub[`{SUB_TABLE_NAME};(enlist .z.p;enlist `AAPL;enlist 103f;enlist 40j)]"),
+            )
+            .await?;
+            q_exec(
+                &mut socket,
+                &format!(".u.pub[`{SUB_TABLE_NAME};(enlist .z.p;enlist `GOOG;enlist 104f;enlist 50j)]"),
+            )
+            .await?;
+            Ok::<(), anyhow::Error>(())
+        })
+    });
+
+    // 3. Subscribe on-graph in real time and collect for a bounded window. The
+    //    run terminates at the duration bound even though kdb_sub never ends.
+    let stream = kdb_sub::<TestTick>(conn.clone(), SUB_TABLE_NAME, "`");
+    let collected = stream.collapse().collect();
+    let run_result = collected.clone().run(
+        RunMode::RealTime,
+        RunFor::Duration(std::time::Duration::from_secs(5)),
+    );
+
+    let publish_result = publisher.join().expect("publisher thread panicked");
+
+    // 4. Best-effort teardown: drop the table and clear subscribers.
+    let teardown_result = rt.block_on(async {
+        let mut socket = connect(&conn).await?;
+        q_exec(
+            &mut socket,
+            &format!("delete {SUB_TABLE_NAME} from `.;.u.w:()!()"),
+        )
+        .await?;
+        Ok::<(), anyhow::Error>(())
+    });
+
+    // Surface run/publish errors before assertions; teardown failure last.
+    run_result?;
+    publish_result?;
+    teardown_result?;
+
+    // 5. Verify every published row was streamed on-graph, in order.
+    let rows = collected.peek_value();
+    let got: Vec<(String, f64, i64)> = rows
+        .iter()
+        .map(|v| (v.value.sym.to_string(), v.value.price, v.value.qty))
+        .collect();
+    let expected = vec![
+        ("AAPL".to_string(), 100.0, 10),
+        ("GOOG".to_string(), 101.0, 20),
+        ("MSFT".to_string(), 102.0, 30),
+        ("AAPL".to_string(), 103.0, 40),
+        ("GOOG".to_string(), 104.0, 50),
+    ];
+    assert_eq!(
+        got, expected,
+        "on-graph rows should match the published rows in order, got {got:?}"
+    );
+    Ok(())
+}

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -88,14 +88,19 @@ struct TestDataBuilder {
     tokio: Runtime,
 }
 
+/// KDB connection from `KDB_TEST_HOST` / `KDB_TEST_PORT` (defaults localhost:5000).
+pub(super) fn test_connection() -> KdbConnection {
+    let port = std::env::var("KDB_TEST_PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(5000);
+    let host = std::env::var("KDB_TEST_HOST").unwrap_or_else(|_| "localhost".to_string());
+    KdbConnection::new(host, port)
+}
+
 impl TestDataBuilder {
     fn connection() -> KdbConnection {
-        let port = std::env::var("KDB_TEST_PORT")
-            .ok()
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(5000);
-        let host = std::env::var("KDB_TEST_HOST").unwrap_or_else(|_| "localhost".to_string());
-        KdbConnection::new(host, port)
+        test_connection()
     }
 
     async fn socket(&self) -> Result<QStream> {
@@ -705,7 +710,7 @@ sub_trades:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$());\
 .u.nsub:{$[x in key .u.w;count .u.w[x];0]}";
 
 /// Send a q expression synchronously, erroring on a q error object (type -128).
-async fn q_exec(socket: &mut QStream, query: &str) -> Result<K> {
+pub(super) async fn q_exec(socket: &mut QStream, query: &str) -> Result<K> {
     let result = socket
         .send_sync_message(&query)
         .await
@@ -716,7 +721,7 @@ async fn q_exec(socket: &mut QStream, query: &str) -> Result<K> {
     Ok(result)
 }
 
-async fn connect(conn: &KdbConnection) -> Result<QStream> {
+pub(super) async fn connect(conn: &KdbConnection) -> Result<QStream> {
     let creds = conn.credentials_string();
     QStream::connect(ConnectionMethod::TCP, &conn.host, conn.port, &creds)
         .await

--- a/wingfoil/src/adapters/kdb/mod.rs
+++ b/wingfoil/src/adapters/kdb/mod.rs
@@ -44,9 +44,13 @@
 //!         )
 //!     },
 //! )
-//!     .collapse()
-//!     .map(|trade| trade.price)
-//!     .print()
+//!     // Each tick is a `Burst<Trade>` — all trades sharing a timestamp. Iterate
+//!     // the burst to see every row; `.collapse()` keeps only the last per tick.
+//!     .for_each(|trades, _time| {
+//!         for trade in &trades {
+//!             println!("{}", trade.price);
+//!         }
+//!     })
 //!     .run(
 //!         RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
 //!         RunFor::Duration(std::time::Duration::from_secs(86400)),

--- a/wingfoil/src/adapters/kdb/mod.rs
+++ b/wingfoil/src/adapters/kdb/mod.rs
@@ -1,7 +1,9 @@
 //! KDB+ database adapter for reading and writing data to q/kdb+ instances.
 //!
 //! This module provides async connectivity to KDB+ databases using the `kdbplus` crate,
-//! allowing query results to be streamed into wingfoil graphs.
+//! allowing query results to be streamed into wingfoil graphs. Historical reads
+//! (`kdb_read`), real-time tickerplant subscriptions (`kdb_sub`), and writes
+//! (`kdb_write`) are all supported.
 //!
 //! # Example
 //!
@@ -31,7 +33,7 @@
 //!     .with_credentials("user", "pass");
 //!
 //! // Read with time-sliced chunking, one slice per hour
-//! kdb_read::<Trade, _>(
+//! kdb_read::<Trade>(
 //!     conn,
 //!     std::time::Duration::from_secs(3600),
 //!     |(t0, t1), date, _| {
@@ -54,6 +56,7 @@
 
 mod read;
 mod read_cached;
+mod sub;
 mod write;
 
 #[cfg(all(test, feature = "kdb-integration-test"))]
@@ -64,6 +67,7 @@ mod integration_tests;
 pub use crate::adapters::cache::CacheConfig;
 pub use read::*;
 pub use read_cached::*;
+pub use sub::*;
 pub use write::*;
 
 /// Re-export kdbplus error type for convenience.

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -834,6 +834,103 @@ mod tests {
         assert_eq!(slices.last().unwrap().2, 0);
     }
 
+    /// DEFECT (part 1/2): when `start_time` is not aligned to `period`, the first
+    /// slice's `t0` is the period boundary *at or before* `start_time` — i.e.
+    /// strictly before it. A caller's documented `time >= t0j` filter therefore
+    /// selects rows in `[t0, start_time)`, whose on-graph time is before the run's
+    /// `start_time`.
+    #[test]
+    fn test_first_slice_precedes_unaligned_start() {
+        let epoch = kdb_epoch();
+        let period = std::time::Duration::from_secs(60); // 60s slices
+        // 00:01:30 — 30s past the 00:01:00 boundary, so NOT period-aligned.
+        let start = NanoTime::new(u64::from(epoch) + 90 * 1_000_000_000);
+        let end = NanoTime::new(u64::from(start) + 5 * 60 * 1_000_000_000);
+
+        let slices = compute_time_slices(start, end, period);
+        let first_t0 = slices[0].0.0;
+
+        assert!(
+            first_t0 < start,
+            "first slice t0 {first_t0:?} should be < start {start:?} — kdb_read over-reads \
+             the interval [t0, start_time) before the requested start"
+        );
+        // Concretely, the 00:01:00 boundary — 30s before start_time.
+        assert_eq!(
+            first_t0,
+            NanoTime::new(u64::from(epoch) + 60 * 1_000_000_000)
+        );
+    }
+
+    /// DEFECT (part 2/2): a value whose time is before `start_time` — exactly what
+    /// part 1 shows the first slice returns — aborts a historical run. This is the
+    /// mechanism by which `kdb_read` "can throw": the engine forbids delivering a
+    /// historical value earlier than the graph clock, which starts at `start_time`.
+    #[test]
+    fn test_row_before_start_time_aborts_run() {
+        use crate::nodes::{NodeOperators, StreamOperators};
+        use crate::{RunFor, RunMode};
+
+        let start = NanoTime::new(1_000_000_000_000);
+        let before = NanoTime::new(u64::from(start) - 1);
+
+        // Mimics kdb_read's first slice yielding a row from [t0, start_time).
+        let stream = crate::nodes::produce_async(move |_ctx| async move {
+            Ok(async_stream::stream! {
+                yield Ok((before, 1u32));
+                yield Ok((start, 2u32));
+            })
+        });
+
+        let result = stream.collapse().collect().run(
+            RunMode::HistoricalFrom(start),
+            RunFor::Duration(std::time::Duration::from_secs(1)),
+        );
+
+        let err = result.expect_err("a row before start_time must abort the run");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("less than graph time") || msg.contains("panicked"),
+            "expected a time-ordering failure (engine reject or NanoTime underflow), got: {msg}"
+        );
+    }
+
+    /// DEFECT (related): `kdb_read` does not clamp emitted rows to the slice
+    /// window — it trusts the caller's query. If a slice returns a row *ahead* of
+    /// its `[t0, t1)` window, the graph clock jumps forward to it; a later slice's
+    /// legitimate in-window row is then behind the clock and the run is aborted by
+    /// the same monotonic-time check. So out-of-window rows throw too.
+    #[test]
+    fn test_row_ahead_of_window_then_in_window_aborts_run() {
+        use crate::nodes::{NodeOperators, StreamOperators};
+        use crate::{RunFor, RunMode};
+
+        let start = NanoTime::new(1_000_000_000_000);
+        // A row a query returns *beyond* its slice window advances the clock...
+        let ahead = NanoTime::new(u64::from(start) + 100);
+        // ...so a later slice's in-window row (earlier than `ahead`) is now "in the past".
+        let in_window = NanoTime::new(u64::from(start) + 30);
+
+        let stream = crate::nodes::produce_async(move |_ctx| async move {
+            Ok(async_stream::stream! {
+                yield Ok((ahead, 1u32));
+                yield Ok((in_window, 2u32));
+            })
+        });
+
+        let result = stream.collapse().collect().run(
+            RunMode::HistoricalFrom(start),
+            RunFor::Duration(std::time::Duration::from_secs(1)),
+        );
+
+        let err = result.expect_err("a row behind the advanced clock must abort the run");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("less than graph time"),
+            "expected the engine's monotonic-time rejection, got: {msg}"
+        );
+    }
+
     /// Round-trip test for `KdbSerialize` + `KdbDeserialize` covering every
     /// supported KDB column type:
     ///

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -55,6 +55,16 @@ impl Rows {
         self.n_rows == 0
     }
 
+    /// Build a [`Rows`] accessor directly from a list of column vectors.
+    ///
+    /// A tickerplant `upd` payload is a bare list of per-column vectors rather
+    /// than a flipped table dictionary; this wraps that list so [`kdb_sub`](crate::kdb_sub)
+    /// can reuse the same indexed row access as [`kdb_read`].
+    pub(super) fn from_column_list(columns: Vec<K>) -> Self {
+        let n_rows = columns.first().map(K::len).unwrap_or(0);
+        Rows { columns, n_rows }
+    }
+
     /// Get a row by index.
     pub fn get(&self, index: usize) -> Option<Row<'_>> {
         if index < self.n_rows {
@@ -265,6 +275,29 @@ impl KdbExt for K {
     }
 }
 
+/// Turn a tickerplant `upd` payload into a [`Rows`] accessor.
+///
+/// The third element of a `(`upd; table; data)` message is either a table
+/// (qtype 98) or a bare list of column vectors, depending on the tickerplant.
+/// Both are normalised to [`Rows`] so [`kdb_sub`](crate::kdb_sub) can decode
+/// them with the same [`KdbDeserialize`] impls that [`kdb_read`] uses.
+pub(super) fn upd_payload_rows(data: &K) -> Result<Rows> {
+    if data.get_type() == qtype::TABLE {
+        data.rows()
+    } else {
+        let columns = data
+            .as_vec::<K>()
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "kdb_sub: upd payload is neither a table nor a list of columns (qtype {})",
+                    data.get_type()
+                )
+            })?
+            .clone();
+        Ok(Rows::from_column_list(columns))
+    }
+}
+
 /// Trait for deserializing KDB row data into Rust types.
 ///
 /// Implementors extract fields from the row using indexed column access and return
@@ -412,14 +445,13 @@ pub(crate) fn compute_time_slices(
 }
 
 #[must_use]
-pub fn kdb_read<T, F>(
+pub fn kdb_read<T>(
     connection: KdbConnection,
     period: std::time::Duration,
-    query_fn: F,
+    query_fn: impl FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 ) -> Rc<dyn Stream<Burst<T>>>
 where
     T: Element + Send + KdbDeserialize + 'static,
-    F: FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 {
     produce_async(move |ctx| {
         let start_time = ctx.start_time;

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -321,14 +321,23 @@ pub trait KdbDeserialize: Sized {
 
 /// Core streaming loop driven by a caller-supplied query closure.
 ///
-/// Calls `query_fn()` before each chunk. Returns `None` to stop, or
-/// `Some(query_string)` to execute next.
+/// Calls `next_slice()` before each chunk. Returns `None` to stop, or
+/// `Some((query, lo, hi))` — the query to execute plus the half-open window
+/// `[lo, hi)` the resulting rows are expected to fall in.
+///
+/// Rows whose extracted time falls outside `[lo, hi)` are **dropped** (with a
+/// single per-slice warning). This is necessary because callers build their own
+/// filters and the first slice starts at the period boundary at or before
+/// `start_time`, so a query can legitimately return rows before `start_time`,
+/// after `end_time`, or otherwise beyond the slice it was asked to fill. The
+/// graph clock is monotonic and bounded to the run window, so emitting such rows
+/// would abort the run.
 ///
 /// `prev_time` is reset each chunk so time-of-day columns work correctly when
 /// advancing across date partitions (timestamps restart at midnight on each new date).
 fn chunk_stream<T>(
     mut socket: QStream,
-    mut query_fn: impl FnMut() -> Option<String> + Send + 'static,
+    mut next_slice: impl FnMut() -> Option<(String, NanoTime, NanoTime)> + Send + 'static,
 ) -> impl futures::Stream<Item = anyhow::Result<(NanoTime, T)>> + Send + 'static
 where
     T: KdbDeserialize + Send + 'static,
@@ -336,7 +345,7 @@ where
     async_stream::stream! {
         let mut interner = SymbolInterner::default();
 
-        'outer: while let Some(query) = query_fn() {
+        'outer: while let Some((query, lo, hi)) = next_slice() {
             info!("KDB query: {query}");
             let fetch_start = std::time::Instant::now();
             let result: K = match socket.send_sync_message(&query.as_str()).await {
@@ -353,11 +362,21 @@ where
             info!("KDB query: {} rows in {:?}", row_count, fetch_start.elapsed());
 
             let mut prev_time: Option<NanoTime> = None;
+            let mut dropped: usize = 0;
             for row in &rows {
                 let (time, record) = match T::from_kdb_row(row, &columns, &mut interner) {
                     Ok(r) => r,
                     Err(e) => { yield Err(e.into()); break 'outer; }
                 };
+
+                // Drop rows the query returned outside this slice's [lo, hi)
+                // window (before start_time, at/after end_time, or beyond the
+                // slice bounds). Emitting them would drive the monotonic graph
+                // clock backwards and abort the run.
+                if time < lo || time >= hi {
+                    dropped += 1;
+                    continue;
+                }
 
                 if let Some(prev) = prev_time
                     && time < prev
@@ -371,6 +390,13 @@ where
                 prev_time = Some(time);
 
                 yield Ok((time, record));
+            }
+
+            if dropped > 0 {
+                log::warn!(
+                    "kdb_read: dropped {dropped} row(s) outside the requested window \
+                    [{lo:?}, {hi:?}); the query returned data beyond the slice it was asked to fill"
+                );
             }
         }
     }
@@ -490,9 +516,17 @@ where
 
             let mut slices_iter = slices.into_iter();
             let mut query_fn = query_fn;
-            let slice_fn = move || -> Option<String> {
-                let (within, date, iteration) = slices_iter.next()?;
-                Some(query_fn(within, date, iteration))
+            let slice_fn = move || -> Option<(String, NanoTime, NanoTime)> {
+                let ((t0, t1), date, iteration) = slices_iter.next()?;
+                // The query still uses the period-aligned (t0, t1) for clean
+                // round-number boundaries, but rows are clamped to the run's
+                // [start_time, end_time) so out-of-window rows are dropped rather
+                // than aborting the run. `t0` may precede `start_time` on the
+                // first slice; `t1` may exceed `end_time` on the last.
+                let lo = t0.max(start_time);
+                let hi = t1.min(end_time);
+                let query = query_fn((t0, t1), date, iteration);
+                Some((query, lo, hi))
             };
 
             Ok(chunk_stream::<T>(socket, slice_fn))
@@ -834,11 +868,13 @@ mod tests {
         assert_eq!(slices.last().unwrap().2, 0);
     }
 
-    /// DEFECT (part 1/2): when `start_time` is not aligned to `period`, the first
-    /// slice's `t0` is the period boundary *at or before* `start_time` — i.e.
-    /// strictly before it. A caller's documented `time >= t0j` filter therefore
-    /// selects rows in `[t0, start_time)`, whose on-graph time is before the run's
-    /// `start_time`.
+    /// When `start_time` is not aligned to `period`, the first slice's `t0` is the
+    /// period boundary *at or before* `start_time` — i.e. strictly before it. A
+    /// caller's documented `time >= t0j` filter therefore selects rows in
+    /// `[t0, start_time)`, whose on-graph time is before the run's `start_time`.
+    /// `kdb_read` clamps emitted rows to `[start_time, end_time)` so these are
+    /// dropped rather than aborting the run; this test pins the over-read that
+    /// makes the clamp necessary.
     #[test]
     fn test_first_slice_precedes_unaligned_start() {
         let epoch = kdb_epoch();
@@ -862,10 +898,12 @@ mod tests {
         );
     }
 
-    /// DEFECT (part 2/2): a value whose time is before `start_time` — exactly what
-    /// part 1 shows the first slice returns — aborts a historical run. This is the
-    /// mechanism by which `kdb_read` "can throw": the engine forbids delivering a
-    /// historical value earlier than the graph clock, which starts at `start_time`.
+    /// Engine constraint that motivates the clamp: a value whose time is before
+    /// `start_time` aborts a historical run. The engine forbids delivering a
+    /// historical value earlier than the graph clock (which starts at
+    /// `start_time`) — in release with an explicit error, in debug via a
+    /// `NanoTime` subtraction underflow. `kdb_read` avoids both by dropping such
+    /// rows; this test pins why unclamped rows are unsafe to emit.
     #[test]
     fn test_row_before_start_time_aborts_run() {
         use crate::nodes::{NodeOperators, StreamOperators};
@@ -895,11 +933,12 @@ mod tests {
         );
     }
 
-    /// DEFECT (related): `kdb_read` does not clamp emitted rows to the slice
-    /// window — it trusts the caller's query. If a slice returns a row *ahead* of
-    /// its `[t0, t1)` window, the graph clock jumps forward to it; a later slice's
-    /// legitimate in-window row is then behind the clock and the run is aborted by
-    /// the same monotonic-time check. So out-of-window rows throw too.
+    /// Engine constraint (ahead-of-window case): if a slice's query returns a row
+    /// *ahead* of its `[t0, t1)` window, the graph clock jumps forward to it and a
+    /// later slice's legitimate in-window row would then be behind the clock,
+    /// aborting the run via the same monotonic-time check. `kdb_read`'s per-slice
+    /// clamp (drop at/after `hi`) prevents the forward jump; this test pins the
+    /// hazard the upper bound guards against.
     #[test]
     fn test_row_ahead_of_window_then_in_window_aborts_run() {
         use crate::nodes::{NodeOperators, StreamOperators};

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -1,6 +1,7 @@
 //! KDB+ read functionality for streaming data from q/kdb+ instances.
 
 use super::{KdbConnection, Sym, SymbolInterner};
+use crate::adapters::common::{TimeWindow, WindowFilter};
 use crate::nodes::produce_async;
 use crate::types::*;
 use anyhow::{Result, bail};
@@ -322,22 +323,22 @@ pub trait KdbDeserialize: Sized {
 /// Core streaming loop driven by a caller-supplied query closure.
 ///
 /// Calls `next_slice()` before each chunk. Returns `None` to stop, or
-/// `Some((query, lo, hi))` — the query to execute plus the half-open window
-/// `[lo, hi)` the resulting rows are expected to fall in.
+/// `Some((query, window))` — the query to execute plus the on-graph time
+/// [`TimeWindow`] the resulting rows are expected to fall in.
 ///
-/// Rows whose extracted time falls outside `[lo, hi)` are **dropped** (with a
-/// single per-slice warning). This is necessary because callers build their own
-/// filters and the first slice starts at the period boundary at or before
-/// `start_time`, so a query can legitimately return rows before `start_time`,
-/// after `end_time`, or otherwise beyond the slice it was asked to fill. The
-/// graph clock is monotonic and bounded to the run window, so emitting such rows
-/// would abort the run.
+/// Rows whose extracted time falls outside `window` are **dropped** (via
+/// [`WindowFilter`], with a single per-slice warning). This is necessary because
+/// callers build their own filters and the first slice starts at the period
+/// boundary at or before `start_time`, so a query can legitimately return rows
+/// before `start_time`, after `end_time`, or otherwise beyond the slice it was
+/// asked to fill. The graph clock is monotonic and bounded to the run window, so
+/// emitting such rows would abort the run.
 ///
 /// `prev_time` is reset each chunk so time-of-day columns work correctly when
 /// advancing across date partitions (timestamps restart at midnight on each new date).
 fn chunk_stream<T>(
     mut socket: QStream,
-    mut next_slice: impl FnMut() -> Option<(String, NanoTime, NanoTime)> + Send + 'static,
+    mut next_slice: impl FnMut() -> Option<(String, TimeWindow)> + Send + 'static,
 ) -> impl futures::Stream<Item = anyhow::Result<(NanoTime, T)>> + Send + 'static
 where
     T: KdbDeserialize + Send + 'static,
@@ -345,7 +346,7 @@ where
     async_stream::stream! {
         let mut interner = SymbolInterner::default();
 
-        'outer: while let Some((query, lo, hi)) = next_slice() {
+        'outer: while let Some((query, window)) = next_slice() {
             info!("KDB query: {query}");
             let fetch_start = std::time::Instant::now();
             let result: K = match socket.send_sync_message(&query.as_str()).await {
@@ -362,19 +363,17 @@ where
             info!("KDB query: {} rows in {:?}", row_count, fetch_start.elapsed());
 
             let mut prev_time: Option<NanoTime> = None;
-            let mut dropped: usize = 0;
+            let mut filter = WindowFilter::new("kdb_read", window);
             for row in &rows {
                 let (time, record) = match T::from_kdb_row(row, &columns, &mut interner) {
                     Ok(r) => r,
                     Err(e) => { yield Err(e.into()); break 'outer; }
                 };
 
-                // Drop rows the query returned outside this slice's [lo, hi)
-                // window (before start_time, at/after end_time, or beyond the
-                // slice bounds). Emitting them would drive the monotonic graph
-                // clock backwards and abort the run.
-                if time < lo || time >= hi {
-                    dropped += 1;
+                // Drop rows the query returned outside the run window (before
+                // start_time, at/after end_time, or beyond the slice bounds).
+                // Emitting them would drive the monotonic graph clock backwards.
+                if !filter.keep(time) {
                     continue;
                 }
 
@@ -391,13 +390,7 @@ where
 
                 yield Ok((time, record));
             }
-
-            if dropped > 0 {
-                log::warn!(
-                    "kdb_read: dropped {dropped} row(s) outside the requested window \
-                    [{lo:?}, {hi:?}); the query returned data beyond the slice it was asked to fill"
-                );
-            }
+            filter.finish();
         }
     }
 }
@@ -516,17 +509,16 @@ where
 
             let mut slices_iter = slices.into_iter();
             let mut query_fn = query_fn;
-            let slice_fn = move || -> Option<(String, NanoTime, NanoTime)> {
+            let slice_fn = move || -> Option<(String, TimeWindow)> {
                 let ((t0, t1), date, iteration) = slices_iter.next()?;
                 // The query still uses the period-aligned (t0, t1) for clean
                 // round-number boundaries, but rows are clamped to the run's
                 // [start_time, end_time) so out-of-window rows are dropped rather
                 // than aborting the run. `t0` may precede `start_time` on the
                 // first slice; `t1` may exceed `end_time` on the last.
-                let lo = t0.max(start_time);
-                let hi = t1.min(end_time);
+                let window = TimeWindow::clamp(t0, t1, start_time, end_time);
                 let query = query_fn((t0, t1), date, iteration);
-                Some((query, lo, hi))
+                Some((query, window))
             };
 
             Ok(chunk_stream::<T>(socket, slice_fn))

--- a/wingfoil/src/adapters/kdb/read_cached.rs
+++ b/wingfoil/src/adapters/kdb/read_cached.rs
@@ -36,6 +36,15 @@ use std::rc::Rc;
 /// fields), old cache files will deserialise as garbage or return an error. The
 /// fix is to call [`CacheConfig::clear`] (or delete the cache directory) and re-run.
 ///
+/// # Out-of-window rows
+///
+/// Like [`kdb_read`], rows a query returns outside the run's
+/// `[start_time, end_time)` window are dropped at emit time (with a per-slice
+/// warning) rather than aborting the run. The **cache stores the full slice
+/// result** (`[t0, t1)`), because the cache key is the query string and does not
+/// encode `start_time`/`end_time`; the clamp is applied on the way out, on both
+/// cache hits and misses.
+///
 /// # Example
 /// ```ignore
 /// let config = CacheConfig::new("/tmp/my-backtest-cache", 512 * 1024 * 1024);
@@ -100,6 +109,14 @@ where
                 let mut query_fn = query_fn;
 
                 'slices: for (within, date, iteration) in slices {
+                    // Effective window for this slice: clamp the period-aligned
+                    // (t0, t1) to the run's [start_time, end_time). Rows the query
+                    // returns outside it are dropped at emit time (below). The cache
+                    // still stores the full [t0, t1) result, since the cache key is
+                    // the query string and does not encode start_time/end_time.
+                    let (t0, t1) = within;
+                    let lo = t0.max(start_time);
+                    let hi = t1.min(end_time);
                     let query = query_fn(within, date, iteration);
                     let key = CacheKey::from_parts(&[&query]);
 
@@ -113,8 +130,19 @@ where
                     };
 
                     if let Some(rows) = cached {
+                        let mut dropped = 0usize;
                         for (time, record) in rows {
+                            if time < lo || time >= hi {
+                                dropped += 1;
+                                continue;
+                            }
                             yield Ok((time, record));
+                        }
+                        if dropped > 0 {
+                            log::warn!(
+                                "kdb_read_cached: dropped {dropped} cached row(s) outside the \
+                                requested window [{lo:?}, {hi:?})"
+                            );
                         }
                         continue;
                     }
@@ -193,8 +221,19 @@ where
                         log::warn!("KDB cache write error: {e}");
                     }
 
+                    let mut dropped = 0usize;
                     for (time, record) in parsed {
+                        if time < lo || time >= hi {
+                            dropped += 1;
+                            continue;
+                        }
                         yield Ok((time, record));
+                    }
+                    if dropped > 0 {
+                        log::warn!(
+                            "kdb_read_cached: dropped {dropped} row(s) outside the requested \
+                            window [{lo:?}, {hi:?}); the query returned data beyond the slice"
+                        );
                     }
                 }
             })

--- a/wingfoil/src/adapters/kdb/read_cached.rs
+++ b/wingfoil/src/adapters/kdb/read_cached.rs
@@ -3,6 +3,7 @@
 use super::read::compute_time_slices;
 use super::{KdbConnection, KdbDeserialize, KdbExt, SymbolInterner};
 use crate::adapters::cache::{CacheConfig, CacheKey, FileCache};
+use crate::adapters::common::{TimeWindow, WindowFilter};
 use crate::nodes::produce_async;
 use crate::types::*;
 use anyhow::bail;
@@ -115,8 +116,7 @@ where
                     // still stores the full [t0, t1) result, since the cache key is
                     // the query string and does not encode start_time/end_time.
                     let (t0, t1) = within;
-                    let lo = t0.max(start_time);
-                    let hi = t1.min(end_time);
+                    let window = TimeWindow::clamp(t0, t1, start_time, end_time);
                     let query = query_fn(within, date, iteration);
                     let key = CacheKey::from_parts(&[&query]);
 
@@ -130,20 +130,14 @@ where
                     };
 
                     if let Some(rows) = cached {
-                        let mut dropped = 0usize;
+                        let mut filter = WindowFilter::new("kdb_read_cached", window);
                         for (time, record) in rows {
-                            if time < lo || time >= hi {
-                                dropped += 1;
+                            if !filter.keep(time) {
                                 continue;
                             }
                             yield Ok((time, record));
                         }
-                        if dropped > 0 {
-                            log::warn!(
-                                "kdb_read_cached: dropped {dropped} cached row(s) outside the \
-                                requested window [{lo:?}, {hi:?})"
-                            );
-                        }
+                        filter.finish();
                         continue;
                     }
 
@@ -221,20 +215,14 @@ where
                         log::warn!("KDB cache write error: {e}");
                     }
 
-                    let mut dropped = 0usize;
+                    let mut filter = WindowFilter::new("kdb_read_cached", window);
                     for (time, record) in parsed {
-                        if time < lo || time >= hi {
-                            dropped += 1;
+                        if !filter.keep(time) {
                             continue;
                         }
                         yield Ok((time, record));
                     }
-                    if dropped > 0 {
-                        log::warn!(
-                            "kdb_read_cached: dropped {dropped} row(s) outside the requested \
-                            window [{lo:?}, {hi:?}); the query returned data beyond the slice"
-                        );
-                    }
+                    filter.finish();
                 }
             })
         }

--- a/wingfoil/src/adapters/kdb/read_cached.rs
+++ b/wingfoil/src/adapters/kdb/read_cached.rs
@@ -39,7 +39,7 @@ use std::rc::Rc;
 /// # Example
 /// ```ignore
 /// let config = CacheConfig::new("/tmp/my-backtest-cache", 512 * 1024 * 1024);
-/// let stream = kdb_read_cached::<Trade, _>(
+/// let stream = kdb_read_cached::<Trade>(
 ///     KdbConnection::new("localhost", 5000),
 ///     Duration::from_secs(3600),
 ///     config,
@@ -51,11 +51,11 @@ use std::rc::Rc;
 /// );
 /// ```
 #[must_use]
-pub fn kdb_read_cached<T, F>(
+pub fn kdb_read_cached<T>(
     connection: KdbConnection,
     period: std::time::Duration,
     cache_config: CacheConfig,
-    query_fn: F,
+    query_fn: impl FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 ) -> Rc<dyn Stream<Burst<T>>>
 where
     T: Element
@@ -65,7 +65,6 @@ where
         + serde::Serialize
         + for<'de> serde::Deserialize<'de>
         + 'static,
-    F: FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
 {
     produce_async(move |ctx| {
         let start_time = ctx.start_time;

--- a/wingfoil/src/adapters/kdb/sub.rs
+++ b/wingfoil/src/adapters/kdb/sub.rs
@@ -1,0 +1,189 @@
+//! KDB+ real-time subscription via a tickerplant.
+//!
+//! [`kdb_sub`] is the real-time counterpart to [`kdb_read`](super::kdb_read)
+//! (bounded historical replay): it subscribes to a q **tickerplant** and streams
+//! rows on-graph as they are published, using the same [`KdbDeserialize`] impls.
+
+use super::read::upd_payload_rows;
+use super::{KdbConnection, KdbDeserialize, KdbExt, SymbolInterner};
+use crate::RunMode;
+use crate::nodes::produce_async;
+use crate::types::*;
+use anyhow::Context;
+use kdb_plus_fixed::ipc::{ConnectionMethod, QStream};
+use kdb_plus_fixed::qtype;
+use log::info;
+use std::rc::Rc;
+
+/// Live-subscribe to a KDB+ tickerplant and stream published rows in real time.
+///
+/// Complements [`kdb_read`](super::kdb_read) (bounded historical replay) with an
+/// unbounded real-time source. Rows published to `table` while the graph runs are
+/// streamed on-graph as `Burst<T>`, decoded by the same [`KdbDeserialize`] impl
+/// `kdb_read` uses.
+///
+/// # How it works
+///
+/// A tickerplant is genuinely push-based (unlike the etcd/postgres LISTEN model,
+/// where the notification is only a wake-up and rows are re-queried):
+///
+/// 1. Opens a connection and sends `.u.sub[`table;syms]` **synchronously**. The
+///    reply carries the table schema, from which the column names are captured.
+/// 2. Loops on [`QStream::receive_message`], decoding each async
+///    `(`upd; table; data)` message the tickerplant pushes. The `data` payload —
+///    a table or a bare list of column vectors — is turned into rows and each is
+///    handed to `T::from_kdb_row`. Non-`upd` control messages (e.g. the
+///    end-of-day `.u.end`) are ignored.
+///
+/// # Subscription arguments
+///
+/// - `table` — the tickerplant table name (no leading backtick), e.g. `"trades"`.
+/// - `symbols` — a q symbol-list literal selecting which syms to receive:
+///   `` "`" `` for all, `` "`AAPL`MSFT" `` to filter. This is spliced into the
+///   `.u.sub` call, mirroring `kdb_read`'s caller-builds-the-query approach.
+///
+/// # Requirements
+///
+/// - `RunMode::RealTime` (use `kdb_read` for historical replay); bails otherwise.
+/// - `.u.sub` tails from the moment of subscription — it does **not** replay the
+///   tickerplant's log or the RDB's in-memory buffer, so rows published before the
+///   graph started are not delivered. Under `RunMode::RealTime` the on-graph time
+///   is the row's arrival (wall-clock) time; the timestamp column extracted by
+///   `from_kdb_row` is carried through but not used to order the real-time stream.
+#[must_use]
+pub fn kdb_sub<T>(
+    connection: KdbConnection,
+    table: impl Into<String>,
+    symbols: impl Into<String>,
+) -> Rc<dyn Stream<Burst<T>>>
+where
+    T: Element + Send + KdbDeserialize + 'static,
+{
+    let table = table.into();
+    let symbols = symbols.into();
+    produce_async(move |ctx| {
+        let run_mode = ctx.run_mode;
+        let connection = connection;
+        let table = table;
+        let symbols = symbols;
+
+        async move {
+            if !matches!(run_mode, RunMode::RealTime) {
+                anyhow::bail!(
+                    "kdb_sub requires RunMode::RealTime; use kdb_read for historical replay"
+                );
+            }
+
+            let creds = connection.credentials_string();
+            let mut socket = QStream::connect(
+                ConnectionMethod::TCP,
+                &connection.host,
+                connection.port,
+                &creds,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "kdb_sub: failed to connect to {}:{}",
+                    connection.host, connection.port
+                )
+            })?;
+
+            // Subscribe synchronously; the reply is `(`table; schema)`, from which
+            // we capture the column names for positional row decoding.
+            let sub_query = format!(".u.sub[`{table};{symbols}]");
+            info!("kdb_sub: {sub_query}");
+            let sub_reply = socket
+                .send_sync_message(&sub_query.as_str())
+                .await
+                .with_context(|| format!("kdb_sub: subscription `{sub_query}` failed"))?;
+            let columns: Vec<String> = sub_reply
+                .element_at(1)
+                .ok()
+                .and_then(|schema| schema.column_names().ok())
+                .unwrap_or_default();
+
+            Ok(async_stream::stream! {
+                let mut interner = SymbolInterner::default();
+                loop {
+                    let (_msg_type, msg) = match socket.receive_message().await {
+                        Ok(m) => m,
+                        Err(e) => {
+                            yield Err(anyhow::Error::new(e).context("kdb_sub: receive failed"));
+                            break;
+                        }
+                    };
+
+                    // A tickerplant update is `(`upd; `table; data)` — a 3-element
+                    // compound list whose first element is the symbol `upd`. Skip
+                    // anything else (heartbeats, `.u.end`, etc.).
+                    if msg.get_type() != qtype::COMPOUND_LIST || msg.len() < 3 {
+                        continue;
+                    }
+                    match msg.element_at(0).ok().as_ref().and_then(|f| f.get_symbol().ok()) {
+                        Some("upd") => {}
+                        _ => continue,
+                    }
+
+                    let data = match msg.element_at(2) {
+                        Ok(d) => d,
+                        Err(e) => {
+                            yield Err(anyhow::Error::new(e).context("kdb_sub: upd message has no data"));
+                            break;
+                        }
+                    };
+
+                    let rows = match upd_payload_rows(&data) {
+                        Ok(rows) => rows,
+                        Err(e) => { yield Err(e); break; }
+                    };
+
+                    for row in &rows {
+                        match T::from_kdb_row(row, &columns, &mut interner) {
+                            Ok((time, record)) => yield Ok((time, record)),
+                            Err(e) => { yield Err(anyhow::Error::new(e)); return; }
+                        }
+                    }
+                }
+            })
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::kdb::{KdbError, Row};
+    use crate::nodes::{NodeOperators, StreamOperators};
+    use crate::{RunFor, RunMode};
+
+    #[derive(Debug, Clone, Default)]
+    struct TestRow;
+
+    impl KdbDeserialize for TestRow {
+        fn from_kdb_row(
+            _row: Row<'_>,
+            _columns: &[String],
+            _interner: &mut SymbolInterner,
+        ) -> std::result::Result<(NanoTime, Self), KdbError> {
+            Ok((NanoTime::ZERO, TestRow))
+        }
+    }
+
+    #[test]
+    fn test_sub_rejects_historical_mode() {
+        // Bails on the run-mode guard before any connection is attempted.
+        let result = kdb_sub::<TestRow>(KdbConnection::new("127.0.0.1", 1), "trades", "`")
+            .collapse()
+            .collect()
+            .run(
+                RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
+                RunFor::Cycles(1),
+            );
+        let err = result.expect_err("historical mode must be rejected");
+        assert!(
+            format!("{err:#}").contains("requires RunMode::RealTime"),
+            "unexpected error: {err:#}"
+        );
+    }
+}

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -4,10 +4,10 @@
 pub mod aeron;
 #[cfg(feature = "kdb")]
 pub mod cache;
-// Shared adapter helpers (e.g. the out-of-window row filter). Add your adapter's
-// feature to this gate when it becomes the first non-kdb consumer.
-#[cfg(feature = "kdb")]
-pub(crate) mod common;
+/// Shared helpers reusable across I/O adapters (e.g. the out-of-window row
+/// filter for historical reads). Always compiled so any adapter can use it
+/// without touching feature gates.
+pub mod common;
 #[cfg(feature = "csv")]
 pub mod csv;
 #[cfg(feature = "etcd")]

--- a/wingfoil/src/adapters/mod.rs
+++ b/wingfoil/src/adapters/mod.rs
@@ -4,6 +4,10 @@
 pub mod aeron;
 #[cfg(feature = "kdb")]
 pub mod cache;
+// Shared adapter helpers (e.g. the out-of-window row filter). Add your adapter's
+// feature to this gate when it becomes the first non-kdb consumer.
+#[cfg(feature = "kdb")]
+pub(crate) mod common;
 #[cfg(feature = "csv")]
 pub mod csv;
 #[cfg(feature = "etcd")]


### PR DESCRIPTION
## Summary

Adds `kdb_sub`, a real-time counterpart to `kdb_read` for subscribing to KDB+ tickerplants and streaming published rows on-graph as they arrive. Also refactors `kdb_read` to drop out-of-window rows rather than aborting the run, fixing a correctness issue when the first slice's query returns rows before `start_time`.

## Key Changes

- **New `kdb_sub` function** (`src/adapters/kdb/sub.rs`):
  - Subscribes to a KDB+ tickerplant via `.u.sub[table;symbols]` synchronous call
  - Loops on `QStream::receive_message()` to decode async `(upd; table; data)` messages
  - Reuses the same `KdbDeserialize` trait as `kdb_read` for row decoding
  - Requires `RunMode::RealTime`; bails on historical modes
  - Handles both table and bare column-vector payloads via new `upd_payload_rows` helper

- **Out-of-window row filtering in `kdb_read`**:
  - Refactored `chunk_stream` to accept `next_slice()` closure returning `(query, lo, hi)` window bounds
  - Drops rows whose extracted time falls outside `[lo, hi)` with per-slice warning
  - Fixes correctness issue: first slice starts at period boundary at/before `start_time`, so `time >= t0j` filter can legitimately return rows before `start_time`; emitting them would drive the monotonic graph clock backwards and abort the run
  - Added comprehensive tests pinning the hazards (rows before start, rows ahead of window)

- **Shared infrastructure**:
  - New `Rows::from_column_list()` to wrap bare column vectors as a `Rows` accessor
  - New `upd_payload_rows()` helper to normalize tickerplant payloads (table or column list) to `Rows`
  - Simplified `kdb_read` signature: removed generic `F` type parameter, now infers from closure

- **Integration tests**:
  - `test_kdb_sub_realtime_receives_published_rows`: end-to-end test with in-process tickerplant, publisher thread, and on-graph subscription
  - `test_kdb_read_drops_rows_outside_window`: regression test for out-of-window row handling
  - Updated all existing `kdb_read` call sites to use simplified signature

- **Documentation**:
  - Updated `CLAUDE.md` to document `kdb_sub` and the out-of-window row clamp behavior
  - Updated module docstring and examples to reflect real-time subscription support

## Implementation Details

- `kdb_sub` uses `async_stream::stream!` macro for the receive loop, matching `kdb_read`'s async pattern
- Symbol interner is maintained across messages to preserve symbol identity within a subscription session
- Non-`upd` control messages (heartbeats, `.u.end`) are silently skipped
- The tickerplant integration test defines a minimal in-process TP (`.u.sub`, `.u.pub`, `.u.nsub`) to avoid external dependencies
- Row clamping in `kdb_read` is transparent to callers; the query still uses period-aligned boundaries for clean round numbers, but emitted rows are bounded to the run window

https://claude.ai/code/session_019Fr77Rz3zype3Ae2Aqb2K4