### PR TITLE
wingfoil-next: port time-windowed rolling statistics

### DIFF
--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -373,15 +373,18 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
 
 1. **statistics** — pure computation, the largest single chunk, huge test
    suite, zero IO. Best stress test of engine-owned state; do it first.
-   🟡 *started*: all three statistics families now have real ports with
-   parity tests — exponential (`Ewma`, PerTick + clock-driven HalfLife,
+   🟡 *started*: the statistics families are largely ported with parity
+   tests — exponential (`Ewma`, PerTick + clock-driven HalfLife,
    `tests/statistics.rs`); count-windowed rolling
    (`RollingSum`/`Mean`/`Min`/`Max`/`Var`/`Std`/`Median` — monotonic-deque and
-   incremental-moment variants, `tests/statistics_rolling.rs`); and cumulative
+   incremental-moment variants, `tests/statistics_rolling.rs`); cumulative
    / unbounded (`CumulativeSum`/`Mean`/`Min`/`Max`/`Var`/`Std`/`Median` —
-   Welford online moments for mean/var/std, `tests/statistics_cumulative.rs`).
-   Remaining: time-windowed rolling and time-weighted moments (`Weighting::Time`
-   over `Window::Time`).
+   Welford online moments for mean/var/std, `tests/statistics_cumulative.rs`);
+   and **time-windowed** rolling (`TimeWindowedSum`/`Mean`/`Min`/`Max`/`Var`/
+   `Std`/`Median` over a bounded `Window::Time`, count-weighted — incremental
+   sum/moments, monotonic-deque min/max, recompute median,
+   `tests/statistics_time_windowed.rs`). Remaining: the time-*weighted* moment
+   path (`Weighting::Time`, both cumulative and windowed).
 2. **cache**, **common** (WindowFilter) — small, pure.
 3. **csv** — replay source + sink; exercises 0.3 historical bursts.
 4. **redis, postgres, etcd** — request/response shaped; fallible cycle +

--- a/wingfoil-next/src/ops.rs
+++ b/wingfoil-next/src/ops.rs
@@ -1343,6 +1343,376 @@ impl Op for CumulativeMedian {
     }
 }
 
+// ── time-windowed rolling statistics (Window::Time, count-weighted) ──────────
+//
+// Each op keeps the samples currently inside a bounded time window — the last
+// `window` nanoseconds of graph time — and computes a statistic over them.
+// Eviction semantics, reproduced from the classic `WindowStream` /
+// `RollingMomentStream` `Window::Time` path (`wingfoil/src/adapters/statistics.rs`):
+//
+//   * on each tick the current sample is pushed at `now = ctx.time()`, then
+//     every front entry whose age `now - t` is **strictly greater** than
+//     `window` is evicted — so an entry exactly `window` old is retained (an
+//     inclusive trailing boundary);
+//   * the just-pushed sample has age 0, so it is always in window and the window
+//     is **never empty** (classic has no empty-window instant — even a zero-width
+//     window keeps the current sample); and
+//   * `var`/`std` use the sample (ddof = 1) convention — `0.0` until at least two
+//     samples are in the window.
+//
+// All are count-weighted (the ordinary statistic over the samples in the
+// window). The time-*weighted* windowed combo (`Weighting::Time` over
+// `Window::Time`) is a separate follow-up.
+
+/// True when an entry at time `t` observed from `now` has aged past `window`
+/// nanoseconds (the classic strictly-greater trailing boundary). Time is
+/// monotonic, so `now >= t` and the subtraction never underflows.
+fn aged_out(now: NanoTime, t: NanoTime, window: u64) -> bool {
+    u64::from(now) - u64::from(t) > window
+}
+
+/// Ring-buffer state for the time-windowed sum: the `(time, value)` samples
+/// currently inside the window and their running total, maintained
+/// incrementally (add on push, subtract on evict) rather than rescanned.
+#[derive(Default)]
+pub struct TimeWindowSumState {
+    buffer: VecDeque<(NanoTime, f64)>,
+    sum: f64,
+}
+
+impl TimeWindowSumState {
+    /// Push `sample` at `now`, evict aged entries, and return the running sum
+    /// over what remains.
+    fn push(&mut self, now: NanoTime, sample: f64, window: u64) -> f64 {
+        self.buffer.push_back((now, sample));
+        self.sum += sample;
+        while let Some(&(t, v)) = self.buffer.front() {
+            if aged_out(now, t, window) {
+                self.sum -= v;
+                self.buffer.pop_front();
+            } else {
+                break;
+            }
+        }
+        self.sum
+    }
+}
+
+/// Sum over a bounded time window of the last `window` (a [`NanoTime`] duration)
+/// of graph time — O(1) per tick. Mirrors the classic `sum(Window::Time(_))`.
+pub struct TimeWindowedSum;
+
+#[op(build = time_windowed_sum)]
+impl Op for TimeWindowedSum {
+    type Cfg = NanoTime;
+    type State = TimeWindowSumState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWindowSumState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        let out = state.push(ctx.time(), *input.0, u64::from(*cfg));
+        Ok(Tick::Value(out))
+    }
+}
+
+/// Ring-buffer state for the time-windowed mean / variance / std: the
+/// `(time, value)` samples in the window plus incrementally maintained
+/// count-weighted moments (Welford's algorithm with exact removal), so a tick
+/// is O(1) amortised. Mirrors the classic `RollingMomentStream` under
+/// `Weighting::Count` with a `Window::Time` eviction rule.
+#[derive(Default)]
+pub struct TimeWindowMomentState {
+    buffer: VecDeque<(NanoTime, f64)>,
+    count: u64,
+    mean: f64,
+    m2: f64,
+}
+
+impl TimeWindowMomentState {
+    /// Fold a new sample into the moments (Welford update).
+    fn add(&mut self, x: f64) {
+        self.count += 1;
+        let mean_old = self.mean;
+        self.mean += (x - mean_old) / self.count as f64;
+        self.m2 += (x - mean_old) * (x - self.mean);
+    }
+
+    /// Exact inverse of [`add`](Self::add): drop a previously added sample as it
+    /// leaves the window, in O(1). `m2` is clamped at zero against
+    /// revert-scheme floating-point drift.
+    fn remove(&mut self, x: f64) {
+        if self.count <= 1 {
+            self.count = 0;
+            self.mean = 0.0;
+            self.m2 = 0.0;
+            return;
+        }
+        let n = self.count as f64;
+        let mean_old = (n * self.mean - x) / (n - 1.0);
+        self.m2 -= (x - mean_old) * (x - self.mean);
+        if self.m2 < 0.0 {
+            self.m2 = 0.0;
+        }
+        self.mean = mean_old;
+        self.count -= 1;
+    }
+
+    /// Push `sample` at `now` and evict every aged entry, removing each from the
+    /// moments as it leaves.
+    fn push(&mut self, now: NanoTime, sample: f64, window: u64) {
+        self.buffer.push_back((now, sample));
+        self.add(sample);
+        while let Some(&(t, v)) = self.buffer.front() {
+            if aged_out(now, t, window) {
+                self.buffer.pop_front();
+                self.remove(v);
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Sample variance (ddof = 1) — `0.0` while fewer than two samples are in
+    /// the window.
+    fn variance(&self) -> f64 {
+        if self.count < 2 {
+            return 0.0;
+        }
+        self.m2 / (self.count as f64 - 1.0)
+    }
+}
+
+/// Arithmetic mean over a bounded time window — O(1) amortised per tick.
+/// Mirrors the classic `mean(Window::Time(_), Weighting::Count)`.
+pub struct TimeWindowedMean;
+
+#[op(build = time_windowed_mean)]
+impl Op for TimeWindowedMean {
+    type Cfg = NanoTime;
+    type State = TimeWindowMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWindowMomentState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.push(ctx.time(), *input.0, u64::from(*cfg));
+        // The current sample is always in window, so `count >= 1` and `mean`
+        // holds the window mean (equal to the sample on the first tick).
+        Ok(Tick::Value(state.mean))
+    }
+}
+
+/// **Sample** variance (ddof = 1) over a bounded time window — O(1) amortised
+/// per tick. Mirrors the classic `variance(Window::Time(_), Weighting::Count)`.
+pub struct TimeWindowedVar;
+
+#[op(build = time_windowed_var)]
+impl Op for TimeWindowedVar {
+    type Cfg = NanoTime;
+    type State = TimeWindowMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWindowMomentState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.push(ctx.time(), *input.0, u64::from(*cfg));
+        Ok(Tick::Value(state.variance()))
+    }
+}
+
+/// **Sample** standard deviation over a bounded time window — the square root of
+/// [`TimeWindowedVar`], clamped at zero before the root so a constant window
+/// yields `0.0`, not `NaN`. Mirrors the classic `std(Window::Time(_),
+/// Weighting::Count)`.
+pub struct TimeWindowedStd;
+
+#[op(build = time_windowed_std)]
+impl Op for TimeWindowedStd {
+    type Cfg = NanoTime;
+    type State = TimeWindowMomentState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWindowMomentState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        state.push(ctx.time(), *input.0, u64::from(*cfg));
+        Ok(Tick::Value(state.variance().max(0.0).sqrt()))
+    }
+}
+
+/// Monotonic-deque state for the time-windowed min & max. Holds `(time, value)`
+/// candidates kept monotonic in value and increasing in time front-to-back, so
+/// the front is always the window extreme — O(1) amortised per tick. Unlike the
+/// classic time-windowed `WindowStream` (a per-tick scan), this uses the same
+/// monotonic-deque trick as the classic *count*-windowed `RollingExtremeStream`,
+/// front-evicting by age instead of by index; the emitted values are identical.
+#[derive(Default)]
+pub struct TimeWindowExtremeState {
+    deque: VecDeque<(NanoTime, f64)>,
+}
+
+impl TimeWindowExtremeState {
+    /// Push `sample` at `now` and return the window extreme. `is_min` selects
+    /// which back candidates the new sample dominates: for a minimum we drop
+    /// candidates `>= sample`, for a maximum `<= sample`.
+    fn push(&mut self, now: NanoTime, sample: f64, window: u64, is_min: bool) -> f64 {
+        // Drop back candidates the new sample dominates (they can never again be
+        // the extreme while it is in the window).
+        while let Some(&(_, back)) = self.deque.back() {
+            let dominated = if is_min {
+                back >= sample
+            } else {
+                back <= sample
+            };
+            if dominated {
+                self.deque.pop_back();
+            } else {
+                break;
+            }
+        }
+        self.deque.push_back((now, sample));
+
+        // Drop the front while it has aged out. The just-pushed sample has age
+        // 0, so the deque never empties.
+        while let Some(&(t, _)) = self.deque.front() {
+            if aged_out(now, t, window) {
+                self.deque.pop_front();
+            } else {
+                break;
+            }
+        }
+        self.deque
+            .front()
+            .expect("invariant: just-pushed sample is within the window")
+            .1
+    }
+}
+
+/// Minimum over a bounded time window, via a monotonic deque — O(1) amortised
+/// per tick. Mirrors the classic `min(Window::Time(_))`.
+pub struct TimeWindowedMin;
+
+#[op(build = time_windowed_min)]
+impl Op for TimeWindowedMin {
+    type Cfg = NanoTime;
+    type State = TimeWindowExtremeState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWindowExtremeState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        let out = state.push(ctx.time(), *input.0, u64::from(*cfg), true);
+        Ok(Tick::Value(out))
+    }
+}
+
+/// Maximum over a bounded time window, via a monotonic deque — O(1) amortised
+/// per tick. Mirrors the classic `max(Window::Time(_))`.
+pub struct TimeWindowedMax;
+
+#[op(build = time_windowed_max)]
+impl Op for TimeWindowedMax {
+    type Cfg = NanoTime;
+    type State = TimeWindowExtremeState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWindowExtremeState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        let out = state.push(ctx.time(), *input.0, u64::from(*cfg), false);
+        Ok(Tick::Value(out))
+    }
+}
+
+/// Ring-buffer state for the time-windowed median — retains the `(time, value)`
+/// samples in the window and recomputes the median (sort) each tick, matching
+/// the classic recompute-per-tick `WindowStream` (the median has no cheap
+/// incremental form here).
+#[derive(Default)]
+pub struct TimeWindowMedianState {
+    buffer: VecDeque<(NanoTime, f64)>,
+}
+
+impl TimeWindowMedianState {
+    /// Push `sample` at `now`, evict aged entries, and return the median of the
+    /// retained samples. An even count averages the two middle values, so this
+    /// reproduces the classic count-weighted median.
+    fn push(&mut self, now: NanoTime, sample: f64, window: u64) -> f64 {
+        self.buffer.push_back((now, sample));
+        while let Some(&(t, _)) = self.buffer.front() {
+            if aged_out(now, t, window) {
+                self.buffer.pop_front();
+            } else {
+                break;
+            }
+        }
+        let mut sorted: Vec<f64> = self.buffer.iter().map(|&(_, v)| v).collect();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n = sorted.len();
+        if n % 2 == 1 {
+            sorted[n / 2]
+        } else {
+            (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+        }
+    }
+}
+
+/// Median over a bounded time window. Recomputed per tick (O(w log w) over the
+/// `w` retained samples); an even count averages the two middle values,
+/// matching the classic count-weighted median. Mirrors the classic
+/// `median(Window::Time(_), Weighting::Count)`.
+pub struct TimeWindowedMedian;
+
+#[op(build = time_windowed_median)]
+impl Op for TimeWindowedMedian {
+    type Cfg = NanoTime;
+    type State = TimeWindowMedianState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWindowMedianState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        let out = state.push(ctx.time(), *input.0, u64::from(*cfg));
+        Ok(Tick::Value(out))
+    }
+}
+
 /// Emits its source value when the condition stream's current value is true.
 pub struct Filter<T>(PhantomData<T>);
 

--- a/wingfoil-next/src/stats.rs
+++ b/wingfoil-next/src/stats.rs
@@ -9,6 +9,8 @@
 
 use std::time::Duration;
 
+use wingfoil::NanoTime;
+
 use crate::fluent::Stream;
 use crate::ops::EwmaDecay;
 
@@ -83,6 +85,35 @@ pub trait StatisticsOps {
     /// its two middle values). Retains all samples, so its memory grows with
     /// the stream.
     fn cumulative_median(&self) -> Stream<f64>;
+
+    /// Sum over a bounded **time** window — the samples seen in the last
+    /// `window` of graph time (an entry exactly `window` old is retained). O(1)
+    /// per tick.
+    fn time_windowed_sum(&self, window: Duration) -> Stream<f64>;
+
+    /// Arithmetic mean over a bounded time window (count-weighted — the ordinary
+    /// mean of the samples in the window). O(1) amortised per tick.
+    fn time_windowed_mean(&self, window: Duration) -> Stream<f64>;
+
+    /// Minimum over a bounded time window, via a monotonic deque — O(1)
+    /// amortised per tick.
+    fn time_windowed_min(&self, window: Duration) -> Stream<f64>;
+
+    /// Maximum over a bounded time window, via a monotonic deque — O(1)
+    /// amortised per tick.
+    fn time_windowed_max(&self, window: Duration) -> Stream<f64>;
+
+    /// **Sample** variance (ddof = 1) over a bounded time window — `0.0` until
+    /// two samples are in the window. O(1) amortised per tick.
+    fn time_windowed_var(&self, window: Duration) -> Stream<f64>;
+
+    /// **Sample** standard deviation over a bounded time window — the square
+    /// root of [`time_windowed_var`](Self::time_windowed_var).
+    fn time_windowed_std(&self, window: Duration) -> Stream<f64>;
+
+    /// Median over a bounded time window (an even count averages its two middle
+    /// values). Recomputed per tick over the retained window.
+    fn time_windowed_median(&self, window: Duration) -> Stream<f64>;
 }
 
 impl StatisticsOps for Stream<f64> {
@@ -156,5 +187,40 @@ impl StatisticsOps for Stream<f64> {
 
     fn cumulative_median(&self) -> Stream<f64> {
         self.wire(|b, h| b.cumulative_median(h))
+    }
+
+    fn time_windowed_sum(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_sum(h, window))
+    }
+
+    fn time_windowed_mean(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_mean(h, window))
+    }
+
+    fn time_windowed_min(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_min(h, window))
+    }
+
+    fn time_windowed_max(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_max(h, window))
+    }
+
+    fn time_windowed_var(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_var(h, window))
+    }
+
+    fn time_windowed_std(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_std(h, window))
+    }
+
+    fn time_windowed_median(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_median(h, window))
     }
 }

--- a/wingfoil-next/tests/statistics_time_windowed.rs
+++ b/wingfoil-next/tests/statistics_time_windowed.rs
@@ -1,0 +1,289 @@
+//! Parity tests for the **time-windowed** rolling statistics
+//! (`time_windowed_sum` / `mean` / `min` / `max` / `var` / `std` / `median`),
+//! ported from the classic `adapters::statistics` operators over
+//! `Window::Time(_)` with `Weighting::Count` (the classic `WindowStream` /
+//! `RollingMomentStream` time-window path, `wingfoil/src/adapters/statistics.rs`).
+//!
+//! Eviction / boundary semantics reproduced (classic `Window::Time`):
+//!
+//! * on each tick the current sample is pushed at `now = ctx.time()`, then every
+//!   entry whose age `now - t` is **strictly greater** than the window is
+//!   evicted — so an entry exactly `window` old is **retained** (an inclusive
+//!   trailing boundary);
+//! * the current sample has age 0, so it is always in window and the window is
+//!   **never empty** — classic has no empty-window instant, and even a
+//!   zero-width window keeps the current sample;
+//! * `var`/`std` use the sample (ddof = 1) convention — `0.0` until at least two
+//!   samples are in the window (`std` clamps at zero, never `NaN`);
+//! * `median` averages the two middle values for an even count.
+//!
+//! Ticks are 100ns apart, so a 250ns window retains the three most recent
+//! samples (ages 0, 100, 200) and drops the rest — mirroring the classic
+//! `WIN = 250ns` fixtures. The counter fixture `1,2,3,4,5` therefore ends on the
+//! window `{3,4,5}`, and the tests pin the **whole** emitted series so the
+//! mid-stream evictions (the value 1 ageing out at t = 300ns, then 2 at
+//! t = 400ns) are exercised, not just the final window.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::fluent::Stream;
+use wingfoil_next::prelude::*;
+use wingfoil_next::stats::StatisticsOps;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// A 250ns window over 100ns-spaced ticks retains the three most recent samples.
+const WIN: Duration = Duration::from_nanos(250);
+
+/// 1, 2, 3, 4, 5 as `f64`, one tick every 100ns (ticks at 0,100,200,300,400ns).
+fn counter_f64(g: &GraphBuilder) -> Stream<f64> {
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(|i| *i as f64)
+}
+
+/// Assert two `f64` series equal element-wise within a tolerance.
+fn assert_series_approx(got: &[f64], expected: &[f64]) {
+    assert_eq!(got.len(), expected.len(), "length: {got:?} vs {expected:?}");
+    for (i, (g, e)) in got.iter().zip(expected).enumerate() {
+        assert!(
+            (g - e).abs() < 1e-9,
+            "at {i}: got {g}, expected {e} (series {got:?} vs {expected:?})"
+        );
+    }
+}
+
+// ── time_windowed_sum ────────────────────────────────────────────────────────
+
+/// Windows retained per tick (250ns): {1},{1,2},{1,2,3},{2,3,4},{3,4,5}. The
+/// value 1 ages out at t=300ns and 2 at t=400ns, so the sums are
+/// 1,3,6,9,12 — the eviction is doing real work (a cumulative sum would give
+/// 1,3,6,10,15).
+#[test]
+fn time_windowed_sum_counter() {
+    let g = GraphBuilder::new();
+    let s = counter_f64(&g).time_windowed_sum(WIN).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1.0, 3.0, 6.0, 9.0, 12.0], r.value(&s));
+}
+
+// ── time_windowed_mean ───────────────────────────────────────────────────────
+
+/// Same windows: means 1, 1.5, 2, 3, 4. The final `{3,4,5}` mean is 4.0
+/// (mirrors classic `rolling_mean_over_time_window_count_and_time`, count case).
+#[test]
+fn time_windowed_mean_counter() {
+    let g = GraphBuilder::new();
+    let m = counter_f64(&g).time_windowed_mean(WIN).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&m), &[1.0, 1.5, 2.0, 3.0, 4.0]);
+}
+
+// ── time_windowed_min / time_windowed_max ────────────────────────────────────
+
+/// Windows {1},{1,2},{1,2,3},{2,3,4},{3,4,5}: min rises 1,1,1,2,3 as the small
+/// values age out (a cumulative min would stay 1), max is 1,2,3,4,5. Final
+/// {3,4,5}: min 3, max 5 (mirrors classic `rolling_min_max_over_time_window`).
+#[test]
+fn time_windowed_min_max_counter() {
+    let g = GraphBuilder::new();
+    let mn = counter_f64(&g).time_windowed_min(WIN).accumulate();
+    let mx = counter_f64(&g).time_windowed_max(WIN).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1.0, 1.0, 1.0, 2.0, 3.0], r.value(&mn));
+    assert_eq!(vec![1.0, 2.0, 3.0, 4.0, 5.0], r.value(&mx));
+}
+
+/// Min/max over a non-monotonic sequence in a 250ns window, checked every tick
+/// against a brute-force scan of the retained window — exercises the monotonic
+/// deque evicting from both ends (stale front by age, dominated back on push).
+#[test]
+fn time_windowed_min_max_non_monotonic_matches_brute_force() {
+    const N: u32 = 40;
+    let seq = |n: u64| ((n * 7) % 13) as f64;
+
+    let g = GraphBuilder::new();
+    let mn = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .time_windowed_min(WIN)
+        .accumulate();
+    let mx = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .time_windowed_max(WIN)
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(N)).unwrap();
+
+    let got_min = r.value(&mn);
+    let got_max = r.value(&mx);
+    // After tick k (0-based) the stream has emitted seq(1..=k+1) at times
+    // 0,100,..,k*100; the 250ns window retains those within 250ns of now = k*100,
+    // i.e. ages 0,100,200 → the last three (or fewer near the start).
+    for k in 0..got_min.len() {
+        let n = (k + 1) as u64;
+        let start = if n > 3 { n - 2 } else { 1 };
+        let window: Vec<f64> = (start..=n).map(seq).collect();
+        let emin = window.iter().copied().fold(f64::INFINITY, f64::min);
+        let emax = window.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        assert_eq!(got_min[k], emin, "min mismatch at tick {k}");
+        assert_eq!(got_max[k], emax, "max mismatch at tick {k}");
+    }
+}
+
+// ── time_windowed_var / time_windowed_std ────────────────────────────────────
+
+/// Windows {1},{1,2},{1,2,3},{2,3,4},{3,4,5} sample variance (ddof = 1):
+/// 0 (n<2), 0.5, 1, 1, 1. Final `{3,4,5}` var 1.0 (mirrors classic
+/// `rolling_var_over_time_window_count`). `std` is the element-wise root.
+#[test]
+fn time_windowed_var_std_counter() {
+    let g = GraphBuilder::new();
+    let var = counter_f64(&g).time_windowed_var(WIN).accumulate();
+    let std = counter_f64(&g).time_windowed_std(WIN).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let expected_var = [0.0, 0.5, 1.0, 1.0, 1.0];
+    assert_series_approx(&r.value(&var), &expected_var);
+    let expected_std: Vec<f64> = expected_var.iter().map(|v| v.sqrt()).collect();
+    assert_series_approx(&r.value(&std), &expected_std);
+}
+
+/// The incremental add/remove moments must match a direct recompute over the
+/// retained window (i.e. eviction has not drifted): slide a 350ns window over a
+/// non-trivial sequence and compare the final mean/variance to a from-scratch
+/// computation over exactly the samples still in the window.
+#[test]
+fn time_windowed_moments_match_direct_recompute() {
+    const N: u32 = 60;
+    // 350ns window over 100ns ticks retains ages 0,100,200,300 → four samples.
+    const WIN_NS: u64 = 350;
+    let win = Duration::from_nanos(WIN_NS);
+    let seq = |n: u64| ((n % 7) as f64) * 1.5 - 3.0;
+
+    let g = GraphBuilder::new();
+    let mean = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .time_windowed_mean(win);
+    let var = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .time_windowed_var(win);
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(N)).unwrap();
+
+    // count() emits 1..=N at times 0,100,..,(N-1)*100; final now = (N-1)*100.
+    // Retained = samples within WIN_NS of now (age <= WIN_NS).
+    let now = (N as u64 - 1) * 100;
+    let retained: Vec<f64> = (1..=N as u64)
+        .filter(|n| now - (n - 1) * 100 <= WIN_NS)
+        .map(seq)
+        .collect();
+    let em = retained.iter().sum::<f64>() / retained.len() as f64;
+    let ev = retained.iter().map(|v| (v - em).powi(2)).sum::<f64>() / (retained.len() as f64 - 1.0);
+    assert!(
+        (r.value(&mean) - em).abs() < 1e-9,
+        "mean {} vs {em}",
+        r.value(&mean)
+    );
+    assert!(
+        (r.value(&var) - ev).abs() < 1e-9,
+        "var {} vs {ev}",
+        r.value(&var)
+    );
+}
+
+/// A constant stream over a time window has zero variance; `std` must clamp at
+/// zero (revert-scheme drift can make the incremental variance a hair negative)
+/// rather than emit `NaN`.
+#[test]
+fn time_windowed_std_of_constant_is_zero_not_nan() {
+    let g = GraphBuilder::new();
+    let std = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(|_| 7.0)
+        .time_windowed_std(WIN)
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(8)).unwrap();
+    for v in r.value(&std) {
+        assert!(!v.is_nan(), "std must not be NaN");
+        assert!(
+            v.abs() < 1e-10,
+            "constant window std should be 0.0, got {v}"
+        );
+    }
+}
+
+// ── time_windowed_median ─────────────────────────────────────────────────────
+
+/// Windows {1},{1,2},{1,2,3},{2,3,4},{3,4,5}: medians 1, 1.5 (even), 2, 3, 4.
+/// Final {3,4,5} median 4.0 (mirrors classic `rolling_median_over_time_window`).
+#[test]
+fn time_windowed_median_counter() {
+    let g = GraphBuilder::new();
+    let med = counter_f64(&g).time_windowed_median(WIN).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&med), &[1.0, 1.5, 2.0, 3.0, 4.0]);
+}
+
+// ── zero-width window (degenerate, never empty) ──────────────────────────────
+
+/// Classic never produces an empty window (the current sample has age 0 and is
+/// always retained). A zero-width window is the degenerate limit: every entry
+/// except the current one (age > 0) is evicted, so each stat is a function of
+/// just the latest value — sum = mean = min = max = median = value, var = std =
+/// 0. This pins the closest-to-empty behaviour classic allows.
+#[test]
+fn time_windowed_zero_width_keeps_only_current() {
+    let g = GraphBuilder::new();
+    let zero = Duration::ZERO;
+    let s = counter_f64(&g).time_windowed_sum(zero).accumulate();
+    let m = counter_f64(&g).time_windowed_mean(zero).accumulate();
+    let mn = counter_f64(&g).time_windowed_min(zero).accumulate();
+    let mx = counter_f64(&g).time_windowed_max(zero).accumulate();
+    let var = counter_f64(&g).time_windowed_var(zero).accumulate();
+    let med = counter_f64(&g).time_windowed_median(zero).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let identity = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    assert_eq!(identity, r.value(&s));
+    assert_eq!(identity, r.value(&m));
+    assert_eq!(identity, r.value(&mn));
+    assert_eq!(identity, r.value(&mx));
+    assert_eq!(identity, r.value(&med));
+    assert_eq!(vec![0.0; 5], r.value(&var));
+}
+
+// ── tick-time parity ─────────────────────────────────────────────────────────
+
+/// A time-windowed op ticks once per upstream tick (eviction is internal), so
+/// the emitted times are exactly the ticker's: 0,100,200,300,400ns. Pin both
+/// the tick times and the paired `time_windowed_min` values.
+#[test]
+fn time_windowed_tick_times_match_upstream() {
+    let g = GraphBuilder::new();
+    let acc = counter_f64(&g)
+        .time_windowed_min(WIN)
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let series = r.value(&acc);
+    let times: Vec<u64> = series.iter().map(|(t, _)| u64::from(*t)).collect();
+    let values: Vec<f64> = series.iter().map(|(_, v)| *v).collect();
+    assert_eq!(vec![0, 100, 200, 300, 400], times);
+    assert_eq!(vec![1.0, 1.0, 1.0, 2.0, 3.0], values);
+}


### PR DESCRIPTION
## What

Ports the classic **`Window::Time`** (bounded time-window, count-weighted) variants of sum / mean / min / max / var / std / median from `adapters::statistics` into the wingfoil-next op catalog — the classic `WindowStream` / `RollingMomentStream` time-window path. Completes the rolling/cumulative statistics coverage alongside #482 (count-weighted cumulative) and #484 (time-weighted cumulative); all are additive on `ops.rs`/`stats.rs`/`docs/port-plan.md`.

### Stats landed & complexity

| op | classic reference | approach | per-tick cost |
|----|-------------------|----------|---------------|
| `time_windowed_sum` | `sum(Window::Time)` | running total (add/subtract) | **O(1)** |
| `time_windowed_mean` | `mean(Window::Time, Count)` | incremental Welford moments (add + exact remove) | **O(1)** amortised |
| `time_windowed_var` | `variance(Window::Time, Count)` | same moments, sample var ddof=1 | **O(1)** amortised |
| `time_windowed_std` | `std(Window::Time, Count)` | sqrt of var, clamped ≥ 0 | **O(1)** amortised |
| `time_windowed_min` | `min(Window::Time)` | monotonic deque, age-based front eviction | **O(1)** amortised |
| `time_windowed_max` | `max(Window::Time)` | monotonic deque, age-based front eviction | **O(1)** amortised |
| `time_windowed_median` | `median(Window::Time, Count)` | recompute (sort) over retained window | O(w log w) over the w retained |

Note on min/max: classic's *time*-windowed extreme uses a per-tick rescan (`WindowStream`); this PR instead applies the monotonic-deque trick classic uses for its *count*-windowed extreme (`RollingExtremeStream`), front-evicting by age instead of by index — O(1) amortised, and the emitted values are identical. Mean/var/std reuse the count-weighted Welford add/remove (numerically identical to `WeightedMoments` with unit weights, matching classic's `Weighting::Count`). Median matches classic's recompute-per-tick exactly.

All variants are **count-weighted** (the ordinary statistic over the samples currently in the window).

## Eviction / boundary semantics reproduced

- On each tick the current sample is pushed at `now = ctx.time()`, then every entry whose age `now - t` is **strictly greater** than the window is evicted — so an entry exactly `window` old is **retained** (an inclusive trailing boundary, matching classic's `age > duration` predicate).
- The current sample has age 0, so it is always in window → the window is **never empty**. Classic has no empty-window instant; the closest case is a **zero-width** window, which degenerates to just the current sample (each stat becomes a function of the latest value; var/std = 0). Tested explicitly.
- `var`/`std` use the sample (ddof = 1) convention — `0.0` until at least two samples are in the window; `std` clamps at zero (never `NaN`).

A `window: Duration` config threads through the fluent methods (converted to `NanoTime` at wiring time); the ops carry `Cfg = NanoTime`. Each is a single-input `Op` with `#[op(build = ...)]` (auto-generates the interpreted `Builder` wiring); fluent methods on `StatisticsOps` in `stats.rs`.

## Parity approach

Tests in `wingfoil-next/tests/statistics_time_windowed.rs` (historical mode) pin the **whole** emitted series tick-by-tick on a 250ns window over 100ns ticks, chosen so values provably age out **mid-stream** (value 1 leaves at t=300ns, value 2 at t=400ns) — so eviction is genuinely exercised, not just the final window. Highlights:

- Full-series checks for sum (`1,3,6,9,12` — vs cumulative `1,3,6,10,15`), mean, min (`1,1,1,2,3` — rises as small values age out), max, var, std, median over `1..5`; final windows match the classic `WIN=250ns` fixtures (sum 12, mean 4, var 1, min 3, max 5, median 4).
- **Brute-force per-tick cross-check** for min/max over a non-monotonic sequence (deque evicts from both ends).
- **Direct recompute-over-retained-window cross-check** for the incremental moments over a 350ns window (guards against add/remove drift).
- Constant-window `std` → `0.0` (not `NaN`).
- Degenerate zero-width window (closest-to-empty case).
- Tick-time parity: one output per input tick, times `0,100,200,300,400ns`.

## What remains after this PR

The statistics port is now complete except for the **time-weighted** moment path (`Weighting::Time`) over a **bounded window** — i.e. the `RollingMomentStream` `Weighting::Time` branch (each in-window sample weighted by its in-effect Δt, with exact-removal on eviction). The cumulative time-weighted form already landed in #484; this remaining combo is time-weighting *within a window*.

## Deferred

- `graph!`-macro rows (compiled/nested engines) — left to the concurrent `rolling_*` macro PR; interpreted + fluent wiring is complete for all seven ops.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo test -p wingfoil-next` — all pass (10 new tests in `statistics_time_windowed`, plus the full existing suite)
- `cargo clippy -p wingfoil-next --all-targets -- -D warnings` — clean
- No `.unwrap()` outside `#[cfg(test)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_