### PR TITLE
Add feedback channel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Short code snippets for each adapter live in the [examples README](https://githu
 | [`async`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/async/) | Integrate Tokio async/await at graph edges (adapters) while keeping the core graph synchronous. |
 | [`threading`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/threading/) | Distribute graph execution across worker threads with `producer()` / `mapper()`. |
 | [`dynamic`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/dynamic/) | Add and remove nodes at runtime. Includes `demux`, `dynamic-group`, and `dynamic-manual` variants. |
+| [`feedback`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/feedback/) | Close a loop between two nodes with a `feedback` channel — a proportional control loop where the plant's output feeds back into the controller's input, which a plain DAG can't express. |
 | [`tracing`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/tracing/) | Instrumentation modes (log, tracing, instruments) for event and span handling. |
 | [`latency`](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/examples/latency/) | Per-hop latency stamping with `Traced<T, L>` and `LatencyReport`, transported over iceoryx2. |
 

--- a/wingfoil/examples/feedback/README.md
+++ b/wingfoil/examples/feedback/README.md
@@ -1,0 +1,92 @@
+## Feedback Example
+
+A wingfoil graph is a *directed acyclic* graph: you build it in dependency order
+and the scheduler walks it one way, from sources to sinks. A `feedback` channel
+lets you close a loop between two nodes — where A's input depends on B and B's
+input depends on A — which a DAG can't otherwise express.
+
+`feedback::<T>()` returns a pair:
+
+- `tx` — a `FeedbackSink<T>`, the **write** end. Cloneable, movable into closures.
+- `rx` — a `Stream<T>` (or `Node`, via `feedback_node()`). It has no upstreams,
+  so the graph stays acyclic. A value written via `tx` is emitted on the next
+  engine tick — a one-step delay, exactly the sample delay a discrete control
+  loop expects.
+
+Because `rx` gives you the read end of a value *before* that value is produced,
+you can reference it upstream of the node that computes it.
+
+### A proportional control loop
+
+This example regulates a room's temperature to a setpoint with a proportional
+controller. The loop runs through three nodes:
+
+```text
+                 ┌──────────── feedback (temperature) ───────────┐
+                 │                                                │
+                 ▼                                                │
+   setpoint ─▶ ┌───────┐   error   ┌────────┐  heater  ┌───────┐  │
+               │ error │ ────────▶ │ heater │ ───────▶ │ plant │ ─┘
+   clock ────▶ └───────┘           └────────┘          └───────┘
+              (controller)      (control signal)        (room)
+```
+
+`error` needs the temperature, but the temperature is produced by `plant`,
+downstream of `error`. The feedback channel carries it back around the loop.
+
+```rust,ignore
+use std::time::Duration;
+use wingfoil::*;
+
+let period = Duration::from_secs(1);
+let setpoint = 20.0_f64;
+let gain = 0.5_f64;
+
+// A clock to advance the loop one step per period.
+let clock = ticker(period).count();
+
+// temp_rx lets us reference the temperature before the plant produces it.
+let (temp_tx, temp_rx) = feedback::<f64>();
+
+// Controller: distance from setpoint, then how hard to drive the heater.
+let error = bimap(
+    Dep::Active(clock),
+    Dep::Passive(temp_rx.clone()),
+    move |_, temp| setpoint - temp,
+);
+let heater = error.map(move |e| gain * e);
+
+// Plant (the room): new temperature = old temperature + heater output.
+let plant = bimap(Dep::Active(heater), Dep::Passive(temp_rx), |power, temp| temp + power);
+
+// Close the loop by feeding each new temperature back.
+plant
+    .feedback(temp_tx)
+    .for_each(|t, _| println!("temperature: {t:.3}"))
+    .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Duration(period * 7))?;
+```
+
+Run it:
+
+```bash
+cargo run --example feedback
+```
+
+The temperature converges on the setpoint, each step closing half the remaining
+gap:
+
+```text
+temperature: 10.000
+temperature: 15.000
+temperature: 17.500
+temperature: 18.750
+temperature: 19.375
+temperature: 19.688
+temperature: 19.844
+temperature: 19.922
+```
+
+See the [`feedback` API docs](https://docs.rs/wingfoil/latest/wingfoil/fn.feedback.html)
+for the full surface, including `feedback_node()` for tick-only reset signals
+(often paired with
+[`delay_with_reset`](https://docs.rs/wingfoil/latest/wingfoil/trait.StreamOperators.html)).

--- a/wingfoil/examples/feedback/main.rs
+++ b/wingfoil/examples/feedback/main.rs
@@ -1,0 +1,50 @@
+#![doc = include_str!("./README.md")]
+
+use std::time::Duration;
+
+use wingfoil::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let period = Duration::from_secs(1);
+    let setpoint = 20.0_f64; // target temperature
+    let gain = 0.5_f64; // proportional controller gain
+
+    // A clock to advance the control loop one step per period.
+    let clock = ticker(period).count();
+
+    // The feedback channel carries the room temperature. `temp_rx` lets us
+    // reference the temperature *before* the plant that produces it exists —
+    // which is what makes the loop below constructible at all.
+    let (temp_tx, temp_rx) = feedback::<f64>();
+
+    // Controller: how far are we from the setpoint, and how hard to drive.
+    // `error` reads the fed-back temperature (passive: the clock drives ticks).
+    let error = bimap(
+        Dep::Active(clock),
+        Dep::Passive(temp_rx.clone()),
+        move |_, temp| setpoint - temp,
+    );
+    // Control signal: how hard to drive the heater.
+    let heater = error.map(move |e| gain * e);
+
+    // Plant: the room. New temperature = old temperature + heater output.
+    let plant = bimap(Dep::Active(heater), Dep::Passive(temp_rx), |power, temp| {
+        temp + power
+    });
+
+    // Close the loop: feed each new temperature back so the next step's
+    // `error` can read it. plant -> heater -> error -> plant is a genuine
+    // cycle; the feedback channel is the only edge that can express it.
+    let temperature = plant.feedback(temp_tx);
+
+    temperature
+        .for_each(|t, _| println!("temperature: {t:.3}"))
+        .run(
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Duration(period * 7),
+        )?;
+
+    Ok(())
+}


### PR DESCRIPTION
Add a runnable `feedback` example demonstrating how to route a
downstream value back into the graph on the next cycle using a
`feedback` channel — expressing cyclic, stateful calculations (a
running total) without breaking the DAG. Link it from the core-concepts
table in the top-level README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V7KzSXKi5AeWS1FD2yVWcV