### PR TITLE
wingfoil-next: sparse dirty-list dispatch engine, catalog ops, CSV/line adapters, rolling stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7683,7 +7683,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "criterion",
+ "csv",
  "futures",
+ "serde",
+ "serde-aux",
  "tokio",
  "trybuild",
  "wingfoil",

--- a/wingfoil-next/Cargo.toml
+++ b/wingfoil-next/Cargo.toml
@@ -28,6 +28,13 @@ tokio = { version = "1", features = [
     "macros",
 ], optional = true }
 
+# `csv` feature: the serde-typed CSV replay source + file sink adapter. Optional
+# so the default build stays dependency-free. Versions mirror the classic
+# `wingfoil` crate's csv adapter.
+csv = { version = "1.4", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde-aux = { version = "4.7.0", optional = true }
+
 [dev-dependencies]
 # Compile-fail tests pinning the `graph!` macro's key error paths.
 trybuild = "1"
@@ -36,6 +43,7 @@ criterion = "0.8.1"
 [features]
 default = []
 async = ["dep:tokio", "dep:futures"]
+csv = ["dep:csv", "dep:serde", "dep:serde-aux"]
 
 [[example]]
 name = "async_source"
@@ -48,3 +56,7 @@ required-features = ["async"]
 [[bench]]
 name = "fanout"
 harness = false
+
+[[example]]
+name = "csv_adapter"
+required-features = ["csv"]

--- a/wingfoil-next/examples/csv_adapter.rs
+++ b/wingfoil-next/examples/csv_adapter.rs
@@ -1,0 +1,63 @@
+//! The CSV adapter end to end: replay a CSV file as a deterministic historical
+//! burst stream, transform each row, and write the result back to a CSV file.
+//! Run with the `csv` feature:
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --features csv --example csv_adapter
+//! ```
+
+use std::io::Write;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::csv::{CsvSinkOps, csv_read};
+use wingfoil_next::prelude::*;
+
+/// A named-field record — serde field names become the CSV header columns.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct Quote {
+    timestamp: u64,
+    price: f64,
+}
+
+fn main() -> anyhow::Result<()> {
+    // Stage an input CSV in a temp directory (no header rows).
+    let dir = std::env::temp_dir();
+    let input = dir.join("wingfoil_next_csv_adapter_in.csv");
+    let output = dir.join("wingfoil_next_csv_adapter_out.csv");
+    {
+        let mut f = std::fs::File::create(&input)?;
+        writeln!(f, "100,10.0")?;
+        writeln!(f, "200,11.5")?;
+        writeln!(f, "300,9.75")?;
+    }
+
+    // Read → transform (bump every price by 1.0) → write, on the graph clock.
+    let g = GraphBuilder::new();
+    let rows = csv_read(&g, &input, |q: &Quote| NanoTime::new(q.timestamp), false)?;
+    let bumped = rows.map(|b| {
+        b.iter()
+            .map(|q| Quote {
+                timestamp: q.timestamp,
+                price: q.price + 1.0,
+            })
+            .collect::<Burst<Quote>>()
+    });
+    let _sink = bumped.csv_write(&output)?;
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+
+    println!("wrote {}:", output.display());
+    print!("{}", std::fs::read_to_string(&output)?);
+
+    // Single-value convenience: a plain `Stream<T>` sinks by wrapping each value
+    // into a one-element burst first.
+    let g = GraphBuilder::new();
+    let totals = csv_read(&g, &input, |q: &Quote| NanoTime::new(q.timestamp), false)?
+        .map(|b| Burst::from([b.iter().map(|q| q.price).sum::<f64>()]));
+    let _totals_sink = totals.csv_write(dir.join("wingfoil_next_csv_adapter_totals.csv"))?;
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+
+    Ok(())
+}

--- a/wingfoil-next/examples/lines_adapter.rs
+++ b/wingfoil-next/examples/lines_adapter.rs
@@ -1,0 +1,54 @@
+//! The dependency-free line-oriented file adapter end to end: replay a text
+//! file through a graph, transform it, and write the result to another file —
+//! the smallest complete Op-pattern I/O edge in both directions.
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example lines_adapter
+//! ```
+
+use std::fs;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::Burst;
+use wingfoil_next::adapters::lines::{LinesSinkOps, replay_lines};
+use wingfoil_next::prelude::*;
+
+fn main() -> anyhow::Result<()> {
+    // A couple of temp files in the OS temp dir, uniquely named.
+    let dir = std::env::temp_dir();
+    let input = dir.join(format!("wingfoil_lines_in_{}.txt", std::process::id()));
+    let output = dir.join(format!("wingfoil_lines_out_{}.txt", std::process::id()));
+    fs::write(&input, "alpha\nbravo\ncharlie\ndelta\n")?;
+
+    // Wire the graph: replay the file (deterministic historical replay, one
+    // record per successive graph instant), upper-case each record, and write
+    // the results out as lines.
+    let g = GraphBuilder::new();
+    let lines = replay_lines(&g, &input)?;
+    let shouted = lines.map(|burst: &Burst<String>| {
+        burst
+            .iter()
+            .map(|s| s.to_uppercase())
+            .collect::<Burst<String>>()
+    });
+    let _sink = shouted.write_lines(&output)?;
+    // Keep the original timestamps around to show the replay schedule.
+    let stamped = lines.with_time().accumulate();
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+
+    println!("replayed records at their graph timestamps:");
+    for (time, burst) in runner.value(&stamped) {
+        println!("  {time}: {:?}", burst.iter().collect::<Vec<_>>());
+    }
+
+    println!("\nwrote {}:", output.display());
+    for line in fs::read_to_string(&output)?.lines() {
+        println!("  {line}");
+    }
+
+    fs::remove_file(&input).ok();
+    fs::remove_file(&output).ok();
+    Ok(())
+}

--- a/wingfoil-next/src/adapters/csv.rs
+++ b/wingfoil-next/src/adapters/csv.rs
@@ -1,0 +1,204 @@
+//! A CSV file adapter — a serde-typed replay **source** and a file **sink**,
+//! the parsing cousin of the dependency-free [`lines`](crate::adapters::lines)
+//! adapter (see `docs/port-plan.md`, Phase 4: "csv — replay source + sink;
+//! exercises 0.3 historical bursts"). It ports the classic
+//! `wingfoil::adapters::csv` module onto the Op model.
+//!
+//! Records are ordinary Rust types that implement [`serde::Serialize`] /
+//! [`serde::de::DeserializeOwned`] — a named struct, or a positional tuple such
+//! as `(NanoTime, u32)`. The `csv` crate handles field mapping exactly as it
+//! does for the classic adapter.
+//!
+//! # Layering
+//!
+//! Following the [`lines`](crate::adapters::lines) / [`stats`](crate::stats)
+//! pattern, the adapter is *not* in the [`prelude`](crate::prelude). Bring in
+//! what you need explicitly:
+//!
+//! - **Source** — the free builder function [`csv_read`] on a
+//!   [`GraphBuilder`]: deterministic historical replay of a CSV file, emitting
+//!   `Stream<Burst<T>>`.
+//! - **Sink** — the [`CsvSinkOps`] extension trait on `Stream<Burst<T>>`,
+//!   enabled with `use wingfoil_next::adapters::csv::CsvSinkOps;`.
+//!
+//! # Historical replay (the burst model)
+//!
+//! [`csv_read`] reads and deserializes the whole file up front, then stamps
+//! each record with `get_time(&record)` and queues it onto a
+//! [`channel`](crate::fluent::SourceOps::channel) source through
+//! [`ChannelSender::send_at`](crate::channel::ChannelSender::send_at); the
+//! sender is [`close`](crate::channel::ChannelSender::close)d immediately. The
+//! channel receiver groups records sharing a timestamp into one atomic
+//! [`Burst`](crate::Burst) and replays them deterministically at their
+//! timestamps — lossless, in order, independent of wall-clock. This mirrors the
+//! classic `csv_read`, whose `TryIteratorStream` groups same-timestamp rows
+//! into one burst (use `.collapse_accumulate()` when the source is strictly
+//! ascending and you want a flat `Vec<T>`).
+//!
+//! Two consequences of using the channel source (deviations from classic):
+//! record timestamps must be **non-decreasing**
+//! (the historical receiver rejects out-of-order sends), and a row that fails
+//! to deserialize is propagated as a [`Message::Error`](crate::channel::Message)
+//! so it still aborts the run — the same observable outcome as classic (the run
+//! fails with a "failed to deserialize row" context), just surfaced at the
+//! start of the replay rather than mid-stream.
+//!
+//! # Sink
+//!
+//! [`CsvSinkOps::csv_write`] opens the target file once at wiring time, writes
+//! the header up front (a leading `time` column plus the record's serde field
+//! names, via `serde_aux` introspection — a positional tuple record has no
+//! named fields, so no header is written, matching classic), and returns a
+//! `Stream<()>` sink built on
+//! [`with_time`](crate::fluent::StreamOps::with_time) then
+//! [`for_each`](crate::fluent::StreamOps::for_each): each cycle serializes every
+//! record in the incoming burst as one `(time, record)` row and flushes, with
+//! any I/O or serialization error propagated through the fallible cycle (`?` and
+//! `.context`).
+
+use std::cell::RefCell;
+use std::fs::File;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_aux::serde_introspection::serde_introspect;
+use wingfoil::NanoTime;
+
+use crate::Burst;
+use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
+
+/// Deterministic historical replay of a CSV file: each record is emitted as a
+/// [`Burst<T>`] on the graph clock at `get_time(&record)`, with records sharing
+/// a timestamp grouped into one atomic burst.
+///
+/// The file is read and deserialized in full up front and queued onto a
+/// [`channel`](crate::fluent::SourceOps::channel) source, so replay is
+/// reproducible and needs no producer thread. Run the graph with
+/// `RunMode::HistoricalFrom(t)` where `t` is at or before the first record's
+/// timestamp (e.g. `NanoTime::ZERO`). Use
+/// [`collapse_accumulate`](crate::fluent::Stream::collapse_accumulate) when the
+/// source is strictly ascending and you want a flat `Vec<T>`.
+///
+/// `has_headers` toggles whether the first line is a header (skipped) or data,
+/// exactly as `csv::ReaderBuilder::has_headers`.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened. A row that fails to
+/// deserialize does not panic — it is propagated into the graph as a channel
+/// error and surfaces as a run failure with a "failed to deserialize row"
+/// context (the same outcome as the classic adapter). Record timestamps must be
+/// non-decreasing; an out-of-order record fails the run.
+pub fn csv_read<T, F>(
+    g: &GraphBuilder,
+    path: impl AsRef<Path>,
+    get_time: F,
+    has_headers: bool,
+) -> Result<Stream<Burst<T>>>
+where
+    T: Clone + Default + DeserializeOwned + 'static,
+    F: Fn(&T) -> NanoTime,
+{
+    let path = path.as_ref();
+    let file =
+        File::open(path).with_context(|| format!("csv_read: failed to open {}", path.display()))?;
+    let display = path.display().to_string();
+    let (stream, sender) = g.channel::<T>();
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(has_headers)
+        .from_reader(file);
+    for record in reader.deserialize::<T>() {
+        match record {
+            Ok(rec) => {
+                let time = get_time(&rec);
+                sender.send_at(rec, time);
+            }
+            // Mirror classic: a malformed row aborts the run rather than
+            // panicking. The channel error carries the same context string the
+            // classic adapter uses, so callers see the identical message.
+            Err(e) => {
+                sender.send_error(anyhow::Error::new(e).context(format!(
+                    "csv_read: failed to deserialize row from {display}"
+                )));
+                break;
+            }
+        }
+    }
+    // Queue the end-of-stream so the historical receiver stops collecting.
+    sender.close();
+    Ok(stream)
+}
+
+/// A CSV file sink — the outbound counterpart of [`csv_read`].
+///
+/// An extension trait on `Stream<Burst<T>>` (so `use`ing it enables
+/// `stream.csv_write(path)` chaining), layered over the existing
+/// [`with_time`](crate::fluent::StreamOps::with_time) +
+/// [`for_each`](crate::fluent::StreamOps::for_each) ops the same way
+/// [`LinesSinkOps`](crate::adapters::lines::LinesSinkOps) layers over
+/// `for_each`. Each emitted burst writes every record as one `(time, record)`
+/// row — a leading `time` column carrying the graph time — then flushes; an I/O
+/// or serialization error aborts the run with context.
+///
+/// Single-value streams wrap into a one-element burst first, e.g.
+/// `stream.map(|v| burst![v.clone()]).csv_write(path)`.
+pub trait CsvSinkOps<T> {
+    /// Write each record to `path` as a `(time, record)` CSV row, **truncating**
+    /// the file first (created if absent). The header (a `time` column plus the
+    /// record's serde field names) is written up front unless the record is a
+    /// positional tuple with no named fields. Returns the sink `Stream<()>`, or
+    /// an error if the file cannot be opened.
+    fn csv_write(&self, path: impl AsRef<Path>) -> Result<Stream<()>>;
+}
+
+impl<T> CsvSinkOps<T> for Stream<Burst<T>>
+where
+    T: Serialize + DeserializeOwned + Clone + Default + 'static,
+{
+    fn csv_write(&self, path: impl AsRef<Path>) -> Result<Stream<()>> {
+        let path = path.as_ref();
+        let mut writer = csv::WriterBuilder::new()
+            .has_headers(false)
+            .from_path(path)
+            .with_context(|| format!("csv_write: failed to open {} for writing", path.display()))?;
+        write_header::<T>(&mut writer)
+            .with_context(|| format!("csv_write: writing header to {}", path.display()))?;
+        let display = path.display().to_string();
+        // `for_each` takes an `Fn`; the `csv::Writer` needs `&mut`, so it lives
+        // behind a `RefCell`.
+        let writer = RefCell::new(writer);
+        Ok(self
+            .with_time()
+            .for_each(move |(time, burst): &(NanoTime, Burst<T>)| {
+                let mut w = writer.borrow_mut();
+                for rec in burst.iter() {
+                    w.serialize((*time, rec)).with_context(|| {
+                        format!("csv_write: failed to serialize record to {display}")
+                    })?;
+                }
+                w.flush()
+                    .with_context(|| format!("csv_write: flushing {display}"))?;
+                Ok(())
+            }))
+    }
+}
+
+/// Write the CSV header: a leading `time` field followed by the record's serde
+/// field names. A positional tuple record has no named fields, so nothing is
+/// written — matching the classic adapter (whose tuple output has no header).
+fn write_header<T: Serialize + DeserializeOwned + 'static>(
+    writer: &mut csv::Writer<File>,
+) -> Result<()> {
+    let fields = serde_introspect::<T>();
+    if !fields.is_empty() {
+        writer
+            .write_field("time")
+            .context("failed to write CSV time header")?;
+        writer
+            .write_record(fields)
+            .context("failed to write CSV header record")?;
+    }
+    Ok(())
+}

--- a/wingfoil-next/src/adapters/lines.rs
+++ b/wingfoil-next/src/adapters/lines.rs
@@ -95,10 +95,19 @@ pub fn replay_lines_scheduled(
     for (i, line) in BufReader::new(file).lines().enumerate() {
         let line =
             line.with_context(|| format!("lines adapter: reading line {i} of {}", path.display()))?;
-        // `step * i` on the u32 tick index keeps timestamps non-decreasing (the
-        // channel receiver requires it); a distinct `step` per record yields
-        // one line per burst, a zero step groups them.
-        sender.send_at(line, base + step * (i as u32));
+        // A distinct `step` per record yields one line per burst, a zero step
+        // groups them; either way timestamps stay non-decreasing (the channel
+        // receiver requires it). `try_from` turns the u32 tick-index ceiling
+        // into a clear error rather than a silent wrap that would rewind the
+        // clock and fail the run far from its cause.
+        let tick = u32::try_from(i).with_context(|| {
+            format!(
+                "lines adapter: {} has more lines than the {} the replay clock can schedule",
+                path.display(),
+                u32::MAX
+            )
+        })?;
+        sender.send_at(line, base + step * tick);
     }
     // Queue the end-of-stream so the historical receiver stops collecting.
     sender.close();
@@ -111,30 +120,50 @@ pub fn replay_lines_scheduled(
 /// sources have nothing to busy-poll in a historical replay).
 ///
 /// Reads whatever the file holds at `poll` time, line by line; a line that is
-/// not yet terminated by a newline, or a read error, yields no tick. This is a
-/// deliberately minimal tail (it does not follow rotations) — the deterministic
-/// path is [`replay_lines`]. Returns an error if the file cannot be opened.
+/// not yet terminated by a newline, or a read error, yields no tick. A line
+/// that straddles a poll boundary (its bytes arrive across several polls) is
+/// **reassembled**: the partial bytes are held until the terminating newline
+/// arrives, then emitted whole — never in fragments and never dropped. This is
+/// a deliberately minimal tail (it does not follow rotations) — the
+/// deterministic path is [`replay_lines`]. Returns an error if the file cannot
+/// be opened.
 pub fn tail_lines(g: &GraphBuilder, path: impl AsRef<Path>) -> Result<Stream<Burst<String>>> {
     let path = path.as_ref();
     let file = File::open(path)
         .with_context(|| format!("lines adapter: opening tail file {}", path.display()))?;
-    let reader = Rc::new(RefCell::new(BufReader::new(file)));
+    // `read_line` consumes whatever bytes are available even when no newline is
+    // present, so a line whose bytes span multiple polls must be accumulated in
+    // `pending` across calls; a fresh buffer each poll would drop those bytes
+    // and later emit a corrupted remainder. `pending` carries them until the
+    // newline lands.
+    let state = Rc::new(RefCell::new((BufReader::new(file), String::new())));
     Ok(g.poll(move || {
-        let mut buf = String::new();
-        match reader.borrow_mut().read_line(&mut buf) {
-            // A complete, newline-terminated line: emit it (without the `\n`).
-            Ok(n) if n > 0 && buf.ends_with('\n') => {
-                buf.pop();
-                if buf.ends_with('\r') {
-                    buf.pop();
-                }
-                Some(Burst::from([buf]))
-            }
-            // EOF, a partial (un-terminated) trailing line, or a read error:
-            // nothing to emit this cycle.
-            _ => None,
-        }
+        let (reader, pending) = &mut *state.borrow_mut();
+        poll_line(reader, pending).map(|line| Burst::from([line]))
     }))
+}
+
+/// Read toward the next newline, accumulating partial bytes in `pending` across
+/// calls. Returns the completed line (its trailing `\n`, and any `\r`, stripped)
+/// once the terminator arrives, resetting `pending`; returns `None` on EOF, a
+/// still-unterminated line, or a read error — leaving the bytes read so far in
+/// `pending` for the next call. Factored out of [`tail_lines`] so the
+/// straddled-line reassembly is unit-testable without a realtime run.
+fn poll_line<R: BufRead>(reader: &mut R, pending: &mut String) -> Option<String> {
+    match reader.read_line(pending) {
+        // A complete, newline-terminated line: take it (stripping the line
+        // ending) and clear `pending` for the next line.
+        Ok(n) if n > 0 && pending.ends_with('\n') => {
+            pending.pop();
+            if pending.ends_with('\r') {
+                pending.pop();
+            }
+            Some(std::mem::take(pending))
+        }
+        // EOF, a partial (un-terminated) trailing line, or a read error:
+        // nothing to emit this cycle. Whatever was read stays in `pending`.
+        _ => None,
+    }
 }
 
 /// A line-oriented file sink — the outbound counterpart of [`replay_lines`].
@@ -203,4 +232,75 @@ where
             .with_context(|| format!("lines adapter: flushing {display}"))?;
         Ok(())
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::poll_line;
+    use std::collections::VecDeque;
+    use std::io::{BufReader, Read, Result as IoResult};
+
+    /// A reader that hands out preset chunks one `read` at a time; an empty
+    /// chunk yields `Ok(0)` (a momentary EOF), modelling a file still being
+    /// appended to — exactly the straddled-line case [`poll_line`] must
+    /// reassemble.
+    struct ChunkReader {
+        chunks: VecDeque<&'static [u8]>,
+    }
+
+    impl Read for ChunkReader {
+        fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+            match self.chunks.pop_front() {
+                Some(chunk) => {
+                    let n = chunk.len().min(buf.len());
+                    buf[..n].copy_from_slice(&chunk[..n]);
+                    Ok(n)
+                }
+                None => Ok(0),
+            }
+        }
+    }
+
+    /// The regression this guards: `read_line` consumes the partial bytes even
+    /// with no newline, so a fresh-buffer-per-poll tail would drop "par" and
+    /// later emit a corrupted "tial". `poll_line` must hold the partial line and
+    /// emit it whole once the terminator arrives.
+    #[test]
+    fn poll_line_reassembles_a_line_split_across_polls() {
+        // "par" arrives, then a momentary EOF, then the rest "tial\n".
+        let mut reader = BufReader::new(ChunkReader {
+            chunks: VecDeque::from([&b"par"[..], &b""[..], &b"tial\n"[..]]),
+        });
+        let mut pending = String::new();
+
+        // First poll: only the partial "par" — nothing emitted, bytes retained.
+        assert_eq!(poll_line(&mut reader, &mut pending), None);
+        assert_eq!(pending, "par");
+
+        // Second poll: the rest lands and the whole line comes out intact.
+        assert_eq!(
+            poll_line(&mut reader, &mut pending),
+            Some("partial".to_string())
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn poll_line_strips_crlf_and_emits_each_line_once() {
+        let mut reader = BufReader::new(ChunkReader {
+            chunks: VecDeque::from([&b"alpha\r\nbeta\n"[..]]),
+        });
+        let mut pending = String::new();
+        assert_eq!(
+            poll_line(&mut reader, &mut pending),
+            Some("alpha".to_string())
+        );
+        assert_eq!(
+            poll_line(&mut reader, &mut pending),
+            Some("beta".to_string())
+        );
+        // Drained: no more complete lines.
+        assert_eq!(poll_line(&mut reader, &mut pending), None);
+        assert!(pending.is_empty());
+    }
 }

--- a/wingfoil-next/src/adapters/lines.rs
+++ b/wingfoil-next/src/adapters/lines.rs
@@ -1,0 +1,206 @@
+//! A dependency-free, line-oriented file adapter — the smallest complete
+//! demonstration of an Op-pattern I/O edge, in both directions.
+//!
+//! It reads and writes newline-delimited **records** (plain `String` lines, no
+//! serde) using nothing but `std::fs` / `std::io`. It is the dependency-free
+//! cousin of the planned CSV adapter (see `docs/port-plan.md`, Phase 4:
+//! "csv — replay source + sink; exercises historical bursts"): the same shape,
+//! without the parsing.
+//!
+//! # Layering
+//!
+//! Following the [`stats`](crate::stats) module's pattern, the adapter is *not*
+//! in the [`prelude`](crate::prelude). Bring in what you need explicitly:
+//!
+//! - **Sources** — free builder functions on a [`GraphBuilder`]:
+//!   [`replay_lines`] / [`replay_lines_scheduled`] (deterministic historical
+//!   replay) and [`tail_lines`] (a realtime `poll`-driven tail). Each returns a
+//!   `Stream<Burst<String>>`.
+//! - **Sink** — the [`LinesSinkOps`] extension trait on
+//!   `Stream<Burst<T>>`, enabled with
+//!   `use wingfoil_next::adapters::lines::LinesSinkOps;`.
+//!
+//! # Historical replay (the burst model)
+//!
+//! [`replay_lines`] reads the whole file up front and schedules each record
+//! onto the graph clock through a [`channel`](crate::fluent::SourceOps::channel)
+//! source: record `i` is stamped at `base + i * step` with
+//! [`ChannelSender::send_at`](crate::channel::ChannelSender::send_at), and the
+//! sender is [`close`](crate::channel::ChannelSender::close)d immediately. The
+//! channel receiver groups same-timestamp records into one atomic
+//! [`Burst`](crate::Burst) and replays them deterministically at their
+//! timestamps — lossless, in order, independent of wall-clock. With the default
+//! `step` of one nanosecond every record lands at a distinct instant, so each
+//! burst carries exactly one line; a zero `step` (or a `base`/`step` that makes
+//! records collide) groups colliding records into a single burst. The whole
+//! feed is queued *before* the run, so replay needs no producer thread and is
+//! fully reproducible under `RunMode::HistoricalFrom`.
+//!
+//! # Sink
+//!
+//! [`LinesSinkOps::write_lines`] / [`LinesSinkOps::append_lines`] open the
+//! target file once at wiring time and return a `Stream<()>` sink built on the
+//! existing [`for_each`](crate::fluent::StreamOps::for_each) op: each cycle
+//! writes every record in the incoming burst as its own line and flushes, with
+//! any I/O error propagated through the fallible cycle (`?` + `.context`).
+
+use std::cell::RefCell;
+use std::fmt::Display;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::Path;
+use std::rc::Rc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use wingfoil::NanoTime;
+
+use crate::Burst;
+use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
+
+/// Deterministic historical replay of a newline-delimited file, one record per
+/// successive graph instant.
+///
+/// Sugar for [`replay_lines_scheduled`] with `base = NanoTime::ZERO` and
+/// `step = 1ns`, so record `i` is delivered at time `i` and every burst holds
+/// exactly one line. Run the graph with `RunMode::HistoricalFrom(t)` where
+/// `t <= base` (e.g. `NanoTime::ZERO`).
+///
+/// Returns an error if the file cannot be opened or a line cannot be read.
+pub fn replay_lines(g: &GraphBuilder, path: impl AsRef<Path>) -> Result<Stream<Burst<String>>> {
+    replay_lines_scheduled(g, path, NanoTime::ZERO, Duration::from_nanos(1))
+}
+
+/// Deterministic historical replay with an explicit schedule: record `i` is
+/// stamped at `base + i * step` and replayed on the graph clock as a
+/// [`Burst`]. Records sharing a timestamp (e.g. `step == 0`) ride one atomic
+/// burst; otherwise each burst holds a single line.
+///
+/// The file is read in full and queued onto a
+/// [`channel`](crate::fluent::SourceOps::channel) source up front, so replay is
+/// reproducible and needs no producer thread. `base` must be at or after the
+/// run's start time (the channel receiver rejects a pre-start timestamp).
+///
+/// Returns an error if the file cannot be opened or a line cannot be read.
+pub fn replay_lines_scheduled(
+    g: &GraphBuilder,
+    path: impl AsRef<Path>,
+    base: NanoTime,
+    step: Duration,
+) -> Result<Stream<Burst<String>>> {
+    let path = path.as_ref();
+    let file = File::open(path)
+        .with_context(|| format!("lines adapter: opening source file {}", path.display()))?;
+    let (stream, sender) = g.channel::<String>();
+    for (i, line) in BufReader::new(file).lines().enumerate() {
+        let line =
+            line.with_context(|| format!("lines adapter: reading line {i} of {}", path.display()))?;
+        // `step * i` on the u32 tick index keeps timestamps non-decreasing (the
+        // channel receiver requires it); a distinct `step` per record yields
+        // one line per burst, a zero step groups them.
+        sender.send_at(line, base + step * (i as u32));
+    }
+    // Queue the end-of-stream so the historical receiver stops collecting.
+    sender.close();
+    Ok(stream)
+}
+
+/// A best-effort **realtime** tail of a newline-delimited file: a busy-poll
+/// [`poll`](crate::fluent::SourceOps::poll) source that emits each newly read
+/// line as a single-element [`Burst`]. Requires `RunMode::RealTime` (poll
+/// sources have nothing to busy-poll in a historical replay).
+///
+/// Reads whatever the file holds at `poll` time, line by line; a line that is
+/// not yet terminated by a newline, or a read error, yields no tick. This is a
+/// deliberately minimal tail (it does not follow rotations) — the deterministic
+/// path is [`replay_lines`]. Returns an error if the file cannot be opened.
+pub fn tail_lines(g: &GraphBuilder, path: impl AsRef<Path>) -> Result<Stream<Burst<String>>> {
+    let path = path.as_ref();
+    let file = File::open(path)
+        .with_context(|| format!("lines adapter: opening tail file {}", path.display()))?;
+    let reader = Rc::new(RefCell::new(BufReader::new(file)));
+    Ok(g.poll(move || {
+        let mut buf = String::new();
+        match reader.borrow_mut().read_line(&mut buf) {
+            // A complete, newline-terminated line: emit it (without the `\n`).
+            Ok(n) if n > 0 && buf.ends_with('\n') => {
+                buf.pop();
+                if buf.ends_with('\r') {
+                    buf.pop();
+                }
+                Some(Burst::from([buf]))
+            }
+            // EOF, a partial (un-terminated) trailing line, or a read error:
+            // nothing to emit this cycle.
+            _ => None,
+        }
+    }))
+}
+
+/// A line-oriented file sink — the outbound counterpart of [`replay_lines`].
+///
+/// An extension trait on `Stream<Burst<T>>` (so `use`ing it enables
+/// `stream.write_lines(path)` chaining), layered over the existing
+/// [`for_each`](crate::fluent::StreamOps::for_each) op the same way
+/// [`StatisticsOps`](crate::stats::StatisticsOps) layers over `wire`. Each
+/// emitted burst writes every record as its own line, then flushes; an I/O
+/// error aborts the run with context.
+pub trait LinesSinkOps<T> {
+    /// Write each record to `path` as a line, **truncating** the file first
+    /// (created if absent). Returns the sink `Stream<()>`, or an error if the
+    /// file cannot be opened.
+    fn write_lines(&self, path: impl AsRef<Path>) -> Result<Stream<()>>;
+
+    /// Write each record to `path` as a line, **appending** to any existing
+    /// content (created if absent). Returns the sink `Stream<()>`, or an error
+    /// if the file cannot be opened.
+    fn append_lines(&self, path: impl AsRef<Path>) -> Result<Stream<()>>;
+}
+
+impl<T> LinesSinkOps<T> for Stream<Burst<T>>
+where
+    T: Display + Clone + Default + 'static,
+{
+    fn write_lines(&self, path: impl AsRef<Path>) -> Result<Stream<()>> {
+        sink_lines(self, path, false)
+    }
+
+    fn append_lines(&self, path: impl AsRef<Path>) -> Result<Stream<()>> {
+        sink_lines(self, path, true)
+    }
+}
+
+/// Shared implementation of the two [`LinesSinkOps`] methods: open the file
+/// once (truncate for write, append for append) and wire a `for_each` sink that
+/// writes every record in each burst as a line, flushing per cycle.
+fn sink_lines<T>(
+    stream: &Stream<Burst<T>>,
+    path: impl AsRef<Path>,
+    append: bool,
+) -> Result<Stream<()>>
+where
+    T: Display + Clone + Default + 'static,
+{
+    let path = path.as_ref();
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(append)
+        .truncate(!append)
+        .open(path)
+        .with_context(|| format!("lines adapter: opening sink file {}", path.display()))?;
+    let display = path.display().to_string();
+    // `for_each` takes an `Fn`; the `BufWriter` needs `&mut`, so it lives behind
+    // a `RefCell`.
+    let writer = RefCell::new(BufWriter::new(file));
+    Ok(stream.for_each(move |burst: &Burst<T>| {
+        let mut w = writer.borrow_mut();
+        for record in burst.iter() {
+            writeln!(w, "{record}")
+                .with_context(|| format!("lines adapter: writing to {display}"))?;
+        }
+        w.flush()
+            .with_context(|| format!("lines adapter: flushing {display}"))?;
+        Ok(())
+    }))
+}

--- a/wingfoil-next/src/adapters/mod.rs
+++ b/wingfoil-next/src/adapters/mod.rs
@@ -11,5 +11,9 @@
 //! - [`lines`] — a dependency-free, line-oriented file adapter (historical
 //!   replay source + realtime tail + file sink), the smallest complete
 //!   demonstration of an I/O edge in both directions.
+//! - [`csv`] — a serde-typed CSV file adapter (historical replay source + file
+//!   sink) behind the `csv` feature, the parsing cousin of [`lines`].
 
+#[cfg(feature = "csv")]
+pub mod csv;
 pub mod lines;

--- a/wingfoil-next/src/adapters/mod.rs
+++ b/wingfoil-next/src/adapters/mod.rs
@@ -1,0 +1,15 @@
+//! I/O adapters — the graph's edges to the outside world, built strictly on
+//! the public Op-pattern API (sources over
+//! [`channel`](crate::fluent::SourceOps::channel) / [`poll`](crate::fluent::SourceOps::poll),
+//! sinks over [`for_each`](crate::fluent::StreamOps::for_each)).
+//!
+//! Each adapter lives in its own module and stays *out* of the
+//! [`prelude`](crate::prelude); bring one in explicitly, e.g.
+//! `use wingfoil_next::adapters::lines::LinesSinkOps;`. This mirrors the
+//! [`stats`](crate::stats) module's extension-trait layering.
+//!
+//! - [`lines`] — a dependency-free, line-oriented file adapter (historical
+//!   replay source + realtime tail + file sink), the smallest complete
+//!   demonstration of an I/O edge in both directions.
+
+pub mod lines;

--- a/wingfoil-next/src/compat.rs
+++ b/wingfoil-next/src/compat.rs
@@ -23,11 +23,12 @@
 //! the full ~40-method surface is mechanical from here.
 
 use std::cell::RefCell;
+use std::ops::{Not, Sub};
 use std::rc::Rc;
 use std::time::Duration;
 
 use anyhow::Result;
-use wingfoil::{RunFor, RunMode};
+use wingfoil::{NanoTime, RunFor, RunMode};
 
 use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
 use crate::interp::Runner;
@@ -103,6 +104,24 @@ impl<T: 'static> Signal<T> {
         self.wrap(self.stream.fold(init, f))
     }
 
+    /// Pair each value with the current engine time: `(time, value)`.
+    pub fn with_time(&self) -> Signal<(NanoTime, T)>
+    where
+        T: Clone,
+    {
+        self.wrap(self.stream.with_time())
+    }
+
+    /// Emit the current engine time whenever this signal ticks.
+    pub fn ticked_at(&self) -> Signal<NanoTime> {
+        self.wrap(self.stream.ticked_at())
+    }
+
+    /// Emit elapsed engine time (`now - start`) whenever this signal ticks.
+    pub fn ticked_at_elapsed(&self) -> Signal<NanoTime> {
+        self.wrap(self.stream.ticked_at_elapsed())
+    }
+
     /// Run the graph to its bound, storing the runner for `peek_value`.
     ///
     /// Re-running is not supported: the shared [`GraphBuilder`] is consumed by
@@ -156,12 +175,63 @@ impl<T: Clone + Default + 'static> Signal<T> {
     pub fn accumulate(&self) -> Signal<Vec<T>> {
         self.wrap(self.stream.accumulate())
     }
+
+    /// Emit the current value whenever `trigger` ticks (passive read).
+    pub fn sample(&self, trigger: &Signal<()>) -> Signal<T> {
+        self.wrap(self.stream.sample(&trigger.stream))
+    }
+
+    /// Merge with another signal; the earliest-supplied ticked input wins.
+    pub fn merge(&self, other: &Signal<T>) -> Signal<T> {
+        self.wrap(self.stream.merge(&other.stream))
+    }
+
+    /// Pass through the first `limit` values, then stay quiet.
+    pub fn limit(&self, limit: u32) -> Signal<T> {
+        self.wrap(self.stream.limit(limit))
+    }
+
+    /// Rate-limit: emit at most once per `interval`.
+    pub fn throttle(&self, interval: Duration) -> Signal<T> {
+        self.wrap(self.stream.throttle(interval))
+    }
+
+    /// Buffer values and flush them as a `Vec` on each `interval` boundary
+    /// (and once more on the last cycle).
+    pub fn window(&self, interval: Duration) -> Signal<Vec<T>> {
+        self.wrap(self.stream.window(interval))
+    }
+
+    /// Buffer values and flush them as a `Vec` once `capacity` accumulate
+    /// (and once more on the last cycle).
+    pub fn buffer(&self, capacity: usize) -> Signal<Vec<T>> {
+        self.wrap(self.stream.buffer(capacity))
+    }
 }
 
 impl<T: Clone + Default + PartialEq + 'static> Signal<T> {
     /// Re-emit each value `delay` later.
     pub fn delay(&self, delay: Duration) -> Signal<T> {
         self.wrap(self.stream.delay(delay))
+    }
+
+    /// Suppress consecutive duplicate values (emit on change only).
+    pub fn distinct(&self) -> Signal<T> {
+        self.wrap(self.stream.distinct())
+    }
+}
+
+impl<T: Clone + Default + Sub<Output = T> + 'static> Signal<T> {
+    /// Emit the successive difference `value - previous`; quiet on the first.
+    pub fn difference(&self) -> Signal<T> {
+        self.wrap(self.stream.difference())
+    }
+}
+
+impl<T: Clone + Default + Not<Output = T> + 'static> Signal<T> {
+    /// Negate each value (`!value`) — sugar over `map`.
+    pub fn not(&self) -> Signal<T> {
+        self.wrap(self.stream.not())
     }
 }
 

--- a/wingfoil-next/src/fluent.rs
+++ b/wingfoil-next/src/fluent.rs
@@ -21,6 +21,7 @@
 //! [`Runner`] is identical).
 
 use std::cell::{Cell, RefCell};
+use std::fmt::Debug;
 use std::ops::{Not, Sub};
 use std::rc::Rc;
 use std::time::Duration;
@@ -363,6 +364,34 @@ pub trait StreamOps<T>: Sized {
         D: Clone + Default + 'static,
         F: Fn(&T, &B, &C) -> D + 'static;
 
+    /// Combine with another stream via a *fallible* closure — the `try_`
+    /// counterpart to [`join`](StreamOps::join). Both inputs active; a returned
+    /// `Err` aborts the run with context (the classic `try_bimap`).
+    fn try_join<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
+    where
+        B: 'static,
+        C: Clone + Default + 'static,
+        F: Fn(&T, &B) -> Result<C> + 'static;
+
+    /// [`join_passive`](StreamOps::join_passive) with a *fallible* closure:
+    /// this stream triggers the combine, `other` is read passively, and a
+    /// returned `Err` aborts the run with context.
+    fn try_join_passive<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
+    where
+        B: 'static,
+        C: Clone + Default + 'static,
+        F: Fn(&T, &B) -> Result<C> + 'static;
+
+    /// Combine three streams (all active) via a *fallible* closure — the
+    /// `try_` counterpart to [`join3`](StreamOps::join3). A returned `Err`
+    /// aborts the run with context (the classic `try_trimap`).
+    fn try_join3<B, C, D, F>(&self, b: &Stream<B>, c: &Stream<C>, f: F) -> Stream<D>
+    where
+        B: 'static,
+        C: 'static,
+        D: Clone + Default + 'static,
+        F: Fn(&T, &B, &C) -> Result<D> + 'static;
+
     /// Emit only when `condition`'s current value is true.
     fn filter(&self, condition: &Stream<bool>) -> Stream<T>
     where
@@ -439,6 +468,18 @@ pub trait StreamOps<T>: Sized {
     fn not(&self) -> Stream<T>
     where
         T: Clone + Default + Not<Output = T> + 'static;
+
+    /// Pass each value through unchanged while buffering it, then print the
+    /// whole buffer (`{value:?}` per line) at teardown (the classic `print`).
+    fn print(&self) -> Stream<T>
+    where
+        T: Clone + Default + Debug + 'static;
+
+    /// Pass each value through unchanged, printing a performance summary at
+    /// the end of the run (the classic `timed`).
+    fn timed(&self) -> Stream<T>
+    where
+        T: Clone + Default + 'static;
 
     /// Re-emit each value `delay` later.
     fn delay(&self, delay: Duration) -> Stream<T>
@@ -553,6 +594,37 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         self.wire(|bld, h| bld.trimap(h, true, bh, true, ch, true, f))
     }
 
+    fn try_join<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
+    where
+        B: 'static,
+        C: Clone + Default + 'static,
+        F: Fn(&T, &B) -> Result<C> + 'static,
+    {
+        let other = other.handle();
+        self.wire(|b, h| b.try_bimap(h, true, other, true, f))
+    }
+
+    fn try_join_passive<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
+    where
+        B: 'static,
+        C: Clone + Default + 'static,
+        F: Fn(&T, &B) -> Result<C> + 'static,
+    {
+        let other = other.handle();
+        self.wire(|b, h| b.try_bimap(h, true, other, false, f))
+    }
+
+    fn try_join3<B, C, D, F>(&self, b: &Stream<B>, c: &Stream<C>, f: F) -> Stream<D>
+    where
+        B: 'static,
+        C: 'static,
+        D: Clone + Default + 'static,
+        F: Fn(&T, &B, &C) -> Result<D> + 'static,
+    {
+        let (bh, ch) = (b.handle(), c.handle());
+        self.wire(|bld, h| bld.try_trimap(h, true, bh, true, ch, true, f))
+    }
+
     fn filter(&self, condition: &Stream<bool>) -> Stream<T>
     where
         T: Clone + Default + 'static,
@@ -657,6 +729,20 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         T: Clone + Default + Not<Output = T> + 'static,
     {
         self.map(|v| !v.clone())
+    }
+
+    fn print(&self) -> Stream<T>
+    where
+        T: Clone + Default + Debug + 'static,
+    {
+        self.wire(|b, h| b.print(h))
+    }
+
+    fn timed(&self) -> Stream<T>
+    where
+        T: Clone + Default + 'static,
+    {
+        self.wire(|b, h| b.timed(h))
     }
 
     fn delay(&self, delay: Duration) -> Stream<T>

--- a/wingfoil-next/src/interp.rs
+++ b/wingfoil-next/src/interp.rs
@@ -1420,8 +1420,10 @@ impl Runner {
 
     /// Select the dispatch strategy for subsequent [`run`](Runner::run)s.
     /// Defaults to [`Dispatch::Sparse`]; [`Dispatch::FullSweep`] is the
-    /// reference oracle (identical results, O(N) per cycle). Chainable.
-    pub fn with_dispatch(&mut self, dispatch: Dispatch) -> &mut Self {
+    /// reference oracle (identical results, O(N) per cycle). Consumes and
+    /// returns `self` so it chains off [`build`](Builder::build):
+    /// `let mut r = g.build().with_dispatch(Dispatch::FullSweep);`.
+    pub fn with_dispatch(mut self, dispatch: Dispatch) -> Self {
         self.dispatch = dispatch;
         self
     }

--- a/wingfoil-next/src/interp.rs
+++ b/wingfoil-next/src/interp.rs
@@ -1277,8 +1277,28 @@ impl Builder {
             id: self.id,
             active_downs,
             seed_nodes,
+            dispatch: Dispatch::default(),
         }
     }
+}
+
+/// Which dispatch strategy [`Runner::run`] uses. Both produce **identical**
+/// observable results; they differ only in per-cycle cost.
+///
+/// [`Sparse`](Dispatch::Sparse) — the default and production path — drives a
+/// dirty-list seeded from the tick frontier, so per-cycle work is proportional
+/// to the nodes that actually fire. [`FullSweep`](Dispatch::FullSweep) is the
+/// original `O(N)`-per-cycle topological sweep, retained as an executable
+/// reference oracle: `runner.with_dispatch(Dispatch::FullSweep)` re-runs the
+/// same graph under the old engine for differential parity checks and
+/// sparse-vs-`N` benchmarking.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Dispatch {
+    /// Sparse dirty-list (default): work ∝ active nodes.
+    #[default]
+    Sparse,
+    /// Full topological sweep: work ∝ graph size `N`. Reference oracle.
+    FullSweep,
 }
 
 /// Executes a wired graph. Dispatch is a sparse dirty-list — classic wingfoil's
@@ -1309,6 +1329,8 @@ pub struct Runner {
     /// Frontier sources seeded each cycle: `always` ops and callback-activated
     /// ops (the latter only fire when the kernel marks them dirty).
     seed_nodes: Vec<usize>,
+    /// Which dispatch loop `run` uses. `Sparse` by default; see [`Dispatch`].
+    dispatch: Dispatch,
 }
 
 impl Runner {
@@ -1366,78 +1388,13 @@ impl Runner {
         }
 
         if first_err.is_none() {
-            let n = self.nodes.len();
-            let mut dirty = vec![false; n];
-            // Sparse dirty-list scratch, allocated once and reused every cycle:
-            //   * `queue` — the dirty work set, a min-heap on node index so it
-            //     drains in ascending (wiring/topological) order. Every active
-            //     downstream has a higher index than its upstream, so a node
-            //     enqueued while processing `i` is always popped after `i` —
-            //     the heap never revisits a processed node.
-            //   * `node_dirty[i]` — guards a recombine node against being
-            //     enqueued twice, so it fires exactly once per cycle.
-            //   * `fired` — every node cycled this tick; the per-cycle `ticked`
-            //     and `node_dirty` resets touch only these, not all `N`, so
-            //     per-cycle work stays proportional to the active node count.
-            let mut queue: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
-            let mut node_dirty = vec![false; n];
-            let mut fired: Vec<usize> = Vec::new();
-            // Check `finished` *before* `begin_cycle` parks: a channel that
-            // received `EndOfStream` in the previous cycle ends the run now,
-            // rather than waiting for the bound while a live sender clone keeps
-            // the waker channel connected.
-            'run: while !self.finished.get() && kernel.begin_cycle(&mut dirty) {
-                // Seed the frontier: `always` ops fire unconditionally;
-                // callback-activated ops (tickers, `delay` pops, feedback
-                // source, channel replay) fire only when the kernel marked them
-                // dirty this cycle. Everything else reaches the queue by
-                // downstream propagation below.
-                for &i in &self.seed_nodes {
-                    if (self.nodes[i].activation.always || dirty[i]) && !node_dirty[i] {
-                        node_dirty[i] = true;
-                        queue.push(Reverse(i));
-                    }
-                }
-                // Drain in ascending index order. A node that ticks marks its
-                // active downstream neighbours (all at higher indices, so still
-                // ahead in the drain) dirty — propagating the tick frontier,
-                // each node firing once after everything it reads.
-                while let Some(Reverse(i)) = queue.pop() {
-                    let did = match (self.nodes[i].cycle)(&mut kernel) {
-                        Ok(did) => did,
-                        Err(e) => {
-                            let label = self.nodes[i].label;
-                            first_err = Some(e.context(format!("node {i} ({label}) cycle")));
-                            break 'run;
-                        }
-                    };
-                    // `ticked[i]` must be visible to downstreams that read it
-                    // (`merge` tie-break, `delay` first-value seeding) before
-                    // they fire; index order guarantees every node `i` reads
-                    // has already set its flag.
-                    self.ticked.borrow_mut()[i] = did;
-                    fired.push(i);
-                    if did {
-                        for &d in &self.active_downs[i] {
-                            if !node_dirty[d] {
-                                node_dirty[d] = true;
-                                queue.push(Reverse(d));
-                            }
-                        }
-                    }
-                }
-                // Reset only the nodes we touched (the queue is already drained
-                // empty), keeping the per-cycle reset sparse.
-                {
-                    let mut t = self.ticked.borrow_mut();
-                    for &i in &fired {
-                        t[i] = false;
-                        node_dirty[i] = false;
-                    }
-                }
-                fired.clear();
-                kernel.end_cycle(&mut dirty);
-            }
+            // Both dispatch strategies produce identical observable results
+            // (see `Dispatch`); the sparse dirty-list is the default, the full
+            // sweep is retained as an executable reference oracle.
+            first_err = match self.dispatch {
+                Dispatch::Sparse => self.run_cycles_sparse(&mut kernel),
+                Dispatch::FullSweep => self.run_cycles_full_sweep(&mut kernel),
+            };
         }
 
         // Cleanup always runs; a stop/teardown error only surfaces if no
@@ -1459,6 +1416,131 @@ impl Runner {
             Some(e) => Err(e),
             None => Ok(()),
         }
+    }
+
+    /// Select the dispatch strategy for subsequent [`run`](Runner::run)s.
+    /// Defaults to [`Dispatch::Sparse`]; [`Dispatch::FullSweep`] is the
+    /// reference oracle (identical results, O(N) per cycle). Chainable.
+    pub fn with_dispatch(&mut self, dispatch: Dispatch) -> &mut Self {
+        self.dispatch = dispatch;
+        self
+    }
+
+    /// The sparse dirty-list dispatch loop. Seeds the tick frontier into an
+    /// index-ordered min-heap and drains it, propagating ticks through
+    /// [`active_downs`](Runner::active_downs); per-cycle work is proportional to
+    /// the nodes that fire. Returns the first cycle error, or `None` if the run
+    /// reached its bound cleanly.
+    fn run_cycles_sparse(&mut self, kernel: &mut Kernel) -> Option<anyhow::Error> {
+        let n = self.nodes.len();
+        let mut dirty = vec![false; n];
+        // Sparse dirty-list scratch, allocated once and reused every cycle:
+        //   * `queue` — the dirty work set, a min-heap on node index so it
+        //     drains in ascending (wiring/topological) order. Every active
+        //     downstream has a higher index than its upstream, so a node
+        //     enqueued while processing `i` is always popped after `i` — the
+        //     heap never revisits a processed node.
+        //   * `node_dirty[i]` — guards a recombine node against being enqueued
+        //     twice, so it fires exactly once per cycle.
+        //   * `fired` — every node cycled this tick; the per-cycle `ticked` and
+        //     `node_dirty` resets touch only these, not all `N`, so per-cycle
+        //     work stays proportional to the active node count.
+        let mut queue: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
+        let mut node_dirty = vec![false; n];
+        let mut fired: Vec<usize> = Vec::new();
+        // Check `finished` *before* `begin_cycle` parks: a channel that received
+        // `EndOfStream` in the previous cycle ends the run now, rather than
+        // waiting for the bound while a live sender clone keeps the waker
+        // channel connected.
+        while !self.finished.get() && kernel.begin_cycle(&mut dirty) {
+            // Seed the frontier: `always` ops fire unconditionally;
+            // callback-activated ops (tickers, `delay` pops, feedback source,
+            // channel replay) fire only when the kernel marked them dirty this
+            // cycle. Everything else reaches the queue by downstream
+            // propagation below.
+            for &i in &self.seed_nodes {
+                if (self.nodes[i].activation.always || dirty[i]) && !node_dirty[i] {
+                    node_dirty[i] = true;
+                    queue.push(Reverse(i));
+                }
+            }
+            // Drain in ascending index order. A node that ticks marks its
+            // active downstream neighbours (all at higher indices, so still
+            // ahead in the drain) dirty — propagating the tick frontier, each
+            // node firing once after everything it reads.
+            while let Some(Reverse(i)) = queue.pop() {
+                let did = match (self.nodes[i].cycle)(kernel) {
+                    Ok(did) => did,
+                    Err(e) => {
+                        let label = self.nodes[i].label;
+                        return Some(e.context(format!("node {i} ({label}) cycle")));
+                    }
+                };
+                // `ticked[i]` must be visible to downstreams that read it
+                // (`merge` tie-break, `delay` first-value seeding) before they
+                // fire; index order guarantees every node `i` reads has already
+                // set its flag.
+                self.ticked.borrow_mut()[i] = did;
+                fired.push(i);
+                if did {
+                    for &d in &self.active_downs[i] {
+                        if !node_dirty[d] {
+                            node_dirty[d] = true;
+                            queue.push(Reverse(d));
+                        }
+                    }
+                }
+            }
+            // Reset only the nodes we touched (the queue is already drained
+            // empty), keeping the per-cycle reset sparse.
+            {
+                let mut t = self.ticked.borrow_mut();
+                for &i in &fired {
+                    t[i] = false;
+                    node_dirty[i] = false;
+                }
+            }
+            fired.clear();
+            kernel.end_cycle(&mut dirty);
+        }
+        None
+    }
+
+    /// The original full topological sweep, retained as a reference oracle:
+    /// every cycle it walks **all** nodes in wiring order and runs those whose
+    /// active upstream ticked (or which the kernel marked dirty) — `O(N)` per
+    /// cycle regardless of how many nodes fire. Observably identical to
+    /// [`run_cycles_sparse`](Runner::run_cycles_sparse); kept for differential
+    /// testing and benchmarking (see [`Dispatch`]).
+    fn run_cycles_full_sweep(&mut self, kernel: &mut Kernel) -> Option<anyhow::Error> {
+        let n = self.nodes.len();
+        let mut dirty = vec![false; n];
+        while !self.finished.get() && kernel.begin_cycle(&mut dirty) {
+            for (i, node) in self.nodes.iter_mut().enumerate() {
+                let due = node.activation.always
+                    || (node.activation.callback_activated() && dirty[i])
+                    || {
+                        let t = self.ticked.borrow();
+                        node.active_ups.iter().any(|&u| t[u])
+                    };
+                let did = if due {
+                    match (node.cycle)(kernel) {
+                        Ok(did) => did,
+                        Err(e) => {
+                            return Some(e.context(format!("node {i} ({}) cycle", node.label)));
+                        }
+                    }
+                } else {
+                    false
+                };
+                self.ticked.borrow_mut()[i] = did;
+            }
+            for t in self.ticked.borrow_mut().iter_mut() {
+                *t = false;
+            }
+            kernel.end_cycle(&mut dirty);
+        }
+        None
     }
 
     /// Current value of a node's output slot.

--- a/wingfoil-next/src/interp.rs
+++ b/wingfoil-next/src/interp.rs
@@ -34,6 +34,7 @@ use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, VecDeque};
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -50,8 +51,8 @@ use crate::Burst;
 use crate::channel::{ChannelSender, Message};
 use crate::op::{Activation, Ctx, Op, Tick};
 use crate::ops::{
-    Const, Delay, DelayState, Filter, Finally, Fold, Join, Join3, Merge2, Poll, Sample, Throttle,
-    Ticker, Window, WindowState, WithTime,
+    Const, Delay, DelayState, Filter, Finally, Fold, Join, Join3, Merge2, Poll, Print, Sample,
+    Throttle, Ticker, Timed, TimedState, TryJoin, TryJoin3, Window, WindowState, WithTime,
 };
 use wingfoil::codegen::{Kernel, KernelWaker, ReadyReceiver, waker_channel};
 use wingfoil::{NanoTime, RunFor, RunMode, TimeQueue};
@@ -780,6 +781,67 @@ impl Builder {
         self.make_handle(idx)
     }
 
+    /// The classic `try_trimap`: [`trimap`](Self::trimap) with a *fallible*
+    /// closure. Any `Err` propagates to abort the run with context; the
+    /// active/passive edge and dispatch semantics are identical to `trimap`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_trimap<A, B, C, D, F>(
+        &mut self,
+        a: Handle<A>,
+        a_active: bool,
+        b: Handle<B>,
+        b_active: bool,
+        c: Handle<C>,
+        c_active: bool,
+        f: F,
+    ) -> Handle<D>
+    where
+        A: 'static,
+        B: 'static,
+        C: 'static,
+        D: Clone + Default + 'static,
+        F: Fn(&A, &B, &C) -> Result<D> + 'static,
+    {
+        let idx = self.nodes.len();
+        let a_slot = self.slot(a);
+        let b_slot = self.slot(b);
+        let c_slot = self.slot(c);
+        let out = self.new_slot(D::default());
+        let cs = Self::cell(f, ());
+        let mut active = Vec::with_capacity(3);
+        if a_active {
+            active.push(a.idx);
+        }
+        if b_active {
+            active.push(b.idx);
+        }
+        if c_active {
+            active.push(c.idx);
+        }
+        self.push_node(
+            active,
+            TryJoin3::<A, B, C, D, F>::ACTIVATION,
+            "try_trimap",
+            Box::new(move |k| {
+                let (cfg, state) = &mut *cs.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                let va = a_slot.borrow();
+                let vb = b_slot.borrow();
+                let vc = c_slot.borrow();
+                match TryJoin3::<A, B, C, D, F>::cycle(cfg, state, (&va, &vb, &vc), &mut ctx)? {
+                    Tick::Value(v) => {
+                        drop((va, vb, vc));
+                        *out.borrow_mut() = v;
+                        Ok(true)
+                    }
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        self.make_handle(idx)
+    }
+
     pub fn filter<T: Clone + Default + 'static>(
         &mut self,
         src: Handle<T>,
@@ -924,6 +986,59 @@ impl Builder {
                 let va = a_slot.borrow();
                 let vb = b_slot.borrow();
                 match Join::<A, B, C, F>::cycle(cfg, state, (&va, &vb), &mut ctx)? {
+                    Tick::Value(v) => {
+                        drop(va);
+                        drop(vb);
+                        *out.borrow_mut() = v;
+                        Ok(true)
+                    }
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        self.make_handle(idx)
+    }
+
+    /// The classic `try_bimap`: [`bimap`](Self::bimap) with a *fallible*
+    /// closure. Any `Err` propagates to abort the run with context; the
+    /// active/passive edge and dispatch semantics are identical to `bimap`.
+    pub fn try_bimap<A, B, C, F>(
+        &mut self,
+        a: Handle<A>,
+        a_active: bool,
+        b: Handle<B>,
+        b_active: bool,
+        f: F,
+    ) -> Handle<C>
+    where
+        A: 'static,
+        B: 'static,
+        C: Clone + Default + 'static,
+        F: Fn(&A, &B) -> Result<C> + 'static,
+    {
+        let idx = self.nodes.len();
+        let a_slot = self.slot(a);
+        let b_slot = self.slot(b);
+        let out = self.new_slot(C::default());
+        let cs = Self::cell(f, ());
+        let mut active = Vec::with_capacity(2);
+        if a_active {
+            active.push(a.idx);
+        }
+        if b_active {
+            active.push(b.idx);
+        }
+        self.push_node(
+            active,
+            TryJoin::<A, B, C, F>::ACTIVATION,
+            "try_bimap",
+            Box::new(move |k| {
+                let (cfg, state) = &mut *cs.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                let va = a_slot.borrow();
+                let vb = b_slot.borrow();
+                match TryJoin::<A, B, C, F>::cycle(cfg, state, (&va, &vb), &mut ctx)? {
                     Tick::Value(v) => {
                         drop(va);
                         drop(vb);
@@ -1112,6 +1227,94 @@ impl Builder {
             let (cfg, state) = &mut *cs2.borrow_mut();
             let mut ctx = Ctx::new(k, idx);
             Finally::<A, F>::teardown(cfg, state, &mut ctx)
+        });
+        self.make_handle(idx)
+    }
+
+    /// The classic `print`: pass each value through unchanged while buffering
+    /// it, then print the whole buffer (`{value:?}` per line) at teardown.
+    /// Hand-written (not `#[op]`) because it carries a teardown hook.
+    pub fn print<T: Clone + Default + Debug + 'static>(&mut self, src: Handle<T>) -> Handle<T> {
+        let idx = self.nodes.len();
+        let src_slot = self.slot(src);
+        let out = self.new_slot(T::default());
+        let cs = Self::cell((), Vec::<T>::new());
+        let cs2 = cs.clone();
+        self.push_node(
+            vec![src.idx],
+            Print::<T>::ACTIVATION,
+            "print",
+            Box::new(move |k| {
+                let (cfg, state) = &mut *cs.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                let a = src_slot.borrow();
+                match Print::<T>::cycle(cfg, state, (&a,), &mut ctx)? {
+                    Tick::Value(v) => {
+                        drop(a);
+                        *out.borrow_mut() = v;
+                        Ok(true)
+                    }
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        // Print buffers during the run and flushes at teardown (classic `Drop`).
+        let node = self
+            .nodes
+            .last_mut()
+            .expect("invariant: print node just pushed");
+        node.teardown = Box::new(move |k| {
+            let (cfg, state) = &mut *cs2.borrow_mut();
+            let mut ctx = Ctx::new(k, idx);
+            Print::<T>::teardown(cfg, state, &mut ctx)
+        });
+        self.make_handle(idx)
+    }
+
+    /// The classic `timed`: pass `src` through unchanged, recording the
+    /// wall-clock start (`start` hook) and printing a performance summary at
+    /// `stop`. Hand-written (not `#[op]`) because it carries start + stop
+    /// hooks.
+    pub fn timed<T: Clone + Default + 'static>(&mut self, src: Handle<T>) -> Handle<T> {
+        let idx = self.nodes.len();
+        let src_slot = self.slot(src);
+        let out = self.new_slot(T::default());
+        let cs = Self::cell((), TimedState::default());
+        let cs_start = cs.clone();
+        let cs_stop = cs.clone();
+        self.push_node(
+            vec![src.idx],
+            Timed::<T>::ACTIVATION,
+            "timed",
+            Box::new(move |k| {
+                let (cfg, state) = &mut *cs.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                let a = src_slot.borrow();
+                match Timed::<T>::cycle(cfg, state, (&a,), &mut ctx)? {
+                    Tick::Value(v) => {
+                        drop(a);
+                        *out.borrow_mut() = v;
+                        Ok(true)
+                    }
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(move |k| {
+                let (cfg, state) = &mut *cs_start.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                Timed::<T>::start(cfg, state, &mut ctx)
+            }),
+        );
+        // `timed`'s summary prints at stop, after the last cycle.
+        let node = self
+            .nodes
+            .last_mut()
+            .expect("invariant: timed node just pushed");
+        node.stop = Box::new(move |k| {
+            let (cfg, state) = &mut *cs_stop.borrow_mut();
+            let mut ctx = Ctx::new(k, idx);
+            Timed::<T>::stop(cfg, state, &mut ctx)
         });
         self.make_handle(idx)
     }

--- a/wingfoil-next/src/interp.rs
+++ b/wingfoil-next/src/interp.rs
@@ -8,27 +8,32 @@
 //! monomorphized function* a compiled runner calls; the engines share
 //! semantics by construction.
 //!
-//! Execution model (and a known gap): each cycle this engine sweeps **all**
-//! nodes in wiring (topological) order and runs those whose active upstream
-//! ticked (or which the kernel marked dirty). Insertion order is always a
-//! valid topological order — the fluent API forces a stream to exist before
-//! it can be referenced — so this is glitch-free and fires each node exactly
-//! once after its upstreams, giving results **identical** to classic
-//! wingfoil. But classic instead propagates **breadth-first from the ticked
-//! sources through a dirty-list**, touching only nodes that can fire; the
-//! `O(N)`-per-cycle sweep here does not match that on large, sparsely-ticking
-//! graphs. Closing that (breadth-first dirty-list + arena value store) is a
-//! planned engine phase — see `docs/port-plan.md` "Phase 4.5"; it is a
-//! mechanism/performance change only, results stay identical.
+//! Execution model: a sparse dirty-list, matching classic wingfoil's
+//! `dirty_nodes_by_layer` (see `docs/port-plan.md` "Phase 4.5"). At `build()`
+//! each node gets an *active-downstream* adjacency list. Each cycle seeds a
+//! work set from the frontier — `always` busy-poll ops and kernel-marked
+//! callback-activated ops (tickers, `delay` pops, feedback source, channel
+//! replay) — then propagates the tick frontier forward: a node that ticks
+//! marks its active downstream neighbours dirty. The work set drains in
+//! ascending node **index** order (an index min-heap); wiring order is a valid
+//! topological order over *all* edges — active and passive, since the fluent
+//! API forces a stream to exist before it is referenced — so each node fires
+//! exactly once after everything it reads. This is glitch-free, gives results
+//! **identical** to classic wingfoil (and byte-identical to the previous
+//! full-index sweep it replaces), but per-cycle work is proportional to the
+//! nodes that actually fire, not the graph size `N`.
 //!
-//! Value slots are individual `Rc<RefCell<T>>`s (the arena is part of that
-//! same phase). `run` is fallible — it returns the first
+//! Value slots are individual `Rc<RefCell<T>>`s; the arena/SoA store is a
+//! deliberately separate follow-on (the slot boundary is frozen here so the
+//! catalog and adapter ports are not touched twice — see the Phase 4.5
+//! coupling note in the port plan). `run` is fallible — it returns the first
 //! `start`/`cycle`/`stop`/`teardown` error (with node context) and still runs
 //! cleanup afterwards, matching the classic engine.
 
 use std::any::Any;
 use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, VecDeque};
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1229,6 +1234,37 @@ impl Builder {
     }
 
     pub fn build(self) -> Runner {
+        // Sparse-dispatch topology, precomputed once so per-cycle work is
+        // proportional to the nodes that fire, not the graph size `N`:
+        //
+        //   * `active_downs[u]` — the reverse of `active_ups`: the nodes a
+        //     ticking `u` marks dirty. Dispatch propagates the tick frontier
+        //     forward through these edges (passive edges are absent — read but
+        //     not triggering).
+        //   * `seed_nodes` — the frontier dispatch seeds each cycle: `always`
+        //     (busy-poll) and callback-activated nodes (tickers, feedback
+        //     source, channel/external, `delay`'s scheduled pop, …).
+        //     Precomputed so seeding is O(#sources), not O(N).
+        //
+        // Dispatch orders the per-cycle work set by ascending node **index**
+        // (see `Runner::run`). Wiring order is a valid topological order over
+        // *all* edges — active and passive — since the fluent API forces a
+        // stream to exist before it is referenced, so index order processes
+        // every node after everything it reads. That is what lets passive
+        // reads (e.g. `sample` of a `delay`ed slot) observe the same value the
+        // old full-index sweep produced, without tracking passive edges here.
+        let n = self.nodes.len();
+        let mut active_downs: Vec<Vec<usize>> = vec![Vec::new(); n];
+        let mut seed_nodes: Vec<usize> = Vec::new();
+        for i in 0..n {
+            for &u in &self.nodes[i].active_ups {
+                active_downs[u].push(i);
+            }
+            let act = self.nodes[i].activation;
+            if act.always || act.callback_activated() {
+                seed_nodes.push(i);
+            }
+        }
         Runner {
             nodes: self.nodes,
             slots: self.slots,
@@ -1239,14 +1275,23 @@ impl Builder {
             has_channel: self.has_channel,
             finished: self.finished,
             id: self.id,
+            active_downs,
+            seed_nodes,
         }
     }
 }
 
-/// Executes a wired graph. Dispatch walks nodes in wiring (topological)
-/// order each cycle: a node runs when an active upstream ticked, or — only
-/// for ops that declared [`Activation::schedules`](crate::op::Activation) — when the
-/// kernel marked it dirty.
+/// Executes a wired graph. Dispatch is a sparse dirty-list — classic wingfoil's
+/// `dirty_nodes_by_layer` model — so per-cycle work is proportional to the
+/// nodes that actually fire, not the graph size `N`. Each cycle seeds a work
+/// set from the frontier ([`seed_nodes`](Runner::seed_nodes): `always`
+/// busy-poll ops and kernel-marked callback-activated ops), then propagates the
+/// tick frontier forward: a node that ticks marks its active downstream
+/// neighbours ([`active_downs`](Runner::active_downs)) dirty. The work set is
+/// drained in ascending node **index** order (wiring order, a valid topological
+/// order over active *and* passive edges), so each node fires exactly once
+/// after everything it reads — glitch-free, single-fire, and byte-identical to
+/// the previous full-index sweep.
 pub struct Runner {
     nodes: Vec<NodeRt>,
     slots: Vec<Rc<dyn Any>>,
@@ -1257,6 +1302,13 @@ pub struct Runner {
     has_channel: bool,
     finished: Rc<Cell<bool>>,
     id: u64,
+    /// `active_downs[i]` = nodes triggered when `i` ticks (reverse of
+    /// `active_ups`). Passive edges are deliberately absent — they are read but
+    /// do not propagate ticks.
+    active_downs: Vec<Vec<usize>>,
+    /// Frontier sources seeded each cycle: `always` ops and callback-activated
+    /// ops (the latter only fire when the kernel marks them dirty).
+    seed_nodes: Vec<usize>,
 }
 
 impl Runner {
@@ -1316,35 +1368,74 @@ impl Runner {
         if first_err.is_none() {
             let n = self.nodes.len();
             let mut dirty = vec![false; n];
+            // Sparse dirty-list scratch, allocated once and reused every cycle:
+            //   * `queue` — the dirty work set, a min-heap on node index so it
+            //     drains in ascending (wiring/topological) order. Every active
+            //     downstream has a higher index than its upstream, so a node
+            //     enqueued while processing `i` is always popped after `i` —
+            //     the heap never revisits a processed node.
+            //   * `node_dirty[i]` — guards a recombine node against being
+            //     enqueued twice, so it fires exactly once per cycle.
+            //   * `fired` — every node cycled this tick; the per-cycle `ticked`
+            //     and `node_dirty` resets touch only these, not all `N`, so
+            //     per-cycle work stays proportional to the active node count.
+            let mut queue: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
+            let mut node_dirty = vec![false; n];
+            let mut fired: Vec<usize> = Vec::new();
             // Check `finished` *before* `begin_cycle` parks: a channel that
             // received `EndOfStream` in the previous cycle ends the run now,
             // rather than waiting for the bound while a live sender clone keeps
             // the waker channel connected.
             'run: while !self.finished.get() && kernel.begin_cycle(&mut dirty) {
-                for (i, node) in self.nodes.iter_mut().enumerate() {
-                    let due = node.activation.always
-                        || (node.activation.callback_activated() && dirty[i])
-                        || {
-                            let t = self.ticked.borrow();
-                            node.active_ups.iter().any(|&u| t[u])
-                        };
-                    let did = if due {
-                        match (node.cycle)(&mut kernel) {
-                            Ok(did) => did,
-                            Err(e) => {
-                                first_err =
-                                    Some(e.context(format!("node {i} ({}) cycle", node.label)));
-                                break 'run;
+                // Seed the frontier: `always` ops fire unconditionally;
+                // callback-activated ops (tickers, `delay` pops, feedback
+                // source, channel replay) fire only when the kernel marked them
+                // dirty this cycle. Everything else reaches the queue by
+                // downstream propagation below.
+                for &i in &self.seed_nodes {
+                    if (self.nodes[i].activation.always || dirty[i]) && !node_dirty[i] {
+                        node_dirty[i] = true;
+                        queue.push(Reverse(i));
+                    }
+                }
+                // Drain in ascending index order. A node that ticks marks its
+                // active downstream neighbours (all at higher indices, so still
+                // ahead in the drain) dirty — propagating the tick frontier,
+                // each node firing once after everything it reads.
+                while let Some(Reverse(i)) = queue.pop() {
+                    let did = match (self.nodes[i].cycle)(&mut kernel) {
+                        Ok(did) => did,
+                        Err(e) => {
+                            let label = self.nodes[i].label;
+                            first_err = Some(e.context(format!("node {i} ({label}) cycle")));
+                            break 'run;
+                        }
+                    };
+                    // `ticked[i]` must be visible to downstreams that read it
+                    // (`merge` tie-break, `delay` first-value seeding) before
+                    // they fire; index order guarantees every node `i` reads
+                    // has already set its flag.
+                    self.ticked.borrow_mut()[i] = did;
+                    fired.push(i);
+                    if did {
+                        for &d in &self.active_downs[i] {
+                            if !node_dirty[d] {
+                                node_dirty[d] = true;
+                                queue.push(Reverse(d));
                             }
                         }
-                    } else {
-                        false
-                    };
-                    self.ticked.borrow_mut()[i] = did;
+                    }
                 }
-                for t in self.ticked.borrow_mut().iter_mut() {
-                    *t = false;
+                // Reset only the nodes we touched (the queue is already drained
+                // empty), keeping the per-cycle reset sparse.
+                {
+                    let mut t = self.ticked.borrow_mut();
+                    for &i in &fired {
+                        t[i] = false;
+                        node_dirty[i] = false;
+                    }
                 }
+                fired.clear();
                 kernel.end_cycle(&mut dirty);
             }
         }

--- a/wingfoil-next/src/lib.rs
+++ b/wingfoil-next/src/lib.rs
@@ -71,6 +71,7 @@
 //! store and breadth-first dirty-list scheduling for the interpreted engine
 //! (see `docs/port-plan.md` "Phase 4.5"), and dynamic (runtime-mutated) graphs.
 
+pub mod adapters;
 #[cfg(feature = "async")]
 pub mod async_source;
 pub mod channel;

--- a/wingfoil-next/src/ops.rs
+++ b/wingfoil-next/src/ops.rs
@@ -629,6 +629,283 @@ impl Op for RollingMean {
     }
 }
 
+/// Ring-buffer state for the rolling variance / std ops: the most recent
+/// `window` samples plus incrementally maintained count-weighted moments
+/// (Welford's algorithm with exact removal), so a tick is O(1). Mirrors the
+/// classic `RollingMomentStream` under `Weighting::Count`.
+pub struct RollingMomentState {
+    buffer: VecDeque<f64>,
+    count: u64,
+    mean: f64,
+    m2: f64,
+}
+
+impl Default for RollingMomentState {
+    fn default() -> Self {
+        Self {
+            buffer: VecDeque::new(),
+            count: 0,
+            mean: 0.0,
+            m2: 0.0,
+        }
+    }
+}
+
+impl RollingMomentState {
+    /// Fold a new sample into the moments (Welford update).
+    fn add(&mut self, x: f64) {
+        self.count += 1;
+        let mean_old = self.mean;
+        self.mean += (x - mean_old) / self.count as f64;
+        self.m2 += (x - mean_old) * (x - self.mean);
+    }
+
+    /// Exact inverse of [`add`](Self::add): drop a previously added sample so a
+    /// sliding window can evict its oldest contribution in O(1). Like any
+    /// revert-based scheme this can accumulate floating-point error, so `m2` is
+    /// clamped at zero.
+    fn remove(&mut self, x: f64) {
+        // Removing the final contribution empties the accumulator; reset
+        // cleanly rather than dividing by a count at (or below) zero.
+        if self.count <= 1 {
+            self.count = 0;
+            self.mean = 0.0;
+            self.m2 = 0.0;
+            return;
+        }
+        let n = self.count as f64;
+        let mean_old = (n * self.mean - x) / (n - 1.0);
+        self.m2 -= (x - mean_old) * (x - self.mean);
+        if self.m2 < 0.0 {
+            self.m2 = 0.0;
+        }
+        self.mean = mean_old;
+        self.count -= 1;
+    }
+
+    /// Push a sample, evicting the oldest once the window is full.
+    fn push(&mut self, sample: f64, window: usize) {
+        self.buffer.push_back(sample);
+        self.add(sample);
+        if self.buffer.len() > window {
+            let oldest = self
+                .buffer
+                .pop_front()
+                .expect("invariant: len > window >= 1 implies non-empty");
+            self.remove(oldest);
+        }
+    }
+
+    /// Sample variance (ddof = 1) — the classic `Weighting::Count` convention.
+    /// Yields `0.0` while fewer than two samples are present (rather than NaN).
+    fn variance(&self) -> f64 {
+        if self.count < 2 {
+            return 0.0;
+        }
+        self.m2 / (self.count as f64 - 1.0)
+    }
+}
+
+/// Rolling **sample** variance (ddof = 1) over the most recent `window` `f64`
+/// samples. Matches the classic statistics adapter's `Weighting::Count`
+/// convention: the divisor is `n - 1`, and the result is `0.0` until at least
+/// two samples are in the window. `Cfg` = window.
+pub struct RollingVar;
+
+#[op(build = rolling_var)]
+impl Op for RollingVar {
+    type Cfg = usize;
+    type State = RollingMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut RollingMomentState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.push(*input.0, (*cfg).max(1));
+        Ok(Tick::Value(state.variance()))
+    }
+}
+
+/// Rolling **sample** standard deviation over the most recent `window` `f64`
+/// samples — the square root of [`RollingVar`] under the same (ddof = 1)
+/// convention. Clamped at zero before the square root so a constant window
+/// (whose incremental variance can drift a hair negative) yields `0.0`, not
+/// `NaN`. `Cfg` = window.
+pub struct RollingStd;
+
+#[op(build = rolling_std)]
+impl Op for RollingStd {
+    type Cfg = usize;
+    type State = RollingMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut RollingMomentState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.push(*input.0, (*cfg).max(1));
+        Ok(Tick::Value(state.variance().max(0.0).sqrt()))
+    }
+}
+
+/// Monotonic-deque state for the rolling min & max ops. Holds `(index, value)`
+/// candidates kept monotonic in value, so the front is always the window
+/// extreme — O(1) amortised per tick. Mirrors the classic `RollingExtremeStream`
+/// (a monotonic deque, not a per-tick window scan, so the tick semantics match
+/// the classic node exactly even though a scan would give the same values).
+#[derive(Default)]
+pub struct RollingExtremeState {
+    deque: VecDeque<(u64, f64)>,
+    index: u64,
+}
+
+impl RollingExtremeState {
+    /// Push a sample and return the current window extreme. `is_min` selects
+    /// which back candidates the new sample dominates: for a minimum we drop
+    /// candidates `>= sample`, for a maximum `<= sample`.
+    fn push(&mut self, sample: f64, window: usize, is_min: bool) -> f64 {
+        let window = window.max(1) as u64;
+        let i = self.index;
+        self.index += 1;
+
+        // Drop back candidates the new sample dominates (they can never again
+        // be the extreme while it is in the window).
+        while let Some(&(_, back)) = self.deque.back() {
+            let dominated = if is_min {
+                back >= sample
+            } else {
+                back <= sample
+            };
+            if dominated {
+                self.deque.pop_back();
+            } else {
+                break;
+            }
+        }
+        self.deque.push_back((i, sample));
+
+        // Drop the front once it falls outside the last `window` indices. The
+        // just-pushed `i` is always in window, so the deque never empties.
+        while let Some(&(idx, _)) = self.deque.front() {
+            if i - idx >= window {
+                self.deque.pop_front();
+            } else {
+                break;
+            }
+        }
+        self.deque
+            .front()
+            .expect("invariant: deque holds the current sample")
+            .1
+    }
+}
+
+/// Rolling minimum over the most recent `window` `f64` samples, via a monotonic
+/// deque — O(1) amortised per tick. `Cfg` = window.
+pub struct RollingMin;
+
+#[op(build = rolling_min)]
+impl Op for RollingMin {
+    type Cfg = usize;
+    type State = RollingExtremeState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut RollingExtremeState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        Ok(Tick::Value(state.push(*input.0, *cfg, true)))
+    }
+}
+
+/// Rolling maximum over the most recent `window` `f64` samples, via a monotonic
+/// deque — O(1) amortised per tick. `Cfg` = window.
+pub struct RollingMax;
+
+#[op(build = rolling_max)]
+impl Op for RollingMax {
+    type Cfg = usize;
+    type State = RollingExtremeState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut RollingExtremeState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        Ok(Tick::Value(state.push(*input.0, *cfg, false)))
+    }
+}
+
+/// Ring-buffer state for the rolling median op — retains the most recent
+/// `window` samples and recomputes the median (sort) each tick, matching the
+/// classic recompute-per-tick `WindowStream` (the median has no cheap
+/// incremental form here).
+#[derive(Default)]
+pub struct RollingMedianState {
+    buffer: VecDeque<f64>,
+}
+
+impl RollingMedianState {
+    /// Push a sample (evicting the oldest past `window`) and return the median
+    /// of the retained samples. An even-sized window averages the two middle
+    /// values, so unit weights reproduce the ordinary median — the classic
+    /// `Weighting::Count` behaviour.
+    fn push(&mut self, sample: f64, window: usize) -> f64 {
+        self.buffer.push_back(sample);
+        while self.buffer.len() > window {
+            self.buffer.pop_front();
+        }
+        let mut sorted: Vec<f64> = self.buffer.iter().copied().collect();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n = sorted.len();
+        if n % 2 == 1 {
+            sorted[n / 2]
+        } else {
+            (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+        }
+    }
+}
+
+/// Rolling median over the most recent `window` `f64` samples. Recomputed per
+/// tick (O(window)); an even window averages its two middle values, matching
+/// the classic statistics adapter's count-weighted median. `Cfg` = window.
+pub struct RollingMedian;
+
+#[op(build = rolling_median)]
+impl Op for RollingMedian {
+    type Cfg = usize;
+    type State = RollingMedianState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut RollingMedianState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        Ok(Tick::Value(state.push(*input.0, (*cfg).max(1))))
+    }
+}
+
 /// Emits its source value when the condition stream's current value is true.
 pub struct Filter<T>(PhantomData<T>);
 

--- a/wingfoil-next/src/ops.rs
+++ b/wingfoil-next/src/ops.rs
@@ -12,8 +12,10 @@
 //! See `docs/port-plan.md` "Adding an op" for the full recipe.
 
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::Sub;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 
@@ -290,6 +292,101 @@ where
     }
 }
 
+/// Passes each value through unchanged while buffering it, then prints the
+/// whole buffer (`{value:?}` per line) at teardown. The classic `print` node,
+/// whose buffered `Drop` becomes the op's [`teardown`](Op::teardown) hook —
+/// so the summary still prints even if a cycle aborted the run. `State` is the
+/// buffer.
+pub struct Print<T>(PhantomData<T>);
+
+impl<T: Clone + Debug + 'static> Op for Print<T> {
+    type Cfg = ();
+    type State = Vec<T>;
+    type In<'a> = (&'a T,);
+    type Out = T;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut Vec<T>,
+        input: (&T,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<T>> {
+        state.push(input.0.clone());
+        Ok(Tick::Value(input.0.clone()))
+    }
+
+    fn teardown(_cfg: &mut (), state: &mut Vec<T>, _ctx: &mut Ctx<'_>) -> Result<()> {
+        for val in state.iter() {
+            println!("{val:?}");
+        }
+        Ok(())
+    }
+}
+
+/// Pending state for a [`Timed`] op: the tick count and the wall-clock start
+/// instant (set at [`start`](Op::start)).
+#[derive(Default)]
+pub struct TimedState {
+    cycles: u64,
+    wall_start: Option<Instant>,
+}
+
+/// Passes its source value through unchanged, recording the wall-clock start
+/// at [`start`](Op::start) and printing a performance summary at
+/// [`stop`](Op::stop) (tick count, wall-clock duration, per-tick average, and
+/// the engine-time span covered). The classic `timed` node.
+///
+/// Deviations from classic (observable value stream is identical — a
+/// pass-through — only the diagnostic differs): the summary goes to `stderr`
+/// via `eprintln!` rather than `log::info!` (wingfoil-next has no `log`
+/// dependency), and — since [`Ctx`] exposes no run mode — it always reports
+/// the wall-vs-engine speedup rather than branching on historical/realtime.
+pub struct Timed<T>(PhantomData<T>);
+
+impl<T: Clone + 'static> Op for Timed<T> {
+    type Cfg = ();
+    type State = TimedState;
+    type In<'a> = (&'a T,);
+    type Out = T;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn start(_cfg: &mut (), state: &mut TimedState, _ctx: &mut Ctx<'_>) -> Result<()> {
+        state.wall_start = Some(Instant::now());
+        Ok(())
+    }
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut TimedState,
+        input: (&T,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<T>> {
+        state.cycles += 1;
+        Ok(Tick::Value(input.0.clone()))
+    }
+
+    fn stop(_cfg: &mut (), state: &mut TimedState, ctx: &mut Ctx<'_>) -> Result<()> {
+        let engine_elapsed = Duration::from(ctx.time() - ctx.start_time());
+        let wall = state
+            .wall_start
+            .map(|s| s.elapsed())
+            .unwrap_or(engine_elapsed);
+        let cycles = state.cycles;
+        let avg = Duration::from_nanos((wall.as_nanos() / u128::from(cycles.max(1))) as u64);
+        let speedup = if wall.as_secs_f64() > 0.0 {
+            engine_elapsed.as_secs_f64() / wall.as_secs_f64()
+        } else {
+            f64::INFINITY
+        };
+        eprintln!(
+            "{cycles} ticks processed in {wall:?}, {avg:?} average.   \
+             Covered {engine_elapsed:?} of engine time (x{speedup:.1})."
+        );
+        Ok(())
+    }
+}
+
 /// Buffers values and flushes them as a `Vec` on each fixed time boundary
 /// (`interval`), plus a final flush on the last cycle. `Cfg` = interval;
 /// `State` holds the next boundary and the pending buffer.
@@ -404,6 +501,36 @@ where
         _ctx: &mut Ctx<'_>,
     ) -> Result<Tick<D>> {
         Ok(Tick::Value(cfg(input.0, input.1, input.2)))
+    }
+}
+
+/// Combines three streams with a *fallible* closure — the classic
+/// `try_trimap`. The `try_` counterpart to [`Join3`]: any returned `Err`
+/// propagates to abort the run with context. The closure is `Fn`, like
+/// [`Join3`].
+pub struct TryJoin3<A, B, C, D, F>(PhantomData<(A, B, C, D, F)>);
+
+impl<A, B, C, D, F> Op for TryJoin3<A, B, C, D, F>
+where
+    A: 'static,
+    B: 'static,
+    C: 'static,
+    D: Clone + 'static,
+    F: Fn(&A, &B, &C) -> Result<D> + 'static,
+{
+    type Cfg = F;
+    type State = ();
+    type In<'a> = (&'a A, &'a B, &'a C);
+    type Out = D;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut F,
+        _state: &mut (),
+        input: (&A, &B, &C),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<D>> {
+        Ok(Tick::Value(cfg(input.0, input.1, input.2)?))
     }
 }
 
@@ -1078,6 +1205,31 @@ where
 
     fn cycle(cfg: &mut F, _state: &mut (), input: (&A, &B), _ctx: &mut Ctx<'_>) -> Result<Tick<C>> {
         Ok(Tick::Value(cfg(input.0, input.1)))
+    }
+}
+
+/// Joins two streams with a *fallible* closure — the classic `try_bimap`. The
+/// `try_` counterpart to [`Join`]: any returned `Err` propagates to abort the
+/// run with context. Each upstream is independently active or passive (an
+/// engine dispatch concern); both values are always read. The closure is `Fn`,
+/// like [`Join`].
+pub struct TryJoin<A, B, C, F>(PhantomData<(A, B, C, F)>);
+
+impl<A, B, C, F> Op for TryJoin<A, B, C, F>
+where
+    A: 'static,
+    B: 'static,
+    C: Clone + 'static,
+    F: Fn(&A, &B) -> Result<C> + 'static,
+{
+    type Cfg = F;
+    type State = ();
+    type In<'a> = (&'a A, &'a B);
+    type Out = C;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(cfg: &mut F, _state: &mut (), input: (&A, &B), _ctx: &mut Ctx<'_>) -> Result<Tick<C>> {
+        Ok(Tick::Value(cfg(input.0, input.1)?))
     }
 }
 

--- a/wingfoil-next/src/stats.rs
+++ b/wingfoil-next/src/stats.rs
@@ -33,6 +33,26 @@ pub trait StatisticsOps {
 
     /// Mean over a sliding window of the last `window` values.
     fn rolling_mean(&self, window: usize) -> Stream<f64>;
+
+    /// Minimum over a sliding window of the last `window` values.
+    fn rolling_min(&self, window: usize) -> Stream<f64>;
+
+    /// Maximum over a sliding window of the last `window` values.
+    fn rolling_max(&self, window: usize) -> Stream<f64>;
+
+    /// Sample variance (ddof = 1) over a sliding window of the last `window`
+    /// values — the classic statistics adapter's count-weighted convention
+    /// (divisor `n - 1`, `0.0` until two samples are present).
+    fn rolling_var(&self, window: usize) -> Stream<f64>;
+
+    /// Sample standard deviation over a sliding window of the last `window`
+    /// values — the square root of [`rolling_var`](Self::rolling_var) under the
+    /// same (ddof = 1) convention.
+    fn rolling_std(&self, window: usize) -> Stream<f64>;
+
+    /// Median over a sliding window of the last `window` values (an even window
+    /// averages its two middle values).
+    fn rolling_median(&self, window: usize) -> Stream<f64>;
 }
 
 impl StatisticsOps for Stream<f64> {
@@ -58,5 +78,25 @@ impl StatisticsOps for Stream<f64> {
 
     fn rolling_mean(&self, window: usize) -> Stream<f64> {
         self.wire(|b, h| b.rolling_mean(h, window))
+    }
+
+    fn rolling_min(&self, window: usize) -> Stream<f64> {
+        self.wire(|b, h| b.rolling_min(h, window))
+    }
+
+    fn rolling_max(&self, window: usize) -> Stream<f64> {
+        self.wire(|b, h| b.rolling_max(h, window))
+    }
+
+    fn rolling_var(&self, window: usize) -> Stream<f64> {
+        self.wire(|b, h| b.rolling_var(h, window))
+    }
+
+    fn rolling_std(&self, window: usize) -> Stream<f64> {
+        self.wire(|b, h| b.rolling_std(h, window))
+    }
+
+    fn rolling_median(&self, window: usize) -> Stream<f64> {
+        self.wire(|b, h| b.rolling_median(h, window))
     }
 }

--- a/wingfoil-next/tests/catalog_ops.rs
+++ b/wingfoil-next/tests/catalog_ops.rs
@@ -1,0 +1,156 @@
+//! Phase 2 node-catalog parity for the multi-input `try_*` combines and the
+//! `print` / `timed` pass-through diagnostics. Each test mirrors the classic
+//! node's own unit test (`try_bimap`, `try_trimap`, `print`, `timed`) —
+//! reproducing the same values and, for the passive cases, the same tick
+//! times.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+// --- try_join (classic `try_bimap`) ----------------------------------------
+
+/// `try_join` combines two active streams with a fallible closure — mirrors
+/// classic `try_bimap::try_bimap_success` (a + b*10, last = 55 at cycle 5).
+#[test]
+fn try_join_success() {
+    let g = GraphBuilder::new();
+    let tick = g.ticker(Duration::from_nanos(100));
+    let a = tick.count();
+    let b = tick.count().map(|x| x * 10);
+    let combined = a.try_join(&b, |a: &u64, b: &u64| Ok(a + b));
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(55, r.value(&combined));
+}
+
+/// A closure error aborts the run — mirrors classic
+/// `try_bimap::try_bimap_error`.
+#[test]
+fn try_join_error_aborts_run() {
+    let g = GraphBuilder::new();
+    let tick = g.ticker(Duration::from_nanos(100));
+    let a = tick.count();
+    let b = tick.count();
+    let _combined = a.try_join(&b, |_: &u64, _: &u64| -> anyhow::Result<u64> {
+        anyhow::bail!("oops")
+    });
+    let mut r = g.build();
+    assert!(r.run(HISTORICAL, RunFor::Cycles(1)).is_err());
+}
+
+/// A passive `try_join` input is read but does not trigger — mirrors classic
+/// `try_bimap::try_bimap_passive_does_not_trigger`. The combine fires only on
+/// the active (slow, 100ns) input, at t = 0, 100, 200.
+#[test]
+fn try_join_passive_does_not_trigger() {
+    let g = GraphBuilder::new();
+    let a = g.ticker(Duration::from_nanos(100)).count(); // active
+    let b = g.ticker(Duration::from_nanos(50)).count(); // passive
+    let combined = a.try_join_passive(&b, |a: &u64, b: &u64| Ok(a + b));
+    let times = combined.ticked_at().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(
+        vec![NanoTime::new(0), NanoTime::new(100), NanoTime::new(200)],
+        r.value(&times)
+    );
+}
+
+// --- try_join3 (classic `try_trimap`) --------------------------------------
+
+/// `try_join3` combines three active streams with a fallible closure —
+/// mirrors classic `try_trimap::try_trimap_success` (a + b*10 + c*100, last =
+/// 555 at cycle 5).
+#[test]
+fn try_join3_success() {
+    let g = GraphBuilder::new();
+    let tick = g.ticker(Duration::from_nanos(100));
+    let a = tick.count();
+    let b = tick.count().map(|x| x * 10);
+    let c = tick.count().map(|x| x * 100);
+    let combined = a.try_join3(&b, &c, |a: &u64, b: &u64, c: &u64| Ok(a + b + c));
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(555, r.value(&combined));
+}
+
+/// A closure error aborts the run — mirrors classic
+/// `try_trimap::try_trimap_error`.
+#[test]
+fn try_join3_error_aborts_run() {
+    let g = GraphBuilder::new();
+    let tick = g.ticker(Duration::from_nanos(100));
+    let a = tick.count();
+    let b = tick.count();
+    let c = tick.count();
+    let _combined = a.try_join3(&b, &c, |_: &u64, _: &u64, _: &u64| -> anyhow::Result<u64> {
+        anyhow::bail!("oops")
+    });
+    let mut r = g.build();
+    assert!(r.run(HISTORICAL, RunFor::Cycles(1)).is_err());
+}
+
+/// Passive `try_join3` inputs are read but do not trigger — mirrors classic
+/// `try_trimap::try_trimap_passive_does_not_trigger`. Fires only on the active
+/// (slow, 100ns) input, at t = 0, 100, 200.
+#[test]
+fn try_join3_passive_does_not_trigger() {
+    let g = GraphBuilder::new();
+    let a = g.ticker(Duration::from_nanos(100)).count(); // active
+    let b = g.ticker(Duration::from_nanos(50)).count(); // passive
+    let c = g.ticker(Duration::from_nanos(50)).count(); // passive
+    // `try_join3` makes all three active; use the builder directly to keep b
+    // and c passive, matching the classic test.
+    let times = a
+        .wire(|bld, h| {
+            let (bh, ch) = (b.handle(), c.handle());
+            bld.try_trimap(
+                h,
+                true,
+                bh,
+                false,
+                ch,
+                false,
+                |a: &u64, b: &u64, c: &u64| Ok(a + b + c),
+            )
+        })
+        .ticked_at()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(
+        vec![NanoTime::new(0), NanoTime::new(100), NanoTime::new(200)],
+        r.value(&times)
+    );
+}
+
+// --- print -----------------------------------------------------------------
+
+/// `print` passes values through unchanged (the buffered print is a teardown
+/// side effect) — mirrors classic `print::print_passes_through_values`.
+#[test]
+fn print_passes_through_values() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(100)).count();
+    let acc = count.print().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1, 2, 3], r.value(&acc));
+}
+
+// --- timed -----------------------------------------------------------------
+
+/// `timed` passes values through unchanged (the summary is a stop side
+/// effect) — mirrors classic `timed::timed_historical`.
+#[test]
+fn timed_passes_through_values() {
+    let g = GraphBuilder::new();
+    let out = g.ticker(Duration::from_nanos(100)).count().timed();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(5, r.value(&out));
+}

--- a/wingfoil-next/tests/compat.rs
+++ b/wingfoil-next/tests/compat.rs
@@ -83,3 +83,154 @@ fn second_run_errors_and_leaves_first_result_intact() {
     // The first run's runner is untouched, so peek still returns its value.
     assert_eq!(5, counted.peek_value());
 }
+
+// --- Expanded operator surface, all in the classic idiom -------------------
+
+/// `limit` passes the first N values, then stays quiet.
+#[test]
+fn classic_limit_passes_first_n() {
+    let count = ticker(Duration::from_nanos(100)).count();
+    let limited = count.limit(3).accumulate();
+    limited.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1, 2, 3], limited.peek_value());
+}
+
+/// `distinct` suppresses consecutive duplicates (emit on change only).
+#[test]
+fn classic_distinct_drops_repeats() {
+    // counts 1..=6 mapped through integer halving: 0,1,1,2,2,3 -> distinct 0,1,2,3
+    let count = ticker(Duration::from_nanos(100)).count();
+    let stepped = count.map(|i| i / 2).distinct().accumulate();
+    stepped.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(vec![0, 1, 2, 3], stepped.peek_value());
+}
+
+/// `difference` emits `value - previous`, quiet on the first value.
+#[test]
+fn classic_difference_of_successive_values() {
+    // squares 1,4,9,16 -> successive differences 3,5,7
+    let count = ticker(Duration::from_nanos(100)).count();
+    let diffs = count.map(|i| i * i).difference().accumulate();
+    diffs.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(vec![3, 5, 7], diffs.peek_value());
+}
+
+/// `not` negates each value — here a parity flag.
+#[test]
+fn classic_not_negates() {
+    let count = ticker(Duration::from_nanos(100)).count();
+    // is_even over counts 1,2,3,4 -> false,true,false,true; not -> true,false,true,false
+    let flipped = count.map(|i| i.is_multiple_of(2)).not().accumulate();
+    flipped.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(vec![true, false, true, false], flipped.peek_value());
+}
+
+/// `merge` recombines two disjoint sub-streams of one source; exactly one
+/// ticks each cycle, so the merge reconstructs the original sequence.
+#[test]
+fn classic_merge_recombines_disjoint_streams() {
+    let count = ticker(Duration::from_nanos(100)).count();
+    let evens = count.filter(&count.map(|i| i.is_multiple_of(2)));
+    let odds = count.filter(&count.map(|i| !i.is_multiple_of(2)));
+    let merged = odds.merge(&evens).accumulate();
+    merged.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(vec![1, 2, 3, 4], merged.peek_value());
+}
+
+/// `sample` reads the current value of one stream whenever a trigger ticks.
+#[test]
+fn classic_sample_reads_on_trigger() {
+    let tk = ticker(Duration::from_nanos(100));
+    let count = tk.count();
+    let value = count.map(|i| i * 10); // 10,20,30,40,50,60
+    // trigger ticks only on even counts (cycles 2,4,6)
+    let trigger = tk.filter(&count.map(|i| i.is_multiple_of(2)));
+    let sampled = value.sample(&trigger).accumulate();
+    sampled.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(vec![20, 40, 60], sampled.peek_value());
+}
+
+/// `with_time` pairs each value with the engine time it ticked at.
+#[test]
+fn classic_with_time_pairs_time_and_value() {
+    let timed = ticker(Duration::from_nanos(100))
+        .count()
+        .with_time()
+        .accumulate();
+    timed.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::from(0u64), 1u64),
+            (NanoTime::from(100u64), 2u64),
+            (NanoTime::from(200u64), 3u64),
+        ],
+        timed.peek_value()
+    );
+}
+
+/// `ticked_at` emits the engine time on each tick.
+#[test]
+fn classic_ticked_at_emits_engine_time() {
+    let times = ticker(Duration::from_nanos(100)).ticked_at().accumulate();
+    times.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![
+            NanoTime::from(0u64),
+            NanoTime::from(100u64),
+            NanoTime::from(200u64),
+        ],
+        times.peek_value()
+    );
+}
+
+/// `ticked_at_elapsed` emits time since the run start (start = 0 here).
+#[test]
+fn classic_ticked_at_elapsed_emits_elapsed() {
+    let elapsed = ticker(Duration::from_nanos(100))
+        .ticked_at_elapsed()
+        .accumulate();
+    elapsed.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![
+            NanoTime::from(0u64),
+            NanoTime::from(100u64),
+            NanoTime::from(200u64),
+        ],
+        elapsed.peek_value()
+    );
+}
+
+/// `throttle` rate-limits emission to at most once per interval.
+#[test]
+fn classic_throttle_rate_limits() {
+    // ticks at t=0,100,200,300,400; throttle(250) admits t=0 then t=300
+    let throttled = ticker(Duration::from_nanos(100))
+        .count()
+        .throttle(Duration::from_nanos(250))
+        .accumulate();
+    throttled.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1, 4], throttled.peek_value());
+}
+
+/// `window` buffers values and flushes them on each interval boundary.
+#[test]
+fn classic_window_flushes_on_interval() {
+    let windowed = ticker(Duration::from_nanos(100))
+        .count()
+        .window(Duration::from_nanos(300))
+        .accumulate();
+    windowed.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(vec![vec![1, 2, 3], vec![4, 5, 6]], windowed.peek_value());
+}
+
+/// `buffer` flushes a `Vec` once `capacity` values accumulate (plus a final
+/// partial flush on the last cycle).
+#[test]
+fn classic_buffer_flushes_by_capacity() {
+    let buffered = ticker(Duration::from_nanos(100))
+        .count()
+        .buffer(2)
+        .accumulate();
+    buffered.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![vec![1, 2], vec![3, 4], vec![5]], buffered.peek_value());
+}

--- a/wingfoil-next/tests/csv_adapter.rs
+++ b/wingfoil-next/tests/csv_adapter.rs
@@ -1,0 +1,213 @@
+//! CSV adapter (Phase 4): a serde-typed historical replay **source** and a file
+//! **sink**. These tests port the classic `wingfoil::adapters::csv` unit tests
+//! as parity tests (all-rows / single-burst emission, same-timestamp grouping,
+//! missing-file and malformed-row error handling) and add an end-to-end
+//! read → transform → write round trip asserting the output contents and the
+//! replay ordering/timestamps.
+
+#![cfg(feature = "csv")]
+
+use std::path::PathBuf;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::csv::{CsvSinkOps, csv_read};
+use wingfoil_next::prelude::*;
+
+/// The classic parity record: a positional `(time, value)` tuple.
+type Record = (NanoTime, u32);
+
+fn get_time(r: &Record) -> NanoTime {
+    r.0
+}
+
+/// Stage a CSV fixture in a uniquely-named temp file (unique per test so
+/// parallel runs don't collide).
+fn write_tmp(name: &str, contents: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("wf_next_csv_{}_{name}", std::process::id()));
+    std::fs::write(&path, contents).expect("write temp fixture");
+    path
+}
+
+/// Read output back as `\n`-normalized lines (the csv crate terminates rows
+/// with CRLF; normalizing keeps the assertions terminator-agnostic).
+fn output_lines(path: &PathBuf) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .expect("read output")
+        .replace('\r', "")
+        .lines()
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Classic `csv_read_emits_all_rows` + `csv_read_each_row_is_single_burst`:
+/// six distinct-timestamp rows replay as six single-element bursts, every row
+/// (including the last) delivered.
+#[test]
+fn csv_read_emits_all_rows_each_a_single_burst() {
+    let path = write_tmp(
+        "all_rows.csv",
+        "1001,1\n1002,2\n1003,3\n1004,4\n1005,5\n1006,6\n",
+    );
+
+    let g = GraphBuilder::new();
+    let rows = csv_read(&g, &path, get_time, false).unwrap();
+    let acc = rows.with_time().accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    let ticks = r.value(&acc);
+    // Six distinct timestamps → six bursts, each holding exactly one row.
+    assert_eq!(ticks.len(), 6);
+    assert!(ticks.iter().all(|(_, b)| b.len() == 1));
+    // Every value present, in order.
+    let values: Vec<u32> = ticks
+        .iter()
+        .flat_map(|(_, b)| b.iter().map(|r| r.1))
+        .collect();
+    assert_eq!(values, vec![1, 2, 3, 4, 5, 6]);
+    // Delivered at their own timestamps.
+    let times: Vec<NanoTime> = ticks.iter().map(|(t, _)| *t).collect();
+    assert_eq!(times, (1001..=1006).map(NanoTime::new).collect::<Vec<_>>());
+}
+
+/// Classic `csv_read_groups_same_timestamp_into_one_burst`: timestamps
+/// 1001, 1002, 1003(×2), 1004 → 4 ticks, the two 1003 rows in one atomic burst.
+#[test]
+fn csv_read_groups_same_timestamp_into_one_burst() {
+    let path = write_tmp("multi.csv", "1001,1\n1002,2\n1003,3\n1003,3\n1004,4\n");
+
+    let g = GraphBuilder::new();
+    let rows = csv_read(&g, &path, get_time, false).unwrap();
+    let acc = rows.with_time().accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    let ticks = r.value(&acc);
+    assert_eq!(ticks.len(), 4, "four distinct timestamps");
+    let burst_1003 = ticks
+        .iter()
+        .find(|(t, _)| *t == NanoTime::new(1003))
+        .expect("a burst at t=1003");
+    assert_eq!(burst_1003.1.len(), 2, "both 1003 rows ride one burst");
+}
+
+/// Classic `csv_read_missing_file_returns_error_with_context`: a missing file
+/// surfaces a contextual error at wiring time rather than panicking.
+#[test]
+fn csv_read_missing_file_returns_error_with_context() {
+    let g = GraphBuilder::new();
+    let result = csv_read::<Record, _>(
+        &g,
+        std::env::temp_dir().join("wf_next_csv_does_not_exist.csv"),
+        get_time,
+        false,
+    );
+    // `Stream` isn't `Debug`, so match rather than `expect_err`.
+    let err = match result {
+        Ok(_) => panic!("expected an error for a missing file"),
+        Err(e) => e,
+    };
+    assert!(
+        format!("{err:#}").contains("csv_read: failed to open"),
+        "unexpected error message: {err:#}"
+    );
+}
+
+/// Classic `csv_read_malformed_row_surfaces_error_not_panic`: a row that fails
+/// to deserialize aborts the run with a contextual error rather than panicking.
+/// (Deviation from classic: surfaced through the channel at the start of the
+/// replay rather than mid-stream — same observable outcome and message.)
+#[test]
+fn csv_read_malformed_row_surfaces_error_not_panic() {
+    let path = write_tmp("malformed.csv", "1001,1\n1002,notanumber\n1003,3\n");
+
+    let g = GraphBuilder::new();
+    let rows = csv_read::<Record, _>(&g, &path, get_time, false)
+        .expect("file opens fine; the error is in a row");
+    let _acc = rows.with_time().accumulate();
+    let mut r = g.build();
+    let result = r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever);
+
+    let err = result.expect_err("expected a deserialize error");
+    assert!(
+        format!("{err:#}").contains("failed to deserialize row"),
+        "unexpected error message: {err:#}"
+    );
+}
+
+/// End-to-end round trip: read a CSV, transform every row (double the value) on
+/// the graph clock, and write it back. Asserts both the replay
+/// ordering/timestamps and the exact output-file contents.
+#[test]
+fn csv_round_trip_read_transform_write() {
+    let path = write_tmp("round_in.csv", "1001,1\n1002,2\n1003,3\n1003,3\n1004,4\n");
+    let out = write_tmp("round_out.csv", "");
+
+    let g = GraphBuilder::new();
+    let rows = csv_read(&g, &path, get_time, false).unwrap();
+    // Transform: double each value, preserving the burst grouping.
+    let doubled = rows.map(|b: &Burst<Record>| {
+        b.iter()
+            .map(|(t, v)| (*t, v * 2))
+            .collect::<Burst<Record>>()
+    });
+    let acc = doubled.with_time().accumulate();
+    let _sink = doubled.csv_write(&out).unwrap();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    // Replay ordering/timestamps: four ticks, the 1003 pair in one burst.
+    let ticks = r.value(&acc);
+    let times: Vec<NanoTime> = ticks.iter().map(|(t, _)| *t).collect();
+    assert_eq!(
+        times,
+        vec![
+            NanoTime::new(1001),
+            NanoTime::new(1002),
+            NanoTime::new(1003),
+            NanoTime::new(1004),
+        ]
+    );
+
+    // Output contents: one `(time, orig_time, doubled_value)` row per record; a
+    // tuple record has no named fields, so there is no header row.
+    assert_eq!(
+        output_lines(&out),
+        vec![
+            "1001,1001,2",
+            "1002,1002,4",
+            "1003,1003,6",
+            "1003,1003,6",
+            "1004,1004,8",
+        ]
+    );
+}
+
+/// A named-struct record exercises the header path: the sink writes a leading
+/// `time` column plus the record's serde field names, then one row per record.
+#[test]
+fn csv_sink_writes_header_for_named_struct() {
+    #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+    struct Quote {
+        timestamp: u64,
+        price: u32,
+    }
+
+    let path = write_tmp("struct_in.csv", "100,10\n200,20\n");
+    let out = write_tmp("struct_out.csv", "");
+
+    let g = GraphBuilder::new();
+    let rows = csv_read(&g, &path, |q: &Quote| NanoTime::new(q.timestamp), false).unwrap();
+    let _sink = rows.csv_write(&out).unwrap();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    assert_eq!(
+        output_lines(&out),
+        vec!["time,timestamp,price", "100,100,10", "200,200,20"],
+    );
+}

--- a/wingfoil-next/tests/island_scheduling.rs
+++ b/wingfoil-next/tests/island_scheduling.rs
@@ -1,7 +1,10 @@
 //! Islands containing the combinators the existing nested-island suite does
-//! not exercise: `constant` + `merge` + `filter` in one island, and a
-//! statistics op (`ewma_per_tick`) in another. Closes the fable-review blind
-//! spot "no island containing merge/filter/constant/statistics".
+//! not exercise: `constant` + `merge` + `filter` in one island, a statistics
+//! op (`ewma_per_tick`) in another, and a `ticker` + `delay` island (two
+//! independent scheduling ops) that stresses the compiled island's private
+//! schedule-queue demux with multiple pending keys. Closes the fable-review
+//! blind spots "no island containing merge/filter/constant/statistics" and "no
+//! island with two inner scheduling ops (ticker + delay)".
 //!
 //! Each test pins interpreted == compiled == nested-in-interpreted, and (for
 //! the value-carrying islands) cross-checks the nested expansion against the
@@ -99,4 +102,41 @@ fn island_statistics_ewma_all_paths() {
         (r.value(&island) - interpreted).abs() < 1e-10,
         "interpreted == nested"
     );
+}
+
+wingfoil_next::graph! {
+    // Two independent scheduling ops in one island: the `ticker` source and a
+    // `delay`. In the compiled island both live in the same private schedule
+    // queue, so their due-times interleave — exercising the queue demux with
+    // more than one pending key (the odds_evens/ewma islands have at most one).
+    fn ticker_and_delay(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let base = g.ticker(Duration::from_secs(1)).count();
+        let delayed = base.delay(Duration::from_secs(2));
+        let merged = base.merge(&delayed).accumulate();
+        merged
+    }
+}
+
+/// The exact series is pinned by three-path agreement rather than hand-derived
+/// here — the point of the test is that the compiled island's schedule-queue
+/// demux, driven by two interleaving pending keys (ticker + delay), produces
+/// the *same* result as the interpreted engine and a nested mount. A demux bug
+/// that dropped or misrouted one pending key would break the agreement.
+#[test]
+fn island_two_scheduling_ops_all_paths() {
+    let run_for = RunFor::Cycles(6);
+
+    let (mut runner, out) = ticker_and_delay::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    let interpreted = runner.value(out);
+    assert!(!interpreted.is_empty(), "the island produces a series");
+
+    let (compiled,) = ticker_and_delay::compiled(HISTORICAL, run_for).unwrap();
+    assert_eq!(interpreted, compiled, "interpreted == compiled");
+
+    let g = GraphBuilder::new();
+    let island = ticker_and_delay::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, run_for).unwrap();
+    assert_eq!(interpreted, r.value(&island), "interpreted == nested");
 }

--- a/wingfoil-next/tests/island_scheduling.rs
+++ b/wingfoil-next/tests/island_scheduling.rs
@@ -1,0 +1,102 @@
+//! Islands containing the combinators the existing nested-island suite does
+//! not exercise: `constant` + `merge` + `filter` in one island, and a
+//! statistics op (`ewma_per_tick`) in another. Closes the fable-review blind
+//! spot "no island containing merge/filter/constant/statistics".
+//!
+//! Each test pins interpreted == compiled == nested-in-interpreted, and (for
+//! the value-carrying islands) cross-checks the nested expansion against the
+//! identical wiring done flat in the same graph, so all execution paths run
+//! under the same kernel on the same cycles and must agree exactly.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+use wingfoil_next::stats::StatisticsOps;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+wingfoil_next::graph! {
+    // `constant` (a one-shot source), `filter` (a conditional gate), and
+    // `merge` (a tie-broken join) all inside one island.
+    fn merge_filter_constant(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let n = g.ticker(Duration::from_nanos(10)).count();
+        let keep_even = n.map(|i| i.is_multiple_of(2));
+        let evens = n.filter(&keep_even);
+        let seed = g.constant(9u64);
+        let merged = seed.merge(&evens).accumulate();
+        merged
+    }
+}
+
+/// The island emits the constant `9` on cycle 1 (only the constant ticks
+/// there — `n=1` is odd, so the filter stays shut), then the evens `2, 4, 6`
+/// as they pass the filter: `[9, 2, 4, 6]` over six cycles.
+#[test]
+fn island_merge_filter_constant_all_paths() {
+    let run_for = RunFor::Cycles(6);
+
+    let (mut runner, out) = merge_filter_constant::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    let interpreted = runner.value(out);
+    assert_eq!(vec![9, 2, 4, 6], interpreted);
+
+    let (compiled,) = merge_filter_constant::compiled(HISTORICAL, run_for).unwrap();
+    assert_eq!(interpreted, compiled, "interpreted == compiled");
+
+    // Nested inside an interpreted graph, cross-checked against identical flat
+    // wiring driven by the same kernel.
+    let g = GraphBuilder::new();
+    let island = merge_filter_constant::nested(&g);
+    let flat = {
+        let n = g.ticker(Duration::from_nanos(10)).count();
+        let keep_even = n.map(|i| i.is_multiple_of(2));
+        let evens = n.filter(&keep_even);
+        let seed = g.constant(9u64);
+        seed.merge(&evens).accumulate()
+    };
+    let mut r = g.build();
+    r.run(HISTORICAL, run_for).unwrap();
+    assert_eq!(interpreted, r.value(&island), "interpreted == nested");
+    assert_eq!(r.value(&flat), r.value(&island), "nested == flat wiring");
+}
+
+wingfoil_next::graph! {
+    // A statistics op (clock-aware, stateful) inside an island.
+    fn ewma_island(g: &GraphBuilder) -> Stream<f64> {
+        let x = g.ticker(Duration::from_nanos(100)).count().map(|i| *i as f64);
+        let e = x.ewma_per_tick(0.5);
+        e
+    }
+}
+
+/// EWMA (alpha 0.5) seeded on the first sample over `1, 2, 3, 4` settles to
+/// `3.125` — the same decay the flat statistics suite pins, now proving the op
+/// works identically when mounted as a compiled island.
+#[test]
+fn island_statistics_ewma_all_paths() {
+    let run_for = RunFor::Cycles(4);
+
+    let (mut runner, e) = ewma_island::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    let interpreted = runner.value(e);
+    assert!(
+        (interpreted - 3.125).abs() < 1e-10,
+        "interpreted = {interpreted}"
+    );
+
+    let (compiled,) = ewma_island::compiled(HISTORICAL, run_for).unwrap();
+    assert!(
+        (compiled - interpreted).abs() < 1e-10,
+        "interpreted == compiled"
+    );
+
+    let g = GraphBuilder::new();
+    let island = ewma_island::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, run_for).unwrap();
+    assert!(
+        (r.value(&island) - interpreted).abs() < 1e-10,
+        "interpreted == nested"
+    );
+}

--- a/wingfoil-next/tests/lines_adapter.rs
+++ b/wingfoil-next/tests/lines_adapter.rs
@@ -1,0 +1,173 @@
+//! The dependency-free line-oriented file adapter: deterministic historical
+//! replay of a file through a graph, a transform, and a file sink — asserting
+//! both the written output and the replay ordering / timestamps.
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::Burst;
+use wingfoil_next::adapters::lines::{LinesSinkOps, replay_lines, replay_lines_scheduled};
+use wingfoil_next::prelude::*;
+
+/// A unique temp path per call, so parallel tests never collide.
+fn temp_path(tag: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "wingfoil_lines_{}_{}_{}.txt",
+        tag,
+        std::process::id(),
+        n
+    ))
+}
+
+/// End to end: replay a file through the source, transform each record, write
+/// it back through the sink, and assert the output file's exact contents.
+#[test]
+fn replay_transform_and_sink_roundtrips_through_files() {
+    let input = temp_path("in");
+    let output = temp_path("out");
+    fs::write(&input, "alpha\nbravo\ncharlie\ndelta\n").unwrap();
+
+    let g = GraphBuilder::new();
+    let lines = replay_lines(&g, &input).unwrap();
+    let shouted = lines.map(|burst: &Burst<String>| {
+        burst
+            .iter()
+            .map(|s| s.to_uppercase())
+            .collect::<Burst<String>>()
+    });
+    shouted.write_lines(&output).unwrap();
+
+    let mut runner = g.build();
+    runner
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    let written = fs::read_to_string(&output).unwrap();
+    assert_eq!(written, "ALPHA\nBRAVO\nCHARLIE\nDELTA\n");
+
+    fs::remove_file(&input).ok();
+    fs::remove_file(&output).ok();
+}
+
+/// The historical replay is deterministic: each record is delivered on the
+/// graph clock at `base + i * step`, in order, one line per burst.
+#[test]
+fn replay_is_scheduled_deterministically_on_the_graph_clock() {
+    let input = temp_path("sched");
+    fs::write(&input, "one\ntwo\nthree\n").unwrap();
+
+    let base = NanoTime::new(1_000);
+    let step = std::time::Duration::from_nanos(10);
+
+    let g = GraphBuilder::new();
+    let lines = replay_lines_scheduled(&g, &input, base, step).unwrap();
+    // Pair each burst with the engine time it was delivered at.
+    let stamped = lines.with_time().accumulate();
+
+    let mut runner = g.build();
+    runner
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    let got: Vec<(NanoTime, Vec<String>)> = runner
+        .value(&stamped)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().cloned().collect()))
+        .collect();
+
+    assert_eq!(
+        got,
+        vec![
+            (NanoTime::new(1_000), vec!["one".to_string()]),
+            (NanoTime::new(1_010), vec!["two".to_string()]),
+            (NanoTime::new(1_020), vec!["three".to_string()]),
+        ],
+    );
+
+    fs::remove_file(&input).ok();
+}
+
+/// A zero step collapses same-instant records into one atomic burst — the
+/// historical burst model (never split, never coalesced).
+#[test]
+fn zero_step_groups_records_into_one_burst() {
+    let input = temp_path("burst");
+    fs::write(&input, "a\nb\nc\n").unwrap();
+
+    let g = GraphBuilder::new();
+    let lines = replay_lines_scheduled(
+        &g,
+        &input,
+        NanoTime::ZERO,
+        std::time::Duration::from_nanos(0),
+    )
+    .unwrap();
+    let stamped = lines.with_time().accumulate();
+
+    let mut runner = g.build();
+    runner
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    let got: Vec<(NanoTime, Vec<String>)> = runner
+        .value(&stamped)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().cloned().collect()))
+        .collect();
+
+    // All three records ride a single burst at time zero.
+    assert_eq!(
+        got,
+        vec![(
+            NanoTime::ZERO,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        )],
+    );
+
+    fs::remove_file(&input).ok();
+}
+
+/// An append sink adds to existing content rather than truncating.
+#[test]
+fn append_sink_preserves_existing_content() {
+    let input = temp_path("append_in");
+    let output = temp_path("append_out");
+    fs::write(&input, "x\ny\n").unwrap();
+    fs::write(&output, "header\n").unwrap();
+
+    let g = GraphBuilder::new();
+    let lines = replay_lines(&g, &input).unwrap();
+    lines.append_lines(&output).unwrap();
+
+    let mut runner = g.build();
+    runner
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    assert_eq!(fs::read_to_string(&output).unwrap(), "header\nx\ny\n");
+
+    fs::remove_file(&input).ok();
+    fs::remove_file(&output).ok();
+}
+
+/// Opening a missing source file surfaces an error at wiring time (with
+/// context), rather than panicking.
+#[test]
+fn missing_source_file_is_an_error() {
+    let g = GraphBuilder::new();
+    let missing = temp_path("does_not_exist");
+    // `.err()` drops the `Ok(Stream)` (which is not `Debug`), so this avoids the
+    // `Debug` bound `unwrap_err` would require.
+    let err = replay_lines(&g, &missing)
+        .err()
+        .expect("opening a missing file must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("lines adapter: opening source file"),
+        "unexpected error: {msg}"
+    );
+}

--- a/wingfoil-next/tests/merge_tiebreak.rs
+++ b/wingfoil-next/tests/merge_tiebreak.rs
@@ -1,0 +1,54 @@
+//! Merge tie-break parity when **both** inputs tick in the same cycle — the
+//! fable-review blind spot "merge tie-break never tested with both inputs
+//! ticking in one cycle" (the existing `odds_evens` streams are disjoint by
+//! construction, so the tie-break arm never runs and the compiled tick-pair
+//! ordering could be swapped with the tests staying green).
+//!
+//! `merge2` is `if a_ticked { a } else if b_ticked { b }` — the earliest-
+//! supplied ticked input wins. Two tickers of the *same* period tick on every
+//! cycle, so the merge fires its tie-break arm every cycle and the first input
+//! (`a`) must win. All three emission paths (interpreted, compiled, nested)
+//! must agree, so a swapped tick-pair ordering in any one is caught.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+wingfoil_next::graph! {
+    fn merge_tie(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        // Same period ⇒ both tick every cycle ⇒ the merge tie-break runs each
+        // cycle. `a` = 1,2,3,4; `b` = 101,102,103,104.
+        let a = g.ticker(Duration::from_nanos(10)).count();
+        let b = g.ticker(Duration::from_nanos(10)).count().map(|c| *c + 100);
+        let merged = a.merge(&b).accumulate();
+        merged
+    }
+}
+
+#[test]
+fn merge_tie_break_first_input_wins_all_paths() {
+    let run_for = RunFor::Cycles(4);
+
+    let (mut runner, out) = merge_tie::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    let interpreted = runner.value(out);
+    // `a` wins every tie, so the merged series is a's, not b's (which would be
+    // 101,102,103,104 had the ordering been swapped).
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        interpreted,
+        "earliest-supplied input wins"
+    );
+
+    let (compiled,) = merge_tie::compiled(HISTORICAL, run_for).unwrap();
+    assert_eq!(interpreted, compiled, "interpreted == compiled");
+
+    let g = GraphBuilder::new();
+    let island = merge_tie::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, run_for).unwrap();
+    assert_eq!(interpreted, r.value(&island), "interpreted == nested");
+}

--- a/wingfoil-next/tests/sparse_graph.rs
+++ b/wingfoil-next/tests/sparse_graph.rs
@@ -1,0 +1,118 @@
+//! Phase 4.5 sparse-dispatch guard: the interpreted engine drives a dirty-list
+//! seeded from the tick frontier, so per-cycle work is proportional to the
+//! nodes that actually fire — not the graph size. These tests pin the two
+//! properties that matters: a quiet sub-graph is *never* cycled on a tick it
+//! has no part in, and the engine stays correct on a wide, sparsely-ticking
+//! graph.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// A wide graph: one *fast* driver feeds a tiny active chain that ticks every
+/// cycle; a bank of `IDLE_WIDTH` maps hangs off a *slow* driver that fires far
+/// less often. Each op counts its own `cycle` invocations. The sparse engine
+/// must cycle an idle map only on the cycles its slow upstream actually ticked
+/// — so the idle bank's total work equals `IDLE_WIDTH × slow_fires`, a handful,
+/// never `IDLE_WIDTH × cycles`. A regression to an all-nodes sweep (or an
+/// over-eager propagation) would fire the idle bank on the fast-only cycles and
+/// blow this count up.
+#[test]
+fn quiet_subgraph_is_not_cycled_on_unrelated_ticks() {
+    let g = GraphBuilder::new();
+
+    let active_hits = Arc::new(AtomicUsize::new(0));
+    let idle_hits = Arc::new(AtomicUsize::new(0));
+
+    // Fast driver: 1,2,3,… once per cycle (period 10ns).
+    let fast_count = g.ticker(Duration::from_nanos(10)).count();
+    let ah = active_hits.clone();
+    let active = fast_count
+        .map(move |v| {
+            ah.fetch_add(1, Ordering::Relaxed);
+            *v
+        })
+        .accumulate();
+
+    // Slow driver: an order of magnitude quieter (period 1000ns).
+    let slow_count = g.ticker(Duration::from_nanos(1000)).count();
+    const IDLE_WIDTH: usize = 500;
+    let mut idle = Vec::with_capacity(IDLE_WIDTH);
+    for _ in 0..IDLE_WIDTH {
+        let ih = idle_hits.clone();
+        idle.push(slow_count.map(move |v| {
+            ih.fetch_add(1, Ordering::Relaxed);
+            *v
+        }));
+    }
+
+    let mut r = g.build();
+    // Long enough that the slow driver fires at least once while the fast one
+    // fires ~150 times.
+    r.run(HISTORICAL, RunFor::Cycles(150)).unwrap();
+
+    let fast_fires = r.value(&fast_count) as usize;
+    let slow_fires = r.value(&slow_count) as usize;
+    let active_work = active_hits.load(Ordering::Relaxed);
+    let idle_work = idle_hits.load(Ordering::Relaxed);
+
+    // The active chain accumulated every fast value, in order.
+    assert_eq!(
+        r.value(&active),
+        (1..=fast_fires as u64).collect::<Vec<_>>(),
+        "active chain sees every fast tick"
+    );
+    // The active chain fires exactly once per fast tick.
+    assert_eq!(active_work, fast_fires, "active chain fires per fast tick");
+    // The idle bank fires exactly once per idle map per slow tick — and the
+    // slow driver genuinely ticked, so this exercises the idle path too.
+    assert!(slow_fires >= 1, "slow driver should fire at least once");
+    assert_eq!(
+        idle_work,
+        IDLE_WIDTH * slow_fires,
+        "idle bank cycles only on slow ticks, never on fast-only cycles"
+    );
+    // The whole point: the 500-wide idle bank was NOT swept every cycle.
+    assert!(slow_fires < fast_fires, "slow driver is quieter than fast");
+    assert!(
+        idle_work < IDLE_WIDTH * fast_fires,
+        "sparse: idle work {idle_work} ≪ dense sweep {}",
+        IDLE_WIDTH * fast_fires
+    );
+}
+
+/// Correctness at scale: a wide fan-out where every branch is a distinct
+/// arithmetic transform of one shared counter. The engine must fire each branch
+/// once per cycle after the shared source, glitch-free, and land the right
+/// value in every slot.
+#[test]
+fn wide_fanout_is_correct() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count();
+
+    const WIDTH: usize = 300;
+    let mut branches = Vec::with_capacity(WIDTH);
+    for k in 0..WIDTH {
+        let k = k as u64;
+        branches.push(count.map(move |v| *v * 1000 + k));
+    }
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(20)).unwrap();
+
+    // After 20 cycles the shared count is 20; every branch reflects it.
+    let count_final = r.value(&count);
+    assert_eq!(count_final, 20);
+    for (k, b) in branches.iter().enumerate() {
+        assert_eq!(
+            r.value(b),
+            count_final * 1000 + k as u64,
+            "branch {k} holds its own transform of the shared count"
+        );
+    }
+}

--- a/wingfoil-next/tests/sparse_graph.rs
+++ b/wingfoil-next/tests/sparse_graph.rs
@@ -40,8 +40,7 @@ fn sparse_matches_full_sweep_oracle() {
 
     let g2 = GraphBuilder::new();
     let h2 = wire(&g2);
-    let mut r2 = g2.build();
-    r2.with_dispatch(Dispatch::FullSweep);
+    let mut r2 = g2.build().with_dispatch(Dispatch::FullSweep);
     r2.run(HISTORICAL, RunFor::Cycles(15)).unwrap();
     let full_sweep = r2.value(&h2);
 

--- a/wingfoil-next/tests/sparse_graph.rs
+++ b/wingfoil-next/tests/sparse_graph.rs
@@ -123,6 +123,82 @@ fn quiet_subgraph_is_not_cycled_on_unrelated_ticks() {
     );
 }
 
+/// Randomised differential parity: build many pseudo-random graphs and assert
+/// the sparse engine and the retained full-sweep oracle agree on every one. A
+/// single hand-wired graph (see `sparse_matches_full_sweep_oracle`) only covers
+/// the shapes we thought to write; this fuzzes the two engines against each
+/// other across a broad mix of schedulers, passive edges, tie-broken merges,
+/// stateful folds/delays and wide fan-in, which is exactly what the oracle was
+/// retained for. A deterministic LCG seeds each graph, so a failure reproduces
+/// from its printed seed.
+#[test]
+fn sparse_matches_full_sweep_across_random_graphs() {
+    // Build the *same* graph structure from a seed (the LCG is deterministic),
+    // returning an accumulated series to compare. Kept to `u64` streams so every
+    // combinator stays well-typed.
+    fn build_random(g: &GraphBuilder, seed: u64) -> Stream<Vec<u64>> {
+        let mut rng = seed;
+        let mut next = || {
+            // A standard 64-bit LCG (Knuth's constants); we use the high bits.
+            rng = rng
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            rng >> 33
+        };
+
+        // A handful of independent schedulers at distinct periods, so islands
+        // tick on different cycles — the case sparse dispatch is most about.
+        let mut pool: Vec<Stream<u64>> = vec![
+            g.ticker(Duration::from_nanos(1 + next() % 4)).count(),
+            g.ticker(Duration::from_nanos(1 + next() % 6)).count(),
+            g.ticker(Duration::from_nanos(1 + next() % 9)).count(),
+        ];
+
+        let steps = 8 + next() % 12;
+        for _ in 0..steps {
+            let ai = next() as usize % pool.len();
+            let bi = next() as usize % pool.len();
+            let k = 1 + next() % 7;
+            let s = match next() % 8 {
+                0 => pool[ai].map(move |v| v.wrapping_add(k)),
+                1 => pool[ai].map(move |v| v.wrapping_mul(k)),
+                2 => pool[ai].delay(Duration::from_nanos(1 + next() % 4)),
+                3 => pool[ai].fold(0u64, |acc, v| *acc = acc.wrapping_add(*v)),
+                4 => pool[ai].merge(&pool[bi]),
+                5 => pool[ai].join(&pool[bi], |x, y| x.wrapping_add(*y)),
+                6 => {
+                    let trig = g.ticker(Duration::from_nanos(1 + next() % 3));
+                    pool[ai].sample(&trig)
+                }
+                _ => {
+                    let cond = pool[ai].map(|v| v.is_multiple_of(2));
+                    pool[bi].filter(&cond)
+                }
+            };
+            pool.push(s);
+        }
+        pool.last().expect("pool seeded non-empty").accumulate()
+    }
+
+    for seed in 0..64u64 {
+        let g_sparse = GraphBuilder::new();
+        let h_sparse = build_random(&g_sparse, seed);
+        let mut r_sparse = g_sparse.build();
+        r_sparse.run(HISTORICAL, RunFor::Cycles(40)).unwrap();
+
+        let g_full = GraphBuilder::new();
+        let h_full = build_random(&g_full, seed);
+        let mut r_full = g_full.build().with_dispatch(Dispatch::FullSweep);
+        r_full.run(HISTORICAL, RunFor::Cycles(40)).unwrap();
+
+        assert_eq!(
+            r_sparse.value(&h_sparse),
+            r_full.value(&h_full),
+            "sparse and full-sweep disagree on random graph seed {seed}"
+        );
+    }
+}
+
 /// Correctness at scale: a wide fan-out where every branch is a distinct
 /// arithmetic transform of one shared counter. The engine must fire each branch
 /// once per cycle after the shared source, glitch-free, and land the right

--- a/wingfoil-next/tests/sparse_graph.rs
+++ b/wingfoil-next/tests/sparse_graph.rs
@@ -10,9 +10,47 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::interp::Dispatch;
 use wingfoil_next::prelude::*;
 
 const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// The sparse dirty-list and the retained full-sweep oracle must produce
+/// byte-identical results. Runs one non-trivial graph — scheduling (ticker,
+/// delay), a passive edge (`sample` of a delayed slot, the case most sensitive
+/// to evaluation order), a filter, and a tie-broken `merge` — under both
+/// dispatch strategies and asserts they agree.
+#[test]
+fn sparse_matches_full_sweep_oracle() {
+    fn wire(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let n = g.ticker(Duration::from_nanos(10)).count();
+        let keep_even = n.map(|i| i.is_multiple_of(2));
+        let evens = n.filter(&keep_even);
+        let delayed = n.delay(Duration::from_nanos(30));
+        let trig = g.ticker(Duration::from_nanos(10));
+        let sampled = delayed.sample(&trig);
+        sampled.merge(&evens).accumulate()
+    }
+
+    let g1 = GraphBuilder::new();
+    let h1 = wire(&g1);
+    let mut r1 = g1.build();
+    r1.run(HISTORICAL, RunFor::Cycles(15)).unwrap();
+    let sparse = r1.value(&h1);
+
+    let g2 = GraphBuilder::new();
+    let h2 = wire(&g2);
+    let mut r2 = g2.build();
+    r2.with_dispatch(Dispatch::FullSweep);
+    r2.run(HISTORICAL, RunFor::Cycles(15)).unwrap();
+    let full_sweep = r2.value(&h2);
+
+    assert!(!sparse.is_empty(), "graph produces a series");
+    assert_eq!(
+        sparse, full_sweep,
+        "sparse dispatch matches the full-sweep oracle"
+    );
+}
 
 /// A wide graph: one *fast* driver feeds a tiny active chain that ticks every
 /// cycle; a bank of `IDLE_WIDTH` maps hangs off a *slow* driver that fires far

--- a/wingfoil-next/tests/statistics_rolling.rs
+++ b/wingfoil-next/tests/statistics_rolling.rs
@@ -1,0 +1,209 @@
+//! Parity tests for the count-windowed rolling statistics catalog
+//! (`rolling_min` / `rolling_max` / `rolling_var` / `rolling_std` /
+//! `rolling_median`), ported from the classic `adapters::statistics`
+//! operators. Each test pins the emitted series **value-by-value** and, where
+//! relevant, **tick-by-tick** against a hand-computed expected series derived
+//! from the classic node semantics:
+//!
+//! * window clamped to `max(1)` (a zero window behaves as a window of one);
+//! * `var`/`std` use the **sample** (ddof = 1) convention — divisor `n - 1`,
+//!   and `0.0` until at least two samples are present (`std` clamps at zero so
+//!   a constant window is `0.0`, not `NaN`);
+//! * `median` averages the two middle values for an even-sized window;
+//! * a rolling op ticks once per upstream tick (no seeding delay), so the
+//!   output series has one entry per input tick.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::fluent::Stream;
+use wingfoil_next::prelude::*;
+use wingfoil_next::stats::StatisticsOps;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// 1, 2, 3, 4, 5 as `f64`, one tick every 100ns (ticks at 0,100,200,300,400ns).
+fn counter_f64(g: &GraphBuilder) -> Stream<f64> {
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(|i| *i as f64)
+}
+
+/// A non-monotonic `f64` sequence `((n * 7) % 13)` for `n = 1..`, so the
+/// monotonic-deque min/max evict from both ends and the median actually sorts.
+fn non_monotonic(g: &GraphBuilder) -> Stream<f64> {
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(|n| ((*n * 7) % 13) as f64)
+}
+
+/// Assert two `f64` series equal element-wise within a tolerance.
+fn assert_series_approx(got: &[f64], expected: &[f64]) {
+    assert_eq!(got.len(), expected.len(), "length: {got:?} vs {expected:?}");
+    for (i, (g, e)) in got.iter().zip(expected).enumerate() {
+        assert!(
+            (g - e).abs() < 1e-10,
+            "at {i}: got {g}, expected {e} (series {got:?} vs {expected:?})"
+        );
+    }
+}
+
+// ── rolling_min / rolling_max ────────────────────────────────────────────────
+
+/// Window 2 over 1,2,3,4,5. Min windows: {1},{1,2},{2,3},{3,4},{4,5} → 1,1,2,3,4;
+/// max: 1,2,3,4,5.
+#[test]
+fn rolling_min_max_counter() {
+    let g = GraphBuilder::new();
+    let mn = counter_f64(&g).rolling_min(2).accumulate();
+    let mx = counter_f64(&g).rolling_max(2).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1.0, 1.0, 2.0, 3.0, 4.0], r.value(&mn));
+    assert_eq!(vec![1.0, 2.0, 3.0, 4.0, 5.0], r.value(&mx));
+}
+
+/// Window 3 over the non-monotonic 7,1,8,2,9,3,10,4 — exercises deque eviction
+/// from both ends. Windows:
+/// {7},{7,1},{7,1,8},{1,8,2},{8,2,9},{2,9,3},{9,3,10},{3,10,4}.
+#[test]
+fn rolling_min_max_non_monotonic() {
+    let g = GraphBuilder::new();
+    let mn = non_monotonic(&g).rolling_min(3).accumulate();
+    let mx = non_monotonic(&g).rolling_max(3).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(8)).unwrap();
+    assert_eq!(vec![7.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0], r.value(&mn));
+    assert_eq!(vec![7.0, 7.0, 8.0, 8.0, 9.0, 9.0, 10.0, 10.0], r.value(&mx));
+}
+
+// ── rolling_var / rolling_std ────────────────────────────────────────────────
+
+/// Window 3 over 1,2,3,4,5 (sample variance, ddof = 1). Windows and vars:
+/// {1}→0 (n<2), {1,2}→0.5, {1,2,3}→1, {2,3,4}→1, {3,4,5}→1. `std` is the
+/// element-wise square root.
+#[test]
+fn rolling_var_std_counter() {
+    let g = GraphBuilder::new();
+    let var = counter_f64(&g).rolling_var(3).accumulate();
+    let std = counter_f64(&g).rolling_std(3).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let expected_var = [0.0, 0.5, 1.0, 1.0, 1.0];
+    assert_series_approx(&r.value(&var), &expected_var);
+    let expected_std: Vec<f64> = expected_var.iter().map(|v| v.sqrt()).collect();
+    assert_series_approx(&r.value(&std), &expected_std);
+}
+
+/// A constant window has zero variance; floating-point cancellation in the
+/// incremental moments can make it a hair negative, so `std` must clamp at zero
+/// rather than emit `NaN` (mirrors classic
+/// `rolling_std_of_constant_window_is_zero_not_nan`).
+#[test]
+fn rolling_std_of_constant_window_is_zero_not_nan() {
+    let g = GraphBuilder::new();
+    let std = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(|_| 7.0)
+        .rolling_std(3)
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    for v in r.value(&std) {
+        assert!(!v.is_nan(), "rolling_std must not be NaN");
+        assert!(
+            v.abs() < 1e-10,
+            "constant window std should be 0.0, got {v}"
+        );
+    }
+}
+
+/// The incremental add/remove must not drift: slide a window across a long
+/// non-trivial sequence and compare the final variance to a direct recompute.
+#[test]
+fn rolling_var_incremental_matches_direct_recompute() {
+    const N: u32 = 200;
+    const W: u64 = 10;
+    let seq = |n: u64| ((n % 7) as f64) * 1.5 - 3.0;
+
+    let g = GraphBuilder::new();
+    let var = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .rolling_var(W as usize);
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(N)).unwrap();
+
+    // `count()` emits 1..=N, so the final window is the last W values.
+    let window: Vec<f64> = ((N as u64 - W + 1)..=N as u64).map(seq).collect();
+    let mean = window.iter().sum::<f64>() / W as f64;
+    let expected = window.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (W as f64 - 1.0);
+    assert!((r.value(&var) - expected).abs() < 1e-9);
+}
+
+// ── rolling_median ───────────────────────────────────────────────────────────
+
+/// Window 3 over 1,2,3,4,5. Windows and medians: {1}→1, {1,2}→1.5 (even),
+/// {1,2,3}→2, {2,3,4}→3, {3,4,5}→4.
+#[test]
+fn rolling_median_counter() {
+    let g = GraphBuilder::new();
+    let med = counter_f64(&g).rolling_median(3).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1.0, 1.5, 2.0, 3.0, 4.0], r.value(&med));
+}
+
+/// Window 3 over the non-monotonic 7,1,8,2,9 — the median must sort each
+/// window: {7}→7, {7,1}→4 (even), {7,1,8}→7, {1,8,2}→2, {8,2,9}→8.
+#[test]
+fn rolling_median_non_monotonic() {
+    let g = GraphBuilder::new();
+    let med = non_monotonic(&g).rolling_median(3).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![7.0, 4.0, 7.0, 2.0, 8.0], r.value(&med));
+}
+
+// ── window clamp ─────────────────────────────────────────────────────────────
+
+/// A window of 0 clamps to `max(1)` (classic's `window.max(1)`), so every op
+/// behaves as a window of one: each output is a function of just the latest
+/// value (min = max = median = value; var = std = 0).
+#[test]
+fn rolling_window_zero_clamps_to_one() {
+    let g = GraphBuilder::new();
+    let mn = counter_f64(&g).rolling_min(0).accumulate();
+    let mx = counter_f64(&g).rolling_max(0).accumulate();
+    let var = counter_f64(&g).rolling_var(0).accumulate();
+    let std = counter_f64(&g).rolling_std(0).accumulate();
+    let med = counter_f64(&g).rolling_median(0).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let identity = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    assert_eq!(identity, r.value(&mn));
+    assert_eq!(identity, r.value(&mx));
+    assert_eq!(identity, r.value(&med));
+    assert_eq!(vec![0.0; 5], r.value(&var));
+    assert_eq!(vec![0.0; 5], r.value(&std));
+}
+
+// ── tick-time parity ─────────────────────────────────────────────────────────
+
+/// The rolling ops tick once per upstream tick with no seeding delay, so the
+/// emitted times are exactly the ticker's: 0,100,200,300,400ns. Pin both the
+/// tick times and the paired values for `rolling_min`.
+#[test]
+fn rolling_min_tick_times_match_upstream() {
+    let g = GraphBuilder::new();
+    let acc = counter_f64(&g).rolling_min(2).with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let series = r.value(&acc);
+    let times: Vec<u64> = series.iter().map(|(t, _)| u64::from(*t)).collect();
+    let values: Vec<f64> = series.iter().map(|(_, v)| *v).collect();
+    assert_eq!(vec![0, 100, 200, 300, 400], times);
+    assert_eq!(vec![1.0, 1.0, 2.0, 3.0, 4.0], values);
+}

--- a/wingfoil-next/tests/trybuild/async_graph_fn.rs
+++ b/wingfoil-next/tests/trybuild/async_graph_fn.rs
@@ -1,0 +1,12 @@
+#![allow(unused)]
+use std::time::Duration;
+use wingfoil_next::prelude::*;
+
+wingfoil_next::graph! {
+    async fn bad(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).count();
+        out
+    }
+}
+
+fn main() {}

--- a/wingfoil-next/tests/trybuild/async_graph_fn.stderr
+++ b/wingfoil-next/tests/trybuild/async_graph_fn.stderr
@@ -1,0 +1,5 @@
+error: graph functions must be plain `fn`s
+ --> tests/trybuild/async_graph_fn.rs:6:5
+  |
+6 |     async fn bad(g: &GraphBuilder) -> Stream<u64> {
+  |     ^^^^^

--- a/wingfoil-next/tests/trybuild/generic_graph_fn.rs
+++ b/wingfoil-next/tests/trybuild/generic_graph_fn.rs
@@ -1,0 +1,12 @@
+#![allow(unused)]
+use std::time::Duration;
+use wingfoil_next::prelude::*;
+
+wingfoil_next::graph! {
+    fn bad<T>(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).count();
+        out
+    }
+}
+
+fn main() {}

--- a/wingfoil-next/tests/trybuild/generic_graph_fn.stderr
+++ b/wingfoil-next/tests/trybuild/generic_graph_fn.stderr
@@ -1,0 +1,5 @@
+error: graph functions cannot be generic
+ --> tests/trybuild/generic_graph_fn.rs:6:11
+  |
+6 |     fn bad<T>(g: &GraphBuilder) -> Stream<u64> {
+  |           ^

--- a/wingfoil-next/tests/trybuild/missing_return_type.rs
+++ b/wingfoil-next/tests/trybuild/missing_return_type.rs
@@ -1,0 +1,11 @@
+#![allow(unused)]
+use std::time::Duration;
+use wingfoil_next::prelude::*;
+
+wingfoil_next::graph! {
+    fn bad(g: &GraphBuilder) {
+        let out = g.ticker(Duration::from_nanos(10)).count();
+    }
+}
+
+fn main() {}

--- a/wingfoil-next/tests/trybuild/missing_return_type.stderr
+++ b/wingfoil-next/tests/trybuild/missing_return_type.stderr
@@ -1,0 +1,5 @@
+error: graph functions must return `Stream<T>` (or a tuple of `Stream<T>`s)
+ --> tests/trybuild/missing_return_type.rs:6:5
+  |
+6 |     fn bad(g: &GraphBuilder) {
+  |     ^^

--- a/wingfoil-next/tests/trybuild/stream_param_by_value.rs
+++ b/wingfoil-next/tests/trybuild/stream_param_by_value.rs
@@ -1,0 +1,12 @@
+#![allow(unused)]
+use std::time::Duration;
+use wingfoil_next::prelude::*;
+
+wingfoil_next::graph! {
+    fn bad(g: &GraphBuilder, src: Stream<u64>) -> Stream<u64> {
+        let out = src.map(|i| i + 1);
+        out
+    }
+}
+
+fn main() {}

--- a/wingfoil-next/tests/trybuild/stream_param_by_value.stderr
+++ b/wingfoil-next/tests/trybuild/stream_param_by_value.stderr
@@ -1,0 +1,5 @@
+error: stream parameters must be taken by reference: `name: &Stream<T>`
+ --> tests/trybuild/stream_param_by_value.rs:6:35
+  |
+6 |     fn bad(g: &GraphBuilder, src: Stream<u64>) -> Stream<u64> {
+  |                                   ^^^^^^


### PR DESCRIPTION
Builds on the `wingfoil-next` experimental crate (base: `next`). Adds a sparse
dispatch engine alongside the existing full-sweep interpreter, expands the op
catalog and compat facade, ports two adapters, and lands broad test coverage.

## Engine

- **Sparse dirty-list dispatch** (Phase 4.5) — an incremental scheduler that
  only re-cycles nodes reachable from what ticked, as an alternative to the
  full-sweep engine (`interp.rs`).
- **Full-sweep engine retained as a selectable oracle** — kept as a
  `with_dispatch` option so the two engines can be diffed for parity in tests.
- **Merge tie-break + two-op island scheduling gaps closed** — deterministic
  ordering when independent scheduling islands fire in the same cycle
  (`tests/merge_tiebreak.rs`, `tests/island_scheduling.rs`).
- `with_dispatch` now consumes and returns `Self` for fluent chaining.

## Ops & compat

- **Catalog ops** — `try_bimap` / `try_trimap`, `print`, `timed` (`ops.rs`).
- **compat facade** expanded with core classic operators so classic-style
  wiring works against the next engine (`compat.rs`, `tests/compat.rs`).

## Adapters

- **CSV adapter** port — replay source + file sink, `csv` feature
  (`adapters/csv.rs`, `examples/csv_adapter.rs`, `tests/csv_adapter.rs`).
- **line adapter** example + rolling statistics (`adapters/lines.rs`,
  `stats.rs`, `tests/statistics_rolling.rs`).

## Tests

New integration suites: `catalog_ops`, `compat`, `csv_adapter`,
`island_scheduling`, `lines_adapter`, `merge_tiebreak`, `sparse_graph`,
`statistics_rolling`, plus trybuild UI tests for the `graph!` fn forms
(`async_graph_fn`, `generic_graph_fn`, `missing_return_type`,
`stream_param_by_value`).

---

Rebased onto the latest `next` (`5dc3999`); conflicts in `wingfoil-next/Cargo.toml`
(kept both the `fanout` bench and `csv_adapter` example) and `Cargo.lock`
(merged the dependency list) were resolved. `cargo metadata` resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)