### PR TITLE
Anchor NanoTime::now() to the unix epoch

### DIFF
--- a/wingfoil/src/time.rs
+++ b/wingfoil/src/time.rs
@@ -8,11 +8,32 @@ use serde::{Deserialize, Serialize};
 use std::convert::From;
 use std::ops::{Add, Mul, Sub};
 use std::sync::LazyLock;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 type RawTime = u64;
 
 static CLOCK: LazyLock<Clock> = LazyLock::new(Clock::new);
+
+/// Nanoseconds added to a raw `quanta` reading to convert it to nanoseconds
+/// since the unix epoch.
+///
+/// `quanta::Clock::now()` is monotonic (nanoseconds since an arbitrary anchor,
+/// effectively boot time), but [`NanoTime`] documents "nanoseconds since the
+/// unix epoch". We snap `SystemTime::now()` against the monotonic clock once,
+/// at first use, and add the resulting offset to every subsequent reading. This
+/// keeps quanta's cheap, TSC-based reads while anchoring them to the documented
+/// epoch, so timestamps persisted in real-time mode (kdb/Postgres/CSV writes,
+/// cross-host latency stamps) are correct as absolute times.
+static EPOCH_OFFSET_NANOS: LazyLock<u64> = LazyLock::new(|| {
+    let mono = CLOCK.now().as_u64();
+    let wall = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("invariant: system clock is later than the unix epoch")
+        .as_nanos() as u64;
+    // Wall clock is ~decades ahead of the monotonic anchor, so this never
+    // saturates in practice; `saturating_sub` only guards a clock set to 1970.
+    wall.saturating_sub(mono)
+});
 
 /// A time in nanoseconds since the unix epoch.
 #[derive(
@@ -43,7 +64,7 @@ impl NanoTime {
     const KDB_EPOCH_OFFSET_NANOS: i64 = 946_684_800_000_000_000;
 
     pub fn now() -> Self {
-        Self(CLOCK.now().as_u64())
+        Self(CLOCK.now().as_u64() + *EPOCH_OFFSET_NANOS)
     }
 
     pub fn pretty(&self) -> String {
@@ -194,7 +215,31 @@ impl Mul<i64> for NanoTime {
 mod tests {
     use super::NanoTime;
     use chrono::Datelike;
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn now_is_anchored_to_the_unix_epoch() {
+        // `now()` must return nanoseconds since the unix epoch (its documented
+        // contract), not quanta's boot-relative monotonic reading. Compare
+        // against the wall clock; a few seconds of slack covers scheduling.
+        let wall = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let now = u64::from(NanoTime::now());
+        let diff = now.abs_diff(wall);
+        assert!(
+            diff < 5_000_000_000,
+            "now() ({now}) is not within 5s of the wall clock ({wall}); diff {diff}ns"
+        );
+    }
+
+    #[test]
+    fn now_is_monotonic_non_decreasing() {
+        let a = NanoTime::now();
+        let b = NanoTime::now();
+        assert!(b >= a, "now() went backwards: {a} then {b}");
+    }
 
     #[test]
     fn kdb_timestamp_roundtrip() {


### PR DESCRIPTION
## Summary

`NanoTime` documents itself as *"nanoseconds since the unix epoch"*, but `now()` returned `quanta::Clock::now().as_u64()` directly — which is **monotonic (nanoseconds since boot), not epoch time** (item 0.3 in `docs/IMPROVEMENT_PLAN.md`).

Confirmed empirically in this repo:

```
QUANTA_NOW = 2371397101590        (~39 minutes of boot uptime)
WALL_NOW   = 1783708037247128335  (2026, unix epoch)
diff       ≈ 1,783,705,665 s      (~56 years)
```

In `RunMode::RealTime` this makes every timestamp derived from engine time wrong as an *absolute* time: `to_kdb_timestamp()`, `From<NanoTime> for NaiveDateTime`, and timestamps persisted by the kdb / Postgres / CSV writers all land in the 1970s, and cross-host latency stamps are meaningless.

## Fix

Snap `SystemTime::now()` against the monotonic clock **once**, at first use (`LazyLock`), and add the resulting offset to every reading:

```rust
static EPOCH_OFFSET_NANOS: LazyLock<u64> = LazyLock::new(|| {
    let mono = CLOCK.now().as_u64();
    let wall = SystemTime::now().duration_since(UNIX_EPOCH)
        .expect("invariant: system clock is later than the unix epoch")
        .as_nanos() as u64;
    wall.saturating_sub(mono)
});

pub fn now() -> Self {
    Self(CLOCK.now().as_u64() + *EPOCH_OFFSET_NANOS)
}
```

This keeps quanta's cheap, TSC-based reads (the reason quanta is used) while restoring the documented epoch anchor. Monotonicity is preserved because the offset is a constant.

## Tests

- `now_is_anchored_to_the_unix_epoch` — asserts `now()` is within 5s of the wall clock (would fail on the old boot-relative reading by decades).
- `now_is_monotonic_non_decreasing` — guards the invariant the offset must not break.

Full `cargo test -p wingfoil` passes (218 unit + doctests); default `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all` clean.

## Deferred (noted in the plan, intentionally out of scope here)

The plan also suggests bumping `quanta` 0.9.3 → 0.12.x for its calibration fixes. That's an API/lockfile change independent of this correctness fix, so I've left it as a follow-up to keep this PR minimal and easy to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mNRkJnZZGC1QUULgbbwnA

---
_Generated by [Claude Code](https://claude.ai/code/session_014mNRkJnZZGC1QUULgbbwnA)_