### PR TITLE
wingfoil-next: port cumulative / unbounded statistics

### DIFF
--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -373,12 +373,15 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
 
 1. **statistics** — pure computation, the largest single chunk, huge test
    suite, zero IO. Best stress test of engine-owned state; do it first.
-   🟡 *started*: all three statistics families now have a representative
-   port with parity tests (`tests/statistics.rs`) — exponential (`Ewma`,
-   PerTick + clock-driven HalfLife), windowed (`RollingSum`, `RollingMean`
-   over a ring buffer), and cumulative is expressible via `fold`. Remaining:
-   rolling median/var/std/min-max (monotonic-deque / incremental-moment
-   variants), time-windowed rolling, weighted moments.
+   🟡 *started*: all three statistics families now have real ports with
+   parity tests — exponential (`Ewma`, PerTick + clock-driven HalfLife,
+   `tests/statistics.rs`); count-windowed rolling
+   (`RollingSum`/`Mean`/`Min`/`Max`/`Var`/`Std`/`Median` — monotonic-deque and
+   incremental-moment variants, `tests/statistics_rolling.rs`); and cumulative
+   / unbounded (`CumulativeSum`/`Mean`/`Min`/`Max`/`Var`/`Std`/`Median` —
+   Welford online moments for mean/var/std, `tests/statistics_cumulative.rs`).
+   Remaining: time-windowed rolling and time-weighted moments (`Weighting::Time`
+   over `Window::Time`).
 2. **cache**, **common** (WindowFilter) — small, pure.
 3. **csv** — replay source + sink; exercises 0.3 historical bursts.
 4. **redis, postgres, etcd** — request/response shaped; fallible cycle +

--- a/wingfoil-next/src/ops.rs
+++ b/wingfoil-next/src/ops.rs
@@ -1101,6 +1101,248 @@ impl Op for RollingMedian {
     }
 }
 
+/// Incrementally maintained count-weighted moments over the **whole** stream
+/// (a cumulative / unbounded window), via Welford's online algorithm — O(1)
+/// time and memory, numerically stable (never a naive sum-of-squares). Mirrors
+/// the classic `MomentStream` under `Weighting::Count`: samples never leave, so
+/// unlike [`RollingMomentState`] there is no buffer and no removal.
+#[derive(Default)]
+pub struct CumulativeMomentState {
+    count: u64,
+    mean: f64,
+    m2: f64,
+}
+
+impl CumulativeMomentState {
+    /// Fold a new sample into the running moments (Welford update).
+    fn add(&mut self, x: f64) {
+        self.count += 1;
+        let mean_old = self.mean;
+        self.mean += (x - mean_old) / self.count as f64;
+        self.m2 += (x - mean_old) * (x - self.mean);
+    }
+
+    /// Sample variance (ddof = 1) — the classic `Weighting::Count` convention.
+    /// Yields `0.0` while fewer than two samples have been seen (rather than
+    /// NaN).
+    fn variance(&self) -> f64 {
+        if self.count < 2 {
+            return 0.0;
+        }
+        self.m2 / (self.count as f64 - 1.0)
+    }
+}
+
+/// Cumulative arithmetic mean over every sample seen so far — O(1) per tick via
+/// Welford (see [`CumulativeMomentState`]). Mirrors the classic
+/// `mean(Window::Unbounded, Weighting::Count)`.
+pub struct CumulativeMean;
+
+#[op(build = cumulative_mean)]
+impl Op for CumulativeMean {
+    type Cfg = ();
+    type State = CumulativeMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut CumulativeMomentState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.add(*input.0);
+        Ok(Tick::Value(state.mean))
+    }
+}
+
+/// Cumulative **sample** variance (ddof = 1) over every sample seen so far —
+/// O(1) per tick via Welford (see [`CumulativeMomentState`]). The divisor is
+/// `n - 1`, and the result is `0.0` until at least two samples are present.
+/// Mirrors the classic `variance(Window::Unbounded, Weighting::Count)`.
+pub struct CumulativeVar;
+
+#[op(build = cumulative_var)]
+impl Op for CumulativeVar {
+    type Cfg = ();
+    type State = CumulativeMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut CumulativeMomentState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.add(*input.0);
+        Ok(Tick::Value(state.variance()))
+    }
+}
+
+/// Cumulative **sample** standard deviation over every sample seen so far — the
+/// square root of [`CumulativeVar`] under the same (ddof = 1) convention.
+/// Clamped at zero before the square root so a constant stream (whose
+/// incremental variance can drift a hair negative) yields `0.0`, not `NaN`.
+pub struct CumulativeStd;
+
+#[op(build = cumulative_std)]
+impl Op for CumulativeStd {
+    type Cfg = ();
+    type State = CumulativeMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut CumulativeMomentState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.add(*input.0);
+        Ok(Tick::Value(state.variance().max(0.0).sqrt()))
+    }
+}
+
+/// Cumulative sum over every sample seen so far — a running total, O(1) per
+/// tick. Mirrors the classic `sum(Window::Unbounded)` (`CumulativeStream` with
+/// `CumulativeStat::Sum`).
+pub struct CumulativeSum;
+
+#[op(build = cumulative_sum)]
+impl Op for CumulativeSum {
+    type Cfg = ();
+    /// The running total (starts at `0.0`, so the first sample seeds it).
+    type State = f64;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut f64,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        *state += *input.0;
+        Ok(Tick::Value(*state))
+    }
+}
+
+/// Cumulative minimum over every sample seen so far — a running extreme, O(1)
+/// per tick. The `Option` state distinguishes "no sample yet" from a genuine
+/// `0.0`, so the first sample seeds the extreme rather than `min(0.0, x)`.
+/// Mirrors the classic `min(Window::Unbounded)`.
+pub struct CumulativeMin;
+
+#[op(build = cumulative_min)]
+impl Op for CumulativeMin {
+    type Cfg = ();
+    /// The running minimum; `None` until the first sample seeds it.
+    type State = Option<f64>;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut Option<f64>,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        let sample = *input.0;
+        let acc = match *state {
+            Some(m) => m.min(sample),
+            None => sample,
+        };
+        *state = Some(acc);
+        Ok(Tick::Value(acc))
+    }
+}
+
+/// Cumulative maximum over every sample seen so far — a running extreme, O(1)
+/// per tick. `Option` state seeds on the first sample (see [`CumulativeMin`]).
+/// Mirrors the classic `max(Window::Unbounded)`.
+pub struct CumulativeMax;
+
+#[op(build = cumulative_max)]
+impl Op for CumulativeMax {
+    type Cfg = ();
+    /// The running maximum; `None` until the first sample seeds it.
+    type State = Option<f64>;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut Option<f64>,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        let sample = *input.0;
+        let acc = match *state {
+            Some(m) => m.max(sample),
+            None => sample,
+        };
+        *state = Some(acc);
+        Ok(Tick::Value(acc))
+    }
+}
+
+/// Retains **every** sample so far and recomputes the median (sort) each tick,
+/// mirroring the classic recompute-per-tick `WindowStream` in its unbounded
+/// mode (the median has no cheap incremental form here, so — unlike the other
+/// cumulative stats — its memory grows with the stream).
+#[derive(Default)]
+pub struct CumulativeMedianState {
+    buffer: Vec<f64>,
+}
+
+impl CumulativeMedianState {
+    /// Push a sample (retaining all history) and return the median of every
+    /// sample seen so far. An even count averages the two middle values, so
+    /// this reproduces the classic count-weighted median.
+    fn push(&mut self, sample: f64) -> f64 {
+        self.buffer.push(sample);
+        let mut sorted = self.buffer.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n = sorted.len();
+        if n % 2 == 1 {
+            sorted[n / 2]
+        } else {
+            (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+        }
+    }
+}
+
+/// Cumulative median over every sample seen so far. Recomputed per tick
+/// (O(n log n)); an even count averages the two middle values, matching the
+/// classic count-weighted median. Retains all samples, so its memory grows with
+/// the stream. Mirrors the classic `median(Window::Unbounded, Weighting::Count)`.
+pub struct CumulativeMedian;
+
+#[op(build = cumulative_median)]
+impl Op for CumulativeMedian {
+    type Cfg = ();
+    type State = CumulativeMedianState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut CumulativeMedianState,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        Ok(Tick::Value(state.push(*input.0)))
+    }
+}
+
 /// Emits its source value when the condition stream's current value is true.
 pub struct Filter<T>(PhantomData<T>);
 

--- a/wingfoil-next/src/stats.rs
+++ b/wingfoil-next/src/stats.rs
@@ -53,6 +53,36 @@ pub trait StatisticsOps {
     /// Median over a sliding window of the last `window` values (an even window
     /// averages its two middle values).
     fn rolling_median(&self, window: usize) -> Stream<f64>;
+
+    /// Cumulative sum over every value seen so far (an unbounded / expanding
+    /// window) — a running total, O(1) per tick.
+    fn cumulative_sum(&self) -> Stream<f64>;
+
+    /// Cumulative arithmetic mean over every value seen so far — O(1) per tick
+    /// via Welford's online moments.
+    fn cumulative_mean(&self) -> Stream<f64>;
+
+    /// Cumulative minimum over every value seen so far — a running extreme.
+    fn cumulative_min(&self) -> Stream<f64>;
+
+    /// Cumulative maximum over every value seen so far — a running extreme.
+    fn cumulative_max(&self) -> Stream<f64>;
+
+    /// Cumulative **sample** variance (ddof = 1) over every value seen so far —
+    /// the classic statistics adapter's count-weighted convention (divisor
+    /// `n - 1`, `0.0` until two values are present), maintained incrementally
+    /// with Welford's online moments.
+    fn cumulative_var(&self) -> Stream<f64>;
+
+    /// Cumulative **sample** standard deviation over every value seen so far —
+    /// the square root of [`cumulative_var`](Self::cumulative_var) under the
+    /// same (ddof = 1) convention.
+    fn cumulative_std(&self) -> Stream<f64>;
+
+    /// Cumulative median over every value seen so far (an even count averages
+    /// its two middle values). Retains all samples, so its memory grows with
+    /// the stream.
+    fn cumulative_median(&self) -> Stream<f64>;
 }
 
 impl StatisticsOps for Stream<f64> {
@@ -98,5 +128,33 @@ impl StatisticsOps for Stream<f64> {
 
     fn rolling_median(&self, window: usize) -> Stream<f64> {
         self.wire(|b, h| b.rolling_median(h, window))
+    }
+
+    fn cumulative_sum(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_sum(h))
+    }
+
+    fn cumulative_mean(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_mean(h))
+    }
+
+    fn cumulative_min(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_min(h))
+    }
+
+    fn cumulative_max(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_max(h))
+    }
+
+    fn cumulative_var(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_var(h))
+    }
+
+    fn cumulative_std(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_std(h))
+    }
+
+    fn cumulative_median(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_median(h))
     }
 }

--- a/wingfoil-next/tests/statistics_cumulative.rs
+++ b/wingfoil-next/tests/statistics_cumulative.rs
@@ -1,0 +1,271 @@
+//! Parity tests for the cumulative (unbounded-window) statistics catalog
+//! (`cumulative_sum` / `cumulative_mean` / `cumulative_min` / `cumulative_max`
+//! / `cumulative_var` / `cumulative_std` / `cumulative_median`), ported from
+//! the classic `adapters::statistics` operators over `Window::Unbounded` with
+//! `Weighting::Count`. Each test pins the emitted series **value-by-value**
+//! (and, where relevant, **tick-by-tick**) against a hand-computed expected
+//! series derived from the classic node semantics:
+//!
+//! * mean/variance/std use incrementally maintained moments (Welford's online
+//!   algorithm), so they are numerically faithful — not a naive
+//!   sum-of-squares;
+//! * `var`/`std` use the **sample** (ddof = 1) convention — divisor `n - 1`,
+//!   and `0.0` until at least two samples are present (`std` clamps at zero so
+//!   a constant stream is `0.0`, not `NaN`);
+//! * `median` averages the two middle values for an even count;
+//! * a cumulative op ticks once per upstream tick (no seeding delay), so the
+//!   output series has one entry per input tick.
+//!
+//! The classic parity references are the unit tests `cumulative_sum_min_max`,
+//! `cumulative_median_over_all_samples`, `mean_count_is_arithmetic_mean`, and
+//! `variance_count_is_sample_variance` in `wingfoil/src/adapters/statistics.rs`.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::fluent::Stream;
+use wingfoil_next::prelude::*;
+use wingfoil_next::stats::StatisticsOps;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// 1, 2, 3, 4, 5 as `f64`, one tick every 100ns (ticks at 0,100,200,300,400ns).
+fn counter_f64(g: &GraphBuilder) -> Stream<f64> {
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(|i| *i as f64)
+}
+
+/// A fixed non-trivial sequence emitted one value per tick: the `n`-th tick
+/// (1-based, from `count()`) yields `SEQUENCE[n - 1]`. Used for the hand-checked
+/// variance/median cases so the assertions pin the *decay math*, not a value
+/// that happens to hold for any input (as a constant stream would).
+const SEQUENCE: [f64; 8] = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
+
+fn sequence(g: &GraphBuilder) -> Stream<f64> {
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(|n| SEQUENCE[(*n - 1) as usize])
+}
+
+/// Assert two `f64` series equal element-wise within a tolerance.
+fn assert_series_approx(got: &[f64], expected: &[f64]) {
+    assert_eq!(got.len(), expected.len(), "length: {got:?} vs {expected:?}");
+    for (i, (g, e)) in got.iter().zip(expected).enumerate() {
+        assert!(
+            (g - e).abs() < 1e-10,
+            "at {i}: got {g}, expected {e} (series {got:?} vs {expected:?})"
+        );
+    }
+}
+
+// ── cumulative_sum / cumulative_min / cumulative_max ─────────────────────────
+
+/// Mirrors classic `cumulative_sum_min_max`. Over 1,2,3,4,5 the running sum is
+/// 1,3,6,10,15; the running min stays 1; the running max climbs 1,2,3,4,5.
+/// The min case feeds a *descending* stream (5,4,3,2,1) so the running minimum
+/// must keep falling — a constant or ascending stream would pass trivially.
+#[test]
+fn cumulative_sum_min_max() {
+    let g = GraphBuilder::new();
+    let sum = counter_f64(&g).cumulative_sum().accumulate();
+    let mx = counter_f64(&g).cumulative_max().accumulate();
+    // 6 - n over 1..=5 → 5,4,3,2,1, so the running min falls 5,4,3,2,1.
+    let mn = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(|n| (6 - *n) as f64)
+        .cumulative_min()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1.0, 3.0, 6.0, 10.0, 15.0], r.value(&sum));
+    assert_eq!(vec![5.0, 4.0, 3.0, 2.0, 1.0], r.value(&mn));
+    assert_eq!(vec![1.0, 2.0, 3.0, 4.0, 5.0], r.value(&mx));
+}
+
+/// The running max over an ascending stream climbs; the running min over the
+/// same ascending stream stays pinned at the first value — a direct check that
+/// the `Option`-seeded extreme does not fold in the `0.0` default.
+#[test]
+fn cumulative_min_pins_first_on_ascending() {
+    let g = GraphBuilder::new();
+    let mn = counter_f64(&g).cumulative_min().accumulate();
+    let mx = counter_f64(&g).cumulative_max().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1.0, 1.0, 1.0, 1.0, 1.0], r.value(&mn));
+    assert_eq!(vec![1.0, 2.0, 3.0, 4.0, 5.0], r.value(&mx));
+}
+
+// ── cumulative_mean ──────────────────────────────────────────────────────────
+
+/// Mirrors classic `mean_count_is_arithmetic_mean` (final value 3.0), pinned as
+/// a full series: the expanding arithmetic mean of 1,2,3,4,5 is
+/// 1, 1.5, 2, 2.5, 3.
+#[test]
+fn cumulative_mean_is_expanding_arithmetic_mean() {
+    let g = GraphBuilder::new();
+    let mean = counter_f64(&g).cumulative_mean().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&mean), &[1.0, 1.5, 2.0, 2.5, 3.0]);
+}
+
+// ── cumulative_var / cumulative_std ──────────────────────────────────────────
+
+/// Mirrors classic `variance_count_is_sample_variance` (final value 2.5 over
+/// 1,2,3,4,5), pinned as a full series. Sample variance (ddof = 1) of the first
+/// `k` of 1..5:
+///   {1}→0 (n<2), {1,2}→0.5, {1,2,3}→1, {1,2,3,4}→5/3, {1,2,3,4,5}→2.5.
+/// `std` is the element-wise square root.
+#[test]
+fn cumulative_var_std_counter() {
+    let g = GraphBuilder::new();
+    let var = counter_f64(&g).cumulative_var().accumulate();
+    let std = counter_f64(&g).cumulative_std().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let expected_var = [0.0, 0.5, 1.0, 5.0 / 3.0, 2.5];
+    assert_series_approx(&r.value(&var), &expected_var);
+    let expected_std: Vec<f64> = expected_var.iter().map(|v| v.sqrt()).collect();
+    assert_series_approx(&r.value(&std), &expected_std);
+}
+
+/// A real-variance numeric case on the fixed sequence 2,4,4,4,5,5,7,9 (the
+/// textbook example whose *population* std is exactly 2). The final cumulative
+/// sample variance is a hand-computed known value: mean = 40/8 = 5, sum of
+/// squared deviations = 9+1+1+1+0+0+4+16 = 32, so sample variance = 32/7 and
+/// sample std = sqrt(32/7). Unlike a constant stream (variance 0 for any math),
+/// this pins the actual moment computation.
+#[test]
+fn cumulative_var_std_real_sequence_hand_computed() {
+    let g = GraphBuilder::new();
+    let var = sequence(&g).cumulative_var();
+    let std = sequence(&g).cumulative_std();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(SEQUENCE.len() as u32))
+        .unwrap();
+    let expected_var = 32.0 / 7.0;
+    assert!(
+        (r.value(&var) - expected_var).abs() < 1e-10,
+        "var {} vs {expected_var}",
+        r.value(&var)
+    );
+    assert!(
+        (r.value(&std) - expected_var.sqrt()).abs() < 1e-10,
+        "std {} vs {}",
+        r.value(&std),
+        expected_var.sqrt()
+    );
+}
+
+/// The incremental Welford moments must match a direct recompute over all
+/// history: run a long non-trivial sequence and compare the final cumulative
+/// mean/variance to a from-scratch two-pass computation over every sample.
+#[test]
+fn cumulative_moments_match_direct_recompute() {
+    const N: u32 = 200;
+    let seq = |n: u64| ((n % 7) as f64) * 1.5 - 3.0;
+
+    let g = GraphBuilder::new();
+    let mean = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .cumulative_mean();
+    let var = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .cumulative_var();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(N)).unwrap();
+
+    // `count()` emits 1..=N, so all history is seq(1..=N).
+    let all: Vec<f64> = (1..=N as u64).map(seq).collect();
+    let expected_mean = all.iter().sum::<f64>() / all.len() as f64;
+    let expected_var =
+        all.iter().map(|v| (v - expected_mean).powi(2)).sum::<f64>() / (all.len() as f64 - 1.0);
+    assert!((r.value(&mean) - expected_mean).abs() < 1e-9);
+    assert!((r.value(&var) - expected_var).abs() < 1e-9);
+}
+
+/// A constant stream has zero cumulative variance; floating-point cancellation
+/// can make it a hair negative, so `std` must clamp at zero rather than emit
+/// `NaN` (mirrors the classic constant-window std guard).
+#[test]
+fn cumulative_std_of_constant_is_zero_not_nan() {
+    let g = GraphBuilder::new();
+    let std = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(|_| 7.0)
+        .cumulative_std()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    for v in r.value(&std) {
+        assert!(!v.is_nan(), "cumulative_std must not be NaN");
+        assert!(
+            v.abs() < 1e-10,
+            "constant stream std should be 0.0, got {v}"
+        );
+    }
+}
+
+/// Sample variance is defined as `0.0` (not NaN) with a single sample.
+#[test]
+fn cumulative_var_is_zero_with_single_sample() {
+    let g = GraphBuilder::new();
+    let var = counter_f64(&g).cumulative_var();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
+    assert_eq!(0.0, r.value(&var));
+}
+
+// ── cumulative_median ────────────────────────────────────────────────────────
+
+/// Mirrors classic `cumulative_median_over_all_samples` (final value 3.0 over
+/// 1,2,3,4,5), pinned as a full series. The median of the first `k` of 1..5:
+/// {1}→1, {1,2}→1.5 (even), {1,2,3}→2, {1,2,3,4}→2.5 (even), {1,2,3,4,5}→3.
+#[test]
+fn cumulative_median_counter() {
+    let g = GraphBuilder::new();
+    let med = counter_f64(&g).cumulative_median().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&med), &[1.0, 1.5, 2.0, 2.5, 3.0]);
+}
+
+/// Median must sort *all* retained history, not just recent samples. Over the
+/// non-monotonic 2,4,4,4,5,5,7,9 the cumulative median walks the sorted middle:
+///   {2}→2, {2,4}→3, {2,4,4}→4, {2,4,4,4}→4, {2,4,4,4,5}→4,
+///   {2,4,4,4,5,5}→4, {2,4,4,4,5,5,7}→4, {2,4,4,4,5,5,7,9}→(4+5)/2=4.5.
+#[test]
+fn cumulative_median_non_monotonic() {
+    let g = GraphBuilder::new();
+    let med = sequence(&g).cumulative_median().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(SEQUENCE.len() as u32))
+        .unwrap();
+    assert_series_approx(&r.value(&med), &[2.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.5]);
+}
+
+// ── tick-time parity ─────────────────────────────────────────────────────────
+
+/// The cumulative ops tick once per upstream tick with no seeding delay, so the
+/// emitted times are exactly the ticker's: 0,100,200,300,400ns. Pin both the
+/// tick times and the paired values for `cumulative_sum`.
+#[test]
+fn cumulative_sum_tick_times_match_upstream() {
+    let g = GraphBuilder::new();
+    let acc = counter_f64(&g).cumulative_sum().with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let series = r.value(&acc);
+    let times: Vec<u64> = series.iter().map(|(t, _)| u64::from(*t)).collect();
+    let values: Vec<f64> = series.iter().map(|(_, v)| *v).collect();
+    assert_eq!(vec![0, 100, 200, 300, 400], times);
+    assert_eq!(vec![1.0, 3.0, 6.0, 10.0, 15.0], values);
+}


### PR DESCRIPTION
## What

Ports the **cumulative (unbounded-window, count-weighted)** statistics family from the classic `adapters::statistics` operators into the wingfoil-next op catalog. wingfoil-next already had the count-window rolling variants and EWMA; the cumulative/expanding family was missing.

### Stats landed

| op | classic reference | notes |
|----|-------------------|-------|
| `cumulative_mean` | `MomentStream` (`Weighting::Count`) | Welford online mean |
| `cumulative_var` | `MomentStream` (`Weighting::Count`) | sample variance, ddof = 1; `0.0` until 2 samples |
| `cumulative_std` | `MomentStream` (`Weighting::Count`) | sqrt of var, clamped ≥ 0 (constant stream → `0.0`, not `NaN`) |
| `cumulative_sum` | `CumulativeStream`/`CumulativeStat::Sum` | O(1) running total |
| `cumulative_min` | `CumulativeStream`/`CumulativeStat::Min` | O(1) running extreme (`Option`-seeded) |
| `cumulative_max` | `CumulativeStream`/`CumulativeStat::Max` | O(1) running extreme (`Option`-seeded) |
| `cumulative_median` | `WindowStream` (unbounded mode) | recompute-per-tick over all retained history |

## Incremental algorithm (Welford)

`cumulative_mean`/`var`/`std` share a `CumulativeMomentState` maintaining `(count, mean, m2)` via **Welford's online algorithm** — numerically faithful, single-pass, O(1) per tick, *not* a naive sum-of-squares. This is the cumulative analogue of the existing `RollingMomentState` (which additionally supports exact removal for eviction; the cumulative case never evicts, so it needs no buffer). Sample variance uses the classic `Weighting::Count` convention (divisor `n - 1`, `0.0` until two samples present).

`sum`/`min`/`max` are O(1) running accumulators; `min`/`max` use `Option` state so the first sample seeds the extreme rather than folding in the `0.0` default. `median` retains all history and re-sorts each tick (no cheap incremental form — its memory grows with the stream, matching classic).

## Structure

- Each op is a single-input `Op` in `ops.rs` carrying `#[op(build = <name>)]`, which auto-generates the interpreted `Builder` wiring method.
- Fluent methods added to the `StatisticsOps` trait in `stats.rs`.

## Parity approach

Parity tests in `wingfoil-next/tests/statistics_cumulative.rs` run in historical mode and pin the emitted series **value-by-value** (and tick times) against hand-computed expected values mirroring the classic unit-test semantics (`cumulative_sum_min_max`, `cumulative_median_over_all_samples`, `mean_count_is_arithmetic_mean`, `variance_count_is_sample_variance`). Highlights:

- Full-series checks for mean / var / std / median / sum / min / max over `1..5`.
- **Real-variance numeric case** on the fixed sequence `2,4,4,4,5,5,7,9` (population std exactly 2): hand-computed final sample variance `32/7`, std `sqrt(32/7)` — pins the actual moment math, not a value that holds for any input.
- Descending-stream min and ascending-stream min checks so the running extreme genuinely tracks (a constant stream would pass trivially).
- Incremental Welford vs. from-scratch two-pass recompute cross-check over a 200-sample sequence (guards against drift).
- Constant-stream `std` → `0.0` (not `NaN`) and single-sample `var` → `0.0`.
- Tick-time parity: one output per input tick, times `0,100,200,300,400ns`.

## Deferred

- **Time-windowed** (`Window::Time`) and **time-weighted** (`Weighting::Time`) variants — left for a follow-up PR, as scoped. No `Window`/`Weighting` config enums were introduced here; these are their own named ops.
- **`graph!`-macro rows** (compiled/nested engines): left to the concurrent `rolling_*` macro PR to avoid overlap. Interpreted + fluent wiring is complete for all seven ops. Adding a macro row per op is mechanical (an `OpKind` + `info` arm) but non-trivial with the concurrent change in flight, so it's deferred and noted.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo test -p wingfoil-next` — all pass (11 new tests in `statistics_cumulative`, plus the full existing suite)
- `cargo clippy -p wingfoil-next --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_