### PR TITLE
feat(next-macros): add stateless single-input ops to the compiled path

### DIFF
--- a/wingfoil-next-macros/src/lib.rs
+++ b/wingfoil-next-macros/src/lib.rs
@@ -93,7 +93,10 @@
 //! `.filter(&cond)`, `.fold(init, f)`, `.sample(&trigger)`, `.merge(&other)`,
 //! `.join(&other, f)`, `.delay(duration)`; statistics (on `f64` streams)
 //! `.ewma(decay)` / `.ewma_per_tick(alpha)` / `.ewma_half_life(dur)`,
-//! `.rolling_sum(window)`, `.rolling_mean(window)`; sugar `.count()` and
+//! `.rolling_sum(window)`, `.rolling_mean(window)`; stateless / single-input
+//! `.distinct()`, `.difference()`, `.limit(n)`, `.inspect(f)`,
+//! `.map_filter(f)`, `.with_time()`, `.ticked_at()`, `.ticked_at_elapsed()`;
+//! sugar `.count()` and
 //! `.accumulate()`; and bounded repetition `.map_n(N, f)` (chain `map` N
 //! times) / `.fan(N, |s| <sub-chain>)` (N parallel copies of a sub-chain,
 //! merged). `map_n` / `fan` counts must be integer literals so the unrolled
@@ -144,6 +147,15 @@ enum OpKind {
     Ewma,
     RollingSum,
     RollingMean,
+    // Stateless / single-input ops brought into the compiled path.
+    Distinct,
+    Difference,
+    Limit,
+    Inspect,
+    MapFilter,
+    WithTime,
+    TickedAt,
+    TickedAtElapsed,
 }
 
 /// The shape of an op's `Op::In` tuple — how the cycle call assembles its
@@ -199,6 +211,18 @@ enum ValueSeed {
     /// local (fold seeds its slot with `init`, matching `interp.rs` which does
     /// `new_slot(init.clone())`). Requires the op to keep a `__state` local.
     CloneState,
+    /// `let mut v = (NanoTime::ZERO, Clone::clone(&<upstream value>));` — the
+    /// `with_time` slot seed. `interp.rs` seeds it with
+    /// `(NanoTime::ZERO, src_slot.borrow().clone())`: the engine clock is
+    /// `ZERO` before the first tick (== `NanoTime::default()`), paired with the
+    /// upstream's *own* seed value (not `T::default()`, which would drift when
+    /// the upstream is a `fold` with a non-default init). Reads the upstream's
+    /// already-declared `__v_<up>` local, so it must appear after it in the
+    /// setup order (nodes are emitted topologically, so it does). When the
+    /// upstream is an `Input` (nested only, where `__v_<input>` is not in scope
+    /// at setup) it falls back to `Default` — the island's *observable* pre-tick
+    /// value is the outer graph's `Default` composite-slot seed regardless.
+    WithTimeUpstream,
 }
 
 /// Which of an op's upstream `refs` are *active* (propagate ticks / appear in
@@ -444,6 +468,127 @@ impl OpKind {
                     ty: Some(quote! { usize }),
                 },
                 state_init: StateInit::Default(quote! { ::wingfoil_next::ops::RollingWindowState }),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Suppresses consecutive duplicates. `State = Option<T>` (seeded
+            // `None`), value slot seeded `Out::default()` by `register_op1`.
+            OpKind::Distinct => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::Distinct<_> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::None,
+                state_init: StateInit::Default(quote! { ::core::option::Option }),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Successive difference. `State = Option<T>` (previous value).
+            OpKind::Difference => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::Difference<_> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::None,
+                state_init: StateInit::Default(quote! { ::core::option::Option }),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Passes the first `limit` values then stays quiet. `Cfg = u32`
+            // (the limit), `State = u32` (count emitted, seeded 0).
+            OpKind::Limit => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::Limit<_> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::Expr {
+                    arg: 0,
+                    ty: Some(quote! { u32 }),
+                },
+                state_init: StateInit::Default(quote! { u32 }),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Side-effecting tap that passes its value through. The observer
+            // closure is the config (like Map).
+            OpKind::Inspect => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::Inspect<_, _> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: Some(0),
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::None,
+                state_init: StateInit::None,
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Map + filter in one pass: the closure returns `(B, bool)`. The
+            // closure is the config (like Map).
+            OpKind::MapFilter => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::MapFilter<_, _, _> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: Some(0),
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::None,
+                state_init: StateInit::None,
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Pairs each value with the engine time: emits `(NanoTime, T)`.
+            // Stateless, but its slot seed is *not* `Default` — see
+            // `ValueSeed::WithTimeUpstream`.
+            OpKind::WithTime => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::WithTime<_> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::None,
+                state_init: StateInit::None,
+                value_seed: ValueSeed::WithTimeUpstream,
+                edges: Edges::AllActive,
+            },
+            // Emits the engine time whenever the upstream ticks (value ignored).
+            OpKind::TickedAt => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::TickedAt<_> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::None,
+                state_init: StateInit::None,
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Emits elapsed engine time (`now - start`) on each upstream tick.
+            OpKind::TickedAtElapsed => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::TickedAtElapsed<_> },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::None,
+                state_init: StateInit::None,
                 value_seed: ValueSeed::Default,
                 edges: Edges::AllActive,
             },
@@ -856,6 +1001,39 @@ impl ChainWalker {
                 expect_arity(method, args, 1)?;
                 self.push(name, OpKind::RollingMean, vec![cur], vec![args[0].clone()])
             }
+            // Stateless / single-input catalog ops.
+            "distinct" => {
+                expect_arity(method, args, 0)?;
+                self.push(name, OpKind::Distinct, vec![cur], vec![])
+            }
+            "difference" => {
+                expect_arity(method, args, 0)?;
+                self.push(name, OpKind::Difference, vec![cur], vec![])
+            }
+            "limit" => {
+                expect_arity(method, args, 1)?;
+                self.push(name, OpKind::Limit, vec![cur], vec![args[0].clone()])
+            }
+            "inspect" => {
+                expect_arity(method, args, 1)?;
+                self.push(name, OpKind::Inspect, vec![cur], vec![args[0].clone()])
+            }
+            "map_filter" => {
+                expect_arity(method, args, 1)?;
+                self.push(name, OpKind::MapFilter, vec![cur], vec![args[0].clone()])
+            }
+            "with_time" => {
+                expect_arity(method, args, 0)?;
+                self.push(name, OpKind::WithTime, vec![cur], vec![])
+            }
+            "ticked_at" => {
+                expect_arity(method, args, 0)?;
+                self.push(name, OpKind::TickedAt, vec![cur], vec![])
+            }
+            "ticked_at_elapsed" => {
+                expect_arity(method, args, 0)?;
+                self.push(name, OpKind::TickedAtElapsed, vec![cur], vec![])
+            }
             // Bounded repetition sugar. `map_n(N, f)` unrolls to N chained
             // `map`s; `fan(N, |s| <sub-chain>)` builds N copies of a sub-chain
             // rooted at the current tail and merges them. Both take a literal
@@ -928,7 +1106,9 @@ impl ChainWalker {
                     format!(
                         "unknown combinator `.{other}(..)`; expected one of: map, map_n, fan, \
                          filter, fold, sample, merge, join, delay, count, accumulate, ewma, \
-                         ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean"
+                         ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean, distinct, \
+                         difference, limit, inspect, map_filter, with_time, ticked_at, \
+                         ticked_at_elapsed"
                     ),
                 ));
             }
@@ -1508,7 +1688,7 @@ fn ctx_expr(target: Target, idx: usize) -> TokenStream2 {
 
 /// cfg + state + value slot declarations for one node, driven by the op's
 /// [`OpInfo`] (`cfg_init` / `state_init` / `unit_output`).
-fn node_decl(node: &NodeDef) -> TokenStream2 {
+fn node_decl(def: &GraphDef, node: &NodeDef) -> TokenStream2 {
     // Inputs have no storage here — their value/tick are read from the outer
     // graph in the `nested` prologue.
     if node.op == OpKind::Input {
@@ -1572,6 +1752,25 @@ fn node_decl(node: &NodeDef) -> TokenStream2 {
             ValueSeed::CloneState => {
                 quote! { let mut #value = ::core::clone::Clone::clone(&#state); }
             }
+            ValueSeed::WithTimeUpstream => {
+                // Mirror interp.rs `new_slot((NanoTime::ZERO, src.clone()))`:
+                // ZERO clock (== the pre-first-tick engine time) paired with
+                // the upstream's own seed. An `Input` upstream has no `__v_`
+                // local in scope at setup (nested reads it per-cycle), so fall
+                // back to `Default` there.
+                let up = &def.nodes[node.refs[0]];
+                let time = quote! { ::wingfoil_next::wingfoil::NanoTime::ZERO };
+                match up.op {
+                    OpKind::Input => quote! { let mut #value = Default::default(); },
+                    OpKind::Ticker => quote! { let mut #value = (#time, ()); },
+                    _ => {
+                        let up_v = format_ident!("__v_{}", up.name);
+                        quote! {
+                            let mut #value = (#time, ::core::clone::Clone::clone(&#up_v));
+                        }
+                    }
+                }
+            }
         }
     };
     // Delay keeps an extra engine-level `__seeded` flag so it can store its
@@ -1597,7 +1796,7 @@ fn interleaved_setup(def: &GraphDef) -> Vec<TokenStream2> {
         while let Some((_, stmt)) = passthrough.next_if(|(pos, _)| *pos <= i) {
             setup.push(quote! { #stmt });
         }
-        setup.push(node_decl(node));
+        setup.push(node_decl(def, node));
     }
     for (_, stmt) in passthrough {
         setup.push(quote! { #stmt });

--- a/wingfoil-next/tests/compiled_stateless_ops.rs
+++ b/wingfoil-next/tests/compiled_stateless_ops.rs
@@ -1,0 +1,255 @@
+//! Three-engine parity for the stateless / single-input catalog ops brought
+//! into the `graph!` / `compiled()` path: `distinct`, `difference`, `limit`,
+//! `inspect`, `map_filter`, `with_time`, `ticked_at`, and
+//! `ticked_at_elapsed`.
+//!
+//! Every graph here is a **source island** (sources inside, no stream
+//! parameters), so it emits all three expansions — `interpreted()`,
+//! `compiled()`, and `nested()`. Each test asserts the three agree exactly;
+//! since they are derived from the same tokens, any drift (a wrong dispatch
+//! flag, a mis-seeded value slot, a re-evaluated closure config) shows up as
+//! an inequality here.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const P: Duration = Duration::from_nanos(100);
+
+/// Run a source-island graph through all three engines and assert they agree,
+/// returning the (shared) interpreted value for any additional exact checks.
+macro_rules! three_engine {
+    ($module:ident, $run_for:expr) => {{
+        let run_for = $run_for;
+
+        let (mut runner, out) = $module::interpreted();
+        runner.run(HISTORICAL, run_for).unwrap();
+        let interpreted = runner.value(out);
+
+        let (compiled,) = $module::compiled(HISTORICAL, run_for).unwrap();
+        assert_eq!(interpreted, compiled, "interpreted vs compiled");
+
+        let g = GraphBuilder::new();
+        let island = $module::nested(&g);
+        let mut r = g.build();
+        r.run(HISTORICAL, run_for).unwrap();
+        assert_eq!(interpreted, r.value(&island), "interpreted vs nested");
+
+        interpreted
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// distinct: suppress consecutive duplicates.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn distinct_graph(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let acc = g.ticker(P).count().map(|i| i / 2).distinct().accumulate();
+        acc
+    }
+}
+
+#[test]
+fn distinct_three_engine_parity() {
+    // count = 1,2,3,4,5,6 -> /2 = 0,1,1,2,2,3 -> distinct = 0,1,2,3.
+    let v = three_engine!(distinct_graph, RunFor::Cycles(6));
+    assert_eq!(vec![0, 1, 2, 3], v);
+}
+
+// ---------------------------------------------------------------------------
+// difference: successive value - previous (quiet on the first value).
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn difference_graph(g: &GraphBuilder) -> Stream<Vec<i64>> {
+        let acc = g
+            .ticker(P)
+            .count()
+            .map(|i| (*i * *i) as i64)
+            .difference()
+            .accumulate();
+        acc
+    }
+}
+
+#[test]
+fn difference_three_engine_parity() {
+    // squares of 1,2,3,4 = 1,4,9,16 -> differences = 3,5,7 (first is quiet).
+    let v = three_engine!(difference_graph, RunFor::Cycles(4));
+    assert_eq!(vec![3, 5, 7], v);
+}
+
+// ---------------------------------------------------------------------------
+// limit: pass the first N values, then stay quiet.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn limit_graph(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let acc = g.ticker(P).count().limit(3).accumulate();
+        acc
+    }
+}
+
+#[test]
+fn limit_three_engine_parity() {
+    // count would be 1..=6, but limit(3) passes only the first three.
+    let v = three_engine!(limit_graph, RunFor::Cycles(6));
+    assert_eq!(vec![1, 2, 3], v);
+}
+
+// ---------------------------------------------------------------------------
+// inspect: side-effecting tap that passes its value through unchanged. The
+// observer closure is a `Cfg` type parameter (like `map`), so this also checks
+// a non-mutating closure config flows through the compiled emission.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn inspect_graph(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let acc = g
+            .ticker(P)
+            .count()
+            .inspect(|i| {
+                let _ = i;
+            })
+            .map(|i| i * 3)
+            .accumulate();
+        acc
+    }
+}
+
+#[test]
+fn inspect_three_engine_parity() {
+    let v = three_engine!(inspect_graph, RunFor::Cycles(3));
+    assert_eq!(vec![3, 6, 9], v);
+}
+
+// ---------------------------------------------------------------------------
+// map_filter: map + filter in one pass; the closure returns `(B, bool)`.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn map_filter_graph(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let acc = g
+            .ticker(P)
+            .count()
+            .map_filter(|i| (i * 10, i.is_multiple_of(2)))
+            .accumulate();
+        acc
+    }
+}
+
+#[test]
+fn map_filter_three_engine_parity() {
+    // count 1..=6; emit `i*10` only when `i` is even -> 20, 40, 60.
+    let v = three_engine!(map_filter_graph, RunFor::Cycles(6));
+    assert_eq!(vec![20, 40, 60], v);
+}
+
+// ---------------------------------------------------------------------------
+// with_time: pair each value with the current engine time.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn with_time_graph(g: &GraphBuilder) -> Stream<Vec<(NanoTime, u64)>> {
+        let acc = g.ticker(P).count().with_time().accumulate();
+        acc
+    }
+}
+
+#[test]
+fn with_time_three_engine_parity() {
+    // ticker fires at 0, 100, 200; counts 1, 2, 3.
+    let v = three_engine!(with_time_graph, RunFor::Cycles(3));
+    assert_eq!(
+        vec![
+            (NanoTime::from(0u64), 1),
+            (NanoTime::from(100u64), 2),
+            (NanoTime::from(200u64), 3),
+        ],
+        v
+    );
+}
+
+// ---------------------------------------------------------------------------
+// with_time seeding: a `with_time` fed by a `fold` with a *non-default* init,
+// read via a passive `sample` edge *before* it first ticks. This is the case
+// that would catch seeding drift: interp seeds the slot with
+// `(ZERO, fold_init)`, so a `Default`-seeded compiled slot (`(ZERO, 0)`) would
+// disagree on the pre-first-tick reads. The `fold` only fires once the gate
+// opens (count > 2), so the sample at t=0 and t=100 must read the seed.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn with_time_seed_graph(g: &GraphBuilder) -> Stream<Vec<(NanoTime, u64)>> {
+        let count = g.ticker(P).count();
+        let gate = count.map(|i| *i > 2);
+        let gated = count.filter(&gate);
+        let wt = gated.fold(100u64, |acc, v| *acc += v).with_time();
+        let trigger = g.ticker(P);
+        let acc = wt.sample(&trigger).accumulate();
+        acc
+    }
+}
+
+#[test]
+fn with_time_seed_read_before_first_tick_parity() {
+    // count 1..=4 at t = 0,100,200,300. gate opens at count 3 (t=200), so
+    // `gated` ticks at 200 (v=3) and 300 (v=4); the fold seeds at 100.
+    //   t=0   : fold quiet, wt = seed (ZERO, 100); sample -> (0, 100)
+    //   t=100 : fold quiet, wt = seed (ZERO, 100); sample -> (0, 100)
+    //   t=200 : fold 100+3=103, wt = (200, 103); sample -> (200, 103)
+    //   t=300 : fold 103+4=107, wt = (300, 107); sample -> (300, 107)
+    let v = three_engine!(with_time_seed_graph, RunFor::Cycles(4));
+    assert_eq!(
+        vec![
+            (NanoTime::from(0u64), 100),
+            (NanoTime::from(0u64), 100),
+            (NanoTime::from(200u64), 103),
+            (NanoTime::from(300u64), 107),
+        ],
+        v
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ticked_at: emit the engine time whenever the upstream ticks.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn ticked_at_graph(g: &GraphBuilder) -> Stream<Vec<NanoTime>> {
+        let acc = g.ticker(P).count().ticked_at().accumulate();
+        acc
+    }
+}
+
+#[test]
+fn ticked_at_three_engine_parity() {
+    let v = three_engine!(ticked_at_graph, RunFor::Cycles(3));
+    assert_eq!(
+        vec![
+            NanoTime::from(0u64),
+            NanoTime::from(100u64),
+            NanoTime::from(200u64),
+        ],
+        v
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ticked_at_elapsed: emit elapsed engine time (now - start) on each tick.
+// ---------------------------------------------------------------------------
+wingfoil_next::graph! {
+    fn ticked_at_elapsed_graph(g: &GraphBuilder) -> Stream<Vec<NanoTime>> {
+        let acc = g.ticker(P).count().ticked_at_elapsed().accumulate();
+        acc
+    }
+}
+
+#[test]
+fn ticked_at_elapsed_three_engine_parity() {
+    // start time is ZERO, so elapsed == absolute here: 0, 100, 200.
+    let v = three_engine!(ticked_at_elapsed_graph, RunFor::Cycles(3));
+    assert_eq!(
+        vec![
+            NanoTime::from(0u64),
+            NanoTime::from(100u64),
+            NanoTime::from(200u64),
+        ],
+        v
+    );
+}

--- a/wingfoil-next/tests/trybuild/unknown_combinator.stderr
+++ b/wingfoil-next/tests/trybuild/unknown_combinator.stderr
@@ -1,4 +1,4 @@
-error: unknown combinator `.frobnicate(..)`; expected one of: map, map_n, fan, filter, fold, sample, merge, join, delay, count, accumulate, ewma, ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean
+error: unknown combinator `.frobnicate(..)`; expected one of: map, map_n, fan, filter, fold, sample, merge, join, delay, count, accumulate, ewma, ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean, distinct, difference, limit, inspect, map_filter, with_time, ticked_at, ticked_at_elapsed
  --> tests/trybuild/unknown_combinator.rs:7:62
   |
 7 |         let out = g.ticker(Duration::from_nanos(10)).count().frobnicate();


### PR DESCRIPTION
## What

The interpreted engine + fluent API support ~30 ops, but the `graph!` /
`compiled()` / `nested()` path supported only 13. This PR brings the
**simpler stateless / single-input** ops into the compiled path:

| op | source | notes |
|----|--------|-------|
| `distinct` | `ops.rs` `Distinct<T>` | `State = Option<T>` |
| `difference` | `Difference<T>` | `State = Option<T>` |
| `limit` | `Limit<T>` | `Cfg = u32`, `State = u32` |
| `inspect` | `Inspect<A, F>` | closure config (like `map`) |
| `map_filter` | `MapFilter<A, B, F>` | closure returns `(B, bool)` |
| `with_time` | `WithTime<T>` | non-Default slot seed — see below |
| `ticked_at` | `TickedAt<T>` | emits `NanoTime` |
| `ticked_at_elapsed` | `TickedAtElapsed<T>` | emits `NanoTime` |

Deferred to a follow-up PR (out of scope, as agreed): scheduling/timer ops
(`throttle`, `window`, `buffer`) and the `try_*` / 3-ary variants
(`try_map`, `try_join`, `join3`, `try_join3`, etc.).

## How

For each op, the four macro pieces are added, mirroring an existing template
(`Map` for the stateless closure ops, `RollingSum`/`Fold` for the
stateful-single-input ops):

1. an `OpKind` variant,
2. an `info()` `OpInfo` row with **every field spelled out** (no `..base`
   struct-update — an omitted dispatch flag is a compile error, not a silent
   wrong default),
3. a parse arm in `apply_call`,
4. the op's `CfgInit` / `StateInit` / `ValueSeed`.

### `with_time` slot seeding (the one correctness subtlety)

`interp.rs` seeds the `with_time` slot with `(NanoTime::ZERO, src.clone())`,
**not** `Default::default()`. `NanoTime::ZERO == NanoTime::default()`, so the
time component always matches — but the value component drifts when the
upstream is a `fold` with a **non-default init**: interp shows
`(ZERO, init)` while a `Default`-seeded compiled slot would show
`(ZERO, T::default())` on a pre-first-tick read.

Fixed by adding `ValueSeed::WithTimeUpstream`, which seeds the compiled slot
identically from the upstream's already-declared `__v_<up>` local (the graph
def is now threaded into `node_decl` to resolve it). For an `Input` upstream
in the `nested` path — where `__v_<input>` is not in scope at setup — it falls
back to `Default`; the island's *observable* pre-tick value is the outer
graph's `Default` composite-slot seed regardless.

All other new ops seed via `register_op1` with `Out::default()`, so they use
`ValueSeed::Default`.

## Tests — 3-engine parity (interpreted == compiled == nested)

New `tests/compiled_stateless_ops.rs` runs a source-island micro-graph per op
through all three expansions and asserts they agree exactly (plus exact
expected values). Includes the seeding/timing case that motivated
`WithTimeUpstream`: a `with_time`-over-`fold(100, …)` read via a **passive
`sample` edge before it first ticks** — verified to fail the interpreted-vs-
compiled assertion if the slot is Default-seeded. The existing catalog parity
tests (values **and** tick times) still pass, and the `unknown_combinator`
trybuild fixture was updated for the expanded combinator list.

## Verification

- `cargo fmt --all` — clean
- `cargo test -p wingfoil-next -p wingfoil-next-macros` — all pass (default and `--features async`)
- `cargo clippy -p wingfoil-next -p wingfoil-next-macros --all-targets -- -D warnings` — clean (also with `--features async`)
- No `.unwrap()` outside `#[cfg(test)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_