### PR TITLE
docs: refresh root CLAUDE.md repository structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,19 +13,27 @@ wingfoil/           # Core Rust library
   src/
     lib.rs          # Public API re-exports
     types.rs        # Core traits: Element, Node, MutableNode, Stream
-    graph.rs        # Graph execution engine
+    graph.rs        # Graph execution engine (RunMode, RunFor)
     time.rs         # NanoTime (nanoseconds from UNIX epoch)
-    nodes/          # 37 node implementations (map, filter, fold, etc.)
-    adapters/       # I/O adapters (CSV, sockets, KDB+, iterators)
+    nodes/          # 40+ node implementations (map, filter, fold, delay, feedback, etc.)
+    adapters/       # I/O adapters (CSV, ZMQ, Kafka, KDB+, Redis, Postgres, etcd,
+                    #   FIX, web, Aeron, iceoryx2, Fluvio, augurs, Prometheus, OTLP)
+                    #   — each adapter directory has its own CLAUDE.md
     channel/        # Inter-node communication (kanal)
-    queue/          # Data structures (TimeQueue, HashByRef)
-  examples/         # Usage examples (order_book, rfq, async, breadth_first, circuit_breaker, threading)
+    queue/          # Data structures (TimeQueue, ValueAt)
+  examples/         # Usage examples (order_book, async, breadth_first, dynamic,
+                    #   feedback, threading, plus one per adapter)
   benches/          # Criterion benchmarks
 
-wingfoil-python/    # PyO3 Python bindings
+wingfoil-derive/    # Proc macros (#[node] attribute)
+wingfoil-python/    # PyO3 Python bindings (built with maturin)
   src/
   python/           # Python package
   tests/            # pytest tests
+wingfoil-wire-types/ # Wire-format types shared by the web adapter and wingfoil-wasm
+wingfoil-wasm/      # Browser-side WASM codec (excluded from the default workspace)
+wingfoil-js/        # TypeScript client for the web adapter (@wingfoil/client)
+scripts/            # Dev helpers (setup-dev.sh, ci-logs.sh)
 ```
 
 ## System Dependencies
@@ -57,6 +65,9 @@ cargo test -p wingfoil-python
 
 # Python tests
 cd wingfoil-python && maturin develop && pytest
+
+# TypeScript client tests
+cd wingfoil-js && pnpm test
 
 # Benchmarks
 cargo bench

--- a/wingfoil/src/adapters/aeron/CLAUDE.md
+++ b/wingfoil/src/adapters/aeron/CLAUDE.md
@@ -24,6 +24,9 @@ aeron/
   CLAUDE.md            # This file
 ```
 
+Runnable demos (`--features aeron`, need a live media driver):
+`examples/aeron/main.rs` and `examples/aeron/status_circuit_breaker.rs`.
+
 ## Backends
 
 Enable **exactly one** backend feature:
@@ -117,12 +120,12 @@ from the `full` feature set.
    bind-mounting `/dev/shm` so the host client shares the CNC file over
    `aeron:ipc`.
 
-2. **Format and lint both backends:**
+2. **Format and lint:**
 
    ```bash
    cargo fmt --all
-   cargo clippy -p wingfoil --features aeron,aeron-driver --all-targets -- -D warnings
-   cargo clippy -p wingfoil --features aeron-rs   --all-targets -- -D warnings
+   cargo lint        # default features
+   cargo lint-all    # all features (covers both aeron backends)
    ```
 
 ## Gotchas

--- a/wingfoil/src/adapters/augurs/CLAUDE.md
+++ b/wingfoil/src/adapters/augurs/CLAUDE.md
@@ -18,7 +18,7 @@ The `Vec<f64>` operators take one reading per series per tick.
 
 ```
 augurs/
-  mod.rs         # Module doc, value types, transpose_window() helper
+  mod.rs         # Module doc, value types, transpose_window() + push_windowed() helpers
   forecast.rs    # ETS + MSTL forecasting
   outlier.rs     # MAD + DBSCAN outlier detection
   changepoint.rs # Bayesian online changepoint detection
@@ -27,6 +27,9 @@ augurs/
   cluster.rs     # DBSCAN clustering over the DTW distance matrix
   CLAUDE.md      # This file
 ```
+
+Runnable demo: `cargo run --example augurs --features augurs`
+(`examples/augurs/main.rs`).
 
 ## Key Design Decisions
 
@@ -56,8 +59,9 @@ augurs/
 - **Model / detector choice via config, not new operators.** `augurs_forecast`
   takes an `AugursForecastModel` (`Ets` | `Mstl{periods}`) and `augurs_outlier`
   an `AugursOutlierDetector` (`Mad` | `Dbscan`), keeping one operator per
-  concern. `AugursForecastConfig::mstl(periods)` and
-  `AugursOutlierConfig::dbscan(...)` are the ergonomic constructors.
+  concern. The ergonomic spellings are the `.mstl(periods)` builder method
+  (`AugursForecastConfig::new(w, h).mstl(vec![24])`) and the
+  `AugursOutlierConfig::dbscan(...)` constructor.
 
 - **Warm-up floors.** ETS needs >~8 points (floored at 12). MSTL/STL cannot
   decompose fewer than **two full seasonal periods**, so the forecast floor
@@ -94,6 +98,7 @@ augurs/
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets --all-features
+cargo lint        # default features
+cargo lint-all    # all features
 cargo test -p wingfoil --features augurs adapters::augurs
 ```

--- a/wingfoil/src/adapters/csv/CLAUDE.md
+++ b/wingfoil/src/adapters/csv/CLAUDE.md
@@ -7,7 +7,7 @@ Reads and writes comma-separated values files as wingfoil streams.
 ```
 csv/
   mod.rs        # Module-level doc, re-exports from read and write
-  read.rs       # csv_read, csv_iterator (pub(super))
+  read.rs       # csv_read, private csv_iterator, tests
   write.rs      # CsvWriterNode, CsvOperators, tests
   test_data/    # CSV fixtures used by unit tests
   CLAUDE.md     # This file
@@ -17,8 +17,8 @@ csv/
 
 ### Reading — `csv_read`
 
-- `csv_read(path, get_time_func, has_headers)` — emits `Burst<T>` per tick; multiple rows with the same timestamp are grouped into a single burst (uses `IteratorStream`)
-- Delegates to the private `csv_iterator` which deserialises rows via `serde`
+- `csv_read(path, get_time_func, has_headers)` — returns `anyhow::Result<Rc<dyn Stream<Burst<T>>>>` (a missing file is an error, not a panic); emits `Burst<T>` per tick; multiple rows with the same timestamp are grouped into a single burst (uses `TryIteratorStream`)
+- Delegates to the private `csv_iterator` which deserialises rows via `serde`; a row that fails to deserialize surfaces as a graph-run error rather than a panic
 
 ### Writing — `CsvOperators`
 
@@ -27,20 +27,24 @@ csv/
 
 Headers are written lazily on first tick using `serde_aux::serde_introspection::serde_introspect`.
 
-### `IteratorStream` / `SimpleIteratorStream`
+### `TryIteratorStream` / `IteratorStream` / `SimpleIteratorStream`
 
 These general-purpose nodes live in `crate::nodes` (not the adapters layer).
-The CSV adapter imports them directly; they are also available via `wingfoil::*`.
+The CSV adapter imports `TryIteratorStream` directly (its iterator yields
+`anyhow::Result` items so row errors propagate); they are also available via `wingfoil::*`.
 
 ## Test Data
 
-Unit tests live in `write.rs` and use files under `src/adapters/csv/test_data/`
+Unit tests live in `read.rs` and `write.rs` and use files under `src/adapters/csv/test_data/`
 (paths are relative to the package root `wingfoil/`, which is Cargo's cwd when running tests).
 
 ## Pre-Commit Requirements
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets --all-features
-cargo test -p wingfoil
+cargo lint        # default features
+cargo lint-all    # all features
+cargo test -p wingfoil --features csv
 ```
+
+The adapter is gated behind the (non-default) `csv` feature.

--- a/wingfoil/src/adapters/etcd/CLAUDE.md
+++ b/wingfoil/src/adapters/etcd/CLAUDE.md
@@ -26,11 +26,14 @@ etcd/
 
 ### Writing to etcd — `etcd_pub`
 
-- `etcd_pub(conn, upstream, lease_ttl)` — consumes `Burst<EtcdEntry>`, issues one PUT per entry
-- `EtcdPubOperators::etcd_pub(conn, lease_ttl)` — fluent API on `Rc<dyn Stream<Burst<EtcdEntry>>>`
+- `etcd_pub(conn, upstream, lease_ttl, force)` — consumes `Burst<EtcdEntry>`, issues one PUT per entry
+- `EtcdPubOperators::etcd_pub(conn, lease_ttl, force)` — fluent API, implemented for both
+  `Rc<dyn Stream<Burst<EtcdEntry>>>` and `Rc<dyn Stream<EtcdEntry>>` (single entries are auto-wrapped)
 - Pass `lease_ttl: None` for plain writes (keys persist until deleted)
 - Pass `lease_ttl: Some(Duration)` to attach an etcd lease with automatic keepalive renewal;
   the lease is revoked on clean shutdown so keys vanish immediately
+- `force: true` silently overwrites existing keys; `force: false` issues a conditional
+  transaction (`create_revision == 0`) and errors if the key already exists
 
 ### Types
 
@@ -64,8 +67,8 @@ out as a duplicate.
 
    ```bash
    cargo fmt --all
-   cargo clippy --workspace --all-targets --all-features
-   cargo test -p wingfoil
+   cargo lint        # default features
+   cargo lint-all    # all features
    ```
 
 ## Integration Test Details
@@ -89,13 +92,17 @@ Tests must be run with `--test-threads=1` to avoid port conflicts between contai
 | `test_pub_lease_keys_expire_after_revoke` | Leased keys vanish immediately when consumer stops |
 | `test_pub_lease_keepalive_extends_ttl` | Keepalive renews lease so keys survive past raw TTL |
 | `test_pub_no_lease_keys_persist` | `None` lease: keys remain after consumer stops |
+| `test_pub_force_true_overwrites` | `force: true` silently overwrites an existing key |
+| `test_pub_force_false_fails_if_exists` | `force: false` errors (naming the key) and leaves the original value |
+| `test_pub_force_false_succeeds_if_absent` | `force: false` writes normally when the key is absent |
 | `test_sub_delete_events` | `EtcdEventKind::Delete` is emitted correctly |
 | `test_sub_no_race_between_snapshot_and_watch` | Concurrent write not missed or duplicated |
+| `test_etcd_kv_value_str` | `EtcdEntry::value_str()` UTF-8 accessor (no container needed) |
 
 ## Notes
 
 - `etcd-client` is pinned to `"0.18"`. The API changed significantly between versions.
-- `testcontainers-modules` 0.15 does not include an etcd module; we use `GenericImage`
-  with `gcr.io/etcd-development/etcd` directly.
+- There is no ready-made etcd testcontainers module; tests use `testcontainers` (0.27,
+  `blocking` feature) with `GenericImage` and `gcr.io/etcd-development/etcd` directly.
 - `etcd_sub` is designed for `RunMode::RealTime`. Using it in `HistoricalFrom` mode is
   technically valid but timestamps will be wall-clock `NanoTime::now()`, not historical.

--- a/wingfoil/src/adapters/fix/CLAUDE.md
+++ b/wingfoil/src/adapters/fix/CLAUDE.md
@@ -28,11 +28,25 @@ This avoids the overhead of an async runtime for a protocol where microsecond la
 ### FixConnection and fix_sub
 
 `fix_connect_tls` returns a `FixConnection` bundling the data/status streams and session handle.
-`FixConnection::fix_sub(&["4001"])` creates a graph node that watches the status stream and
-automatically sends `MarketDataRequest` messages once the session reaches `LoggedIn`.
+`FixConnection::fix_sub(symbols)` takes a `Rc<dyn Stream<Vec<String>>>` of symbol IDs (e.g.
+`constant(vec!["4001".into()])`) and creates a graph node that watches the status stream and
+automatically sends `MarketDataRequest` messages once the session reaches `LoggedIn`; symbols
+arriving before logon are queued and subscribed on login.
 `FixConnection::send(msg)` and `FixConnection::sender()` provide raw access for advanced
-use cases (e.g. throttled sweeps, custom message types). `FixSenderNode` is a separate sink for
-cases where a dedicated outbound connection is needed (e.g. order routing).
+use cases (e.g. throttled sweeps, custom message types). `FixOperators::fix_send` (backed by the
+private `FixSenderNode`) is a separate sink for cases where a dedicated outbound connection is
+needed (e.g. order routing).
+
+### Initiator reconnect after a session drop
+
+In `Threaded` mode (which `fix_connect_tls`/`fix_connect_tls_logon` always use), an initiator
+whose *established* session drops reconnects instead of giving up: the session thread pauses
+`RECONNECT_DELAY` (500 ms) so a flapping venue isn't hammered, then re-connects with a fresh
+`FixSession` that re-logs-in. Status consumers see `Disconnected` then a new `LoggedIn` —
+`fix_sub` does not re-send subscriptions on relogin, so resubscription logic must key off
+`LoggedIn` itself if needed. Initial connect *failures* still give up (an `Error` status is
+emitted); acceptors loop to re-accept. `AlwaysSpin` initiators do not reconnect. Covered by the
+`initiator_reconnects_after_a_session_drop` unit test.
 
 ### Pluggable Logon authentication (`FixLogon`)
 
@@ -68,8 +82,9 @@ unused dependency for it.
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings
-cargo test -p wingfoil -- fix::tests    # unit tests (no network)
+cargo lint        # default features
+cargo lint-all    # all features
+cargo test -p wingfoil --features fix -- fix::tests    # unit tests (no network)
 ```
 
 Integration tests (requires LMAX credentials):

--- a/wingfoil/src/adapters/fluvio/CLAUDE.md
+++ b/wingfoil/src/adapters/fluvio/CLAUDE.md
@@ -29,7 +29,8 @@ fluvio/
 ### Writing to Fluvio — `fluvio_pub`
 
 - `fluvio_pub(conn, topic, upstream)` — consumes `Burst<FluvioRecord>`, sends one record per entry
-- `FluvioPubOperators::fluvio_pub(conn, topic)` — fluent API on `Rc<dyn Stream<Burst<FluvioRecord>>>`
+- `FluvioPubOperators::fluvio_pub(conn, topic)` — fluent API, implemented for both
+  `Rc<dyn Stream<Burst<FluvioRecord>>>` and `Rc<dyn Stream<FluvioRecord>>` (single records are auto-wrapped)
 - Records are flushed **once per burst** (after all records in a burst are sent) for batching efficiency
 - `FluvioRecord::new(value)` — keyless record (`RecordKey::NULL`)
 - `FluvioRecord::with_key(key, value)` — record with a string key
@@ -71,23 +72,32 @@ admin.create::<TopicSpec>("my-topic", false, TopicSpec::new_computed(1, 1, None)
 ## Integration Test Details
 
 Tests use `testcontainers` (`SyncRunner`) to start an `infinyon/fluvio:0.18.1`
-container running the SC in local mode. Docker must be running.
+container with **host networking**, running a full local cluster (SC + SPU).
+Docker must be running. `start_fluvio()` in `integration_tests.rs`:
 
-Feature flag: `fluvio-integration-test` (implies `fluvio`).
+1. Starts the SC and waits for the log line `"Streaming Controller started successfully"`,
+   then probes port 9003 until it accepts (the log line races the listener bind).
+2. Registers a `CustomSpuSpec` via `FluvioAdmin` — the SC must know about the SPU
+   before the SPU process connects, otherwise the SC closes the connection.
+3. Execs the SPU process (`/fluvio-run spu`) into the running container.
+4. Sleeps 3 s for the SPU to complete registration.
+
+Host networking is required so the SPU public endpoint (`127.0.0.1:9010`), which
+the SC hands to clients, is reachable from the test process.
+
+Feature flag: `fluvio-integration-test` (implies `fluvio`; also pulls in
+`testcontainers` and `fluvio-controlplane-metadata`).
 
 Tests must be run with `--test-threads=1` to avoid port conflicts.
 
 ### Known gotchas
 
-1. **Container wait time**: The integration tests use `WaitFor::millis(8_000)` for
-   container startup. If tests fail due to the SC not being ready in time, increase
-   this value. The exact log message emitted by the SC on startup is
-   implementation-dependent and may vary across Fluvio versions.
+1. **SC startup race**: the SC logs "started successfully" *before* binding its 9003
+   listener; without the port probe, back-to-back tests fail with `ECONNREFUSED`.
 
-2. **SPU not registered**: The SC container alone does not automatically start an SPU.
-   Producer/consumer operations require a registered SPU. If tests fail with "no SPU
-   registered", the container setup needs to include SPU startup. Consider using
-   `fluvio cluster start --local` inside the container to start both SC and SPU.
+2. **SPU must be pre-registered**: producer/consumer operations require a registered
+   SPU. If tests fail with "no SPU registered", the SPU registration/exec sequence
+   above did not complete — check the 3 s registration sleep is long enough.
 
 3. **Topic must exist**: Fluvio will return an error (`TopicNotFound`) if you try to
    produce to or consume from a topic that does not exist. Always call `create_topic`
@@ -107,7 +117,7 @@ Tests must be run with `--test-threads=1` to avoid port conflicts.
 
 ## Pre-Commit Requirements
 
-1. **Run integration tests (requires Docker + running Fluvio cluster):**
+1. **Run integration tests (requires Docker; tests start their own cluster):**
 
    ```bash
    cargo test --features fluvio-integration-test -p wingfoil \
@@ -118,8 +128,8 @@ Tests must be run with `--test-threads=1` to avoid port conflicts.
 
    ```bash
    cargo fmt --all
-   cargo clippy --workspace --all-targets --all-features
-   cargo test -p wingfoil
+   cargo lint        # default features
+   cargo lint-all    # all features
    ```
 
 ### Test Coverage

--- a/wingfoil/src/adapters/iceoryx2/CLAUDE.md
+++ b/wingfoil/src/adapters/iceoryx2/CLAUDE.md
@@ -6,8 +6,8 @@ Zero-copy inter-process communication (IPC) via shared memory using iceoryx2.
 
 ```
 iceoryx2/
-  mod.rs               # Config types (ServiceContract, SubOpts, PubOpts, Mode, Variant),
-                       #   FixedBytes<N>, Iceoryx2Error, unit tests
+  mod.rs               # Config types (ServiceContract, SliceContract, SubOpts, PubOpts,
+                       #   PubSliceOpts, Mode, Variant), FixedBytes<N>, Iceoryx2Error, unit tests
   read.rs              # iceoryx2_sub*, Iceoryx2ReceiverStream — subscriber (producer)
   write.rs             # iceoryx2_pub* — publisher (consumer)
   local_tests.rs       # in-process Local-variant tests (run with default test suite)
@@ -31,17 +31,18 @@ All participants on the same service must use compatible `Iceoryx2ServiceContrac
 ### Typed vs Slice APIs
 
 - **Typed** (`iceoryx2_sub<T>` / `iceoryx2_pub<T>`) — `T` must be `#[repr(C)]`, `ZeroCopySend`, and self-contained (no heap pointers).
-- **Slice** (`iceoryx2_sub_slice` / `iceoryx2_pub_slice`) — transfers `Vec<u8>` via `[u8]` shared memory slices. Used by Python bindings via `FixedBytes<N>`.
+- **Slice** (`iceoryx2_sub_slice` / `iceoryx2_pub_slice`) — transfers `Vec<u8>` via `[u8]` shared memory slices. Used by the Python bindings (`wingfoil-python/src/py_iceoryx2.rs` calls `iceoryx2_sub_slice_opts` / `iceoryx2_pub_slice_opts`).
 
 ### FixedBytes<N>
 
-A `#[repr(C)]` fixed-size byte buffer implementing `ZeroCopySend`. Bridges the gap between variable-length Python bytes and iceoryx2's fixed-layout shared memory.
+A `#[repr(C)]` fixed-size byte buffer implementing `ZeroCopySend`, for carrying variable-length bytes through the typed API. Currently only defined/tested in `mod.rs` — the Python bindings use the slice API instead.
 
 ## Pre-Commit Requirements
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets --exclude wingfoil-python -- -D warnings
+cargo lint        # default features
+cargo lint-all    # all features
 cargo test -p wingfoil --features iceoryx2
 cargo test -p wingfoil --features iceoryx2-integration-test -- --test-threads=1
 ```

--- a/wingfoil/src/adapters/kafka/CLAUDE.md
+++ b/wingfoil/src/adapters/kafka/CLAUDE.md
@@ -23,11 +23,14 @@ kafka/
   - Subscribes to the topic and streams messages as they arrive
   - Each message becomes a `KafkaEvent` with topic, partition, offset, key, and value
   - Uses `auto.offset.reset = earliest` to read from the beginning for new groups
+  - Uses `enable.auto.commit = true` — at-most-once delivery; disable auto-commit
+    and manage offsets via the rdkafka API if you need at-least-once
 
 ### Writing to Kafka — `kafka_pub`
 
-- `kafka_pub(conn, upstream)` — consumes `Burst<KafkaRecord>`, produces every record in the burst concurrently
-- `KafkaPubOperators::kafka_pub(conn)` — fluent API on `Rc<dyn Stream<Burst<KafkaRecord>>>`
+- `kafka_pub(conn, &upstream)` — consumes `Burst<KafkaRecord>`, produces every record in the burst concurrently
+- `KafkaPubOperators::kafka_pub(conn)` — fluent API on both `Rc<dyn Stream<Burst<KafkaRecord>>>`
+  and `Rc<dyn Stream<KafkaRecord>>` (single records are wrapped in a burst automatically)
 - Each `KafkaRecord` specifies its target topic, allowing multi-topic writes from a single consumer
 - All records in a burst are handed to the producer up front and their delivery futures drained
   together via `FuturesUnordered`, so per-burst latency is one broker roundtrip rather than N
@@ -59,7 +62,8 @@ kafka/
 
    ```bash
    cargo fmt --all
-   cargo clippy --workspace --all-targets --all-features
+   cargo lint        # default features
+   cargo lint-all    # all features
    cargo test -p wingfoil
    ```
 

--- a/wingfoil/src/adapters/kdb/CLAUDE.md
+++ b/wingfoil/src/adapters/kdb/CLAUDE.md
@@ -9,9 +9,12 @@ kdb/
   mod.rs               # Public API, connection types, error handling, Sym
   read.rs              # kdb_read() and helpers (KdbExt, upd_payload_rows, etc.); time slicing lives in adapters::common
   read_cached.rs       # kdb_read_cached() — file-cached variant of kdb_read
+                       #   (cache machinery — CacheConfig, FileCache — lives in adapters::cache)
   sub.rs               # kdb_sub() — real-time tickerplant subscription
   write.rs             # kdb_write() - writing stream data to KDB+ tables
   integration_tests.rs # Integration tests (requires running KDB+ instance)
+  cache_integration_tests.rs # Integration tests for kdb_read_cached (same gating)
+  docker/              # Dockerfile + q binary for running a KDB+ test instance on port 5000
 ```
 
 ## Key Components
@@ -34,9 +37,14 @@ kdb/
     avoid it when multiple rows can share a timestamp
   - Terminates automatically when all slices are exhausted
 - `kdb_read_cached()` - Cached variant of `kdb_read`
-  - Same signature as `kdb_read` plus a `cache_dir: impl Into<PathBuf>` parameter
-  - Checks `<cache_dir>/<hash>.cache` before each slice query; writes on miss
-  - Cache files persist until manually deleted — no TTL, no eviction
+  - Signature: `(connection, period, cache_config: CacheConfig, query_fn)` — takes a
+    `CacheConfig` (re-exported from `adapters::cache`) instead of `kdb_read`'s
+    `buffer_size` parameter
+  - `CacheConfig::new(folder, max_size_bytes)` — checks `<folder>/<hash>.cache`
+    before each slice query; writes on miss
+  - LRU eviction: oldest `.cache` files (by mtime) are deleted once the total on-disk
+    size would exceed `max_size_bytes`; use `u64::MAX` for an unbounded cache and
+    `CacheConfig::clear()` to delete all cached files
   - Lazy TCP connection: if all slices are cache hits, no KDB connection is opened
   - `T` must additionally implement `serde::Serialize + serde::Deserialize`; `Sync` is also required
   - `Sym` is fully supported — it serializes as a plain string (interning not restored on load)
@@ -44,7 +52,8 @@ kdb/
   - Drops rows outside the run window `[start_time, end_time)` like `kdb_read`, but the
     **cache stores the full `[t0, t1)` slice** (the key is the query string, which does not
     encode start/end); the clamp is applied on emit, on both cache hits and misses
-  - **Schema evolution:** `bincode` is not self-describing — delete the cache dir if `T` changes
+  - **Schema evolution:** `bincode` is not self-describing — call `CacheConfig::clear()`
+    (or delete the cache dir) if `T` changes
 - `kdb_sub()` - Real-time subscription to a tickerplant (the live counterpart to `kdb_read`)
   - `kdb_sub(conn, table, symbols)` — `table` is the tickerplant table name (no backtick),
     `symbols` a q symbol-list literal (`` "`" `` = all, `` "`AAPL`MSFT" `` to filter)
@@ -93,14 +102,15 @@ Before committing changes to the KDB adapter, you MUST:
    q -p 5000
 
    # Then run integration tests:
-   cargo test --features kdb-integration-test -p wingfoil
+   cargo test --features kdb-integration-test -p wingfoil -- --test-threads=1
    ```
 
 2. **Run standard formatting and linting:**
 
    ```bash
    cargo fmt --all
-   cargo clippy --workspace --all-targets --all-features
+   cargo lint        # default features
+   cargo lint-all    # all features
    ```
 
 3. **Run unit tests:**
@@ -171,12 +181,12 @@ impl KdbSerialize for Trade {
 ### Reading with kdb_read_cached
 
 ```rust
-// Same query closure as kdb_read, plus a cache directory.
+// Same query closure as kdb_read, plus a CacheConfig (no buffer_size parameter).
 // T must also implement serde::Serialize + serde::Deserialize + Sync.
 let stream = kdb_read_cached::<Trade>(
     conn,
     std::time::Duration::from_secs(3600),
-    "/tmp/my-backtest-cache",
+    CacheConfig::new("/tmp/my-backtest-cache", 512 * 1024 * 1024),
     |(t0, t1), date, _| {
         format!(
             "select from trades where date=2000.01.01+{}, \

--- a/wingfoil/src/adapters/otlp/CLAUDE.md
+++ b/wingfoil/src/adapters/otlp/CLAUDE.md
@@ -15,11 +15,13 @@ Wingfoil adapter for OpenTelemetry export. Two independent pathways:
 ```
 otlp/
   mod.rs               # Public API re-exports, module-level docs
-  push.rs              # OtlpPush trait + push_consumer async fn (metrics)
-  traces.rs            # OtlpSpans trait + spans_consumer async fn (traces)
+  push.rs              # OtlpConfig, OtlpPush trait + push_consumer async fn (metrics)
+  traces.rs            # OtlpAttributeBuffer, OtlpSpans trait + spans_consumer async fn (traces)
   integration_tests.rs # Integration tests (testcontainers — no external setup needed)
   CLAUDE.md            # This file
 ```
+
+Runnable example: `wingfoil/examples/telemetry/otlp/` (see its `run.sh`).
 
 ## Key Design Decisions
 
@@ -27,7 +29,9 @@ otlp/
   Metrics are exported via HTTP/protobuf (`http-proto` feature) to the OTLP `/v1/metrics` endpoint.
   Traces are exported via the HTTP span exporter.
 - A `SdkMeterProvider` with a 500 ms `PeriodicReader` is created per consumer invocation so that
-  the final batch of metrics is flushed before the function returns.
+  the final batch of metrics is flushed before the function returns. The flush happens by
+  **dropping** the provider — explicit `shutdown()` is deliberately avoided (its timeout can fail
+  when the async runtime is unavailable; see opentelemetry-rust issue #3137).
 - The metric name must be a `&'static str` (static string literal) to satisfy the OTel SDK's
   `f64_gauge` builder requirements.
 - **Historical / backtesting mode**: the consumer checks `ctx.run_mode` via `RunParams` and
@@ -43,15 +47,17 @@ otlp/
 ## Feature Flags
 
 - `otlp` — enables the adapter (pulls in `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`,
-  `reqwest`).
+  plus the `async` feature; `reqwest` comes in transitively via `opentelemetry-otlp`'s
+  `reqwest-blocking-client` feature).
 - `otlp-integration-test` — enables `otlp` + `testcontainers` for self-contained integration tests.
 
 ## Pre-Commit Requirements
 
 ```bash
-# 1. Standard checks
+# 1. Standard checks (the lint aliases live in .cargo/config.toml and mirror CI)
 cargo fmt --all
-cargo clippy --workspace --all-targets --all-features
+cargo lint        # default features
+cargo lint-all    # all features
 
 # 2. Unit / doc tests (no external dependencies)
 cargo test --features otlp -p wingfoil -- adapters::otlp
@@ -74,5 +80,5 @@ automatically — no manual Docker setup required. The container is stopped when
   short-running tests. Decrease if tests become flaky; increase if the backend is slow.
 - Non-numeric stream values are parsed as f64 via `.to_string().parse()`. Values that fail
   parsing are recorded as `0.0` and a warning is logged.
-- The collector image version is pinned (`0.116.0`) to avoid unexpected API changes.
+- The collector image version is pinned (`0.149.0`) to avoid unexpected API changes.
   Update the pin deliberately and re-run integration tests.

--- a/wingfoil/src/adapters/prometheus/CLAUDE.md
+++ b/wingfoil/src/adapters/prometheus/CLAUDE.md
@@ -9,10 +9,13 @@ allowing Grafana (or any Prometheus-compatible system) to scrape stream values.
 prometheus/
   mod.rs               # Public API re-exports, module-level docs
   exporter.rs          # PrometheusExporter — hand-rolled HTTP server + MutableNode sink
-  integration_tests.rs # Integration tests (requires running Prometheus; see below)
+  integration_tests.rs # Integration tests (two are self-contained; the scrape test needs
+                       # the Docker stack and skips itself if Prometheus is unreachable)
   docker/              # Docker Compose stack (Prometheus + Grafana) for integration tests
   CLAUDE.md            # This file
 ```
+
+Runnable example: `wingfoil/examples/telemetry/prometheus/` (see its `run.sh`).
 
 ## Key Design Decisions
 
@@ -20,8 +23,8 @@ prometheus/
 - `PrometheusExporter` spawns its own OS thread (same pattern as the ZMQ publisher).
   `serve()` binds synchronously so bind errors surface before the graph starts.
 - Metric nodes are regular `MutableNode` sinks; they read `peek_value()` each tick and publish the
-  stringified value into a per-metric `Arc<ArcSwap<String>>` slot with a lock-free atomic pointer
-  swap. The exporter holds a `Mutex<Vec<(name, slot)>>` registry that is locked only at
+  stringified value into a per-metric `Arc<ArcSwapOption<String>>` slot with a lock-free atomic
+  pointer swap (`None` = never ticked; such slots are omitted from the scrape response). The exporter holds a `Mutex<Vec<(name, slot)>>` registry that is locked only at
   `register()` time and once per HTTP scrape (off the graph thread) — never from `cycle()`. On
   scrape the HTTP thread snapshots the registry, drops the lock, then `.load()`s each slot to
   render the response.
@@ -33,15 +36,16 @@ prometheus/
 
 ## Feature Flags
 
-- `prometheus` — enables the adapter (no external client crate; HTTP server is hand-rolled with `std::net`).
+- `prometheus` — enables the adapter (pulls in `arc-swap` only; no Prometheus client crate — the HTTP server is hand-rolled with `std::net`).
 - `prometheus-integration-test` — enables `prometheus` + `reqwest` (blocking) for the integration tests.
 
 ## Pre-Commit Requirements
 
 ```bash
-# 1. Standard checks
+# 1. Standard checks (the lint aliases live in .cargo/config.toml and mirror CI)
 cargo fmt --all
-cargo clippy --workspace --all-targets --all-features
+cargo lint        # default features
+cargo lint-all    # all features
 
 # 2. Unit tests (no external dependencies)
 cargo test --features prometheus -p wingfoil -- adapters::prometheus
@@ -64,5 +68,6 @@ docker compose -f wingfoil/src/adapters/prometheus/docker/docker-compose.yml dow
 
 - The Prometheus scrape interval in `docker/provisioning/prometheus/prometheus.yml` is 5 s.
   The integration test polls for up to 60 s to account for scrape lag.
-- All tests (unit and integration) use port `0` so the OS assigns a free port. Never hardcode a port
-  number in tests.
+- Self-contained tests bind port `0` so the OS assigns a free port — never hardcode a port number
+  in them. The one exception is the Prometheus scrape test, which must bind a port Prometheus is
+  configured to scrape (`WINGFOIL_METRICS_PORT`, default `9091`).

--- a/wingfoil/src/adapters/redis/CLAUDE.md
+++ b/wingfoil/src/adapters/redis/CLAUDE.md
@@ -99,8 +99,8 @@ persist, so unlike Pub/Sub the integration tests need no subscribe-before-write 
 
    ```bash
    cargo fmt --all
-   cargo clippy --workspace --all-targets --all-features
-   cargo test -p wingfoil
+   cargo lint        # default features
+   cargo lint-all    # all features
    ```
 
 ## Integration Test Details
@@ -140,7 +140,8 @@ Tests must be run with `--test-threads=1` to avoid port conflicts between contai
 
 ## Python bindings
 
-- Binding module: `wingfoil-python/src/py_redis.rs` (`py_redis_sub` + `py_redis_pub_inner`).
+- Binding module: `wingfoil-python/src/py_redis.rs` (`py_redis_sub`, `py_redis_pub_inner`,
+  `py_redis_stream_read`, `py_redis_stream_write_inner`).
 - Integration tests live in `wingfoil-python/tests/test_redis.py`, gated by the
   `requires_redis` pytest marker (registered in `pyproject.toml` and deselected by
   default). Unit-level construction/marshaling tests in the same file run by default.

--- a/wingfoil/src/adapters/web/CLAUDE.md
+++ b/wingfoil/src/adapters/web/CLAUDE.md
@@ -9,7 +9,8 @@ frames as a wingfoil source stream (`web_sub`).
 ```
 web/
   mod.rs               # Re-exports, module-level //! docs, example usage
-  codec.rs             # Envelope + bincode/JSON encoding (backed by wingfoil-wire-types)
+  codec.rs             # Re-exports Envelope/CodecKind/ControlMessage from wingfoil-wire-types
+                       #   (all encode/decode logic lives there) + codec round-trip tests
   server.rs            # WebServer + axum router + per-connection task
   write.rs             # web_pub() sink + WebPubOperators fluent trait
   read.rs              # web_sub() source
@@ -124,7 +125,8 @@ handler.
 ```bash
 # 1. Standard checks
 cargo fmt --all
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo lint        # default features
+cargo lint-all    # all features
 
 # 2. Unit + integration tests (no external service required)
 cargo test --features web -p wingfoil \
@@ -163,4 +165,4 @@ default workspace because it targets `wasm32-unknown-unknown`) provides a
 Rust-compiled-to-wasm decoder/encoder so JS / TS apps can consume and emit
 frames without maintaining hand-written schemas. The `wingfoil-js` npm
 package wraps that wasm module and provides reactive-framework adapters
-(Solid.js, Svelte).
+(Solid.js, Svelte, Vue).

--- a/wingfoil/src/adapters/zmq/CLAUDE.md
+++ b/wingfoil/src/adapters/zmq/CLAUDE.md
@@ -9,7 +9,7 @@ optional registry-based service discovery (`EtcdRegistry`).
 zmq/
   mod.rs               # ZmqStatus, ZmqEvent, public re-exports, module doc
   read.rs              # zmq_sub() — subscriber producer
-  write.rs             # ZeroMqSenderNode, ZeroMqPub trait — publisher consumer
+  write.rs             # ZeroMqSenderNode, ZeroMqPub trait (zmq_pub / zmq_pub_on) — publisher consumer
   registry.rs          # ZmqRegistry/ZmqHandle traits, ZmqPubRegistration/ZmqSubConfig,
                        #   EtcdRegistry (cfg-gated)
   integration_tests.rs # All tests (gated by feature flags)
@@ -40,6 +40,11 @@ the graph emit `ZmqStatus::Connected` / `ZmqStatus::Disconnected` events without
 polling or external state. Monitor events are delivered on an `inproc://` socket
 polled in the same thread as the data socket.
 
+The publisher also opens a monitor socket (watching `ACCEPTED` events) and
+buffers outgoing messages until the first subscriber connects — up to 500 ms
+(`BUFFER_TIMEOUT`), plus a 50 ms subscription-propagation delay after the TCP
+accept — so messages published before the subscriber is ready are not lost.
+
 ## Registry-Based Discovery
 
 ### `ZmqRegistry` / `ZmqHandle` traits
@@ -57,7 +62,7 @@ pub trait ZmqHandle: Send {
 ### `ZmqPubRegistration` / `ZmqSubConfig` config types
 
 These wrapper types use `From` impls to enable a single `zmq_pub` / `zmq_sub`
-method that works for all three use cases without overloading:
+method that works for all the use cases without overloading:
 
 ```rust
 // ZmqPubRegistration
@@ -69,13 +74,18 @@ zmq_sub::<T>("tcp://host:5556")?                   // direct address
 zmq_sub::<T>(("quotes", etcd_registry))?           // discovery
 ```
 
+`zmq_pub` binds on `127.0.0.1`; use `zmq_pub_on(address, port, registration)`
+to bind a routable address for multi-host deployments (otherwise the address
+stored in the registry is unreachable from other machines).
+
 ### `EtcdRegistry` (requires `etcd` feature)
 
 Stores the address in etcd under a 30 s lease. A dedicated `std::thread` runs a
 keepalive loop every 10 s using its own `new_current_thread` tokio runtime.
 `ZmqHandle::revoke()`:
-1. Sets the shutdown `AtomicBool` to stop the keepalive thread.
-2. Joins the keepalive thread (may block up to 10 s).
+1. Signals a shutdown `tokio::sync::Notify`, which wakes the keepalive loop
+   immediately (it `select!`s on the notify vs. the 10 s sleep).
+2. Joins the keepalive thread.
 3. Calls `lease_revoke` so the key disappears immediately.
 
 ### When to use etcd discovery vs direct address
@@ -92,7 +102,8 @@ keepalive loop every 10 s using its own `new_current_thread` tokio runtime.
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets --all-features
+cargo lint        # default features
+cargo lint-all    # all features
 
 # ZMQ tests (no Docker needed)
 cargo test --features zmq-integration-test -p wingfoil \


### PR DESCRIPTION
- Add missing workspace crates (wingfoil-derive, wingfoil-wire-types,
  wingfoil-wasm, wingfoil-js) and scripts/ to the structure overview
- Correct node count and stale module notes (HashByRef -> ValueAt)
- Refresh examples and adapter lists to match the current tree
- Add TypeScript client test command

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KdyxZ7nY8BaGVReAUZxib8