### PR TITLE
feat(next-macros): add rolling min/max/var/std/median to the compiled path

### DIFF
--- a/wingfoil-next-macros/src/lib.rs
+++ b/wingfoil-next-macros/src/lib.rs
@@ -93,7 +93,9 @@
 //! `.filter(&cond)`, `.fold(init, f)`, `.sample(&trigger)`, `.merge(&other)`,
 //! `.join(&other, f)`, `.delay(duration)`; statistics (on `f64` streams)
 //! `.ewma(decay)` / `.ewma_per_tick(alpha)` / `.ewma_half_life(dur)`,
-//! `.rolling_sum(window)`, `.rolling_mean(window)`; sugar `.count()` and
+//! `.rolling_sum(window)`, `.rolling_mean(window)`, `.rolling_min(window)`,
+//! `.rolling_max(window)`, `.rolling_var(window)`, `.rolling_std(window)`,
+//! `.rolling_median(window)`; sugar `.count()` and
 //! `.accumulate()`; and bounded repetition `.map_n(N, f)` (chain `map` N
 //! times) / `.fan(N, |s| <sub-chain>)` (N parallel copies of a sub-chain,
 //! merged). `map_n` / `fan` counts must be integer literals so the unrolled
@@ -144,6 +146,11 @@ enum OpKind {
     Ewma,
     RollingSum,
     RollingMean,
+    RollingMin,
+    RollingMax,
+    RollingVar,
+    RollingStd,
+    RollingMedian,
 }
 
 /// The shape of an op's `Op::In` tuple — how the cycle call assembles its
@@ -444,6 +451,97 @@ impl OpKind {
                     ty: Some(quote! { usize }),
                 },
                 state_init: StateInit::Default(quote! { ::wingfoil_next::ops::RollingWindowState }),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Rolling min / max over the most recent `window` f64 samples (a
+            // monotonic-deque `RollingExtremeState`). `Cfg = usize` (window),
+            // value slot seeded 0.0 (`f64::default()`) by `register_op1`.
+            OpKind::RollingMin => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::RollingMin },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::Expr {
+                    arg: 0,
+                    ty: Some(quote! { usize }),
+                },
+                state_init: StateInit::Default(
+                    quote! { ::wingfoil_next::ops::RollingExtremeState },
+                ),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            OpKind::RollingMax => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::RollingMax },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::Expr {
+                    arg: 0,
+                    ty: Some(quote! { usize }),
+                },
+                state_init: StateInit::Default(
+                    quote! { ::wingfoil_next::ops::RollingExtremeState },
+                ),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Rolling sample variance / std (ddof = 1) over the most recent
+            // `window` f64 samples (Welford moments in `RollingMomentState`).
+            OpKind::RollingVar => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::RollingVar },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::Expr {
+                    arg: 0,
+                    ty: Some(quote! { usize }),
+                },
+                state_init: StateInit::Default(quote! { ::wingfoil_next::ops::RollingMomentState }),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            OpKind::RollingStd => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::RollingStd },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::Expr {
+                    arg: 0,
+                    ty: Some(quote! { usize }),
+                },
+                state_init: StateInit::Default(quote! { ::wingfoil_next::ops::RollingMomentState }),
+                value_seed: ValueSeed::Default,
+                edges: Edges::AllActive,
+            },
+            // Rolling median over the most recent `window` f64 samples
+            // (recompute-per-tick `RollingMedianState`).
+            OpKind::RollingMedian => OpInfo {
+                op_type: quote! { ::wingfoil_next::ops::RollingMedian },
+                callback_activated: false,
+                has_start: false,
+                state_in_start: false,
+                owned_closure: None,
+                unit_output: false,
+                inputs: Inputs::One,
+                cfg_init: CfgInit::Expr {
+                    arg: 0,
+                    ty: Some(quote! { usize }),
+                },
+                state_init: StateInit::Default(quote! { ::wingfoil_next::ops::RollingMedianState }),
                 value_seed: ValueSeed::Default,
                 edges: Edges::AllActive,
             },
@@ -856,6 +954,31 @@ impl ChainWalker {
                 expect_arity(method, args, 1)?;
                 self.push(name, OpKind::RollingMean, vec![cur], vec![args[0].clone()])
             }
+            "rolling_min" => {
+                expect_arity(method, args, 1)?;
+                self.push(name, OpKind::RollingMin, vec![cur], vec![args[0].clone()])
+            }
+            "rolling_max" => {
+                expect_arity(method, args, 1)?;
+                self.push(name, OpKind::RollingMax, vec![cur], vec![args[0].clone()])
+            }
+            "rolling_var" => {
+                expect_arity(method, args, 1)?;
+                self.push(name, OpKind::RollingVar, vec![cur], vec![args[0].clone()])
+            }
+            "rolling_std" => {
+                expect_arity(method, args, 1)?;
+                self.push(name, OpKind::RollingStd, vec![cur], vec![args[0].clone()])
+            }
+            "rolling_median" => {
+                expect_arity(method, args, 1)?;
+                self.push(
+                    name,
+                    OpKind::RollingMedian,
+                    vec![cur],
+                    vec![args[0].clone()],
+                )
+            }
             // Bounded repetition sugar. `map_n(N, f)` unrolls to N chained
             // `map`s; `fan(N, |s| <sub-chain>)` builds N copies of a sub-chain
             // rooted at the current tail and merges them. Both take a literal
@@ -928,7 +1051,8 @@ impl ChainWalker {
                     format!(
                         "unknown combinator `.{other}(..)`; expected one of: map, map_n, fan, \
                          filter, fold, sample, merge, join, delay, count, accumulate, ewma, \
-                         ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean"
+                         ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean, \
+                         rolling_min, rolling_max, rolling_var, rolling_std, rolling_median"
                     ),
                 ));
             }

--- a/wingfoil-next/tests/compiled_rolling_ops.rs
+++ b/wingfoil-next/tests/compiled_rolling_ops.rs
@@ -1,0 +1,124 @@
+//! Three-engine parity for the f64 rolling-window statistics ops in the
+//! `graph!` / `compiled()` path: `rolling_min`, `rolling_max`, `rolling_var`,
+//! `rolling_std`, and `rolling_median`.
+//!
+//! Each graph is a **source island** (sources inside, no stream parameters),
+//! so it emits all three expansions — `interpreted()`, `compiled()`, and
+//! `nested()`. Every op is stateful (a ring-buffer / monotonic-deque / Welford
+//! moment state) but purely input-activated (`Activation::NONE`), so the
+//! straight-line compiled schedule represents it exactly.
+//!
+//! The input sequence is the fixed, non-monotonic series `[3, 1, 4, 1, 5]`
+//! (mapped from `count`), with a window of 3, so min/max/median evict from both
+//! ends and have unambiguous expected values. Because all three engines run the
+//! *same* `Op::cycle` code in the same order, their f64 outputs are
+//! bit-identical — asserted with `assert_eq!` — while the hand-computed
+//! expectations are checked within a tolerance (var/std carry the usual
+//! floating-point residue of incremental Welford updates).
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const P: Duration = Duration::from_nanos(100);
+const CYCLES: RunFor = RunFor::Cycles(5);
+
+/// Run a source-island graph through all three engines, assert they agree
+/// exactly, and return the shared interpreted series.
+macro_rules! three_engine {
+    ($module:ident) => {{
+        let (mut runner, out) = $module::interpreted();
+        runner.run(HISTORICAL, CYCLES).unwrap();
+        let interpreted = runner.value(out);
+
+        let (compiled,) = $module::compiled(HISTORICAL, CYCLES).unwrap();
+        assert_eq!(interpreted, compiled, "interpreted vs compiled");
+
+        let g = GraphBuilder::new();
+        let island = $module::nested(&g);
+        let mut r = g.build();
+        r.run(HISTORICAL, CYCLES).unwrap();
+        assert_eq!(interpreted, r.value(&island), "interpreted vs nested");
+
+        interpreted
+    }};
+}
+
+/// Assert two `f64` series equal element-wise within a tolerance.
+fn assert_series_approx(got: &[f64], expected: &[f64]) {
+    assert_eq!(got.len(), expected.len(), "length: {got:?} vs {expected:?}");
+    for (i, (g, e)) in got.iter().zip(expected).enumerate() {
+        assert!(
+            (g - e).abs() < 1e-10,
+            "at {i}: got {g}, expected {e} (series {got:?} vs {expected:?})"
+        );
+    }
+}
+
+// The shared non-monotonic source `[3, 1, 4, 1, 5]` as f64, one tick per 100ns.
+// (`count` is 1..=5; the closure maps each to the fixed sequence.)
+macro_rules! rolling_graph {
+    ($name:ident, $method:ident) => {
+        wingfoil_next::graph! {
+            fn $name(g: &GraphBuilder) -> Stream<Vec<f64>> {
+                let acc = g
+                    .ticker(P)
+                    .count()
+                    .map(|i| [3.0, 1.0, 4.0, 1.0, 5.0][(*i - 1) as usize])
+                    .$method(3)
+                    .accumulate();
+                acc
+            }
+        }
+    };
+}
+
+rolling_graph!(rolling_min_graph, rolling_min);
+rolling_graph!(rolling_max_graph, rolling_max);
+rolling_graph!(rolling_var_graph, rolling_var);
+rolling_graph!(rolling_std_graph, rolling_std);
+rolling_graph!(rolling_median_graph, rolling_median);
+
+#[test]
+fn rolling_min_three_engine_parity() {
+    let v = three_engine!(rolling_min_graph);
+    assert_eq!(vec![3.0, 1.0, 1.0, 1.0, 1.0], v);
+}
+
+#[test]
+fn rolling_max_three_engine_parity() {
+    let v = three_engine!(rolling_max_graph);
+    assert_eq!(vec![3.0, 3.0, 4.0, 4.0, 5.0], v);
+}
+
+#[test]
+fn rolling_median_three_engine_parity() {
+    let v = three_engine!(rolling_median_graph);
+    assert_eq!(vec![3.0, 2.0, 3.0, 1.0, 4.0], v);
+}
+
+#[test]
+fn rolling_var_three_engine_parity() {
+    let v = three_engine!(rolling_var_graph);
+    // Sample variance (ddof = 1); 0.0 until two samples are present.
+    assert_series_approx(&v, &[0.0, 2.0, 2.333_333_333_333, 3.0, 4.333_333_333_333]);
+}
+
+#[test]
+fn rolling_std_three_engine_parity() {
+    let v = three_engine!(rolling_std_graph);
+    assert_series_approx(
+        &v,
+        &[
+            0.0,
+            // std of the two-sample window [3, 1] is exactly sqrt(2); using the
+            // constant also sidesteps clippy::approx_constant on the literal.
+            std::f64::consts::SQRT_2,
+            1.527_525_231_652,
+            1.732_050_807_569,
+            2.081_665_999_466,
+        ],
+    );
+}

--- a/wingfoil-next/tests/trybuild/unknown_combinator.stderr
+++ b/wingfoil-next/tests/trybuild/unknown_combinator.stderr
@@ -1,4 +1,4 @@
-error: unknown combinator `.frobnicate(..)`; expected one of: map, map_n, fan, filter, fold, sample, merge, join, delay, count, accumulate, ewma, ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean
+error: unknown combinator `.frobnicate(..)`; expected one of: map, map_n, fan, filter, fold, sample, merge, join, delay, count, accumulate, ewma, ewma_per_tick, ewma_half_life, rolling_sum, rolling_mean, rolling_min, rolling_max, rolling_var, rolling_std, rolling_median
  --> tests/trybuild/unknown_combinator.rs:7:62
   |
 7 |         let out = g.ticker(Duration::from_nanos(10)).count().frobnicate();


### PR DESCRIPTION
## What

PR3 of the compiled-path completion (follows #475 and #477, branched fresh
from `next`). Completes the f64 rolling-window statistics family in the
`graph!` / `compiled()` / `nested()` path:

`rolling_min`, `rolling_max`, `rolling_var`, `rolling_std`, `rolling_median`

## How

Each is a one-line `OpKind` variant + a fully-spelled `info()` row modelled
exactly on the existing `rolling_sum` row — `Inputs::One`,
`CfgInit::Expr { usize window }`, `StateInit::Default` over the op's state
struct (`RollingExtremeState` for min/max, `RollingMomentState` for var/std,
`RollingMedianState` for median), `ValueSeed::Default` (they seed `0.0`),
`Edges::AllActive` — plus a parse arm. **No new emission machinery:** all five
are stateful but purely input-activated (`Activation::NONE`), so the
straight-line compiled schedule represents them exactly.

## Tests — 3-engine parity (interpreted == compiled == nested)

`compiled_rolling_ops.rs` runs each op over the fixed non-monotonic series
`[3, 1, 4, 1, 5]` (mapped from `count`) with a window of 3, so min/max/median
evict from both ends and have unambiguous expected values:

| op | expected |
|----|----------|
| `rolling_min` | `[3, 1, 1, 1, 1]` |
| `rolling_max` | `[3, 3, 4, 4, 5]` |
| `rolling_median` | `[3, 2, 3, 1, 4]` |
| `rolling_var` (ddof=1) | `[0, 2, 2.333…, 3, 4.333…]` |
| `rolling_std` | `[0, √2, 1.527…, 1.732…, 2.081…]` |

The three engines run the same `Op::cycle` in the same order, so their f64
outputs are bit-identical (`assert_eq!`); the hand-computed expectations are
checked within `1e-10` (var/std carry the usual incremental-Welford residue).
Updated the `unknown_combinator` trybuild `.stderr` for the expanded list.

## Compiled-path catalog status — what's genuinely left

With this PR the compiled path covers **essentially the whole
macro-expressible catalog** (32 ops). The ops in `wingfoil-next::ops` that
still have **no** compiled/`graph!` equivalent, and why:

- **`poll`** (`Poll`, `Activation::ALWAYS`) and **`for_each`** (`Sink`,
  `Out = ()`) — **IO-edge source / sink.** Excluded from `graph!` *by design*:
  "IO-edge sources and sinks (`external`, `poll`, `for_each`) are not
  expressible — IO lives at the fluent layer, feeding compiled islands through
  their inputs." Not a gap to close.
- **`print`** (`Print`), **`timed`** (`Timed`), **`finally`** (`Finally`) —
  their observable effect lives in a **`stop` / `teardown` lifecycle hook**,
  and the compiled/nested emission currently wires only the `start` hook
  (`node_start`); there is no `node_stop` / `node_teardown`. These are
  diagnostic / cleanup / side-effecting nodes (a pass-through value stream plus
  an end-of-run print or timing summary), so they're low-priority — but
  emitting `stop`/`teardown` in the compiled loop and island teardown is the
  one remaining piece of machinery if we want them.

Everything else (all the pure value-producing combinators, timers, stats, and
fallible/multi-input variants) is now on the compiled path.

## Merge note

Additively edits the same `OpKind` / `info()` / parse-arm / combinator-list
regions as #475 and #477; any textual conflict is trivial to resolve at merge.

## Verification

- `cargo fmt --all` — clean
- `cargo test -p wingfoil-next -p wingfoil-next-macros` — all pass (default **and** `--features async`)
- `cargo clippy -p wingfoil-next -p wingfoil-next-macros --all-targets -- -D warnings` — clean (default and `--features async`)
- No `.unwrap()` outside `#[cfg(test)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_