### PR TITLE
Add Option<usize> buffer_size to produce_async and kdb_read (#140)

### DIFF
--- a/wingfoil-python/src/py_kdb.rs
+++ b/wingfoil-python/src/py_kdb.rs
@@ -157,6 +157,7 @@ pub fn py_kdb_read(
                 t1 = t1.to_kdb_timestamp(),
             )
         },
+        None,
     );
 
     // Collapse burst to single row, convert to PyElement (dict)

--- a/wingfoil/examples/async/README.md
+++ b/wingfoil/examples/async/README.md
@@ -55,7 +55,7 @@ let consumer = async move |_ctx: RunParams, mut source: Pin<Box<dyn FutStream<u3
     Ok(())
 };
 
-produce_async(producer)
+produce_async(producer, None)
     .logged("on-graph", log::Level::Info)
     .collapse()
     .consume_async(Box::new(consumer))

--- a/wingfoil/examples/async/main.rs
+++ b/wingfoil/examples/async/main.rs
@@ -28,7 +28,7 @@ fn main() {
         Ok(())
     };
 
-    produce_async(producer)
+    produce_async(producer, None)
         .logged("on-graph", log::Level::Info)
         .collapse()
         .consume_async(Box::new(consumer))

--- a/wingfoil/examples/kdb/read/main.rs
+++ b/wingfoil/examples/kdb/read/main.rs
@@ -45,6 +45,7 @@ fn main() -> Result<()> {
                 t1.to_kdb_timestamp(),
             )
         },
+        None,
     )
     .logged("prices", Info)
     .run(

--- a/wingfoil/examples/kdb/round_trip/main.rs
+++ b/wingfoil/examples/kdb/round_trip/main.rs
@@ -100,6 +100,7 @@ fn main() -> Result<()> {
                 t1.to_kdb_timestamp()
             )
         },
+        None,
     );
     // tie-out
     let check = validate(baseline, read);

--- a/wingfoil/src/adapters/etcd/read.rs
+++ b/wingfoil/src/adapters/etcd/read.rs
@@ -31,94 +31,97 @@ pub fn etcd_sub(
     prefix: impl Into<String>,
 ) -> Rc<dyn Stream<Burst<EtcdEvent>>> {
     let prefix = prefix.into();
-    produce_async(move |_ctx: RunParams| async move {
-        let mut client = Client::connect(&connection.endpoints, None).await?;
+    produce_async(
+        move |_ctx: RunParams| async move {
+            let mut client = Client::connect(&connection.endpoints, None).await?;
 
-        // 1. Open the watch BEFORE the GET to prevent the snapshot/watch race.
-        let watch_opts = WatchOptions::new().with_prefix();
-        let mut watch_stream = client
-            .watch(prefix.as_bytes(), Some(watch_opts))
-            .await
-            .map_err(|e| anyhow::anyhow!("etcd watch failed: {e}"))?;
+            // 1. Open the watch BEFORE the GET to prevent the snapshot/watch race.
+            let watch_opts = WatchOptions::new().with_prefix();
+            let mut watch_stream = client
+                .watch(prefix.as_bytes(), Some(watch_opts))
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd watch failed: {e}"))?;
 
-        // 2. Read the snapshot and capture its revision.
-        let get_opts = GetOptions::new().with_prefix();
-        let get_resp = client
-            .get(prefix.as_bytes(), Some(get_opts))
-            .await
-            .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
-        let snapshot_rev = get_resp.header().map(|h| h.revision()).unwrap_or(0);
+            // 2. Read the snapshot and capture its revision.
+            let get_opts = GetOptions::new().with_prefix();
+            let get_resp = client
+                .get(prefix.as_bytes(), Some(get_opts))
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
+            let snapshot_rev = get_resp.header().map(|h| h.revision()).unwrap_or(0);
 
-        // 3. Collect snapshot KVs into owned data to move into the stream.
-        let snapshot: Vec<EtcdEvent> = get_resp
-            .kvs()
-            .iter()
-            .map(|kv| EtcdEvent {
-                kind: EtcdEventKind::Put,
-                entry: EtcdEntry {
-                    key: String::from_utf8_lossy(kv.key()).into_owned(),
-                    value: kv.value().to_vec(),
-                },
-                revision: snapshot_rev,
-            })
-            .collect();
+            // 3. Collect snapshot KVs into owned data to move into the stream.
+            let snapshot: Vec<EtcdEvent> = get_resp
+                .kvs()
+                .iter()
+                .map(|kv| EtcdEvent {
+                    kind: EtcdEventKind::Put,
+                    entry: EtcdEntry {
+                        key: String::from_utf8_lossy(kv.key()).into_owned(),
+                        value: kv.value().to_vec(),
+                    },
+                    revision: snapshot_rev,
+                })
+                .collect();
 
-        // 4. Return the combined snapshot + live stream.
-        Ok(async_stream::stream! {
-            // Phase 1: emit snapshot events.
-            for event in snapshot {
-                yield Ok((NanoTime::now(), event));
-            }
+            // 4. Return the combined snapshot + live stream.
+            Ok(async_stream::stream! {
+                // Phase 1: emit snapshot events.
+                for event in snapshot {
+                    yield Ok((NanoTime::now(), event));
+                }
 
-            // Phase 2: drain the watch stream, deduplicating against the snapshot.
-            loop {
-                match watch_stream.next().await {
-                    Some(Ok(resp)) => {
-                        // Skip the initial "watch created" confirmation (no events).
-                        if resp.created() {
-                            continue;
-                        }
-                        if resp.canceled() {
-                            yield Err(anyhow::anyhow!(
-                                "etcd watch cancelled: {}",
-                                resp.cancel_reason()
-                            ));
-                            break;
-                        }
-                        for event in resp.events() {
-                            let kv = match event.kv() {
-                                Some(kv) => kv,
-                                None => continue,
-                            };
-                            let mod_rev = kv.mod_revision();
-                            // Skip events already covered by the snapshot.
-                            if mod_rev <= snapshot_rev {
+                // Phase 2: drain the watch stream, deduplicating against the snapshot.
+                loop {
+                    match watch_stream.next().await {
+                        Some(Ok(resp)) => {
+                            // Skip the initial "watch created" confirmation (no events).
+                            if resp.created() {
                                 continue;
                             }
-                            let kind = match event.event_type() {
-                                etcd_client::EventType::Put => EtcdEventKind::Put,
-                                etcd_client::EventType::Delete => EtcdEventKind::Delete,
-                            };
-                            yield Ok((NanoTime::now(), EtcdEvent {
-                                kind,
-                                entry: EtcdEntry {
-                                    key: String::from_utf8_lossy(kv.key()).into_owned(),
-                                    value: kv.value().to_vec(),
-                                },
-                                revision: mod_rev,
-                            }));
+                            if resp.canceled() {
+                                yield Err(anyhow::anyhow!(
+                                    "etcd watch cancelled: {}",
+                                    resp.cancel_reason()
+                                ));
+                                break;
+                            }
+                            for event in resp.events() {
+                                let kv = match event.kv() {
+                                    Some(kv) => kv,
+                                    None => continue,
+                                };
+                                let mod_rev = kv.mod_revision();
+                                // Skip events already covered by the snapshot.
+                                if mod_rev <= snapshot_rev {
+                                    continue;
+                                }
+                                let kind = match event.event_type() {
+                                    etcd_client::EventType::Put => EtcdEventKind::Put,
+                                    etcd_client::EventType::Delete => EtcdEventKind::Delete,
+                                };
+                                yield Ok((NanoTime::now(), EtcdEvent {
+                                    kind,
+                                    entry: EtcdEntry {
+                                        key: String::from_utf8_lossy(kv.key()).into_owned(),
+                                        value: kv.value().to_vec(),
+                                    },
+                                    revision: mod_rev,
+                                }));
+                            }
+                        }
+                        Some(Err(e)) => {
+                            yield Err(anyhow::anyhow!("etcd watch error: {e}"));
+                            break;
+                        }
+                        None => {
+                            yield Err(anyhow::anyhow!("etcd watch stream closed unexpectedly"));
+                            break;
                         }
                     }
-                    Some(Err(e)) => {
-                        yield Err(anyhow::anyhow!("etcd watch error: {e}"));
-                        break;
-                    }
-                    None => {
-                        yield Err(anyhow::anyhow!("etcd watch stream closed unexpectedly"));
-                        break;
-                    }
                 }
-            }
-        })
-    })
+            })
+        },
+        None,
+    )
 }

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -1072,7 +1072,7 @@ struct FixThreadedSource {
 
 impl FixThreadedSource {
     fn new_initiator(host: &str, port: u16, sender: &str, target: &str) -> Self {
-        let (chan_sender, receiver) = channel_pair(None);
+        let (chan_sender, receiver) = channel_pair(None, None);
         let inner = ChannelReceiverStream::new(receiver, None, None);
         let (inject_sender, inject_receiver) = kanal::bounded(INJECT_QUEUE_CAPACITY);
         Self {
@@ -1100,7 +1100,7 @@ impl FixThreadedSource {
         target: &str,
         logon: FixLogon,
     ) -> Self {
-        let (chan_sender, receiver) = channel_pair(None);
+        let (chan_sender, receiver) = channel_pair(None, None);
         let inner = ChannelReceiverStream::new(receiver, None, None);
         let (inject_sender, inject_receiver) = kanal::bounded(INJECT_QUEUE_CAPACITY);
         Self {
@@ -1122,7 +1122,7 @@ impl FixThreadedSource {
     }
 
     fn new_acceptor(port: u16, sender: &str, target: &str) -> Self {
-        let (chan_sender, receiver) = channel_pair(None);
+        let (chan_sender, receiver) = channel_pair(None, None);
         let inner = ChannelReceiverStream::new(receiver, None, None);
         let (inject_sender, inject_receiver) = kanal::bounded(INJECT_QUEUE_CAPACITY);
         Self {
@@ -1439,9 +1439,9 @@ impl MutableNode for FixSubNode {
 //
 // Shape-wise this is the direct-write equivalent of `AsyncConsumerNode` in
 // nodes/async_io.rs, which instead puts a kanal `ChannelSender` between the
-// graph thread and the sink. If `channel_pair` ever grows a bounded+blocking
-// mode (see comment there), the two could be unified behind a generic
-// "sink node" abstraction parameterised by the actual write call.
+// graph thread and the sink. Wiring that consumer's channel to a bounded
+// `buffer_size` (see comment there) would let the two be unified behind a
+// generic "sink node" abstraction parameterised by the actual write call.
 struct FixSenderNode {
     src: Rc<dyn Stream<FixMessage>>,
     host: String,

--- a/wingfoil/src/adapters/fluvio/read.rs
+++ b/wingfoil/src/adapters/fluvio/read.rs
@@ -52,52 +52,55 @@ pub fn fluvio_sub(
         None
     };
 
-    produce_async(move |_ctx: RunParams| async move {
-        // Check validation result first.
-        if let Some(err) = validation_error {
-            return Err(err);
-        }
+    produce_async(
+        move |_ctx: RunParams| async move {
+            // Check validation result first.
+            if let Some(err) = validation_error {
+                return Err(err);
+            }
 
-        let cluster_config = FluvioClusterConfig::new(&connection.endpoint);
-        let client = Fluvio::connect_with_config(&cluster_config)
-            .await
-            .map_err(|e| anyhow::anyhow!("fluvio connect failed: {e}"))?;
+            let cluster_config = FluvioClusterConfig::new(&connection.endpoint);
+            let client = Fluvio::connect_with_config(&cluster_config)
+                .await
+                .map_err(|e| anyhow::anyhow!("fluvio connect failed: {e}"))?;
 
-        let offset = match start_offset {
-            None => Offset::beginning(),
-            Some(n) => Offset::absolute(n)
-                .map_err(|e| anyhow::anyhow!("invalid fluvio offset {n}: {e}"))?,
-        };
+            let offset = match start_offset {
+                None => Offset::beginning(),
+                Some(n) => Offset::absolute(n)
+                    .map_err(|e| anyhow::anyhow!("invalid fluvio offset {n}: {e}"))?,
+            };
 
-        let consumer_config = ConsumerConfigExt::builder()
-            .topic(topic)
-            .partition(partition)
-            .offset_start(offset)
-            .build()
-            .map_err(|e| anyhow::anyhow!("fluvio consumer config failed: {e}"))?;
+            let consumer_config = ConsumerConfigExt::builder()
+                .topic(topic)
+                .partition(partition)
+                .offset_start(offset)
+                .build()
+                .map_err(|e| anyhow::anyhow!("fluvio consumer config failed: {e}"))?;
 
-        let mut stream = client
-            .consumer_with_config(consumer_config)
-            .await
-            .map_err(|e| anyhow::anyhow!("fluvio consumer create failed: {e}"))?;
+            let mut stream = client
+                .consumer_with_config(consumer_config)
+                .await
+                .map_err(|e| anyhow::anyhow!("fluvio consumer create failed: {e}"))?;
 
-        Ok(async_stream::stream! {
-            while let Some(result) = stream.next().await {
-                match result {
-                    Ok(record) => {
-                        let event = FluvioEvent {
-                            key: record.key().map(|k| k.to_vec()),
-                            value: record.value().to_vec(),
-                            offset: record.offset,
-                        };
-                        yield Ok((NanoTime::now(), event));
-                    }
-                    Err(e) => {
-                        yield Err(anyhow::anyhow!("fluvio record error: {e:?}"));
-                        break;
+            Ok(async_stream::stream! {
+                while let Some(result) = stream.next().await {
+                    match result {
+                        Ok(record) => {
+                            let event = FluvioEvent {
+                                key: record.key().map(|k| k.to_vec()),
+                                value: record.value().to_vec(),
+                                offset: record.offset,
+                            };
+                            yield Ok((NanoTime::now(), event));
+                        }
+                        Err(e) => {
+                            yield Err(anyhow::anyhow!("fluvio record error: {e:?}"));
+                            break;
+                        }
                     }
                 }
-            }
-        })
-    })
+            })
+        },
+        None,
+    )
 }

--- a/wingfoil/src/adapters/iceoryx2/read.rs
+++ b/wingfoil/src/adapters/iceoryx2/read.rs
@@ -407,7 +407,7 @@ where
             Iceoryx2Mode::Threaded | Iceoryx2Mode::Signaled => {
                 state.always_callback();
 
-                let (sender, receiver) = channel_pair(None);
+                let (sender, receiver) = channel_pair(None, None);
                 self.receiver = Some(receiver);
                 self.running.store(true, Ordering::SeqCst);
 
@@ -593,7 +593,7 @@ impl crate::MutableNode for Iceoryx2SliceReceiverStream {
             }
             Iceoryx2Mode::Threaded | Iceoryx2Mode::Signaled => {
                 state.always_callback();
-                let (sender, receiver) = channel_pair(None);
+                let (sender, receiver) = channel_pair(None, None);
                 self.receiver = Some(receiver);
                 self.running.store(true, Ordering::SeqCst);
 

--- a/wingfoil/src/adapters/kafka/read.rs
+++ b/wingfoil/src/adapters/kafka/read.rs
@@ -38,42 +38,45 @@ pub fn kafka_sub(
 ) -> Rc<dyn Stream<Burst<KafkaEvent>>> {
     let topic = topic.into();
     let group_id = group_id.into();
-    produce_async(move |_ctx: RunParams| async move {
-        let consumer: StreamConsumer = ClientConfig::new()
-            .set("bootstrap.servers", &connection.brokers)
-            .set("group.id", &group_id)
-            .set("auto.offset.reset", "earliest")
-            .set("enable.auto.commit", "true")
-            .set("session.timeout.ms", "6000")
-            .create()
-            .map_err(|e| anyhow::anyhow!("kafka consumer create failed: {e}"))?;
+    produce_async(
+        move |_ctx: RunParams| async move {
+            let consumer: StreamConsumer = ClientConfig::new()
+                .set("bootstrap.servers", &connection.brokers)
+                .set("group.id", &group_id)
+                .set("auto.offset.reset", "earliest")
+                .set("enable.auto.commit", "true")
+                .set("session.timeout.ms", "6000")
+                .create()
+                .map_err(|e| anyhow::anyhow!("kafka consumer create failed: {e}"))?;
 
-        consumer
-            .subscribe(&[&topic])
-            .map_err(|e| anyhow::anyhow!("kafka subscribe failed: {e}"))?;
+            consumer
+                .subscribe(&[&topic])
+                .map_err(|e| anyhow::anyhow!("kafka subscribe failed: {e}"))?;
 
-        Ok(async_stream::stream! {
-            loop {
-                match consumer.recv().await {
-                    Ok(msg) => {
-                        let event = KafkaEvent {
-                            topic: msg.topic().to_string(),
-                            partition: msg.partition(),
-                            offset: msg.offset(),
-                            key: msg.key().map(|k| k.to_vec()),
-                            value: msg.payload().unwrap_or_default().to_vec(),
-                        };
-                        yield Ok((NanoTime::now(), event));
-                    }
-                    Err(e) if is_transient_subscribe_error(&e) => continue,
-                    Err(e) => {
-                        yield Err(anyhow::anyhow!("kafka consume error: {e}"));
-                        break;
+            Ok(async_stream::stream! {
+                loop {
+                    match consumer.recv().await {
+                        Ok(msg) => {
+                            let event = KafkaEvent {
+                                topic: msg.topic().to_string(),
+                                partition: msg.partition(),
+                                offset: msg.offset(),
+                                key: msg.key().map(|k| k.to_vec()),
+                                value: msg.payload().unwrap_or_default().to_vec(),
+                            };
+                            yield Ok((NanoTime::now(), event));
+                        }
+                        Err(e) if is_transient_subscribe_error(&e) => continue,
+                        Err(e) => {
+                            yield Err(anyhow::anyhow!("kafka consume error: {e}"));
+                            break;
+                        }
                     }
                 }
-            }
-        })
-    })
+            })
+        },
+        None,
+    )
 }
 
 /// `UnknownTopicOrPartition` is reported while the broker is still catching up on

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -201,6 +201,7 @@ let stream = kdb_read::<Trade>(
             date, t0.to_kdb_timestamp(), t1.to_kdb_timestamp()
         )
     },
+    None, // buffer_size: None = unbounded; Some(n) bounds the channel for back-pressure
 );
 stream
     // Each tick is a `Burst<Trade>` (all trades at one timestamp). Iterate the

--- a/wingfoil/src/adapters/kdb/integration_tests.rs
+++ b/wingfoil/src/adapters/kdb/integration_tests.rs
@@ -295,6 +295,7 @@ fn test_kdb_sorted_data() -> Result<()> {
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
+            None,
         );
         let collected = stream.collapse().collect();
         collected.clone().run(
@@ -342,6 +343,7 @@ fn test_kdb_bad_query() -> Result<()> {
         conn,
         std::time::Duration::from_secs(24 * 3600),
         |_, _, _| "select from nonexistent_table_xyz".to_string(),
+        None,
     );
     let collected = stream.collapse().collect();
     let result = collected.run(
@@ -360,6 +362,7 @@ fn test_kdb_deserialization_error() -> Result<()> {
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
+            None,
         );
         let collected = stream.collapse().collect();
         collected.run(
@@ -397,9 +400,12 @@ fn test_read_read_perf() -> Result<()> {
 
         for &period in &periods {
             let start = std::time::Instant::now();
-            let stream = kdb_read::<TestTrade>(conn.clone(), period, |within, date, _| {
-                slice_query(date, within.0, within.1)
-            });
+            let stream = kdb_read::<TestTrade>(
+                conn.clone(),
+                period,
+                |within, date, _| slice_query(date, within.0, within.1),
+                None,
+            );
             let counter = stream.collapse().count();
             counter.clone().run(
                 RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
@@ -421,6 +427,7 @@ fn test_kdb_connection_refused() -> Result<()> {
         conn,
         std::time::Duration::from_secs(24 * 3600),
         |_, _, _| format!("select from {TABLE_NAME}"),
+        None,
     );
     let collected = stream.collapse().collect();
     let result = collected.run(
@@ -439,6 +446,7 @@ fn test_kdb_empty_table_returns_zero_rows() -> Result<()> {
             conn,
             std::time::Duration::from_secs(24 * 3600),
             |within, date, _| slice_query(date, within.0, within.1),
+            None,
         );
         let collected = stream.collapse().collect();
         collected.clone().run(
@@ -478,6 +486,7 @@ fn test_kdb_read_works() -> Result<()> {
             move |(slice_start, slice_end), date, _iteration| {
                 slice_query(date, slice_start, slice_end)
             },
+            None,
         );
 
         let collected = stream.collapse().collect();
@@ -504,18 +513,21 @@ fn write_and_verify(conn: KdbConnection, trades: Vec<TestTrade>) -> Result<usize
 
     // Build a produce_async stream that yields each trade at a distinct timestamp
     let write_conn = conn.clone();
-    let stream = produce_async(move |_ctx| {
-        let trades = trades;
-        async move {
-            Ok(async_stream::stream! {
-                for (i, trade) in trades.into_iter().enumerate() {
-                    // Use KDB epoch + i seconds as timestamp
-                    let time = NanoTime::from_kdb_timestamp(i as i64 * 1_000_000_000);
-                    yield Ok((time, trade));
-                }
-            })
-        }
-    });
+    let stream = produce_async(
+        move |_ctx| {
+            let trades = trades;
+            async move {
+                Ok(async_stream::stream! {
+                    for (i, trade) in trades.into_iter().enumerate() {
+                        // Use KDB epoch + i seconds as timestamp
+                        let time = NanoTime::from_kdb_timestamp(i as i64 * 1_000_000_000);
+                        yield Ok((time, trade));
+                    }
+                })
+            }
+        },
+        None,
+    );
 
     // Write to KDB
     let writer = kdb_write(write_conn, WRITE_TABLE_NAME, &stream);
@@ -577,6 +589,7 @@ fn test_kdb_write_round_trip() -> Result<()> {
                     t1.to_kdb_timestamp(),
                 )
             },
+            None,
         );
         let collected = read_stream
             .collapse()
@@ -618,18 +631,21 @@ fn test_kdb_write_append() -> Result<()> {
 
         // Write 2 more trades via the graph - use timestamps after existing data
         let write_conn = conn.clone();
-        let stream = produce_async(move |_ctx| {
-            let trades = new_trades;
-            async move {
-                Ok(async_stream::stream! {
-                    for (i, trade) in trades.into_iter().enumerate() {
-                        // Use timestamps after the existing 3 rows (which use 0..3 seconds)
-                        let time = NanoTime::from_kdb_timestamp((10 + i as i64) * 1_000_000_000);
-                        yield Ok((time, trade));
-                    }
-                })
-            }
-        });
+        let stream = produce_async(
+            move |_ctx| {
+                let trades = new_trades;
+                async move {
+                    Ok(async_stream::stream! {
+                        for (i, trade) in trades.into_iter().enumerate() {
+                            // Use timestamps after the existing 3 rows (which use 0..3 seconds)
+                            let time = NanoTime::from_kdb_timestamp((10 + i as i64) * 1_000_000_000);
+                            yield Ok((time, trade));
+                        }
+                    })
+                }
+            },
+            None,
+        );
 
         let writer = kdb_write(write_conn, WRITE_TABLE_NAME, &stream);
         writer.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
@@ -897,13 +913,18 @@ fn test_kdb_read_drops_rows_outside_window() -> Result<()> {
     // 90s past the epoch — deliberately NOT aligned to the 60s period.
     let start = NanoTime::from_kdb_timestamp(90 * 1_000_000_000);
     let period = std::time::Duration::from_secs(60);
-    let stream = kdb_read::<TestTick>(conn.clone(), period, move |(t0, t1), _date, _| {
-        format!(
-            "select from {TBL} where time >= (`timestamp$){}j, time < (`timestamp$){}j",
-            t0.to_kdb_timestamp(),
-            t1.to_kdb_timestamp(),
-        )
-    });
+    let stream = kdb_read::<TestTick>(
+        conn.clone(),
+        period,
+        move |(t0, t1), _date, _| {
+            format!(
+                "select from {TBL} where time >= (`timestamp$){}j, time < (`timestamp$){}j",
+                t0.to_kdb_timestamp(),
+                t1.to_kdb_timestamp(),
+            )
+        },
+        None,
+    );
     let collected = stream.collapse().collect();
     // Run through 270s (start + 180s), covering the 90s/150s/210s rows.
     let run_result = collected.clone().run(

--- a/wingfoil/src/adapters/kdb/mod.rs
+++ b/wingfoil/src/adapters/kdb/mod.rs
@@ -43,6 +43,7 @@
 //!             date, t0.to_kdb_timestamp(), t1.to_kdb_timestamp()
 //!         )
 //!     },
+//!     None, // buffer_size: None = unbounded; Some(n) applies back-pressure
 //! )
 //!     // Each tick is a `Burst<Trade>` — all trades sharing a timestamp. Iterate
 //!     // the burst to see every row; `.collapse()` keeps only the last per tick.

--- a/wingfoil/src/adapters/kdb/read.rs
+++ b/wingfoil/src/adapters/kdb/read.rs
@@ -395,59 +395,67 @@ where
     }
 }
 
+/// `buffer_size` bounds the channel feeding the graph: `None` is unbounded
+/// (a fast KDB replay never blocks but can build an arbitrarily large backlog
+/// if the graph is the bottleneck), while `Some(n)` bounds it to `n` items so
+/// the replay applies back-pressure, capping memory use.
 #[must_use]
 pub fn kdb_read<T>(
     connection: KdbConnection,
     period: std::time::Duration,
     query_fn: impl FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static,
+    buffer_size: Option<usize>,
 ) -> Rc<dyn Stream<Burst<T>>>
 where
     T: Element + Send + KdbDeserialize + 'static,
 {
-    produce_async(move |ctx| {
-        let start_time = ctx.start_time;
-        let end_time_result = ctx.end_time();
+    produce_async(
+        move |ctx| {
+            let start_time = ctx.start_time;
+            let end_time_result = ctx.end_time();
 
-        async move {
-            // `compute_validated_time_slices` consumes `end_time_result`; capture the
-            // concrete bound first (NanoTime is Copy) so the per-slice clamp below can
-            // reference `end_time`. Validation guarantees it is present (bounded, non-MAX).
-            let end_time_bound = end_time_result.as_ref().ok().copied();
-            let slices = compute_validated_time_slices(
-                "kdb_read_time_sliced",
-                start_time,
-                end_time_result,
-                period,
-            )?;
-            let end_time =
-                end_time_bound.expect("compute_validated_time_slices accepted a bounded end_time");
+            async move {
+                // `compute_validated_time_slices` consumes `end_time_result`; capture the
+                // concrete bound first (NanoTime is Copy) so the per-slice clamp below can
+                // reference `end_time`. Validation guarantees it is present (bounded, non-MAX).
+                let end_time_bound = end_time_result.as_ref().ok().copied();
+                let slices = compute_validated_time_slices(
+                    "kdb_read_time_sliced",
+                    start_time,
+                    end_time_result,
+                    period,
+                )?;
+                let end_time = end_time_bound
+                    .expect("compute_validated_time_slices accepted a bounded end_time");
 
-            let creds = connection.credentials_string();
-            let socket = QStream::connect(
-                ConnectionMethod::TCP,
-                &connection.host,
-                connection.port,
-                &creds,
-            )
-            .await?;
+                let creds = connection.credentials_string();
+                let socket = QStream::connect(
+                    ConnectionMethod::TCP,
+                    &connection.host,
+                    connection.port,
+                    &creds,
+                )
+                .await?;
 
-            let mut slices_iter = slices.into_iter();
-            let mut query_fn = query_fn;
-            let slice_fn = move || -> Option<(String, TimeWindow)> {
-                let ((t0, t1), date, iteration) = slices_iter.next()?;
-                // The query still uses the period-aligned (t0, t1) for clean
-                // round-number boundaries, but rows are clamped to the run's
-                // [start_time, end_time) so out-of-window rows are dropped rather
-                // than aborting the run. `t0` may precede `start_time` on the
-                // first slice; `t1` may exceed `end_time` on the last.
-                let window = TimeWindow::clamp(t0, t1, start_time, end_time);
-                let query = query_fn((t0, t1), date, iteration);
-                Some((query, window))
-            };
+                let mut slices_iter = slices.into_iter();
+                let mut query_fn = query_fn;
+                let slice_fn = move || -> Option<(String, TimeWindow)> {
+                    let ((t0, t1), date, iteration) = slices_iter.next()?;
+                    // The query still uses the period-aligned (t0, t1) for clean
+                    // round-number boundaries, but rows are clamped to the run's
+                    // [start_time, end_time) so out-of-window rows are dropped rather
+                    // than aborting the run. `t0` may precede `start_time` on the
+                    // first slice; `t1` may exceed `end_time` on the last.
+                    let window = TimeWindow::clamp(t0, t1, start_time, end_time);
+                    let query = query_fn((t0, t1), date, iteration);
+                    Some((query, window))
+                };
 
-            Ok(chunk_stream::<T>(socket, slice_fn))
-        }
-    })
+                Ok(chunk_stream::<T>(socket, slice_fn))
+            }
+        },
+        buffer_size,
+    )
 }
 
 #[cfg(test)]
@@ -500,12 +508,15 @@ mod tests {
         let before = NanoTime::new(u64::from(start) - 1);
 
         // Mimics kdb_read's first slice yielding a row from [t0, start_time).
-        let stream = crate::nodes::produce_async(move |_ctx| async move {
-            Ok(async_stream::stream! {
-                yield Ok((before, 1u32));
-                yield Ok((start, 2u32));
-            })
-        });
+        let stream = crate::nodes::produce_async(
+            move |_ctx| async move {
+                Ok(async_stream::stream! {
+                    yield Ok((before, 1u32));
+                    yield Ok((start, 2u32));
+                })
+            },
+            None,
+        );
 
         let result = stream.collapse().collect().run(
             RunMode::HistoricalFrom(start),
@@ -537,12 +548,15 @@ mod tests {
         // ...so a later slice's in-window row (earlier than `ahead`) is now "in the past".
         let in_window = NanoTime::new(u64::from(start) + 30);
 
-        let stream = crate::nodes::produce_async(move |_ctx| async move {
-            Ok(async_stream::stream! {
-                yield Ok((ahead, 1u32));
-                yield Ok((in_window, 2u32));
-            })
-        });
+        let stream = crate::nodes::produce_async(
+            move |_ctx| async move {
+                Ok(async_stream::stream! {
+                    yield Ok((ahead, 1u32));
+                    yield Ok((in_window, 2u32));
+                })
+            },
+            None,
+        );
 
         let result = stream.collapse().collect().run(
             RunMode::HistoricalFrom(start),

--- a/wingfoil/src/adapters/kdb/read_cached.rs
+++ b/wingfoil/src/adapters/kdb/read_cached.rs
@@ -74,148 +74,151 @@ where
         + for<'de> serde::Deserialize<'de>
         + 'static,
 {
-    produce_async(move |ctx| {
-        let start_time = ctx.start_time;
-        let end_time_result = ctx.end_time();
+    produce_async(
+        move |ctx| {
+            let start_time = ctx.start_time;
+            let end_time_result = ctx.end_time();
 
-        async move {
-            // `compute_validated_time_slices` consumes `end_time_result`; capture the
-            // concrete bound first (NanoTime is Copy) so the per-slice clamp below can
-            // reference `end_time`. Validation guarantees it is present (bounded, non-MAX).
-            let end_time_bound = end_time_result.as_ref().ok().copied();
-            let slices = compute_validated_time_slices(
-                "kdb_read_cached",
-                start_time,
-                end_time_result,
-                period,
-            )?;
-            let end_time =
-                end_time_bound.expect("compute_validated_time_slices accepted a bounded end_time");
+            async move {
+                // `compute_validated_time_slices` consumes `end_time_result`; capture the
+                // concrete bound first (NanoTime is Copy) so the per-slice clamp below can
+                // reference `end_time`. Validation guarantees it is present (bounded, non-MAX).
+                let end_time_bound = end_time_result.as_ref().ok().copied();
+                let slices = compute_validated_time_slices(
+                    "kdb_read_cached",
+                    start_time,
+                    end_time_result,
+                    period,
+                )?;
+                let end_time = end_time_bound
+                    .expect("compute_validated_time_slices accepted a bounded end_time");
 
-            tokio::fs::create_dir_all(&cache_config.folder).await?;
-            let cache = FileCache::<T>::new(cache_config);
+                tokio::fs::create_dir_all(&cache_config.folder).await?;
+                let cache = FileCache::<T>::new(cache_config);
 
-            Ok(async_stream::stream! {
-                let mut socket: Option<QStream> = None;
-                let mut interner = SymbolInterner::default();
-                let mut query_fn = query_fn;
+                Ok(async_stream::stream! {
+                    let mut socket: Option<QStream> = None;
+                    let mut interner = SymbolInterner::default();
+                    let mut query_fn = query_fn;
 
-                'slices: for (within, date, iteration) in slices {
-                    // Effective window for this slice: clamp the period-aligned
-                    // (t0, t1) to the run's [start_time, end_time). Rows the query
-                    // returns outside it are dropped at emit time (below). The cache
-                    // still stores the full [t0, t1) result, since the cache key is
-                    // the query string and does not encode start_time/end_time.
-                    let (t0, t1) = within;
-                    let window = TimeWindow::clamp(t0, t1, start_time, end_time);
-                    let query = query_fn(within, date, iteration);
-                    let key = CacheKey::from_parts(&[&query]);
+                    'slices: for (within, date, iteration) in slices {
+                        // Effective window for this slice: clamp the period-aligned
+                        // (t0, t1) to the run's [start_time, end_time). Rows the query
+                        // returns outside it are dropped at emit time (below). The cache
+                        // still stores the full [t0, t1) result, since the cache key is
+                        // the query string and does not encode start_time/end_time.
+                        let (t0, t1) = within;
+                        let window = TimeWindow::clamp(t0, t1, start_time, end_time);
+                        let query = query_fn(within, date, iteration);
+                        let key = CacheKey::from_parts(&[&query]);
 
-                    let cached = match cache.get(&key).await {
-                        Ok(Some(rows)) => Some(rows),
-                        Ok(None) => None,
-                        Err(e) => {
-                            log::warn!("KDB cache read error (falling back to KDB): {e}");
-                            None
-                        }
-                    };
-
-                    if let Some(rows) = cached {
-                        let mut filter = WindowFilter::new("kdb_read_cached", window);
-                        for (time, record) in rows {
-                            if !filter.keep(time) {
-                                continue;
-                            }
-                            yield Ok((time, record));
-                        }
-                        filter.finish();
-                        continue;
-                    }
-
-                    // Cache miss or corrupt — connect lazily and query KDB.
-                    if socket.is_none() {
-                        let creds = connection.credentials_string();
-                        match QStream::connect(
-                            ConnectionMethod::TCP,
-                            &connection.host,
-                            connection.port,
-                            &creds,
-                        )
-                        .await
-                        {
-                            Ok(s) => socket = Some(s),
+                        let cached = match cache.get(&key).await {
+                            Ok(Some(rows)) => Some(rows),
+                            Ok(None) => None,
                             Err(e) => {
-                                yield Err(e.into());
-                                break 'slices;
+                                log::warn!("KDB cache read error (falling back to KDB): {e}");
+                                None
+                            }
+                        };
+
+                        if let Some(rows) = cached {
+                            let mut filter = WindowFilter::new("kdb_read_cached", window);
+                            for (time, record) in rows {
+                                if !filter.keep(time) {
+                                    continue;
+                                }
+                                yield Ok((time, record));
+                            }
+                            filter.finish();
+                            continue;
+                        }
+
+                        // Cache miss or corrupt — connect lazily and query KDB.
+                        if socket.is_none() {
+                            let creds = connection.credentials_string();
+                            match QStream::connect(
+                                ConnectionMethod::TCP,
+                                &connection.host,
+                                connection.port,
+                                &creds,
+                            )
+                            .await
+                            {
+                                Ok(s) => socket = Some(s),
+                                Err(e) => {
+                                    yield Err(e.into());
+                                    break 'slices;
+                                }
                             }
                         }
-                    }
-                    // Just populated above on cache miss when None.
-                    let sock = socket
-                        .as_mut()
-                        .expect("socket initialised on cache miss above");
+                        // Just populated above on cache miss when None.
+                        let sock = socket
+                            .as_mut()
+                            .expect("socket initialised on cache miss above");
 
-                    info!("KDB query: {query}");
-                    let fetch_start = std::time::Instant::now();
-                    let result: K = match sock.send_sync_message(&query.as_str()).await {
-                        Ok(r) => r,
-                        Err(e) => {
-                            yield Err(e.into());
-                            break 'slices;
-                        }
-                    };
-
-                    let (columns, rows) = match (result.column_names(), result.rows()) {
-                        (Ok(cols), Ok(rows)) => (cols, rows),
-                        (Err(e), _) | (_, Err(e)) => {
-                            yield Err(e);
-                            break 'slices;
-                        }
-                    };
-
-                    let row_count = rows.len();
-                    info!("KDB query: {} rows in {:?}", row_count, fetch_start.elapsed());
-
-                    // Parse rows, validate ascending time order, and collect.
-                    // Only cached after a full successful parse — no partial writes.
-                    let mut parsed: Vec<(NanoTime, T)> = Vec::with_capacity(row_count);
-                    let mut prev_time: Option<NanoTime> = None;
-                    for row in &rows {
-                        let (time, record) = match T::from_kdb_row(row, &columns, &mut interner) {
+                        info!("KDB query: {query}");
+                        let fetch_start = std::time::Instant::now();
+                        let result: K = match sock.send_sync_message(&query.as_str()).await {
                             Ok(r) => r,
                             Err(e) => {
                                 yield Err(e.into());
                                 break 'slices;
                             }
                         };
-                        if let Some(prev) = prev_time
-                            && time < prev
-                        {
-                            yield Err(anyhow::anyhow!(
-                                "KDB data is not sorted by time: got {time:?} after {prev:?}. \
-                                Add `xasc` to your query to sort the data."
-                            ));
-                            break 'slices;
-                        }
-                        prev_time = Some(time);
-                        parsed.push((time, record));
-                    }
 
-                    // Write to cache; log on failure but don't abort the stream.
-                    if let Err(e) = cache.put(&key, &query, &parsed).await {
-                        log::warn!("KDB cache write error: {e}");
-                    }
+                        let (columns, rows) = match (result.column_names(), result.rows()) {
+                            (Ok(cols), Ok(rows)) => (cols, rows),
+                            (Err(e), _) | (_, Err(e)) => {
+                                yield Err(e);
+                                break 'slices;
+                            }
+                        };
 
-                    let mut filter = WindowFilter::new("kdb_read_cached", window);
-                    for (time, record) in parsed {
-                        if !filter.keep(time) {
-                            continue;
+                        let row_count = rows.len();
+                        info!("KDB query: {} rows in {:?}", row_count, fetch_start.elapsed());
+
+                        // Parse rows, validate ascending time order, and collect.
+                        // Only cached after a full successful parse — no partial writes.
+                        let mut parsed: Vec<(NanoTime, T)> = Vec::with_capacity(row_count);
+                        let mut prev_time: Option<NanoTime> = None;
+                        for row in &rows {
+                            let (time, record) = match T::from_kdb_row(row, &columns, &mut interner) {
+                                Ok(r) => r,
+                                Err(e) => {
+                                    yield Err(e.into());
+                                    break 'slices;
+                                }
+                            };
+                            if let Some(prev) = prev_time
+                                && time < prev
+                            {
+                                yield Err(anyhow::anyhow!(
+                                    "KDB data is not sorted by time: got {time:?} after {prev:?}. \
+                                    Add `xasc` to your query to sort the data."
+                                ));
+                                break 'slices;
+                            }
+                            prev_time = Some(time);
+                            parsed.push((time, record));
                         }
-                        yield Ok((time, record));
+
+                        // Write to cache; log on failure but don't abort the stream.
+                        if let Err(e) = cache.put(&key, &query, &parsed).await {
+                            log::warn!("KDB cache write error: {e}");
+                        }
+
+                        let mut filter = WindowFilter::new("kdb_read_cached", window);
+                        for (time, record) in parsed {
+                            if !filter.keep(time) {
+                                continue;
+                            }
+                            yield Ok((time, record));
+                        }
+                        filter.finish();
                     }
-                    filter.finish();
-                }
-            })
-        }
-    })
+                })
+            }
+        },
+        None,
+    )
 }

--- a/wingfoil/src/adapters/kdb/sub.rs
+++ b/wingfoil/src/adapters/kdb/sub.rs
@@ -61,93 +61,96 @@ where
 {
     let table = table.into();
     let symbols = symbols.into();
-    produce_async(move |ctx| {
-        let run_mode = ctx.run_mode;
-        let connection = connection;
-        let table = table;
-        let symbols = symbols;
+    produce_async(
+        move |ctx| {
+            let run_mode = ctx.run_mode;
+            let connection = connection;
+            let table = table;
+            let symbols = symbols;
 
-        async move {
-            if !matches!(run_mode, RunMode::RealTime) {
-                anyhow::bail!(
-                    "kdb_sub requires RunMode::RealTime; use kdb_read for historical replay"
-                );
-            }
-
-            let creds = connection.credentials_string();
-            let mut socket = QStream::connect(
-                ConnectionMethod::TCP,
-                &connection.host,
-                connection.port,
-                &creds,
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "kdb_sub: failed to connect to {}:{}",
-                    connection.host, connection.port
-                )
-            })?;
-
-            // Subscribe synchronously; the reply is `(`table; schema)`, from which
-            // we capture the column names for positional row decoding.
-            let sub_query = format!(".u.sub[`{table};{symbols}]");
-            info!("kdb_sub: {sub_query}");
-            let sub_reply = socket
-                .send_sync_message(&sub_query.as_str())
-                .await
-                .with_context(|| format!("kdb_sub: subscription `{sub_query}` failed"))?;
-            let columns: Vec<String> = sub_reply
-                .element_at(1)
-                .ok()
-                .and_then(|schema| schema.column_names().ok())
-                .unwrap_or_default();
-
-            Ok(async_stream::stream! {
-                let mut interner = SymbolInterner::default();
-                loop {
-                    let (_msg_type, msg) = match socket.receive_message().await {
-                        Ok(m) => m,
-                        Err(e) => {
-                            yield Err(anyhow::Error::new(e).context("kdb_sub: receive failed"));
-                            break;
-                        }
-                    };
-
-                    // A tickerplant update is `(`upd; `table; data)` — a 3-element
-                    // compound list whose first element is the symbol `upd`. Skip
-                    // anything else (heartbeats, `.u.end`, etc.).
-                    if msg.get_type() != qtype::COMPOUND_LIST || msg.len() < 3 {
-                        continue;
-                    }
-                    match msg.element_at(0).ok().as_ref().and_then(|f| f.get_symbol().ok()) {
-                        Some("upd") => {}
-                        _ => continue,
-                    }
-
-                    let data = match msg.element_at(2) {
-                        Ok(d) => d,
-                        Err(e) => {
-                            yield Err(anyhow::Error::new(e).context("kdb_sub: upd message has no data"));
-                            break;
-                        }
-                    };
-
-                    let rows = match upd_payload_rows(&data) {
-                        Ok(rows) => rows,
-                        Err(e) => { yield Err(e); break; }
-                    };
-
-                    for row in &rows {
-                        match T::from_kdb_row(row, &columns, &mut interner) {
-                            Ok((time, record)) => yield Ok((time, record)),
-                            Err(e) => { yield Err(anyhow::Error::new(e)); return; }
-                        }
-                    }
+            async move {
+                if !matches!(run_mode, RunMode::RealTime) {
+                    anyhow::bail!(
+                        "kdb_sub requires RunMode::RealTime; use kdb_read for historical replay"
+                    );
                 }
-            })
-        }
-    })
+
+                let creds = connection.credentials_string();
+                let mut socket = QStream::connect(
+                    ConnectionMethod::TCP,
+                    &connection.host,
+                    connection.port,
+                    &creds,
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "kdb_sub: failed to connect to {}:{}",
+                        connection.host, connection.port
+                    )
+                })?;
+
+                // Subscribe synchronously; the reply is `(`table; schema)`, from which
+                // we capture the column names for positional row decoding.
+                let sub_query = format!(".u.sub[`{table};{symbols}]");
+                info!("kdb_sub: {sub_query}");
+                let sub_reply = socket
+                    .send_sync_message(&sub_query.as_str())
+                    .await
+                    .with_context(|| format!("kdb_sub: subscription `{sub_query}` failed"))?;
+                let columns: Vec<String> = sub_reply
+                    .element_at(1)
+                    .ok()
+                    .and_then(|schema| schema.column_names().ok())
+                    .unwrap_or_default();
+
+                Ok(async_stream::stream! {
+                    let mut interner = SymbolInterner::default();
+                    loop {
+                        let (_msg_type, msg) = match socket.receive_message().await {
+                            Ok(m) => m,
+                            Err(e) => {
+                                yield Err(anyhow::Error::new(e).context("kdb_sub: receive failed"));
+                                break;
+                            }
+                        };
+
+                        // A tickerplant update is `(`upd; `table; data)` — a 3-element
+                        // compound list whose first element is the symbol `upd`. Skip
+                        // anything else (heartbeats, `.u.end`, etc.).
+                        if msg.get_type() != qtype::COMPOUND_LIST || msg.len() < 3 {
+                            continue;
+                        }
+                        match msg.element_at(0).ok().as_ref().and_then(|f| f.get_symbol().ok()) {
+                            Some("upd") => {}
+                            _ => continue,
+                        }
+
+                        let data = match msg.element_at(2) {
+                            Ok(d) => d,
+                            Err(e) => {
+                                yield Err(anyhow::Error::new(e).context("kdb_sub: upd message has no data"));
+                                break;
+                            }
+                        };
+
+                        let rows = match upd_payload_rows(&data) {
+                            Ok(rows) => rows,
+                            Err(e) => { yield Err(e); break; }
+                        };
+
+                        for row in &rows {
+                            match T::from_kdb_row(row, &columns, &mut interner) {
+                                Ok((time, record)) => yield Ok((time, record)),
+                                Err(e) => { yield Err(anyhow::Error::new(e)); return; }
+                            }
+                        }
+                    }
+                })
+            }
+        },
+        None,
+    )
 }
 
 #[cfg(test)]

--- a/wingfoil/src/adapters/postgres/integration_tests.rs
+++ b/wingfoil/src/adapters/postgres/integration_tests.rs
@@ -265,14 +265,17 @@ fn test_write_round_trip() -> anyhow::Result<()> {
 
     // Emit three trades at distinct hourly timestamps via the graph, then write them.
     let write_conn = conn.clone();
-    let producer = produce_async(move |_ctx| async move {
-        Ok(async_stream::stream! {
-            for i in 0..3i64 {
-                let time = NanoTime::from_kdb_timestamp(i * 3_600_000_000_000);
-                yield Ok((time, TestTrade { sym: format!("W{i}"), price: 10.0 + i as f64, qty: i }));
-            }
-        })
-    });
+    let producer = produce_async(
+        move |_ctx| async move {
+            Ok(async_stream::stream! {
+                for i in 0..3i64 {
+                    let time = NanoTime::from_kdb_timestamp(i * 3_600_000_000_000);
+                    yield Ok((time, TestTrade { sym: format!("W{i}"), price: 10.0 + i as f64, qty: i }));
+                }
+            })
+        },
+        None,
+    );
     postgres_write(write_conn, "trades", &producer)
         .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
 

--- a/wingfoil/src/adapters/postgres/read.rs
+++ b/wingfoil/src/adapters/postgres/read.rs
@@ -99,101 +99,104 @@ where
     T: Element + Send + PostgresDeserialize + 'static,
 {
     let connection = connection.into();
-    produce_async(move |ctx| {
-        let start_time = ctx.start_time;
-        let end_time_result = ctx.end_time();
-        let connection = connection;
-        let mut query_fn = query_fn;
+    produce_async(
+        move |ctx| {
+            let start_time = ctx.start_time;
+            let end_time_result = ctx.end_time();
+            let connection = connection;
+            let mut query_fn = query_fn;
 
-        async move {
-            // `compute_validated_time_slices` consumes `end_time_result`; capture the
-            // concrete bound first (NanoTime is Copy) so emitted rows can be clamped to
-            // the run's `[start_time, end_time)` window below. Validation guarantees the
-            // value is present (bounded, non-MAX) by the time we unwrap it.
-            let end_time_bound = end_time_result.as_ref().ok().copied();
-            let slices = compute_validated_time_slices(
-                "postgres_read",
-                start_time,
-                end_time_result,
-                period,
-            )?;
-            let end_time =
-                end_time_bound.expect("compute_validated_time_slices accepted a bounded end_time");
+            async move {
+                // `compute_validated_time_slices` consumes `end_time_result`; capture the
+                // concrete bound first (NanoTime is Copy) so emitted rows can be clamped to
+                // the run's `[start_time, end_time)` window below. Validation guarantees the
+                // value is present (bounded, non-MAX) by the time we unwrap it.
+                let end_time_bound = end_time_result.as_ref().ok().copied();
+                let slices = compute_validated_time_slices(
+                    "postgres_read",
+                    start_time,
+                    end_time_result,
+                    period,
+                )?;
+                let end_time = end_time_bound
+                    .expect("compute_validated_time_slices accepted a bounded end_time");
 
-            let (client, conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
-                .await
-                .with_context(|| {
-                    format!(
-                        "postgres_read: failed to connect: {}",
-                        connection.redacted()
-                    )
-                })?;
-            // Drive the connection's protocol handling in the background; it ends
-            // when `client` is dropped after the stream is exhausted.
-            tokio::spawn(async move {
-                if let Err(e) = conn.await {
-                    log::error!("postgres connection error: {e}");
-                }
-            });
-
-            Ok(async_stream::stream! {
-                // Timestamps are full (not time-of-day), so ordering is enforced
-                // across the whole read, not reset per slice.
-                let mut prev_time: Option<NanoTime> = None;
-                'outer: for ((t0, t1), date, iteration) in slices {
-                    let query = query_fn((t0, t1), date, iteration);
-                    info!("postgres query: {query}");
-                    let fetch_start = std::time::Instant::now();
-                    let rows = match client.query(&query, &[]).await {
-                        Ok(rows) => rows,
-                        Err(e) => {
-                            yield Err(anyhow::Error::new(e).context("postgres query failed"));
-                            break;
-                        }
-                    };
-                    info!("postgres query: {} rows in {:?}", rows.len(), fetch_start.elapsed());
-
-                    // The query uses the period-aligned (t0, t1) for clean round-number
-                    // boundaries, but the first slice's t0 can precede start_time (and the
-                    // last slice's t1 exceed end_time), so a `time >= t0` filter may return
-                    // rows outside the run window. Drop rows outside [start_time, end_time)
-                    // via the shared WindowFilter: emitting a row before the graph clock
-                    // aborts the run, and a row past end_time would drive the monotonic
-                    // check to reject a later slice.
-                    let mut filter = WindowFilter::new(
-                        "postgres_read",
-                        TimeWindow::clamp(t0, t1, start_time, end_time),
-                    );
-
-                    for row in &rows {
-                        let (time, record) = match T::from_row(row) {
-                            Ok(r) => r,
-                            Err(e) => { yield Err(e); break 'outer; }
-                        };
-
-                        if !filter.keep(time) {
-                            continue;
-                        }
-
-                        if let Some(prev) = prev_time
-                            && time < prev
-                        {
-                            yield Err(anyhow::anyhow!(
-                                "postgres data is not sorted by time: got {time:?} after {prev:?}. \
-                                Add `ORDER BY time` to your query."
-                            ));
-                            break 'outer;
-                        }
-                        prev_time = Some(time);
-
-                        yield Ok((time, record));
+                let (client, conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "postgres_read: failed to connect: {}",
+                            connection.redacted()
+                        )
+                    })?;
+                // Drive the connection's protocol handling in the background; it ends
+                // when `client` is dropped after the stream is exhausted.
+                tokio::spawn(async move {
+                    if let Err(e) = conn.await {
+                        log::error!("postgres connection error: {e}");
                     }
+                });
 
-                    filter.finish();
-                }
-            })
-        }
-    })
+                Ok(async_stream::stream! {
+                    // Timestamps are full (not time-of-day), so ordering is enforced
+                    // across the whole read, not reset per slice.
+                    let mut prev_time: Option<NanoTime> = None;
+                    'outer: for ((t0, t1), date, iteration) in slices {
+                        let query = query_fn((t0, t1), date, iteration);
+                        info!("postgres query: {query}");
+                        let fetch_start = std::time::Instant::now();
+                        let rows = match client.query(&query, &[]).await {
+                            Ok(rows) => rows,
+                            Err(e) => {
+                                yield Err(anyhow::Error::new(e).context("postgres query failed"));
+                                break;
+                            }
+                        };
+                        info!("postgres query: {} rows in {:?}", rows.len(), fetch_start.elapsed());
+
+                        // The query uses the period-aligned (t0, t1) for clean round-number
+                        // boundaries, but the first slice's t0 can precede start_time (and the
+                        // last slice's t1 exceed end_time), so a `time >= t0` filter may return
+                        // rows outside the run window. Drop rows outside [start_time, end_time)
+                        // via the shared WindowFilter: emitting a row before the graph clock
+                        // aborts the run, and a row past end_time would drive the monotonic
+                        // check to reject a later slice.
+                        let mut filter = WindowFilter::new(
+                            "postgres_read",
+                            TimeWindow::clamp(t0, t1, start_time, end_time),
+                        );
+
+                        for row in &rows {
+                            let (time, record) = match T::from_row(row) {
+                                Ok(r) => r,
+                                Err(e) => { yield Err(e); break 'outer; }
+                            };
+
+                            if !filter.keep(time) {
+                                continue;
+                            }
+
+                            if let Some(prev) = prev_time
+                                && time < prev
+                            {
+                                yield Err(anyhow::anyhow!(
+                                    "postgres data is not sorted by time: got {time:?} after {prev:?}. \
+                                    Add `ORDER BY time` to your query."
+                                ));
+                                break 'outer;
+                            }
+                            prev_time = Some(time);
+
+                            yield Ok((time, record));
+                        }
+
+                        filter.finish();
+                    }
+                })
+            }
+        },
+        None,
+    )
 }
 
 #[cfg(test)]

--- a/wingfoil/src/adapters/postgres/sub.rs
+++ b/wingfoil/src/adapters/postgres/sub.rs
@@ -87,101 +87,106 @@ where
 {
     let connection = connection.into();
     let channel = channel.into();
-    produce_async(move |ctx| {
-        let run_mode = ctx.run_mode;
-        let connection = connection;
-        let channel = channel;
-        let mut query_fn = query_fn;
+    produce_async(
+        move |ctx| {
+            let run_mode = ctx.run_mode;
+            let connection = connection;
+            let channel = channel;
+            let mut query_fn = query_fn;
 
-        async move {
-            if !matches!(run_mode, RunMode::RealTime) {
-                anyhow::bail!(
-                    "postgres_sub requires RunMode::RealTime; \
+            async move {
+                if !matches!(run_mode, RunMode::RealTime) {
+                    anyhow::bail!(
+                        "postgres_sub requires RunMode::RealTime; \
                     use postgres_read for historical replay"
-                );
-            }
+                    );
+                }
 
-            let (client, mut conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
-                .await
-                .with_context(|| {
-                    format!("postgres_sub: failed to connect: {}", connection.redacted())
-                })?;
+                let (client, mut conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
+                    .await
+                    .with_context(|| {
+                        format!("postgres_sub: failed to connect: {}", connection.redacted())
+                    })?;
 
-            // Drive the connection and forward notification wake-ups. Polling
-            // `poll_message` (rather than awaiting the plain connection future)
-            // is what surfaces `AsyncMessage::Notification`s.
-            let (tx, mut rx) = mpsc::unbounded::<()>();
-            tokio::spawn(async move {
-                let mut messages = futures::stream::poll_fn(move |cx| conn.poll_message(cx));
-                while let Some(message) = messages.next().await {
-                    match message {
-                        Ok(AsyncMessage::Notification(_)) => {
-                            if tx.unbounded_send(()).is_err() {
-                                break; // subscriber gone
+                // Drive the connection and forward notification wake-ups. Polling
+                // `poll_message` (rather than awaiting the plain connection future)
+                // is what surfaces `AsyncMessage::Notification`s.
+                let (tx, mut rx) = mpsc::unbounded::<()>();
+                tokio::spawn(async move {
+                    let mut messages = futures::stream::poll_fn(move |cx| conn.poll_message(cx));
+                    while let Some(message) = messages.next().await {
+                        match message {
+                            Ok(AsyncMessage::Notification(_)) => {
+                                if tx.unbounded_send(()).is_err() {
+                                    break; // subscriber gone
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                log::error!("postgres_sub connection error: {e}");
+                                break;
                             }
                         }
-                        Ok(_) => {}
-                        Err(e) => {
-                            log::error!("postgres_sub connection error: {e}");
-                            break;
-                        }
                     }
-                }
-            });
+                });
 
-            // LISTEN before the catch-up query so an insert committed in the
-            // handoff window still produces a wake-up (watch-before-get).
-            client
-                .batch_execute(&format!("LISTEN {}", quote_ident(&channel)))
-                .await
-                .with_context(|| format!("postgres_sub: LISTEN on channel `{channel}` failed"))?;
+                // LISTEN before the catch-up query so an insert committed in the
+                // handoff window still produces a wake-up (watch-before-get).
+                client
+                    .batch_execute(&format!("LISTEN {}", quote_ident(&channel)))
+                    .await
+                    .with_context(|| {
+                        format!("postgres_sub: LISTEN on channel `{channel}` failed")
+                    })?;
 
-            Ok(async_stream::stream! {
-                let mut cursor = start_from;
-                loop {
-                    // Drain everything past the cursor. The first pass is the
-                    // catch-up from `start_from`; later passes fetch what the
-                    // wake-up announced.
-                    let query = query_fn(cursor);
-                    info!("postgres_sub query: {query}");
-                    let rows = match client.query(&query, &[]).await {
-                        Ok(rows) => rows,
-                        Err(e) => {
-                            yield Err(anyhow::Error::new(e).context("postgres_sub query failed"));
-                            break;
-                        }
-                    };
-                    if !rows.is_empty() {
-                        info!("postgres_sub: {} new rows", rows.len());
-                    }
-                    for row in &rows {
-                        let (time, record) = match T::from_row(row) {
-                            Ok(r) => r,
-                            Err(e) => { yield Err(e); return; }
+                Ok(async_stream::stream! {
+                    let mut cursor = start_from;
+                    loop {
+                        // Drain everything past the cursor. The first pass is the
+                        // catch-up from `start_from`; later passes fetch what the
+                        // wake-up announced.
+                        let query = query_fn(cursor);
+                        info!("postgres_sub query: {query}");
+                        let rows = match client.query(&query, &[]).await {
+                            Ok(rows) => rows,
+                            Err(e) => {
+                                yield Err(anyhow::Error::new(e).context("postgres_sub query failed"));
+                                break;
+                            }
                         };
-                        if time > cursor {
-                            cursor = time;
+                        if !rows.is_empty() {
+                            info!("postgres_sub: {} new rows", rows.len());
                         }
-                        yield Ok((time, record));
-                    }
+                        for row in &rows {
+                            let (time, record) = match T::from_row(row) {
+                                Ok(r) => r,
+                                Err(e) => { yield Err(e); return; }
+                            };
+                            if time > cursor {
+                                cursor = time;
+                            }
+                            yield Ok((time, record));
+                        }
 
-                    // Wait for the next wake-up; coalesce any that queued while
-                    // we were querying (they all mean the same thing: re-query).
-                    match rx.next().await {
-                        Some(()) => {
-                            while rx.try_recv().is_ok() {}
-                        }
-                        None => {
-                            yield Err(anyhow::anyhow!(
-                                "postgres_sub: connection to postgres closed"
-                            ));
-                            break;
+                        // Wait for the next wake-up; coalesce any that queued while
+                        // we were querying (they all mean the same thing: re-query).
+                        match rx.next().await {
+                            Some(()) => {
+                                while rx.try_recv().is_ok() {}
+                            }
+                            None => {
+                                yield Err(anyhow::anyhow!(
+                                    "postgres_sub: connection to postgres closed"
+                                ));
+                                break;
+                            }
                         }
                     }
-                }
-            })
-        }
-    })
+                })
+            }
+        },
+        None,
+    )
 }
 
 #[cfg(test)]

--- a/wingfoil/src/adapters/redis/read.rs
+++ b/wingfoil/src/adapters/redis/read.rs
@@ -24,29 +24,32 @@ pub fn redis_sub(
 ) -> Rc<dyn Stream<Burst<RedisEvent>>> {
     let connection = connection.into();
     let channel = channel.into();
-    produce_async(move |_ctx: RunParams| async move {
-        let client = redis::Client::open(connection.url.as_str())
-            .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
-        let mut pubsub = client
-            .get_async_pubsub()
-            .await
-            .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
-        pubsub
-            .subscribe(channel.as_str())
-            .await
-            .map_err(|e| anyhow::anyhow!("redis subscribe to {channel:?} failed: {e}"))?;
+    produce_async(
+        move |_ctx: RunParams| async move {
+            let client = redis::Client::open(connection.url.as_str())
+                .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
+            let mut pubsub = client
+                .get_async_pubsub()
+                .await
+                .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
+            pubsub
+                .subscribe(channel.as_str())
+                .await
+                .map_err(|e| anyhow::anyhow!("redis subscribe to {channel:?} failed: {e}"))?;
 
-        Ok(async_stream::stream! {
-            let mut messages = pubsub.on_message();
-            while let Some(msg) = messages.next().await {
-                let event = RedisEvent {
-                    channel: msg.get_channel_name().to_string(),
-                    payload: msg.get_payload_bytes().to_vec(),
-                };
-                yield Ok((NanoTime::now(), event));
-            }
-            // `on_message` ends only when the connection drops.
-            yield Err(anyhow::anyhow!("redis subscription stream closed unexpectedly"));
-        })
-    })
+            Ok(async_stream::stream! {
+                let mut messages = pubsub.on_message();
+                while let Some(msg) = messages.next().await {
+                    let event = RedisEvent {
+                        channel: msg.get_channel_name().to_string(),
+                        payload: msg.get_payload_bytes().to_vec(),
+                    };
+                    yield Ok((NanoTime::now(), event));
+                }
+                // `on_message` ends only when the connection drops.
+                yield Err(anyhow::anyhow!("redis subscription stream closed unexpectedly"));
+            })
+        },
+        None,
+    )
 }

--- a/wingfoil/src/adapters/redis/stream.rs
+++ b/wingfoil/src/adapters/redis/stream.rs
@@ -47,57 +47,60 @@ pub fn redis_stream_read(
 ) -> Rc<dyn Stream<Burst<RedisStreamEvent>>> {
     let connection = connection.into();
     let key = key.into();
-    produce_async(move |_ctx: RunParams| async move {
-        let client = redis::Client::open(connection.url.as_str())
-            .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
-        let mut conn = client
-            .get_multiplexed_async_connection()
-            .await
-            .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
+    produce_async(
+        move |_ctx: RunParams| async move {
+            let client = redis::Client::open(connection.url.as_str())
+                .map_err(|e| anyhow::anyhow!("redis client open failed: {e}"))?;
+            let mut conn = client
+                .get_multiplexed_async_connection()
+                .await
+                .map_err(|e| anyhow::anyhow!("redis connect failed: {e}"))?;
 
-        // 1. Snapshot all existing entries and capture the last ID.
-        let snapshot: StreamRangeReply = conn
-            .xrange(&key, "-", "+")
-            .await
-            .map_err(|e| anyhow::anyhow!("redis xrange on {key:?} failed: {e}"))?;
-        // "0" means "from the beginning" — used when the stream is empty so the tail
-        // picks up the very first appended entry.
-        let mut last_id = snapshot
-            .ids
-            .last()
-            .map(|id| id.id.clone())
-            .unwrap_or_else(|| "0".to_string());
-        let snapshot_events: Vec<RedisStreamEvent> =
-            snapshot.ids.iter().map(|id| to_event(&key, id)).collect();
+            // 1. Snapshot all existing entries and capture the last ID.
+            let snapshot: StreamRangeReply = conn
+                .xrange(&key, "-", "+")
+                .await
+                .map_err(|e| anyhow::anyhow!("redis xrange on {key:?} failed: {e}"))?;
+            // "0" means "from the beginning" — used when the stream is empty so the tail
+            // picks up the very first appended entry.
+            let mut last_id = snapshot
+                .ids
+                .last()
+                .map(|id| id.id.clone())
+                .unwrap_or_else(|| "0".to_string());
+            let snapshot_events: Vec<RedisStreamEvent> =
+                snapshot.ids.iter().map(|id| to_event(&key, id)).collect();
 
-        Ok(async_stream::stream! {
-            // Phase 1: emit the snapshot.
-            for event in snapshot_events {
-                yield Ok((NanoTime::now(), event));
-            }
+            Ok(async_stream::stream! {
+                // Phase 1: emit the snapshot.
+                for event in snapshot_events {
+                    yield Ok((NanoTime::now(), event));
+                }
 
-            // Phase 2: tail live appends from the snapshot boundary.
-            let opts = StreamReadOptions::default().block(0);
-            loop {
-                let reply: redis::RedisResult<StreamReadReply> =
-                    conn.xread_options(&[&key], &[&last_id], &opts).await;
-                match reply {
-                    Ok(reply) => {
-                        for stream_key in &reply.keys {
-                            for id in &stream_key.ids {
-                                last_id = id.id.clone();
-                                yield Ok((NanoTime::now(), to_event(&stream_key.key, id)));
+                // Phase 2: tail live appends from the snapshot boundary.
+                let opts = StreamReadOptions::default().block(0);
+                loop {
+                    let reply: redis::RedisResult<StreamReadReply> =
+                        conn.xread_options(&[&key], &[&last_id], &opts).await;
+                    match reply {
+                        Ok(reply) => {
+                            for stream_key in &reply.keys {
+                                for id in &stream_key.ids {
+                                    last_id = id.id.clone();
+                                    yield Ok((NanoTime::now(), to_event(&stream_key.key, id)));
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        yield Err(anyhow::anyhow!("redis xread on {key:?} failed: {e}"));
-                        break;
+                        Err(e) => {
+                            yield Err(anyhow::anyhow!("redis xread on {key:?} failed: {e}"));
+                            break;
+                        }
                     }
                 }
-            }
-        })
-    })
+            })
+        },
+        None,
+    )
 }
 
 /// Append a `Burst<RedisStreamRecord>` stream to Redis via `XADD`.

--- a/wingfoil/src/adapters/web/integration_tests.rs
+++ b/wingfoil/src/adapters/web/integration_tests.rs
@@ -409,13 +409,16 @@ fn test_burst_stream_publishes_atomic_arrays() -> anyhow::Result<()> {
     // Two values at t=100 (grouped into one Burst) and one at t=200.
     // `Burst<T>` isn't serializable, so map it to a `Vec<T>` — the wire
     // array the client surfaces as the same-time group.
-    let bursts: Rc<dyn Stream<Burst<u32>>> = produce_async(|_ctx: RunParams| async move {
-        Ok(async_stream::stream! {
-            yield Ok((NanoTime::new(100), 1u32));
-            yield Ok((NanoTime::new(100), 2u32));
-            yield Ok((NanoTime::new(200), 3u32));
-        })
-    });
+    let bursts: Rc<dyn Stream<Burst<u32>>> = produce_async(
+        |_ctx: RunParams| async move {
+            Ok(async_stream::stream! {
+                yield Ok((NanoTime::new(100), 1u32));
+                yield Ok((NanoTime::new(100), 2u32));
+                yield Ok((NanoTime::new(200), 3u32));
+            })
+        },
+        None,
+    );
     let source = bursts.map(|b: Burst<u32>| b.to_vec());
     web_pub(&server, "burst", &source)
         .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;

--- a/wingfoil/src/adapters/web/read.rs
+++ b/wingfoil/src/adapters/web/read.rs
@@ -52,21 +52,24 @@ pub fn web_sub<T: Element + Send + DeserializeOwned>(
         Some(rx)
     };
 
-    produce_async(move |ctx: RunParams| async move {
-        Ok(async_stream::stream! {
-            // A historical run replays deterministically from its sources;
-            // an open client listener would never yield and would block the
-            // run from completing, so treat web_sub as an empty source here.
-            if matches!(ctx.run_mode, crate::RunMode::HistoricalFrom(_)) {
-                return;
-            }
-            let Some(mut rx) = rx_opt else { return; };
-            while let Some(payload) = rx.recv().await {
-                match codec.decode::<T>(&payload) {
-                    Ok(v) => yield Ok((NanoTime::now(), v)),
-                    Err(e) => yield Err(anyhow::anyhow!("web_sub '{topic}': {e}")),
+    produce_async(
+        move |ctx: RunParams| async move {
+            Ok(async_stream::stream! {
+                // A historical run replays deterministically from its sources;
+                // an open client listener would never yield and would block the
+                // run from completing, so treat web_sub as an empty source here.
+                if matches!(ctx.run_mode, crate::RunMode::HistoricalFrom(_)) {
+                    return;
                 }
-            }
-        })
-    })
+                let Some(mut rx) = rx_opt else { return; };
+                while let Some(payload) = rx.recv().await {
+                    match codec.decode::<T>(&payload) {
+                        Ok(v) => yield Ok((NanoTime::now(), v)),
+                        Err(e) => yield Err(anyhow::anyhow!("web_sub '{topic}': {e}")),
+                    }
+                }
+            })
+        },
+        None,
+    )
 }

--- a/wingfoil/src/channel/kanal_chan.rs
+++ b/wingfoil/src/channel/kanal_chan.rs
@@ -20,10 +20,20 @@ use crate::types::Element;
 
 use kanal::{Receiver, Sender};
 
+/// Creates a connected sender/receiver pair.
+///
+/// `buffer_size` controls the channel capacity: `None` creates an unbounded
+/// channel (a fast producer never blocks, but an unbounded backlog can grow),
+/// while `Some(n)` creates a bounded channel of capacity `n` so the producer
+/// blocks once the buffer is full — the standard back-pressure signal.
 pub fn channel_pair<T: Element + Send>(
     ready_notifier: Option<ReadyNotifier>,
+    buffer_size: Option<usize>,
 ) -> (ChannelSender<T>, ChannelReceiver<T>) {
-    let (tx, rx) = kanal::unbounded();
+    let (tx, rx) = match buffer_size {
+        Some(n) => kanal::bounded(n),
+        None => kanal::unbounded(),
+    };
     let sender = ChannelSender::new(tx, ready_notifier);
     let receiver = ChannelReceiver::new(rx);
     (sender, receiver)
@@ -75,27 +85,27 @@ mod tests {
 
     #[test]
     fn channel_pair_creates_working_channel() {
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         tx.send_message(Message::RealtimeValue(42)).unwrap();
         assert_eq!(rx.try_recv(), Some(Message::RealtimeValue(42)));
     }
 
     #[test]
     fn try_recv_returns_none_on_empty() {
-        let (_tx, rx) = channel_pair::<u64>(None);
+        let (_tx, rx) = channel_pair::<u64>(None, None);
         assert_eq!(rx.try_recv(), None);
     }
 
     #[test]
     fn try_recv_returns_end_of_stream_when_closed() {
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         drop(tx);
         assert_eq!(rx.try_recv(), Some(Message::EndOfStream));
     }
 
     #[test]
     fn recv_returns_end_of_stream_when_sender_dropped() {
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         drop(tx);
         assert_eq!(rx.recv(), Message::EndOfStream);
     }
@@ -103,7 +113,7 @@ mod tests {
     #[test]
     fn send_in_historical_mode_wraps_as_historical_value() {
         let state = historical_state();
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         tx.send(&state, 10).unwrap();
         let msg = rx.try_recv().unwrap();
         assert!(matches!(msg, Message::HistoricalValue(_)));
@@ -112,7 +122,7 @@ mod tests {
     #[test]
     fn send_in_realtime_mode_wraps_as_realtime_value() {
         let state = realtime_state();
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         tx.send(&state, 10).unwrap();
         let msg = rx.try_recv().unwrap();
         assert_eq!(msg, Message::RealtimeValue(10));
@@ -121,7 +131,7 @@ mod tests {
     #[test]
     fn send_checkpoint() {
         let state = historical_state();
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         tx.send_checkpoint(&state).unwrap();
         let msg = rx.try_recv().unwrap();
         assert!(matches!(msg, Message::CheckPoint(_)));
@@ -130,7 +140,7 @@ mod tests {
     #[test]
     fn send_in_historical_mode_wraps_value_in_single_burst() {
         let state = historical_state();
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         tx.send(&state, 7).unwrap();
         match rx.try_recv().unwrap() {
             Message::HistoricalValue(value_at) => {
@@ -142,7 +152,7 @@ mod tests {
 
     #[test]
     fn close_sends_end_of_stream_and_idempotent() {
-        let (mut tx, rx) = channel_pair::<u64>(None);
+        let (mut tx, rx) = channel_pair::<u64>(None, None);
         tx.close().unwrap();
         assert_eq!(rx.try_recv(), Some(Message::EndOfStream));
         // second close is a no-op
@@ -151,7 +161,7 @@ mod tests {
 
     #[test]
     fn send_after_close_returns_error() {
-        let (mut tx, _rx) = channel_pair::<u64>(None);
+        let (mut tx, _rx) = channel_pair::<u64>(None, None);
         tx.close().unwrap();
         let state = realtime_state();
         assert!(tx.send(&state, 1).is_err());
@@ -159,7 +169,7 @@ mod tests {
 
     #[test]
     fn receiver_teardown_ok_when_sender_dropped() {
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         drop(tx);
         assert!(rx.teardown().is_ok());
     }
@@ -169,7 +179,7 @@ mod tests {
     fn async_send_after_receiver_dropped_errors_not_panics() {
         // Regression: a receiver dropped during shutdown is a normal teardown
         // race. The async sender must surface ChannelClosed, not panic.
-        let (tx, rx) = channel_pair::<u64>(None);
+        let (tx, rx) = channel_pair::<u64>(None, None);
         let sender = tx.into_async();
         drop(rx);
         let rt = tokio::runtime::Runtime::new().unwrap();

--- a/wingfoil/src/nodes/async_io.rs
+++ b/wingfoil/src/nodes/async_io.rs
@@ -44,13 +44,16 @@ impl<STRM, T> FutStream<T> for STRM where STRM: futures::Stream<Item = (NanoTime
 type ConsumerFunc<T, FUT> = Box<dyn FnOnce(RunParams, Pin<Box<dyn FutStream<T>>>) -> FUT + Send>;
 
 // Routes the source stream into a user-supplied async consumer via a kanal
-// `ChannelSender`. The channel is currently unbounded (see `channel_pair`), so
-// a slow consumer grows memory rather than back-pressuring the graph.
+// `ChannelSender`. This consumer channel is unbounded — it passes `None` to
+// `channel_pair` — so a slow consumer grows memory rather than back-pressuring
+// the graph. (`channel_pair` supports a bounded mode via `Some(n)`, as the
+// async producer exposes through `produce_async`'s `buffer_size`; the consumer
+// side just doesn't wire it up yet.)
 //
 // Shape-wise this is the channel-backed equivalent of `FixSenderNode` in
 // adapters/fix/mod.rs, which writes directly from `cycle` and gets back-
-// pressure for free from the kernel TCP buffer. If `channel_pair` grows a
-// bounded+blocking mode, the two could share a single "sink node"
+// pressure for free from the kernel TCP buffer. Threading a bounded
+// `buffer_size` through here too would let the two share a single "sink node"
 // abstraction parameterised by the actual write call.
 pub(crate) struct AsyncConsumerNode<T, FUT>
 where
@@ -70,7 +73,7 @@ where
     FUT: Future<Output = anyhow::Result<()>> + Send + 'static,
 {
     pub fn new(source: Rc<dyn Stream<T>>, func: ConsumerFunc<T, FUT>) -> Self {
-        let (sender, receiver) = channel_pair(None);
+        let (sender, receiver) = channel_pair(None, None);
         let rx = Some(receiver);
         let handle = None;
 
@@ -182,8 +185,8 @@ where
     FUT: Future<Output = anyhow::Result<S>> + Send + 'static,
     FUNC: FnOnce(RunParams) -> FUT + Send + 'static,
 {
-    pub fn new(func: FUNC) -> Self {
-        let (sender, receiver) = channel_pair(None);
+    pub fn new(func: FUNC, buffer_size: Option<usize>) -> Self {
+        let (sender, receiver) = channel_pair(None, buffer_size);
         let receiver_stream = ChannelReceiverStream::new(receiver, None, None);
         let handle = None;
         let func = Some(func);
@@ -294,6 +297,13 @@ where
 /// The closure receives an [`RunParams`] with `run_mode`, `run_for`, and `start_time`,
 /// allowing producers to adapt their behavior (e.g., derive time ranges for queries).
 ///
+/// `buffer_size` bounds the channel between the async producer and the graph:
+/// `None` uses an unbounded channel (the producer never blocks, but a fast
+/// producer feeding a slower graph can accumulate an arbitrarily large backlog),
+/// while `Some(n)` bounds the channel to `n` items so the producer applies
+/// back-pressure — it blocks once the buffer is full rather than growing memory
+/// without limit.
+///
 /// # Example
 /// ```ignore
 /// produce_async(|ctx| async move {
@@ -302,17 +312,20 @@ where
 ///     Ok(async_stream::stream! {
 ///         // Use start, end in async code...
 ///     })
-/// })
+/// }, None)
 /// ```
 #[must_use]
-pub fn produce_async<T, S, FUT, FUNC>(func: FUNC) -> Rc<dyn Stream<Burst<T>>>
+pub fn produce_async<T, S, FUT, FUNC>(
+    func: FUNC,
+    buffer_size: Option<usize>,
+) -> Rc<dyn Stream<Burst<T>>>
 where
     T: Element + Send,
     S: futures::Stream<Item = anyhow::Result<(NanoTime, T)>> + Send + 'static,
     FUT: Future<Output = anyhow::Result<S>> + Send + 'static,
     FUNC: FnOnce(RunParams) -> FUT + Send + 'static,
 {
-    AsyncProducerStream::new(func).into_stream()
+    AsyncProducerStream::new(func, buffer_size).into_stream()
 }
 
 trait StreamMessageSource<T: Element + Send> {
@@ -464,7 +477,7 @@ mod tests {
             })
         };
 
-        let collected = produce_async(producer).collect();
+        let collected = produce_async(producer, None).collect();
 
         collected
             .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
@@ -498,7 +511,7 @@ mod tests {
             })
         };
 
-        let result = produce_async(producer)
+        let result = produce_async(producer, None)
             .collapse()
             .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever);
 
@@ -547,13 +560,48 @@ mod tests {
                         Ok(())
                     };
 
-                produce_async(example_producer)
+                produce_async(example_producer, None)
                     .collapse()
                     .logged("on-graph", log::Level::Info)
                     .consume_async(Box::new(example_consumer))
                     .run(run_mode, run_for)
                     .unwrap();
             }
+        }
+    }
+
+    /// A bounded channel (`Some(n)`) applies back-pressure but must not drop or
+    /// reorder data: every value the producer emits still reaches the graph, in
+    /// order, exactly as the unbounded (`None`) case does. We assert this across
+    /// buffer sizes, including `Some(1)` — maximum back-pressure, where the
+    /// producer blocks after every single item.
+    #[test]
+    fn produce_async_bounded_buffer_delivers_all_values_in_order() {
+        let _ = env_logger::try_init();
+        let period = Duration::from_nanos(10);
+        let n = 10u32;
+        let expected: Vec<u32> = (0..n).collect();
+
+        for buffer_size in [None, Some(1usize), Some(3), Some(100)] {
+            let producer = move |ctx: RunParams| async move {
+                Ok(async_stream::stream! {
+                    for i in 0..n {
+                        let time = ctx.start_time + period * i;
+                        yield Ok((time, i));
+                    }
+                })
+            };
+
+            let collected = produce_async(producer, buffer_size).collapse().collect();
+            collected
+                .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+                .expect("bounded producer must complete without error");
+
+            let delivered: Vec<u32> = collected.peek_value().iter().map(|v| v.value).collect();
+            assert_eq!(
+                delivered, expected,
+                "buffer_size {buffer_size:?} must deliver all values in order"
+            );
         }
     }
 }

--- a/wingfoil/src/nodes/channel.rs
+++ b/wingfoil/src/nodes/channel.rs
@@ -300,7 +300,7 @@ mod tests {
     /// burst instead of being split across cycles.
     #[test]
     fn same_time_burst_does_not_break_monotonic_engine_time() {
-        let (sender, receiver) = channel_pair::<u64>(None);
+        let (sender, receiver) = channel_pair::<u64>(None, None);
 
         // A burst of two ticks at the *same* engine time, fanned out as separate
         // messages onto the channel.

--- a/wingfoil/src/nodes/graph_node.rs
+++ b/wingfoil/src/nodes/graph_node.rs
@@ -72,7 +72,7 @@ where
                     RunMode::HistoricalFrom(_) => None,
                     RunMode::RealTime => Some(graph_state.ready_notifier()),
                 };
-                let (sender, receiver) = channel_pair(notifier);
+                let (sender, receiver) = channel_pair(notifier, None);
                 let mut receiver_stream = ChannelReceiverStream::new(receiver, None, None);
                 receiver_stream.setup(graph_state)?;
                 self.receiver_stream
@@ -173,7 +173,7 @@ where
 {
     pub fn new(source: Rc<dyn Stream<IN>>, func: FUNC) -> Self {
         let trigger = Some(source.clone().as_node());
-        let (sender_out, receiver_out) = channel_pair(None);
+        let (sender_out, receiver_out) = channel_pair(None, None);
         //let receiver_out = ChannelReceiver::new(rx_out);
         let receiver_stream = ChannelReceiverStream::new(receiver_out, trigger, None);
         let state = GraphMapStreamState::Func(func, sender_out);
@@ -228,7 +228,7 @@ where
                 let run_for = graph_state.run_for();
                 let tokio_runtime = graph_state.tokio_runtime();
                 let start_time = graph_state.start_time();
-                let (mut sender_in, receiver_in) = channel_pair(None);
+                let (mut sender_in, receiver_in) = channel_pair(None, None);
                 let task = move || {
                     let src = ChannelReceiverStream::new(receiver_in, None, tx_notif).into_stream();
                     let node = func(src.clone()).send(sender_out, Some(src.as_node()));

--- a/wingfoil/src/nodes/receiver.rs
+++ b/wingfoil/src/nodes/receiver.rs
@@ -145,7 +145,7 @@ impl<T: Element + Send> ReceiverStream<T> {
         f: impl Fn(ChannelSender<T>, Arc<AtomicBool>) -> anyhow::Result<()> + Send + 'static,
         assert_realtime: bool,
     ) -> Self {
-        let (sender, receiver) = channel_pair(None);
+        let (sender, receiver) = channel_pair(None, None);
         let inner = ChannelReceiverStream::new(receiver, None, None);
         let sender = Some(sender);
         let stop = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
## What & why

`channel_pair` always created an **unbounded** channel, so a fast async producer (a KDB+ replay, a high-frequency async source) feeding a slower graph could accumulate an arbitrarily large backlog with no way to apply back-pressure. This threads an explicit `buffer_size` control through the async producer path.

Closes #140.

## Changes

- **`channel_pair(ready_notifier, buffer_size: Option<usize>)`** (`channel/kanal_chan.rs`) now branches between `kanal::unbounded()` (`None`) and `kanal::bounded(n)` (`Some(n)`).
- **`produce_async(func, buffer_size: Option<usize>)`** and **`kdb_read(connection, period, query_fn, buffer_size: Option<usize>)`** gain a required `buffer_size` parameter:
  - `None` → unbounded (current behaviour).
  - `Some(n)` → bounded channel of capacity `n`; the producer blocks once full — the standard async back-pressure pattern, capping memory use.
- All existing internal callers pass `None`, preserving current behaviour: every adapter read/sub (`redis`, `etcd`, `web`, `postgres`, `fluvio`, `kafka`, `kdb`, `iceoryx2`, `fix`), the async consumer path, the `async`/`kdb` examples, and the Python `kdb` binding.
- Doc comments on the three public fns describe `None` = unbounded vs `Some(n)` = bounded back-pressure; the now-stale "channel is currently unbounded" comments in `async_io.rs` / `fix/mod.rs` are updated.

### Breaking change

`produce_async` and `kdb_read` take a new required parameter (per the issue's proposed API). All in-tree call sites and examples are updated in this PR; external callers must add a trailing `None` (or `Some(n)`) argument.

**Out of scope:** `kdb_read_cached` is left unchanged — the issue scopes only `produce_async` and `kdb_read`, so its breaking surface is not widened here.

## Verification

- New historical-mode unit test `produce_async_bounded_buffer_delivers_all_values_in_order` asserts a bounded channel (`Some(1)`, `Some(3)`, `Some(100)`) delivers every value in order, identically to the unbounded (`None`) case — back-pressure must not drop or reorder data.
- `cargo fmt --all -- --check` — clean
- `cargo lint` (default features) — clean
- `cargo lint-all` (all features, incl. `aeron`/`iceoryx2`/`kdb`/`web`/`postgres`/…) — clean
- `cargo test -p wingfoil` — 226 passed; `cargo test -p wingfoil --features kdb` — 265 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9vhmitxF4Ckmkp2gq96VY)_