### PR TITLE
web: stream historical replays to the browser (bursts + end-of-stream)

### DIFF
--- a/wingfoil-js/README.md
+++ b/wingfoil-js/README.md
@@ -37,6 +37,53 @@ client.subscribe("price", (value, timeNs) => {
 client.publish("ui", { kind: "click", note: "hi" });
 ```
 
+### Bursts
+
+A frame's payload can be a **burst** — several values that share one
+`timeNs`. A scalar payload (a number or struct) is treated as a
+one-element burst; a payload that decodes to an **array** is the whole
+group. (A wingfoil graph produces a group by publishing a `Stream<Vec<T>>`
+— e.g. `web_sub`'s `Burst<T>` mapped to `Vec<T>`.)
+
+`subscribe` collapses the burst to its latest value (the right default for
+"show the current value"). When you must not drop same-timestamp values —
+e.g. appending every point to a chart — subscribe to the whole burst:
+
+```ts
+client.subscribeBurst("price", (values, timeNs) => {
+  for (const v of values) series.push(v);   // values: T[]
+});
+```
+
+## Streaming historical data (backtests / slow computations)
+
+The same client works for a graph running in historical mode
+(`RunMode::HistoricalFrom`) served over a normal `WebServer::…start()` —
+a backtest or slow computation streams its `web_pub` output to the browser
+frame-by-frame, so you can watch a replay unfold. Two things differ from a
+live feed:
+
+- **End-of-stream.** When a historical replay reaches the end of its
+  source, the server sends a `Complete` control frame. Observe it with
+  `onComplete` to render "replay finished" and stop any progress UI:
+
+  ```ts
+  client.onComplete((topic) => {
+    console.log(`stream ${topic} finished`);
+  });
+  ```
+
+- **No reconnect loop.** A finished replay must not reconnect against a
+  server that has intentionally shut down. Once the client sees a
+  `Complete` frame — or the server closes with a normal code (1000 / 1001)
+  — it treats the session as done and stops reconnecting, regardless of
+  `reconnectMs`. Only an abnormal drop (e.g. 1006) still retries.
+
+Streaming clients are lossy and never back-pressure the graph, so a
+loss-free replay depends on the graph not outrunning the client (a
+genuinely compute-bound historical run is the natural fit). See
+`wingfoil/examples/web` (`WINGFOIL_WEB_HISTORICAL=1`) for a runnable demo.
+
 ## Latency tracing
 
 For UIs that drive a wingfoil server using the `Traced<T, L>` /
@@ -105,6 +152,10 @@ Solid's fine-grained signals are the recommended default for kHz+
 streams — signal writes are cheap and paints coalesce to rAF, so
 high-frequency data drives UI without per-frame DOM thrash.
 
+`useTopic` surfaces the latest value; `useTopicBurst` surfaces the whole
+same-`timeNs` burst (`Accessor<T[] | undefined>`) when you need every
+value — e.g. appending each point of a historical replay to a chart.
+
 ### Svelte
 
 ```svelte
@@ -167,3 +218,14 @@ Every WebSocket frame is binary — either a `bincode`-serialized
 (if the server was started with `.codec(CodecKind::Json)`). The
 `wingfoil-wasm` decoder handles both without any user configuration
 other than the codec hint passed to `WingfoilClient`.
+
+The payload is the stream's value serialized by the codec. A scalar is a
+single value; a value that decodes to an array is surfaced as a
+same-`timeNs` **burst** (the client collapses it for `subscribe` and passes
+it whole to `subscribeBurst`). Client → server frames carry a single value.
+
+The control plane (topic `$ctrl`) carries `Hello` on connect, `Subscribe`
+/ `Unsubscribe` from the client, and `Complete { topic }` from the server
+when a publish topic's stream ends (wire protocol version 2). `Complete`
+was appended to the message enum, so a version-1 server that never sends
+it stays compatible — the client simply never fires `onComplete`.

--- a/wingfoil-js/src/index.ts
+++ b/wingfoil-js/src/index.ts
@@ -26,8 +26,38 @@ export interface Envelope {
   payload: Uint8Array;
 }
 
-/** Callback invoked for each decoded payload on a topic. */
+/**
+ * Callback invoked with the latest value of each frame's burst. A frame
+ * carries a *burst* — the values that share one `timeNs` — and the
+ * default `subscribe` collapses it to the last (latest) value, which is
+ * the right default for "show the current value". Use
+ * {@link WingfoilClient.subscribeBurst} to receive the whole group.
+ */
 export type TopicListener = (value: unknown, timeNs: bigint) => void;
+
+/**
+ * Callback invoked with the whole burst — every value that shares one
+ * `timeNs`. A scalar payload is a one-element burst; a graph that publishes
+ * a `Stream<Vec<T>>` sends several values at one timestamp as one frame.
+ */
+export type BurstListener = (values: unknown[], timeNs: bigint) => void;
+
+/**
+ * Normalize a decoded payload into a burst array. A payload that decodes
+ * to an array is the same-`timeNs` group as-is; a scalar payload (number,
+ * struct, …) is wrapped as a single-element burst so scalar and burst
+ * subscribers behave uniformly. Exposed for testing.
+ */
+export function normalizeBurst(decoded: unknown): unknown[] {
+  return Array.isArray(decoded) ? (decoded as unknown[]) : [decoded];
+}
+
+/**
+ * Callback invoked when the server signals a topic's stream has ended
+ * (a [`ControlMessage::Complete`], e.g. a historical replay finishing).
+ * After this fires no further values will arrive on the topic.
+ */
+export type CompleteListener = (topic: string) => void;
 
 /** Callback invoked when the underlying WebSocket state changes. */
 export type ConnectionListener = (state: ConnectionState) => void;
@@ -47,10 +77,44 @@ export interface ClientOptions {
    * `.codec(CodecKind::Json)`.
    */
   codec?: CodecKind;
-  /** Reconnect on close with this delay. Defaults to 1000 ms; `0` disables. */
+  /**
+   * Reconnect on close with this delay. Defaults to 1000 ms; `0` disables.
+   *
+   * A *clean* end is never reconnected regardless of this value: once the
+   * server signals end-of-stream (a `Complete` control frame, e.g. a
+   * historical replay finishing) or closes the socket with a normal code
+   * (1000 / 1001, "going away"), the client treats the session as done and
+   * stops. Only an abnormal drop (e.g. 1006) triggers the reconnect timer.
+   * This prevents a finished historical stream from reconnect-looping
+   * against a server that has intentionally shut down.
+   */
   reconnectMs?: number;
   /** Optional WASM module URL override (advanced). */
   wasmUrl?: string | URL;
+}
+
+/** WebSocket close codes that indicate a deliberate, clean shutdown. */
+const CLEAN_CLOSE_CODES = new Set<number>([1000, 1001]);
+
+/**
+ * Decide whether a closed socket should trigger a reconnect. Exposed for
+ * testing; the client applies it in its `close` handler.
+ *
+ * Reconnect only on an abnormal drop that the caller still wants retried.
+ * A clean finish — the user closed the client, the stream completed, the
+ * server closed with a normal code, or reconnect is disabled — never
+ * reconnects, so a finished historical replay does not loop against a
+ * server that has intentionally shut down.
+ */
+export function shouldReconnect(params: {
+  userClosed: boolean;
+  streamFinished: boolean;
+  closeCode: number;
+  reconnectMs: number;
+}): boolean {
+  const { userClosed, streamFinished, closeCode, reconnectMs } = params;
+  if (userClosed || streamFinished || reconnectMs <= 0) return false;
+  return !CLEAN_CLOSE_CODES.has(closeCode);
 }
 
 /**
@@ -63,9 +127,16 @@ export class WingfoilClient {
   private closed = false;
   private wasmReady = false;
   private readonly listeners = new Map<string, Set<TopicListener>>();
+  private readonly burstListeners = new Map<string, Set<BurstListener>>();
+  private readonly completeListeners = new Set<CompleteListener>();
   private readonly connListeners = new Set<ConnectionListener>();
   private codecKind: CodecKind;
   private serverVersion: number | null = null;
+  /**
+   * Set once the server signals end-of-stream for any topic. A finished
+   * stream must not reconnect — the server is done, not merely dropped.
+   */
+  private streamFinished = false;
 
   constructor(options: ClientOptions) {
     this.opts = {
@@ -91,25 +162,63 @@ export class WingfoilClient {
     }
   }
 
-  /** Subscribe to `topic`. Returns an unsubscribe function. */
+  /**
+   * Subscribe to `topic`, receiving the latest value of each frame's
+   * burst. Returns an unsubscribe function. Use {@link subscribeBurst} to
+   * receive every value in a same-`timeNs` group.
+   */
   subscribe(topic: string, listener: TopicListener): () => void {
+    const fresh = !this.hasTopicListener(topic);
     const set = this.listeners.get(topic) ?? new Set<TopicListener>();
-    const freshTopic = !this.listeners.has(topic);
     set.add(listener);
     this.listeners.set(topic, set);
-    if (freshTopic) this.sendSubscribe([topic]);
+    if (fresh) this.sendSubscribe([topic]);
     return () => this.unsubscribe(topic, listener);
   }
 
-  /** Remove a listener; optionally also send an unsubscribe frame if empty. */
+  /** Remove a scalar listener; send an unsubscribe frame if the topic is now idle. */
   unsubscribe(topic: string, listener: TopicListener): void {
     const set = this.listeners.get(topic);
     if (!set) return;
     set.delete(listener);
-    if (set.size === 0) {
-      this.listeners.delete(topic);
-      this.sendUnsubscribe([topic]);
-    }
+    if (set.size === 0) this.listeners.delete(topic);
+    if (!this.hasTopicListener(topic)) this.sendUnsubscribe([topic]);
+  }
+
+  /**
+   * Subscribe to `topic`, receiving the whole burst (every value that
+   * shares a `timeNs`) per frame. Returns an unsubscribe function. This is
+   * the full-fidelity form — no values are collapsed — useful for charting
+   * a historical replay where several points may land on one timestamp.
+   */
+  subscribeBurst(topic: string, listener: BurstListener): () => void {
+    const fresh = !this.hasTopicListener(topic);
+    const set = this.burstListeners.get(topic) ?? new Set<BurstListener>();
+    set.add(listener);
+    this.burstListeners.set(topic, set);
+    if (fresh) this.sendSubscribe([topic]);
+    return () => this.unsubscribeBurst(topic, listener);
+  }
+
+  /** Remove a burst listener; send an unsubscribe frame if the topic is now idle. */
+  unsubscribeBurst(topic: string, listener: BurstListener): void {
+    const set = this.burstListeners.get(topic);
+    if (!set) return;
+    set.delete(listener);
+    if (set.size === 0) this.burstListeners.delete(topic);
+    if (!this.hasTopicListener(topic)) this.sendUnsubscribe([topic]);
+  }
+
+  /** True when `topic` has any scalar or burst listener attached. */
+  private hasTopicListener(topic: string): boolean {
+    return this.listeners.has(topic) || this.burstListeners.has(topic);
+  }
+
+  /** Every topic with at least one listener (used to resubscribe on reconnect). */
+  private subscribedTopics(): string[] {
+    return Array.from(
+      new Set([...this.listeners.keys(), ...this.burstListeners.keys()]),
+    );
   }
 
   /** Publish a value on `topic` to the server. */
@@ -129,6 +238,17 @@ export class WingfoilClient {
   onConnection(listener: ConnectionListener): () => void {
     this.connListeners.add(listener);
     return () => this.connListeners.delete(listener);
+  }
+
+  /**
+   * Observe end-of-stream signals. The listener fires with the topic name
+   * each time the server sends a `Complete` control frame — for example
+   * when a historical replay reaches the end of its source. Returns a
+   * function that removes the listener.
+   */
+  onComplete(listener: CompleteListener): () => void {
+    this.completeListeners.add(listener);
+    return () => this.completeListeners.delete(listener);
   }
 
   /** Server-reported wire protocol version, once Hello was received. */
@@ -162,13 +282,25 @@ export class WingfoilClient {
     socket.addEventListener("error", (ev) => this.emitConn({ kind: "error", error: ev }));
     socket.addEventListener("close", (ev) => {
       this.emitConn({ kind: "closed", code: ev.code, reason: ev.reason });
-      if (!this.closed && this.opts.reconnectMs > 0) {
+      // Do not reconnect after a clean finish: the stream completed, the
+      // user closed us, reconnect is disabled, or the server closed the
+      // socket deliberately (a normal close code). Only an abnormal drop
+      // reconnects. This stops a finished historical replay from looping
+      // against a server that has intentionally shut down.
+      if (
+        shouldReconnect({
+          userClosed: this.closed,
+          streamFinished: this.streamFinished,
+          closeCode: ev.code,
+          reconnectMs: this.opts.reconnectMs,
+        })
+      ) {
         setTimeout(() => this.connect(), this.opts.reconnectMs);
       }
     });
     socket.addEventListener("open", () => {
       // Re-send any existing subscriptions on reconnect.
-      const topics = Array.from(this.listeners.keys());
+      const topics = this.subscribedTopics();
       if (topics.length > 0) this.sendSubscribe(topics);
     });
   }
@@ -192,20 +324,39 @@ export class WingfoilClient {
       this.handleControl(env.payload);
       return;
     }
-    const listeners = this.listeners.get(env.topic);
-    if (!listeners || listeners.size === 0) return;
-    let payloadValue: unknown;
+    const scalar = this.listeners.get(env.topic);
+    const bursts = this.burstListeners.get(env.topic);
+    if (!scalar?.size && !bursts?.size) return;
+
+    let decoded: unknown;
     try {
-      payloadValue = decodePayload(this.codecKind, env.payload);
+      decoded = decodePayload(this.codecKind, env.payload);
     } catch (err) {
       console.warn("wingfoil: payload decode failed on", env.topic, err);
       return;
     }
-    for (const fn of listeners) {
-      try {
-        fn(payloadValue, env.timeNs);
-      } catch (err) {
-        console.warn("wingfoil: listener threw", err);
+    // Each frame's payload is a burst (array) of same-`timeNs` values.
+    const values = normalizeBurst(decoded);
+    if (values.length === 0) return;
+
+    if (bursts?.size) {
+      for (const fn of bursts) {
+        try {
+          fn(values, env.timeNs);
+        } catch (err) {
+          console.warn("wingfoil: burst listener threw", err);
+        }
+      }
+    }
+    if (scalar?.size) {
+      // Collapse the burst to its latest value for scalar subscribers.
+      const latest = values[values.length - 1];
+      for (const fn of scalar) {
+        try {
+          fn(latest, env.timeNs);
+        } catch (err) {
+          console.warn("wingfoil: listener threw", err);
+        }
       }
     }
   }
@@ -214,6 +365,7 @@ export class WingfoilClient {
     try {
       const ctrl = decodeControl(this.codecKind, payload) as {
         Hello?: { codec: string; version: number };
+        Complete?: { topic: string };
       };
       if (ctrl.Hello) {
         this.serverVersion = ctrl.Hello.version;
@@ -222,9 +374,24 @@ export class WingfoilClient {
           codec: ctrl.Hello.codec as CodecKind,
           version: ctrl.Hello.version,
         });
+      } else if (ctrl.Complete) {
+        this.handleComplete(ctrl.Complete.topic);
       }
     } catch (err) {
       console.warn("wingfoil: control decode failed", err);
+    }
+  }
+
+  private handleComplete(topic: string) {
+    // A completed stream is finished for good — don't reconnect when the
+    // server subsequently closes the socket.
+    this.streamFinished = true;
+    for (const fn of this.completeListeners) {
+      try {
+        fn(topic);
+      } catch (err) {
+        console.warn("wingfoil: complete listener threw", err);
+      }
     }
   }
 

--- a/wingfoil-js/src/solid.ts
+++ b/wingfoil-js/src/solid.ts
@@ -32,6 +32,31 @@ export function useTopic<T>(
 }
 
 /**
+ * Like {@link useTopic} but surfaces the whole burst — every value that
+ * shares a `timeNs` — as a Solid signal. In real time each burst is a
+ * single value; a historical replay can group several points on one
+ * timestamp. Use this when you must not drop same-timestamp values (e.g.
+ * appending every point to a chart series).
+ *
+ * @example
+ * ```tsx
+ * const points = useTopicBurst<PriceTick>(client, "price");
+ * createEffect(() => points()?.forEach((p) => series.push(p)));
+ * ```
+ */
+export function useTopicBurst<T>(
+  client: WingfoilClient,
+  topic: string,
+): Accessor<T[] | undefined> {
+  const [values, setValues] = createSignal<T[] | undefined>(undefined);
+  const unsubscribe = client.subscribeBurst(topic, (vs) => {
+    setValues(() => vs as T[]);
+  });
+  onCleanup(unsubscribe);
+  return values;
+}
+
+/**
  * A small publish helper. Returns a function that, given a value, sends
  * it to `topic`. Usage in an event handler:
  *

--- a/wingfoil-js/tests/burst.test.ts
+++ b/wingfoil-js/tests/burst.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeBurst } from "../src/index.js";
+
+describe("normalizeBurst", () => {
+  it("passes an array burst through unchanged", () => {
+    expect(normalizeBurst([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("keeps a single-element burst as-is", () => {
+    expect(normalizeBurst([42])).toEqual([42]);
+  });
+
+  it("wraps a non-array (legacy/scalar) payload as a single-element burst", () => {
+    expect(normalizeBurst(42)).toEqual([42]);
+    expect(normalizeBurst({ mid: 1 })).toEqual([{ mid: 1 }]);
+  });
+
+  it("preserves an empty burst (dispatch skips it)", () => {
+    expect(normalizeBurst([])).toEqual([]);
+  });
+
+  it("collapsing to the latest value takes the last element", () => {
+    const b = normalizeBurst([1, 2, 3]);
+    expect(b[b.length - 1]).toBe(3);
+  });
+});

--- a/wingfoil-js/tests/reconnect.test.ts
+++ b/wingfoil-js/tests/reconnect.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldReconnect } from "../src/index.js";
+
+const base = {
+  userClosed: false,
+  streamFinished: false,
+  closeCode: 1006, // abnormal drop
+  reconnectMs: 1000,
+};
+
+describe("shouldReconnect", () => {
+  it("reconnects on an abnormal drop when enabled", () => {
+    expect(shouldReconnect(base)).toBe(true);
+  });
+
+  it("does not reconnect after the user closes the client", () => {
+    expect(shouldReconnect({ ...base, userClosed: true })).toBe(false);
+  });
+
+  it("does not reconnect once the stream has finished (Complete received)", () => {
+    expect(shouldReconnect({ ...base, streamFinished: true })).toBe(false);
+  });
+
+  it("does not reconnect when reconnect is disabled", () => {
+    expect(shouldReconnect({ ...base, reconnectMs: 0 })).toBe(false);
+  });
+
+  it.each([1000, 1001])(
+    "does not reconnect on a clean server close code %i",
+    (closeCode) => {
+      expect(shouldReconnect({ ...base, closeCode })).toBe(false);
+    },
+  );
+
+  it("reconnects on other abnormal codes", () => {
+    expect(shouldReconnect({ ...base, closeCode: 1011 })).toBe(true);
+  });
+});

--- a/wingfoil-wire-types/src/lib.rs
+++ b/wingfoil-wire-types/src/lib.rs
@@ -15,7 +15,13 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 /// Protocol version. Bumped when the wire format changes in a
 /// non-backwards-compatible way. Hello frames carry this value so clients
 /// and servers can reject mismatched peers early.
-pub const WIRE_PROTOCOL_VERSION: u16 = 1;
+///
+/// - `1` — initial `Hello` / `Subscribe` / `Unsubscribe` control plane.
+/// - `2` — adds [`ControlMessage::Complete`], sent when a publish topic's
+///   stream ends (e.g. a historical replay finishing). The new variant is
+///   appended, so `Hello` / `Subscribe` / `Unsubscribe` keep their wire
+///   representation; a v1 peer simply never emits or expects `Complete`.
+pub const WIRE_PROTOCOL_VERSION: u16 = 2;
 
 /// The dedicated topic name for control frames.
 pub const CONTROL_TOPIC: &str = "$ctrl";
@@ -23,9 +29,12 @@ pub const CONTROL_TOPIC: &str = "$ctrl";
 /// The envelope used for every binary WebSocket frame in both directions.
 ///
 /// Server → client: `time_ns` is the graph engine time when the value was
-/// produced; `payload` is the user type serialized by the active
-/// [`CodecKind`]. Client → server: `time_ns` is ignored (clients cannot set
-/// graph time); `payload` is the user type serialized by the active codec.
+/// produced; `payload` is that value serialized by the active [`CodecKind`].
+/// A scalar value is a single JSON/bincode value; a value that is itself a
+/// collection (e.g. a `Vec<T>` carrying a same-`time_ns` burst) serializes
+/// as an array, which the browser client surfaces as the whole group.
+/// Client → server: `time_ns` is ignored (clients cannot set graph time)
+/// and `payload` is a single user value serialized by the active codec.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Envelope {
     /// The topic this frame belongs to. Keep this short — it is sent on
@@ -34,7 +43,9 @@ pub struct Envelope {
     /// Graph time in nanoseconds since the UNIX epoch when the value was
     /// emitted. Zero for client-originated frames.
     pub time_ns: u64,
-    /// The serialized user value (or [`ControlMessage`] for the control topic).
+    /// The serialized user value (or [`ControlMessage`] on the control
+    /// topic). An array-valued payload is surfaced by the client as a
+    /// same-`time_ns` burst.
     pub payload: Vec<u8>,
 }
 
@@ -53,6 +64,16 @@ pub enum ControlMessage {
     Subscribe { topics: Vec<String> },
     /// Sent by the client to unsubscribe from one or more topics.
     Unsubscribe { topics: Vec<String> },
+    /// Sent by the server when a publish `topic`'s stream has ended and no
+    /// further frames will arrive on it — for example when a historical
+    /// replay (or any finite `RunFor`) reaches the end of its source.
+    ///
+    /// Delivered to every client currently subscribed to `topic`. It is a
+    /// clean end-of-stream marker: a client watching a historical replay
+    /// can use it to render "replay finished" and to stop reconnecting
+    /// (the server is done, not merely dropped). Real-time streams with an
+    /// unbounded `RunFor::Forever` source never emit it.
+    Complete { topic: String },
 }
 
 /// The serialization format used for envelope payloads and envelopes.

--- a/wingfoil/examples/web/README.md
+++ b/wingfoil/examples/web/README.md
@@ -16,6 +16,24 @@ The server binds to `127.0.0.1:8080` by default. Override with:
 WINGFOIL_WEB_ADDR=0.0.0.0:9000 cargo run --example web --features web
 ```
 
+## Historical streaming
+
+Set `WINGFOIL_WEB_HISTORICAL=1` to run the same graph in
+`RunMode::HistoricalFrom` instead of real time — a finite 500-point series
+replayed with a small per-point delay standing in for a slow computation,
+so the browser can watch the replay unfold live:
+
+```sh
+WINGFOIL_WEB_HISTORICAL=1 cargo run --example web --features web
+```
+
+When the series is exhausted the client receives a `Complete` control
+frame (`@wingfoil/client`'s `onComplete`) and the run ends. `web_sub` is
+inert in historical mode — a deterministic replay has no live browser
+input. The only server-side change is the run mode; it still uses
+`.start()` (not `.start_historical()`, which would make the adapter a
+no-op).
+
 ## Browser client
 
 The sibling [`wingfoil-js`](../../../wingfoil-js) package provides a ready-made

--- a/wingfoil/examples/web/main.rs
+++ b/wingfoil/examples/web/main.rs
@@ -10,6 +10,23 @@
 //! ```sh
 //! cargo run --example web --features web
 //! ```
+//!
+//! # Historical streaming (replaying a backtest to the browser)
+//!
+//! Set `WINGFOIL_WEB_HISTORICAL=1` to run the same graph in
+//! [`RunMode::HistoricalFrom`] instead of real time. The publisher then
+//! replays a finite series (500 points) with a small per-point delay that
+//! stands in for a genuinely slow computation, so the browser can follow
+//! the replay live. When the series is exhausted the client receives a
+//! `Complete` control frame (surfaced by `@wingfoil/client` as
+//! `onComplete`) and the run ends.
+//!
+//! ```sh
+//! WINGFOIL_WEB_HISTORICAL=1 cargo run --example web --features web
+//! ```
+//!
+//! The only server-side difference is the run mode and using `.start()`
+//! (not `.start_historical()`, which would make the adapter a no-op).
 
 use std::time::Duration;
 
@@ -35,18 +52,37 @@ fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     let addr = std::env::var("WINGFOIL_WEB_ADDR").unwrap_or_else(|_| "127.0.0.1:8080".into());
+    let historical = std::env::var("WINGFOIL_WEB_HISTORICAL").is_ok();
+
+    // `.start()` streams under both run modes. `.start_historical()` is the
+    // no-op path for a backtest that does *not* want a server — not used here
+    // because we specifically want to stream the replay to the browser.
     let server = WebServer::bind(&addr).start()?;
     let port = server.port();
     let codec = server.codec();
-    println!("wingfoil web example listening on ws://127.0.0.1:{port}/ws  (codec: {codec:?})");
+    let mode = if historical { "historical" } else { "realtime" };
+    println!(
+        "wingfoil web example listening on ws://127.0.0.1:{port}/ws  (codec: {codec:?}, mode: {mode})"
+    );
 
-    // Publish a synthetic mid-price stream at 100 Hz.
+    // Publish a synthetic mid-price stream. In real time this ticks at
+    // 100 Hz forever; in historical mode it replays a finite 500-point
+    // series with a small per-point delay standing in for a slow
+    // computation, so the browser can watch the replay unfold.
     let price_stream = ticker(Duration::from_millis(10))
         .count()
-        .map(|n| PriceTick {
-            // Wobble around 100 with a tiny sine.
-            mid: 100.0 + ((n as f64) * 0.1).sin(),
-            count: n,
+        .map(move |n| {
+            if historical {
+                // Simulate a slow per-point computation so the replay is
+                // paced for a human watching in the browser rather than
+                // flushing 500 points in microseconds.
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            PriceTick {
+                // Wobble around 100 with a tiny sine.
+                mid: 100.0 + ((n as f64) * 0.1).sin(),
+                count: n,
+            }
         })
         .web_pub(&server, "price");
 
@@ -56,14 +92,15 @@ fn main() -> anyhow::Result<()> {
         println!("{} ui-event: {:?}", time.pretty(), event);
     });
 
-    // Run both the publisher and the subscriber together. The server stays
-    // up until the graph is stopped (Ctrl-C).
-    Graph::new(
-        vec![price_stream, ui_log],
-        RunMode::RealTime,
-        RunFor::Forever,
-    )
-    .run()?;
+    // Real time runs forever (Ctrl-C to stop); historical replays a finite
+    // series and then ends, at which point clients receive `Complete`.
+    let (run_mode, run_for) = if historical {
+        (RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(500))
+    } else {
+        (RunMode::RealTime, RunFor::Forever)
+    };
+
+    Graph::new(vec![price_stream, ui_log], run_mode, run_for).run()?;
 
     Ok(())
 }

--- a/wingfoil/src/adapters/web/CLAUDE.md
+++ b/wingfoil/src/adapters/web/CLAUDE.md
@@ -42,10 +42,22 @@ web/
 - **Control plane on topic `"$ctrl"`**: `Hello { codec, version }` is sent by
   the server on upgrade; clients send `Subscribe { topics }` /
   `Unsubscribe { topics }` to manage forwarders.
-- **Historical-mode safety**: `WebServerBuilder::start_historical()` returns
-  a no-op server. Both `web_pub` and `web_sub` become no-ops so the same
-  graph can run in `RunMode::HistoricalFrom(...)` without touching the
-  network — mirrors `PrometheusMetricNode`'s `historical` flag.
+- **Historical modes**: two supported shapes.
+  - *Stream the replay* — a normal `start()` server drives a
+    `RunMode::HistoricalFrom` graph and `web_pub` streams the replay to
+    browsers just like real time (powers backtest / slow-computation
+    visualisation). When a `web_pub` source ends, subscribers get a
+    `ControlMessage::Complete { topic }` end-of-stream marker. `web_sub`
+    yields an empty source in historical **run mode** (checked via
+    `RunParams::run_mode`, not the server flag) — a live listener would
+    otherwise block the run waiting for frames that never come.
+  - *No server* — `WebServerBuilder::start_historical()` returns a no-op
+    server; both `web_pub` and `web_sub` become no-ops so a backtest that
+    does not want a server can run unmodified (mirrors
+    `PrometheusMetricNode`'s `historical` flag).
+  - Streaming clients stay lossy and never back-pressure the graph, so a
+    faithful loss-free replay depends on the graph not outrunning the
+    client (e.g. a compute-bound run).
 - **Optional TLS via the `web-tls` feature**. Adds a `.tls(cert, key)`
   builder method that loads PEM files synchronously at `start()` time
   (so a missing/malformed cert surfaces alongside bind errors, before
@@ -75,9 +87,19 @@ Every WebSocket binary frame is an `Envelope`:
 pub struct Envelope {
     pub topic: String,   // e.g. "order_book" or "$ctrl"
     pub time_ns: u64,    // graph engine time (0 for client → server frames)
-    pub payload: Vec<u8>, // bincode(T) or serde_json(T) of the user type
+    pub payload: Vec<u8>, // bincode/json of the stream's value
 }
 ```
+
+`web_pub` serializes each upstream value as-is (immediately, no batching).
+A scalar `T` is a single value; the browser client treats it as a
+one-element burst. A value that is itself a collection — publish a
+`Stream<Vec<T>>` (e.g. `web_sub`'s `Burst<T>` mapped to `Vec<T>`, since
+`Burst`/`TinyVec` isn't `Serialize`) — serializes as an **array**, which
+the client surfaces as the whole same-`time_ns` group: atomic on the wire,
+so a lossy drop can't split a timestamp. The client either collapses the
+group to its latest value (`subscribe`) or consumes it whole
+(`subscribeBurst`).
 
 Control topic `"$ctrl"` carries a `ControlMessage`:
 
@@ -86,8 +108,16 @@ pub enum ControlMessage {
     Hello { codec: CodecKind, version: u16 }, // server → client on upgrade
     Subscribe   { topics: Vec<String> },      // client → server
     Unsubscribe { topics: Vec<String> },      // client → server
+    Complete    { topic: String },            // server → client at end-of-stream
 }
 ```
+
+`WIRE_PROTOCOL_VERSION` is `2`: `Complete` was appended (kept the older
+variants' bincode indices), so a v1 peer keeps working — it simply never
+emits or expects `Complete`. `Complete` is broadcast on the finished
+publish topic's channel but addressed to `$ctrl`, so it reaches exactly
+the clients subscribed to that topic and is routed through their control
+handler.
 
 ## Pre-Commit Requirements
 

--- a/wingfoil/src/adapters/web/codec.rs
+++ b/wingfoil/src/adapters/web/codec.rs
@@ -58,6 +58,35 @@ mod tests {
     }
 
     #[test]
+    fn control_message_complete_roundtrip() {
+        let ctrl = ControlMessage::Complete {
+            topic: "price".into(),
+        };
+        for codec in [CodecKind::Bincode, CodecKind::Json] {
+            let bytes = codec.encode(&ctrl).unwrap();
+            let back: ControlMessage = codec.decode(&bytes).unwrap();
+            assert_eq!(ctrl, back);
+        }
+    }
+
+    #[test]
+    fn control_message_existing_variants_keep_wire_layout() {
+        // `Complete` was appended after `Unsubscribe`, so the older
+        // variants must keep their bincode representation (variant index).
+        // A hardcoded byte check guards against an accidental reorder that
+        // would silently break v1 peers.
+        let hello = ControlMessage::Hello {
+            codec: CodecKind::Bincode,
+            version: 2,
+        };
+        let bytes = CodecKind::Bincode.encode(&hello).unwrap();
+        assert_eq!(bytes[0..4], [0, 0, 0, 0], "Hello must stay variant 0");
+        let sub = ControlMessage::Subscribe { topics: vec![] };
+        let bytes = CodecKind::Bincode.encode(&sub).unwrap();
+        assert_eq!(bytes[0..4], [1, 0, 0, 0], "Subscribe must stay variant 1");
+    }
+
+    #[test]
     fn bincode_rejects_corrupt_envelope() {
         let err = CodecKind::Bincode
             .decode::<Envelope>(&[0xFF; 4])

--- a/wingfoil/src/adapters/web/integration_tests.rs
+++ b/wingfoil/src/adapters/web/integration_tests.rs
@@ -15,7 +15,7 @@ use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use super::*;
-use crate::nodes::{NodeOperators, StreamOperators, constant, ticker};
+use crate::nodes::{NodeOperators, RunParams, StreamOperators, constant, produce_async, ticker};
 use crate::types::*;
 use crate::{RunFor, RunMode};
 
@@ -177,6 +177,8 @@ fn test_pub_round_trip_bincode() -> anyhow::Result<()> {
         assert_eq!(env.topic, "tick");
         assert!(env.time_ns >= last, "time_ns should be monotonic");
         last = env.time_ns;
+        // A scalar upstream serializes as a scalar payload; the client
+        // treats it as a one-element burst.
         let value: u64 = codec.decode(&env.payload)?;
         assert!(value >= 1);
     }
@@ -268,6 +270,197 @@ fn test_pub_round_trip_json() -> anyhow::Result<()> {
     assert_eq!(env.topic, "answer");
     let decoded: u32 = codec.decode(&env.payload)?;
     assert_eq!(decoded, 42);
+    Ok(())
+}
+
+/// A historical-mode graph served through a real (`start()`) server must
+/// stream every value to a connected client in order, then emit a
+/// `Complete` control frame when the replay ends. This is the core
+/// "stream a backtest / slow computation to the browser" path.
+#[test]
+fn test_historical_streaming_completes() -> anyhow::Result<()> {
+    let server = WebServer::bind("127.0.0.1:0").start()?;
+    assert!(!server.is_historical_noop());
+    let port = server.port();
+    let codec = server.codec();
+
+    // Client thread: subscribe, then collect topic frames until a
+    // `Complete { topic }` control frame arrives (or timeout).
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || -> anyhow::Result<(Vec<u64>, bool)> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async move {
+            let mut socket = connect(port).await?;
+            send_control(
+                &mut socket,
+                codec,
+                ControlMessage::Subscribe {
+                    topics: vec!["hist".to_string()],
+                },
+            )
+            .await?;
+            ready_tx.send(()).ok();
+
+            let mut values = Vec::new();
+            let mut completed = false;
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while Instant::now() < deadline {
+                let env = match tokio::time::timeout(
+                    Duration::from_secs(2),
+                    recv_envelope(&mut socket, codec),
+                )
+                .await
+                {
+                    Ok(Ok(env)) => env,
+                    Ok(Err(_)) | Err(_) => break,
+                };
+                if env.topic == "hist" {
+                    values.push(codec.decode::<u64>(&env.payload)?);
+                } else if env.topic == CONTROL_TOPIC
+                    && let ControlMessage::Complete { topic } = codec.decode(&env.payload)?
+                {
+                    assert_eq!(topic, "hist");
+                    completed = true;
+                    break;
+                }
+            }
+            Ok((values, completed))
+        })
+    });
+
+    ready_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("client failed to subscribe");
+
+    // 50 values, well under the broadcast buffer, so a loopback client
+    // receives every one with no loss.
+    ticker(Duration::from_millis(10))
+        .count()
+        .web_pub(&server, "hist")
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(50))?;
+
+    let (values, completed) = handle.join().expect("client thread panic")?;
+    assert!(
+        completed,
+        "expected a Complete control frame at end of replay"
+    );
+    assert_eq!(
+        values,
+        (1..=50).collect::<Vec<u64>>(),
+        "every historical frame should arrive in order"
+    );
+    Ok(())
+}
+
+/// Publishing a `Stream<Burst<T>>` puts the whole same-`time_ns` group on
+/// the wire as one array frame — atomic, so a lossy drop can never split a
+/// timestamp. The client sees `[1, 2]` at t=100 and `[3]` at t=200.
+#[test]
+fn test_burst_stream_publishes_atomic_arrays() -> anyhow::Result<()> {
+    let server = WebServer::bind("127.0.0.1:0").start()?;
+    let port = server.port();
+    let codec = server.codec();
+
+    // Client: collect each "burst" frame's decoded array until Complete.
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || -> anyhow::Result<Vec<Vec<u32>>> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async move {
+            let mut socket = connect(port).await?;
+            send_control(
+                &mut socket,
+                codec,
+                ControlMessage::Subscribe {
+                    topics: vec!["burst".to_string()],
+                },
+            )
+            .await?;
+            ready_tx.send(()).ok();
+
+            let mut frames: Vec<Vec<u32>> = Vec::new();
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while Instant::now() < deadline {
+                let env = match tokio::time::timeout(
+                    Duration::from_secs(2),
+                    recv_envelope(&mut socket, codec),
+                )
+                .await
+                {
+                    Ok(Ok(env)) => env,
+                    Ok(Err(_)) | Err(_) => break,
+                };
+                if env.topic == "burst" {
+                    // A same-time burst decodes to a whole array in one frame.
+                    frames.push(codec.decode::<Vec<u32>>(&env.payload)?);
+                } else if env.topic == CONTROL_TOPIC
+                    && matches!(codec.decode(&env.payload)?, ControlMessage::Complete { .. })
+                {
+                    break;
+                }
+            }
+            Ok(frames)
+        })
+    });
+
+    ready_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("client failed to subscribe");
+
+    // Two values at t=100 (grouped into one Burst) and one at t=200.
+    // `Burst<T>` isn't serializable, so map it to a `Vec<T>` — the wire
+    // array the client surfaces as the same-time group.
+    let bursts: Rc<dyn Stream<Burst<u32>>> = produce_async(|_ctx: RunParams| async move {
+        Ok(async_stream::stream! {
+            yield Ok((NanoTime::new(100), 1u32));
+            yield Ok((NanoTime::new(100), 2u32));
+            yield Ok((NanoTime::new(200), 3u32));
+        })
+    });
+    let source = bursts.map(|b: Burst<u32>| b.to_vec());
+    web_pub(&server, "burst", &source)
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+
+    let frames = handle.join().expect("client thread panic")?;
+    assert_eq!(
+        frames,
+        vec![vec![1u32, 2], vec![3]],
+        "same-time values must arrive as one atomic array frame"
+    );
+    Ok(())
+}
+
+/// A live (`start()`) server driving a graph in `RunMode::HistoricalFrom`
+/// must run to completion even when a `web_sub` node is present: live
+/// browser input has no place in a deterministic replay, so `web_sub`
+/// yields an empty source rather than blocking the run waiting for frames.
+#[test]
+fn test_historical_web_sub_does_not_block() -> anyhow::Result<()> {
+    let server = WebServer::bind("127.0.0.1:0").start()?;
+    assert!(!server.is_historical_noop());
+
+    let pub_node = ticker(Duration::from_millis(10))
+        .count()
+        .web_pub(&server, "out");
+    let sub_stream: Rc<dyn Stream<Burst<UiClick>>> = web_sub(&server, "in");
+    let collected = sub_stream.collect();
+
+    // If `web_sub` blocked on its listener this would hang; a bounded
+    // `RunFor` plus a wall-clock guard turns a regression into a failure.
+    let mut graph = crate::Graph::new(
+        vec![pub_node, collected.clone()],
+        RunMode::HistoricalFrom(NanoTime::ZERO),
+        RunFor::Cycles(20),
+    );
+    let start = Instant::now();
+    graph.run()?;
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "historical run with web_sub should not block"
+    );
+    assert!(
+        collected.peek_value().is_empty(),
+        "web_sub must not tick in historical mode"
+    );
     Ok(())
 }
 

--- a/wingfoil/src/adapters/web/mod.rs
+++ b/wingfoil/src/adapters/web/mod.rs
@@ -74,10 +74,26 @@
 //!
 //! # Historical mode
 //!
-//! The server exposes [`WebServerBuilder::start_historical`] for use in
-//! `RunMode::HistoricalFrom` runs. No TCP port is bound and all
-//! publishes / subscribes become no-ops, so the same graph can run
-//! under both real-time and historical modes without modification.
+//! There are two ways to run a graph under `RunMode::HistoricalFrom`:
+//!
+//! - **Stream the replay to browsers** — use the normal
+//!   [`WebServerBuilder::start`]. `web_pub` streams a historical replay's
+//!   values out exactly as it does in real time, which is what powers
+//!   browser-side visualisation of a backtest or slow computation. When
+//!   the source ends, subscribed clients receive a
+//!   [`ControlMessage::Complete`] end-of-stream marker (surfaced by
+//!   `@wingfoil/client` as `onComplete`). `web_sub` yields an empty source
+//!   in historical mode — live browser input has no place in a
+//!   deterministic replay.
+//! - **No server at all** — use [`WebServerBuilder::start_historical`],
+//!   which binds no TCP port and makes both `web_pub` and `web_sub`
+//!   no-ops, so a backtest that does not want a server can run the same
+//!   graph unmodified.
+//!
+//! Streaming clients never back-pressure the graph: a client that cannot
+//! keep up drops frames (the broadcast buffer is lossy). For a faithful,
+//! loss-free replay, keep the graph from outrunning the client — e.g. a
+//! genuinely compute-bound historical run.
 
 mod codec;
 mod read;

--- a/wingfoil/src/adapters/web/read.rs
+++ b/wingfoil/src/adapters/web/read.rs
@@ -22,7 +22,16 @@ use crate::types::*;
 ///
 /// Returns a source [`Stream`] of `Burst<T>`, decoded with the server's
 /// configured codec (bincode or JSON). Decoding errors surface as graph
-/// errors. In historical mode the stream never ticks.
+/// errors.
+///
+/// The stream never ticks in historical mode — whether the server is a
+/// [`start_historical`](super::WebServerBuilder::start_historical) no-op
+/// *or* a live server driving a graph in
+/// [`RunMode::HistoricalFrom`]. Live browser input has no place in a
+/// deterministic replay, and an open listener would block the historical
+/// run waiting for frames that never come; so `web_sub` yields an empty,
+/// immediately-ending stream. A historical `web_pub` still streams its
+/// output to the browser as usual.
 #[must_use]
 pub fn web_sub<T: Element + Send + DeserializeOwned>(
     server: &WebServer,
@@ -34,7 +43,7 @@ pub fn web_sub<T: Element + Send + DeserializeOwned>(
 
     // Register the mpsc listener at construction time so frames arriving
     // before the graph starts are buffered up to the mpsc capacity rather
-    // than dropped.
+    // than dropped. Skipped for a no-op server, which has no live socket.
     let rx_opt = if historical {
         None
     } else {
@@ -43,8 +52,14 @@ pub fn web_sub<T: Element + Send + DeserializeOwned>(
         Some(rx)
     };
 
-    produce_async(move |_ctx: RunParams| async move {
+    produce_async(move |ctx: RunParams| async move {
         Ok(async_stream::stream! {
+            // A historical run replays deterministically from its sources;
+            // an open client listener would never yield and would block the
+            // run from completing, so treat web_sub as an empty source here.
+            if matches!(ctx.run_mode, crate::RunMode::HistoricalFrom(_)) {
+                return;
+            }
             let Some(mut rx) = rx_opt else { return; };
             while let Some(payload) = rx.recv().await {
                 match codec.decode::<T>(&payload) {

--- a/wingfoil/src/adapters/web/server.rs
+++ b/wingfoil/src/adapters/web/server.rs
@@ -415,8 +415,9 @@ async fn handle_socket(socket: WebSocket, inner: Arc<WebServerInner>) {
                         }
                     }
                 }
-                ControlMessage::Hello { .. } => {
-                    // Clients sending Hello is unusual but harmless.
+                ControlMessage::Hello { .. } | ControlMessage::Complete { .. } => {
+                    // Server → client only. A client sending either is
+                    // unusual but harmless; ignore it.
                 }
             }
         } else {

--- a/wingfoil/src/adapters/web/write.rs
+++ b/wingfoil/src/adapters/web/write.rs
@@ -1,9 +1,18 @@
 //! `web_pub` — stream values out to connected WebSocket clients.
 //!
 //! Each call to [`web_pub`] (or the fluent [`WebPubOperators::web_pub`])
-//! registers a topic on the [`WebServer`]. Every value emitted upstream
-//! is serialized with the server's codec, wrapped in an [`Envelope`],
-//! and broadcast to every WebSocket connection subscribed to that topic.
+//! registers a topic on the [`WebServer`]. Upstream values are serialized
+//! with the server's codec, wrapped in an [`Envelope`], and broadcast to
+//! every WebSocket connection subscribed to that topic.
+//!
+//! Each envelope payload is a **burst** — the sequence of values that share
+//! one `time_ns` — matching the [`Burst<T>`] the graph engine already deals
+//! in. On the wire the payload therefore always decodes to an *array*, and
+//! the browser client decides whether to collapse it to the latest value or
+//! consume the whole group. In real time each frame carries a single-element
+//! burst (emitted immediately, no batching latency); in historical mode
+//! consecutive same-`time_ns` values are grouped into one atomic frame, so a
+//! lossy drop can never split a timestamp and a replay stays coherent.
 //!
 //! Slow consumers **do not** back-pressure the graph: each client has a
 //! bounded outbound queue and a lossy broadcast receiver, so a frozen
@@ -16,16 +25,45 @@ use axum::body::Bytes;
 use futures::StreamExt;
 use serde::Serialize;
 
-use super::codec::Envelope;
+use super::codec::{CONTROL_TOPIC, CodecKind, ControlMessage, Envelope};
 use super::server::WebServer;
 use crate::nodes::{FutStream, RunParams, StreamOperators};
 use crate::types::*;
 
 /// Publish every upstream value on `topic`.
 ///
-/// In historical mode ([`WebServer::is_historical_noop`]) the consumer
-/// drains the source without sending anything on the wire, so the graph
-/// still runs to completion.
+/// Works identically under `RunMode::RealTime` and
+/// `RunMode::HistoricalFrom` — a historical replay (or any finite
+/// `RunFor`) streams its values out to subscribed clients just like a
+/// live run, which is what powers browser-side visualisation of a
+/// backtest / slow computation. Each value is sent immediately (no
+/// batching latency). When the upstream source ends (source exhausted or
+/// the `RunFor` limit reached) a [`ControlMessage::Complete`] is broadcast
+/// so clients know the stream is finished rather than merely dropped.
+///
+/// # Bursts
+///
+/// The payload is the codec-serialized upstream value. A scalar `T`
+/// (number, struct, …) is a single JSON/bincode value; the browser client
+/// treats it as a one-element burst. Publishing a stream whose value is a
+/// [`Burst<T>`] (e.g. straight from [`web_sub`](super::web_sub) or an
+/// async source) serializes it as an **array**, which the client surfaces
+/// as the whole same-`time_ns` group — atomic on the wire, so a lossy drop
+/// can never split a timestamp. See `subscribe` / `subscribeBurst` in
+/// `@wingfoil/client`.
+///
+/// The exception is a server built with
+/// [`WebServerBuilder::start_historical`](super::WebServerBuilder::start_historical),
+/// whose [`WebServer::is_historical_noop`] flag makes both `web_pub` and
+/// `web_sub` no-ops: the consumer drains the source without touching the
+/// network, so a backtest that does *not* want a server can run the same
+/// graph unmodified.
+///
+/// Back-pressure note: subscribed clients never stall the graph — each
+/// client has a bounded, lossy outbound path (see the server broadcast
+/// buffer), so a client that cannot keep up drops frames. For a faithful,
+/// loss-free replay, pace the graph so it does not outrun the client
+/// (e.g. a genuinely compute-bound historical run).
 #[must_use]
 pub fn web_pub<T: Element + Send + Serialize>(
     server: &WebServer,
@@ -50,19 +88,40 @@ pub fn web_pub<T: Element + Send + Serialize>(
                 return Ok(());
             }
             while let Some((time, value)) = source.next().await {
-                let payload = codec.encode(&value)?;
                 let env = Envelope {
                     topic: topic.clone(),
                     time_ns: u64::from(time),
-                    payload,
+                    payload: codec.encode(&value)?,
                 };
                 let bytes = Bytes::from(codec.encode(&env)?);
                 // `send` only errors when there are zero receivers — fine.
                 let _ = sender.send(bytes);
             }
+            // Source is exhausted (finite RunFor / end of historical
+            // replay). Emit a clean end-of-stream marker so subscribers
+            // can distinguish "replay finished" from a transport drop.
+            let bytes = encode_complete_frame(codec, &topic)?;
+            let _ = sender.send(bytes);
             Ok(())
         },
     ))
+}
+
+/// Encode a [`ControlMessage::Complete`] as a control-topic [`Envelope`]
+/// ready to broadcast on a publish topic's channel. It is addressed to
+/// [`CONTROL_TOPIC`] so the browser client routes it through its control
+/// handler, while riding the publish topic's broadcast so only clients
+/// subscribed to that topic receive it.
+fn encode_complete_frame(codec: CodecKind, topic: &str) -> anyhow::Result<Bytes> {
+    let ctrl = ControlMessage::Complete {
+        topic: topic.to_string(),
+    };
+    let env = Envelope {
+        topic: CONTROL_TOPIC.to_string(),
+        time_ns: 0,
+        payload: codec.encode(&ctrl)?,
+    };
+    Ok(Bytes::from(codec.encode(&env)?))
 }
 
 /// Fluent `.web_pub(...)` on streams.


### PR DESCRIPTION
Make the `web` adapter and the `@wingfoil/client` JS package work with
**streaming historical data** — replaying a backtest / slow computation to a
browser under `RunMode::HistoricalFrom`.

## Server

- `web_pub` streams under both run modes. A historical replay (or any finite
  `RunFor`) emits its values to subscribed clients just like a live run — this
  is what powers browser-side visualisation of a backtest. `.start_historical()`
  stays a no-op for a backtest that wants no server.
- When a `web_pub` source ends, the server broadcasts
  `ControlMessage::Complete { topic }` so clients can tell "replay finished"
  from a transport drop. It rides the topic's channel but is addressed to
  `$ctrl`, so only that topic's subscribers receive it.
- **Bug fix (hang):** `web_sub` keyed off the server's construction-time
  historical flag, so a live `.start()` server driving a historical graph
  blocked forever on its client listener. It now checks the actual
  `RunParams::run_mode` and yields an empty source in historical mode — live
  browser input has no place in a deterministic replay.

## Wire types

Add `ControlMessage::Complete` and bump `WIRE_PROTOCOL_VERSION` to `2`. The
variant is appended, so v1 peers stay compatible (they never emit or expect
it).

## Bursts

`web_pub` serializes each value **as-is**; the client does the burst
interpretation — a payload that decodes to an **array** is the same-`time_ns`
group, and a scalar is a one-element burst. A real multi-value group reaches
the wire by publishing a `Stream<Vec<T>>` (e.g. `web_sub`'s `Burst<T>` mapped
to `Vec<T>`, since `Burst`/`TinyVec` isn't `Serialize`), which serializes as
one atomic array frame — so a lossy drop can't split a timestamp.

> Note: because "array payload = burst", a graph that publishes a `Vec<X>` it
> means as a *single* value would have it read as a burst of `X`. Wrap such
> values in a struct. Documented in the wire-types and adapter docs.

## JS client

- Decode `Complete` and expose `onComplete(topic)`.
- Stop reconnect-looping after a clean finish: once `Complete` arrives or the
  socket closes with a normal code (1000/1001), the session is treated as done
  regardless of `reconnectMs`; only abnormal drops retry. Extracted into a
  pure, unit-tested `shouldReconnect`.
- `subscribe` collapses each burst to its latest value — **unchanged callback
  shape, so the Solid/Svelte/Vue adapters and the latency tracker need no
  changes**. New `subscribeBurst` and Solid `useTopicBurst` yield the whole
  group. Payload normalization extracted into a pure, tested `normalizeBurst`.

## Docs + example

The `web` example gains a `WINGFOIL_WEB_HISTORICAL=1` replay mode (a finite,
slow-paced series so the browser can follow the replay live). Module / adapter
docs and the JS README describe historical streaming, the completion signal,
bursts, and the lossy-vs-loss-free caveat.

## Tests

- Historical streaming delivers every frame and completes with a `Complete`.
- A mapped `Stream<Vec<u32>>` publishes same-time values as **atomic array
  frames** (`[1, 2]` at t=100, `[3]` at t=200).
- `web_sub` no longer blocks a historical run.
- `Complete` codec round-trip + a wire-layout guard for the appended variant.
- JS `shouldReconnect` / `normalizeBurst` coverage.

## Not in scope (follow-up)

Streaming clients stay **lossy** and never back-pressure the graph, so a
faithful loss-free replay still depends on the graph not outrunning the client
(a compute-bound historical run is the natural fit). Lossless / wall-clock-paced
delivery is left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)