### PR TITLE
Surface channel-closed errors on the async path instead of panicking

### DIFF
--- a/wingfoil/src/channel/kanal_chan.rs
+++ b/wingfoil/src/channel/kanal_chan.rs
@@ -44,14 +44,14 @@ impl<T: Element + Send> ChannelReceiver<T> {
     pub fn recv(&self) -> Message<T> {
         self.kanal_receiver.recv().unwrap_or(Message::EndOfStream)
     }
-    pub fn teardown(&self) {
+    pub fn teardown(&self) -> anyhow::Result<()> {
         for _ in 0..100 {
             if self.kanal_receiver.sender_count() == 0 {
-                return;
+                return Ok(());
             }
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
-        panic!("timed out waiting for sending end of channel to close");
+        anyhow::bail!("timed out waiting for the sending end of the channel to close")
     }
 }
 
@@ -156,6 +156,26 @@ mod tests {
         let state = realtime_state();
         assert!(tx.send(&state, 1).is_err());
     }
+
+    #[test]
+    fn receiver_teardown_ok_when_sender_dropped() {
+        let (tx, rx) = channel_pair::<u64>(None);
+        drop(tx);
+        assert!(rx.teardown().is_ok());
+    }
+
+    #[cfg(feature = "async")]
+    #[test]
+    fn async_send_after_receiver_dropped_errors_not_panics() {
+        // Regression: a receiver dropped during shutdown is a normal teardown
+        // race. The async sender must surface ChannelClosed, not panic.
+        let (tx, rx) = channel_pair::<u64>(None);
+        let sender = tx.into_async();
+        drop(rx);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(sender.send_message(Message::RealtimeValue(1)));
+        assert!(matches!(result, Err(SendNodeError::ChannelClosed)));
+    }
 }
 
 #[cfg(feature = "async")]
@@ -237,7 +257,10 @@ impl<T: Element + Send> ChannelSender<T> {
 
     #[cfg(feature = "async")]
     pub fn into_async(mut self) -> AsyncChannelSender<T> {
-        let kanal_sender = self.kanal_sender.take().unwrap();
+        let kanal_sender = self
+            .kanal_sender
+            .take()
+            .expect("invariant: sender is not closed before into_async");
         let ready_notifier = self.ready_notifier.take();
         AsyncChannelSender::new(kanal_sender, ready_notifier)
     }
@@ -270,20 +293,28 @@ impl<T: Element + Send> AsyncChannelSender<T> {
         }
     }
 
-    pub async fn send_message(&self, message: Message<T>) {
-        self.kanal_sender
+    /// Send a message, surfacing `SendNodeError::ChannelClosed` if the receiver
+    /// has been dropped (a normal shutdown race) rather than panicking. Mirrors
+    /// the synchronous [`ChannelSender::send_message`].
+    pub async fn send_message(&self, message: Message<T>) -> SendResult {
+        let sender = self
+            .kanal_sender
             .as_ref()
-            .unwrap()
+            .ok_or(SendNodeError::ChannelClosed)?;
+        sender
             .send(message)
             .await
-            .unwrap();
+            .map_err(|_| SendNodeError::ChannelClosed)?;
         if let Some(notifier) = &self.ready_notifier {
-            notifier.notify().unwrap();
+            notifier
+                .notify()
+                .map_err(|_| SendNodeError::NotifierClosed)?;
         }
+        Ok(())
     }
 
     #[allow(dead_code)]
-    pub async fn send(&self, run_mode: RunMode, time: NanoTime, value: T) {
+    pub async fn send(&self, run_mode: RunMode, time: NanoTime, value: T) -> SendResult {
         let message = match run_mode {
             RunMode::HistoricalFrom(_) => {
                 let value_at = ValueAt::new(crate::burst![value], time);
@@ -291,18 +322,23 @@ impl<T: Element + Send> AsyncChannelSender<T> {
             }
             RunMode::RealTime => Message::RealtimeValue(value),
         };
-        self.send_message(message).await;
+        self.send_message(message).await
     }
 
     #[allow(dead_code)]
-    pub async fn send_checkpoint(&self, time: NanoTime) {
+    pub async fn send_checkpoint(&self, time: NanoTime) -> SendResult {
         let message = Message::CheckPoint(time);
-        self.send_message(message).await;
+        self.send_message(message).await
     }
 
-    pub async fn close(&mut self) {
-        let message = Message::EndOfStream;
-        self.send_message(message).await;
+    pub async fn close(&mut self) -> SendResult {
+        if self.kanal_sender.is_none() {
+            return Ok(());
+        }
+        // Best-effort EndOfStream: if the receiver is already gone the channel
+        // is effectively closed anyway, so a send error here is not fatal.
+        let _ = self.send_message(Message::EndOfStream).await;
         self.kanal_sender = None;
+        Ok(())
     }
 }

--- a/wingfoil/src/nodes/async_io.rs
+++ b/wingfoil/src/nodes/async_io.rs
@@ -233,7 +233,9 @@ where
         let fut = async move {
             match func(ctx).await {
                 Err(e) => {
-                    sender
+                    // Best-effort: forward the producer error to the consumer.
+                    // If the receiver is already gone there is no one to tell.
+                    let _ = sender
                         .send_message(Message::Error(std::sync::Arc::new(e)))
                         .await;
                 }
@@ -241,11 +243,15 @@ where
                     let source = stream.to_message_stream(run_mode).limit(run_mode, run_for);
                     let mut source = Box::pin(source);
                     while let Some(message) = source.next().await {
-                        sender.send_message(message).await;
+                        // A send error means the receiver was dropped (a normal
+                        // teardown race): stop producing instead of panicking.
+                        if sender.send_message(message).await.is_err() {
+                            break;
+                        }
                     }
                 }
             }
-            sender.close().await;
+            let _ = sender.close().await;
             Ok(())
         };
         let handle = state.tokio_runtime().spawn(fut);

--- a/wingfoil/src/nodes/channel.rs
+++ b/wingfoil/src/nodes/channel.rs
@@ -269,8 +269,7 @@ impl<T: Element + Send> MutableNode for ChannelReceiverStream<T> {
     }
 
     fn teardown(&mut self, _: &mut GraphState) -> anyhow::Result<()> {
-        self.receiver.teardown();
-        Ok(())
+        self.receiver.teardown()
     }
 }
 


### PR DESCRIPTION
## Summary

The async I/O channel path violated the project's no-`.unwrap()` policy in three places, each of which **panics on an ordinary shutdown race** (item 0.6 in `docs/IMPROVEMENT_PLAN.md`, verified in `docs/HANDOVER.md`):

1. `AsyncChannelSender::send_message` unwrapped both the `send(...).await` result and the notifier — a receiver dropped during teardown panicked the producer task instead of surfacing `SendNodeError::ChannelClosed`, which is exactly what the **synchronous** sender already does.
2. `ChannelSender::into_async` unwrapped the sender `Option`.
3. `ChannelReceiver::teardown` `panic!`d after sleep-polling 100×10ms for a sender that hadn't closed.

## Fix

- `AsyncChannelSender::{send_message, send, send_checkpoint, close}` now return `SendResult` and mirror the sync sender's error mapping (`ChannelClosed` / `NotifierClosed`). `close` remains best-effort (a gone receiver is not fatal), matching the sync `close`.
- The async **producer task** (`async_io.rs`) now stops producing when the receiver is gone (`break`) instead of panicking, and forwards a producer error best-effort. A dropped receiver during teardown is a normal race, so this is a clean stop, not a run failure.
- `into_async` uses `.expect("invariant: …")` documenting why the `Option` is always `Some` there (per the error-handling policy's priority-2 rule).
- `ChannelReceiver::teardown` returns `anyhow::Result<()>` and `bail!`s on timeout; its `MutableNode::teardown` caller propagates with `?`.

## Tests

- `async_send_after_receiver_dropped_errors_not_panics` — drops the receiver, then asserts the async `send_message` returns `Err(ChannelClosed)` rather than panicking.
- `receiver_teardown_ok_when_sender_dropped` — pins the new `Result` return.
- Existing `produce_async_mid_stream_error` (error-propagation coverage) still passes.

`cargo test -p wingfoil` → 220 unit + doctests pass; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all` clean. (`async` is a default feature, so all changed code is in the default build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mNRkJnZZGC1QUULgbbwnA

---
_Generated by [Claude Code](https://claude.ai/code/session_014mNRkJnZZGC1QUULgbbwnA)_