### PR TITLE
ci: run test.rust and security.audit on the next branch

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -3,11 +3,11 @@ name: test.rust
 on:
   workflow_call:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
     paths-ignore:
       - ".github/workflows/**"
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
     paths-ignore:
       - ".github/workflows/**"
   workflow_dispatch:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,9 +8,9 @@ name: security.audit
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "next" ]
   schedule:
     # Mondays 06:00 UTC — catch newly disclosed advisories against pinned deps.
     - cron: "0 6 * * 1"


### PR DESCRIPTION
## Problem

The core CI workflows only trigger on `main`:

- `test.rust` (build + test + clippy) — `push`/`pull_request` filtered to `branches: [ "main" ]`
- `security.audit` — same

All active port work targets **`next`**, so PRs against `next` receive **no CI at all** (zero check runs). This is the CI blind spot tracked in #449 / #451.

## Change

Add `next` to the branch filters of both workflows so `next`-targeted PRs (and pushes to `next`) get the same build/test/clippy + advisory gate as `main`. No job logic changes.

```yaml
# test.rust and security.audit
push:         { branches: [ "main", "next" ] }
pull_request: { branches: [ "main", "next" ] }
```

## Notes

- `test.rust` keeps its `paths-ignore: .github/workflows/**`, so this PR (workflow-only) won't itself trigger `test.rust` — expected.
- Existing open `next` PRs will need a re-push / branch sync to fire CI once this merges (GitHub evaluates triggers at event time).
- Scope is deliberately minimal: `rust-fmt.yml` remains `workflow_dispatch`-only and is left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_