### PR TITLE
ci(pypi-publish): read inputs.pypi-target so prod releases hit real PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -78,16 +78,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # Read `inputs.pypi-target`, NOT `github.event.inputs.pypi-target`. The
+      # `inputs` context carries the value for both triggers (workflow_dispatch
+      # *and* workflow_call). `github.event.inputs` is only populated for a
+      # direct workflow_dispatch — on a workflow_call it reflects the *caller's*
+      # triggering event, which for release.yml is a dispatch with no inputs, so
+      # the value was empty and this step silently fell through to TestPyPI while
+      # still reporting success. Fail loudly on anything unexpected instead of
+      # defaulting to test, so a misrouted release can never masquerade as green.
       - name: Set PyPI target
         id: pypi
         run: |
-          if [ "${{ github.event.inputs.pypi-target }}" = "prod" ]; then
-            echo "REPO_URL=https://upload.pypi.org/legacy/" >> $GITHUB_ENV
-            echo "TOKEN_NAME=PROD_PYPI_API_TOKEN" >> $GITHUB_ENV
-          else
-            echo "REPO_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
-            echo "TOKEN_NAME=TEST_PYPI_API_TOKEN" >> $GITHUB_ENV
-          fi
+          case "${{ inputs.pypi-target }}" in
+            prod)
+              echo "REPO_URL=https://upload.pypi.org/legacy/" >> $GITHUB_ENV
+              echo "TOKEN_NAME=PROD_PYPI_API_TOKEN" >> $GITHUB_ENV
+              ;;
+            test)
+              echo "REPO_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
+              echo "TOKEN_NAME=TEST_PYPI_API_TOKEN" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "::error::pypi-target must be 'test' or 'prod', got '${{ inputs.pypi-target }}'"
+              exit 1
+              ;;
+          esac
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The upload-pypi job selected its target from `github.event.inputs.pypi-target`,
which is only populated on a direct workflow_dispatch. When release.yml invokes
this reusable workflow via workflow_call with `pypi-target: prod`, the value
arrives on the `inputs` context instead; `github.event.inputs` reflects the
caller's triggering event (a dispatch with no inputs), so the string was empty
and the step fell through to the TestPyPI branch. The upload then succeeded
against test.pypi.org and the job reported success, so a production release
silently published nothing to the real index.

Read `inputs.pypi-target` (valid for both workflow_dispatch and workflow_call)
and hard-fail on any value other than `test`/`prod` so a misrouted release can
no longer masquerade as a green run.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RgSVp38RkceopJezGeiJZW