### PR TITLE
Redact password from postgres connection errors

### DIFF
--- a/wingfoil/src/adapters/postgres/mod.rs
+++ b/wingfoil/src/adapters/postgres/mod.rs
@@ -178,6 +178,31 @@ impl PostgresConnection {
             conn_str: conn_str.into(),
         }
     }
+
+    /// Render the connection string with the `password` value masked, for safe
+    /// inclusion in error messages and logs.
+    ///
+    /// libpq connection strings are space-separated `key=value` pairs, so the
+    /// `password=...` token is replaced with `password=***` while every other
+    /// field is preserved. A value has no way to contain an unescaped space, so
+    /// splitting on whitespace is sufficient.
+    #[must_use]
+    pub fn redacted(&self) -> String {
+        self.conn_str
+            .split_whitespace()
+            .map(|kv| {
+                if kv
+                    .split_once('=')
+                    .is_some_and(|(k, _)| k.eq_ignore_ascii_case("password"))
+                {
+                    "password=***"
+                } else {
+                    kv
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
 }
 
 impl From<&str> for PostgresConnection {
@@ -206,6 +231,31 @@ mod tests {
     fn test_connection_new() {
         let conn = PostgresConnection::new("host=x".to_string());
         assert_eq!(conn.conn_str, "host=x");
+    }
+
+    #[test]
+    fn test_redacted_masks_password() {
+        let conn = PostgresConnection::new(
+            "host=localhost port=5432 user=postgres password=s3cr3t dbname=postgres",
+        );
+        let out = conn.redacted();
+        assert!(!out.contains("s3cr3t"), "password leaked: {out}");
+        assert_eq!(
+            out,
+            "host=localhost port=5432 user=postgres password=*** dbname=postgres"
+        );
+    }
+
+    #[test]
+    fn test_redacted_is_case_insensitive() {
+        let conn = PostgresConnection::new("host=x PassWord=hunter2");
+        assert_eq!(conn.redacted(), "host=x password=***");
+    }
+
+    #[test]
+    fn test_redacted_noop_without_password() {
+        let conn = PostgresConnection::new("host=localhost dbname=db");
+        assert_eq!(conn.redacted(), "host=localhost dbname=db");
     }
 
     #[test]

--- a/wingfoil/src/adapters/postgres/read.rs
+++ b/wingfoil/src/adapters/postgres/read.rs
@@ -123,7 +123,10 @@ where
             let (client, conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
                 .await
                 .with_context(|| {
-                    format!("postgres_read: failed to connect: {}", connection.conn_str)
+                    format!(
+                        "postgres_read: failed to connect: {}",
+                        connection.redacted()
+                    )
                 })?;
             // Drive the connection's protocol handling in the background; it ends
             // when `client` is dropped after the stream is exhausted.

--- a/wingfoil/src/adapters/postgres/sub.rs
+++ b/wingfoil/src/adapters/postgres/sub.rs
@@ -104,7 +104,7 @@ where
             let (client, mut conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
                 .await
                 .with_context(|| {
-                    format!("postgres_sub: failed to connect: {}", connection.conn_str)
+                    format!("postgres_sub: failed to connect: {}", connection.redacted())
                 })?;
 
             // Drive the connection and forward notification wake-ups. Polling

--- a/wingfoil/src/adapters/postgres/write.rs
+++ b/wingfoil/src/adapters/postgres/write.rs
@@ -66,7 +66,12 @@ where
 {
     let (client, conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
         .await
-        .with_context(|| format!("postgres_write: failed to connect: {}", connection.conn_str))?;
+        .with_context(|| {
+            format!(
+                "postgres_write: failed to connect: {}",
+                connection.redacted()
+            )
+        })?;
     tokio::spawn(async move {
         if let Err(e) = conn.await {
             log::error!("postgres connection error: {e}");


### PR DESCRIPTION
## Summary

`postgres_read`, `postgres_write`, and `postgres_sub` embedded the full libpq connection string — including `password=...` — directly in `anyhow` error context on connect failure. That string flows into logs and graph-abort errors, leaking the database password.

This adds `PostgresConnection::redacted()`, which masks the `password` token while preserving every other field, and uses it at all three `connect()` error sites.

## Changes

- `mod.rs`: new `PostgresConnection::redacted()` — splits the libpq `key=value` string on whitespace and replaces the `password` value with `***` (case-insensitive on the key; no-op when absent).
- `read.rs`, `write.rs`, `sub.rs`: use `connection.redacted()` instead of `connection.conn_str` in the connect-failure `with_context(...)`.

## Testing

- Three new unit tests cover masking, case-insensitivity, and the no-password no-op.
- `cargo test -p wingfoil --features postgres` and `cargo clippy -p wingfoil --features postgres --all-targets` pass clean.

Found during a codebase review (finding 0.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mNRkJnZZGC1QUULgbbwnA)_