### PR TITLE
Port classic examples onto the wingfoil-next fluent API

### DIFF
--- a/wingfoil-next/Cargo.toml
+++ b/wingfoil-next/Cargo.toml
@@ -64,3 +64,25 @@ harness = false
 [[example]]
 name = "csv_adapter"
 required-features = ["csv"]
+
+# Ports of the classic `wingfoil/examples/` onto the next engine's fluent API.
+# Each lives in its own directory with a README, mirroring the classic layout.
+[[example]]
+name = "breadth_first"
+path = "examples/breadth_first/main.rs"
+
+[[example]]
+name = "feedback"
+path = "examples/feedback/main.rs"
+
+[[example]]
+name = "run_mode"
+path = "examples/run_mode/main.rs"
+
+[[example]]
+name = "order_book"
+path = "examples/order_book/main.rs"
+
+[[example]]
+name = "statistics"
+path = "examples/statistics/main.rs"

--- a/wingfoil-next/examples/breadth_first/README.md
+++ b/wingfoil-next/examples/breadth_first/README.md
@@ -1,0 +1,36 @@
+## Breadth-first graph execution
+
+Wingfoil-next inherits the classic engine's breadth-first scheduler, which
+eliminates the O(2^N) explosion that affects depth-first frameworks (reactive
+libraries, async streams) when nodes branch and recombine.
+
+Each `join(&source, &source)` branches the upstream node into two inputs and
+recombines them. Depth-first frameworks visit every path through the graph —
+2^N paths at depth N. Wingfoil's BFS scheduler visits each node exactly once
+per tick, regardless of how many upstream paths lead to it.
+
+```rust
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+let g = GraphBuilder::new();
+let mut source = g.constant(1_u128);
+for _ in 1..128 {
+    source = source.join(&source, |a, b| a + b);
+}
+let out = source.timed();
+let mut runner = g.build();
+runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+println!("value {:?}", runner.value(&out));
+```
+
+127 levels deep — 2^127 as the correct answer — completes in **one tick**:
+
+```text
+value 170141183460469231731687303715884105728
+```
+
+This is the fluent-API port of the classic `breadth_first` example (which uses
+`add(&source, &source)` over the classic engine). The next engine expresses the
+self-referential diamond with `join`, whose two inputs are the same stream
+handle.

--- a/wingfoil-next/examples/breadth_first/main.rs
+++ b/wingfoil-next/examples/breadth_first/main.rs
@@ -1,0 +1,34 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example breadth_first
+//! ```
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+fn main() -> anyhow::Result<()> {
+    let g = GraphBuilder::new();
+
+    // A single source, then 127 diamonds stacked on top of it: each
+    // `join(&source, &source)` reads the *same* upstream node twice and sums —
+    // branch then recombine. The two inputs share one node index, so the
+    // engine visits it once per tick regardless of how many paths lead in.
+    let mut source = g.constant(1_u128);
+    for _ in 1..128 {
+        source = source.join(&source, |a, b| a + b);
+    }
+
+    // `.timed()` prints a one-line perf summary at teardown.
+    let out = source.timed();
+
+    let mut runner = g.build();
+    // The constant fires once; nothing reschedules, so `Forever` self-
+    // terminates after a single tick — the whole 127-deep DAG in one cycle.
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+
+    // 2^127 — the correct answer a depth-first engine would need 2^127 visits
+    // to reach.
+    println!("value {:?}", runner.value(&out));
+    Ok(())
+}

--- a/wingfoil-next/examples/feedback/README.md
+++ b/wingfoil-next/examples/feedback/README.md
@@ -1,0 +1,48 @@
+## Feedback loops
+
+A directed acyclic graph cannot express a cycle directly — but real systems
+have them. A feedback edge breaks the cycle in time: values sent to the sink
+arrive on the paired source *one cycle later*, so the graph stays acyclic while
+the loop still closes.
+
+This is the fluent-API port of the classic `feedback` example: a proportional
+temperature controller. The room (the "plant") is heated toward a setpoint; the
+controller reads the current temperature, computes the error, and drives the
+heater proportionally. The new temperature feeds back for the next step.
+
+```rust
+let (temp_rx, temp_tx) = g.feedback::<f64>();
+let clock = g.ticker(period).count();
+
+// error and plant read the fed-back temperature *passively* (join_passive):
+// the clock / heater drive the tick, the temperature is only read.
+let error = clock.join_passive(&temp_rx, move |_, temp| setpoint - temp);
+let heater = error.map(move |e| gain * e);
+let plant = heater.join_passive(&temp_rx, |power, temp| temp + power);
+
+// Close the loop.
+let temperature = plant.feedback(&temp_tx);
+```
+
+Starting from 0, the temperature converges geometrically toward the setpoint of
+20:
+
+```text
+temperature: 10.000
+temperature: 15.000
+temperature: 17.500
+temperature: 18.750
+temperature: 19.375
+temperature: 19.688
+temperature: 19.844
+temperature: 19.922
+```
+
+### Idiom notes
+
+- `g.feedback::<T>()` returns `(source, sink)` — the reverse of the classic
+  engine's `(tx, rx)` ordering.
+- The classic engine used `bimap(Dep::Active, Dep::Passive, …)`; the next engine
+  spells the same active/passive combine as `join_passive`.
+- `stream.feedback(&sink)` is a pass-through that also forwards each value to the
+  sink for delivery next cycle.

--- a/wingfoil-next/examples/feedback/main.rs
+++ b/wingfoil-next/examples/feedback/main.rs
@@ -1,0 +1,57 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example feedback
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+fn main() -> anyhow::Result<()> {
+    let period = Duration::from_secs(1);
+    let setpoint = 20.0_f64; // target temperature
+    let gain = 0.5_f64; // proportional controller gain
+
+    let g = GraphBuilder::new();
+
+    // A clock to advance the control loop one step per period.
+    let clock = g.ticker(period).count();
+
+    // The feedback edge carries the room temperature. `temp_rx` lets us
+    // reference the temperature *before* the plant that produces it exists —
+    // which is what makes the loop below constructible at all. Values sent to
+    // `temp_tx` arrive on `temp_rx` one cycle later, so the graph stays acyclic.
+    let (temp_rx, temp_tx) = g.feedback::<f64>();
+
+    // Controller: how far are we from the setpoint? `join_passive` reads the
+    // fed-back temperature *passively* — the clock drives the tick, the
+    // temperature is merely read — so `error` advances once per period.
+    let error = clock.join_passive(&temp_rx, move |_, temp| setpoint - temp);
+
+    // Control signal: how hard to drive the heater.
+    let heater = error.map(move |e| gain * e);
+
+    // Plant: the room. New temperature = old temperature + heater output.
+    // Again the old temperature is read passively; the heater drives the tick.
+    let plant = heater.join_passive(&temp_rx, |power, temp| temp + power);
+
+    // Close the loop: feed each new temperature back so the next step's `error`
+    // can read it. plant -> heater -> error -> plant is a genuine cycle; the
+    // feedback edge is the only construct that can express it.
+    let temperature = plant.feedback(&temp_tx);
+
+    let _out = temperature.for_each(|t| {
+        println!("temperature: {t:.3}");
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(
+        RunMode::HistoricalFrom(NanoTime::ZERO),
+        RunFor::Duration(period * 7),
+    )?;
+
+    Ok(())
+}

--- a/wingfoil-next/examples/order_book/README.md
+++ b/wingfoil-next/examples/order_book/README.md
@@ -1,0 +1,47 @@
+## Order book: stateful top-of-book
+
+A stateful streaming example: a limit order book maintained entirely in `fold`
+state. Each tick applies one synthetic message (a resting limit order, or an
+occasional aggressive order that crosses and consumes a level), and the graph
+emits the *top of book* — best bid and best ask — but only when it changes.
+
+```rust
+let book = g
+    .ticker(Duration::from_millis(1))
+    .fold(Book::new(seed), |book, _| book.apply());
+
+let top = book.map(|b| b.top()).distinct();
+let _out = top.for_each(|p| { println!(...); Ok(()) });
+```
+
+Sample output:
+
+```text
+bid  99   ask   -   spread -
+bid  99   ask 101   spread 2
+bid 100   ask 101   spread 1
+...
+```
+
+### Scope and idiom
+
+This is a *simplified* port of the classic `order_book` example. The classic
+version reads real LOBSTER market-data CSV, executes it through a `lobster`
+matching engine, and `split()`s the result into two output streams — a fills
+stream and a prices stream — written to separate CSV files.
+
+Two of those pieces are **not yet available on the next engine**, so the port
+takes a different shape rather than forcing them:
+
+- **`split()` / multi-output nodes** — the classic example emits *both* fills
+  and prices from one node. The next engine's ops are single-output, so this
+  port emits a single top-of-book stream. (A stateful book that produced fills
+  and prices would need a demux/split op.)
+- **The CSV replay + write adapter** — the next engine has a `csv` feature
+  (`examples/csv_adapter`), but this example keeps its feed self-contained (a
+  deterministic LCG) so it runs with no data file and no extra feature flag.
+
+What it *does* demonstrate, cleanly, is the load-bearing idea: an arbitrary
+stateful aggregation (`BTreeMap`-backed order book) carried in `fold` state,
+projected with `map`, de-duplicated with `distinct`, and drained through a
+`for_each` sink — all in the fluent API.

--- a/wingfoil-next/examples/order_book/main.rs
+++ b/wingfoil-next/examples/order_book/main.rs
@@ -1,0 +1,116 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example order_book
+//! ```
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+/// A limit order book: resting bid/ask quantity keyed by price. Kept in `fold`
+/// state and updated one synthetic message at a time.
+#[derive(Clone)]
+struct Book {
+    rng: u64,
+    bids: BTreeMap<u64, u64>,
+    asks: BTreeMap<u64, u64>,
+}
+
+impl Book {
+    fn new(seed: u64) -> Self {
+        Book {
+            rng: seed,
+            bids: BTreeMap::new(),
+            asks: BTreeMap::new(),
+        }
+    }
+
+    /// Deterministic LCG — a self-contained synthetic order feed so the example
+    /// needs no data file.
+    fn next_rand(&mut self) -> u64 {
+        self.rng = self
+            .rng
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.rng >> 33
+    }
+
+    /// Apply one synthetic message: mostly resting limit orders around a mid of
+    /// 100, occasionally an aggressive order that crosses and consumes a level.
+    fn apply(&mut self) {
+        let r = self.next_rand();
+        let is_bid = r & 1 == 0;
+        let offset = (r >> 1) % 5; // 0..4 ticks off the mid
+        let qty = 1 + (r >> 4) % 9; // 1..9
+
+        if r.is_multiple_of(7) {
+            // Aggressive order: take the best level on the opposite side.
+            if is_bid {
+                if let Some((&px, _)) = self.asks.iter().next() {
+                    self.asks.remove(&px);
+                }
+            } else if let Some((&px, _)) = self.bids.iter().next_back() {
+                self.bids.remove(&px);
+            }
+            return;
+        }
+
+        // Resting limit order: bids below the mid, asks above it.
+        if is_bid {
+            let px = 100 - offset;
+            *self.bids.entry(px).or_insert(0) += qty;
+        } else {
+            let px = 101 + offset;
+            *self.asks.entry(px).or_insert(0) += qty;
+        }
+    }
+
+    fn top(&self) -> TwoWayPrice {
+        TwoWayPrice {
+            bid: self.bids.keys().next_back().copied(),
+            ask: self.asks.keys().next().copied(),
+        }
+    }
+}
+
+/// Top of book: best bid and best ask (either side may be empty).
+#[derive(Clone, Default, PartialEq)]
+struct TwoWayPrice {
+    bid: Option<u64>,
+    ask: Option<u64>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let g = GraphBuilder::new();
+
+    // One synthetic message per tick, folded into the book. `fold` emits the
+    // whole book each tick; we then project to top-of-book, keep only the ticks
+    // where it *changed*, and print them.
+    let book = g
+        .ticker(Duration::from_millis(1))
+        .fold(Book::new(0x1234_5678), |book, _| book.apply());
+
+    let top = book.map(|b| b.top()).distinct();
+
+    let _out = top.for_each(|p| {
+        let fmt = |o: &Option<u64>| o.map_or_else(|| "  -".to_string(), |v| format!("{v:>3}"));
+        let spread = match (p.bid, p.ask) {
+            (Some(b), Some(a)) => format!("{}", a as i64 - b as i64),
+            _ => "-".to_string(),
+        };
+        println!(
+            "bid {}   ask {}   spread {}",
+            fmt(&p.bid),
+            fmt(&p.ask),
+            spread
+        );
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(200))?;
+    Ok(())
+}

--- a/wingfoil-next/examples/run_mode/README.md
+++ b/wingfoil-next/examples/run_mode/README.md
@@ -1,0 +1,29 @@
+## Run modes: realtime vs historical
+
+The same graph runs two ways. `RunMode::RealTime` advances on the wall clock —
+what a live deployment uses. `RunMode::HistoricalFrom(t)` replays on a simulated
+clock as fast as the CPU allows — what backtests and deterministic tests use.
+
+This is the fluent-API port of the classic `run_mode` example. A
+`MarketDataBuilder` trait supplies the price stream; a realtime deployment and a
+historical replay pick different implementations, but the business logic wired
+on top of `price` is identical in both. Here both implementations share the
+default mock so the two modes produce the same numbers.
+
+```sh
+cargo run -p wingfoil-next --example run_mode -- realtime
+cargo run -p wingfoil-next --example run_mode -- historical
+```
+
+Both print the same last price (the mock cycles 100.0 – 109.0):
+
+```text
+last price: 105
+```
+
+### Idiom note
+
+In the next engine sources are constructed *from a `GraphBuilder`*, so the
+trait method takes `&GraphBuilder` and returns a `Stream<f64>` — whereas the
+classic engine's `price()` took no arguments and returned an `Rc<dyn
+Stream<f64>>`. The dispatch-on-run-mode pattern is otherwise unchanged.

--- a/wingfoil-next/examples/run_mode/main.rs
+++ b/wingfoil-next/examples/run_mode/main.rs
@@ -1,0 +1,71 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example run_mode -- realtime
+//! cargo run -p wingfoil-next --example run_mode -- historical
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::fluent::Stream;
+use wingfoil_next::prelude::*;
+
+// ── trait ───────────────────────────────────────────────────────────────────
+
+/// A source of market data. The default `price` impl is a mock: a ticker that
+/// emits a synthetic price cycling through 100.0 – 109.0. A real deployment
+/// would override it (a socket in realtime, a file replay in historical); the
+/// graph wiring downstream never changes.
+trait MarketDataBuilder {
+    fn price(&self, g: &GraphBuilder) -> Stream<f64> {
+        g.ticker(Duration::from_nanos(1))
+            .count()
+            .map(|n| 100.0 + (n % 10) as f64)
+    }
+}
+
+// ── implementations ─────────────────────────────────────────────────────────
+
+struct RealTimeMarketDataBuilder;
+struct HistoricalMarketDataBuilder;
+
+impl MarketDataBuilder for RealTimeMarketDataBuilder {}
+impl MarketDataBuilder for HistoricalMarketDataBuilder {}
+
+// ── run ─────────────────────────────────────────────────────────────────────
+
+fn run(run_mode: RunMode) -> anyhow::Result<()> {
+    // Select the appropriate builder for this run mode.
+    let builder: Box<dyn MarketDataBuilder> = match run_mode {
+        RunMode::RealTime => Box::new(RealTimeMarketDataBuilder),
+        RunMode::HistoricalFrom(_) => Box::new(HistoricalMarketDataBuilder),
+    };
+
+    // Build the graph — add business logic here. It is identical in both modes.
+    let g = GraphBuilder::new();
+    let prices = builder.price(&g);
+
+    let mut runner = g.build();
+    runner.run(run_mode, RunFor::Cycles(5))?;
+    println!("last price: {}", runner.value(&prices));
+    Ok(())
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+
+fn main() -> anyhow::Result<()> {
+    let arg = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "historical".into())
+        .to_lowercase();
+    let run_mode = match arg.as_str() {
+        "realtime" => RunMode::RealTime,
+        "historical" => RunMode::HistoricalFrom(NanoTime::ZERO),
+        other => {
+            eprintln!("unknown run mode: {other:?}. Use 'realtime' or 'historical'.");
+            std::process::exit(1);
+        }
+    };
+    run(run_mode)
+}

--- a/wingfoil-next/examples/statistics/README.md
+++ b/wingfoil-next/examples/statistics/README.md
@@ -1,0 +1,44 @@
+## Streaming statistics
+
+Rolling-window statistics and an exponentially-weighted moving average over a
+single price stream, printed as a live table. This is the fluent-API port of the
+classic `statistics` example.
+
+The numeric aggregations live in the `StatisticsOps` trait, kept *out* of the
+prelude so the core combinator vocabulary stays small — bring it in explicitly:
+
+```rust
+use wingfoil_next::stats::StatisticsOps;
+
+let price = g.ticker(Duration::from_millis(100)).count()
+    .map(|n| 100.0 + ((*n as f64) * 0.6).sin() * 5.0);
+
+let ewma = price.ewma_per_tick(0.3);
+let sma  = price.rolling_mean(10);
+let std  = price.rolling_std(10);
+let lo   = price.rolling_min(10);
+let hi   = price.rolling_max(10);
+```
+
+The columns are bundled into one row per tick with `join`, sampled twice a
+second, and printed:
+
+```text
+  time   price    ewma     sma     std     min     max
+  0.0s  102.82  102.82  102.82    0.00  102.82  102.82
+  0.5s   97.79  101.29  102.37    2.70   97.79  104.87
+  1.0s  101.56   99.00   99.84    3.73   95.02  104.87
+  ...
+```
+
+### Scope and idiom
+
+- **Bundling** — the classic example used a `combine(columns)` op that packs an
+  arbitrary number of columns into one `Stream<Burst<f64>>`. The next engine's
+  ops are fixed-arity (join is two-input), so this port bundles the columns with
+  a chain of `join`s building a `Vec<f64>` row. A variadic `combine`/`zip` op is
+  a known gap.
+- **Time-weighting** — the classic example also showed a *time-weighted* mean
+  (`Weighting::Time` / TWAP). The next `StatisticsOps` trait currently exposes
+  the count-weighted rolling ops (`rolling_mean/std/min/max/median`, `ewma`); a
+  time-weighted aggregation family is not yet ported, so this column is omitted.

--- a/wingfoil-next/examples/statistics/main.rs
+++ b/wingfoil-next/examples/statistics/main.rs
@@ -1,0 +1,71 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example statistics
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+use wingfoil_next::stats::StatisticsOps;
+
+fn main() -> anyhow::Result<()> {
+    let g = GraphBuilder::new();
+
+    // A single synthetic price stream: a gentle sine wave around 100, one
+    // sample every 100ms. Every statistic below is derived from this one stream.
+    let price = g
+        .ticker(Duration::from_millis(100))
+        .count()
+        .map(|n| 100.0 + ((*n as f64) * 0.6).sin() * 5.0);
+
+    // One statistic per column, all derived from the shared price stream. The
+    // `StatisticsOps` trait (opt-in — imported separately from the prelude)
+    // supplies EWMA and rolling-window ops on any `Stream<f64>`.
+    let ewma = price.ewma_per_tick(0.3);
+    let sma = price.rolling_mean(10);
+    let std = price.rolling_std(10);
+    let lo = price.rolling_min(10);
+    let hi = price.rolling_max(10);
+
+    // Bundle the columns into one row per tick. `join` ticks when either input
+    // ticks; since every column derives from `price` they all advance on the
+    // same cycle, so each row is internally consistent.
+    let push = |row: &Vec<f64>, x: &f64| {
+        let mut row = row.clone();
+        row.push(*x);
+        row
+    };
+    let row = price
+        .join(&ewma, |p, e| vec![*p, *e])
+        .join(&sma, push)
+        .join(&std, push)
+        .join(&lo, push)
+        .join(&hi, push);
+
+    // Print a header, then sample the row twice a second and print it live.
+    let labels = ["price", "ewma", "sma", "std", "min", "max"];
+    print!("{:>6}", "time");
+    for label in labels {
+        print!(" {label:>7}");
+    }
+    println!();
+
+    let trigger = g.ticker(Duration::from_millis(500));
+    let _out = row.with_time().sample(&trigger).for_each(|(time, values)| {
+        print!("{:>5.1}s", f64::from(*time) / 1e9);
+        for value in values {
+            print!(" {value:>7.2}");
+        }
+        println!();
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(
+        RunMode::HistoricalFrom(NanoTime::ZERO),
+        RunFor::Duration(Duration::from_secs(5)),
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
Ports a batch of the simpler classic `wingfoil/examples/` onto the `wingfoil-next` engine, to demonstrate the new fluent / `graph!` API and surface any API gaps. Each new example lives in `wingfoil-next/examples/<name>/main.rs` with its own README (mirroring the classic layout) and is registered as a `[[example]]` in `wingfoil-next/Cargo.toml`.

## Examples ported

| Example | Idiom | Classic ops it exercises |
|---|---|---|
| **breadth_first** | fluent | The 127-deep diamond DAG. Expresses `add(&source, &source)` as `join(&source, &source)` — two inputs sharing one node handle. 2^127 computed in **one tick**, proving the BFS scheduler visits each node once regardless of how many paths lead in. |
| **feedback** | fluent | A proportional temperature control loop. The classic `bimap(Dep::Active, Dep::Passive, …)` + `feedback` becomes `join_passive` + `stream.feedback(&sink)` over a `g.feedback::<f64>()` edge. Converges geometrically to the setpoint. |
| **run_mode** | fluent | Realtime-vs-historical selection via a `MarketDataBuilder` trait and a CLI arg. The trait method now takes `&GraphBuilder` and returns `Stream<f64>` (sources are built from the builder); the dispatch pattern is otherwise unchanged. |
| **order_book** | fluent | A **simplified** stateful port: a `BTreeMap`-backed limit order book carried in `fold` state, fed by a self-contained deterministic LCG, projected to top-of-book with `map`, de-duplicated with `distinct`, drained through `for_each`. See the gap note below for what was dropped. |
| **statistics** | fluent + opt-in `StatisticsOps` | Rolling-window stats + EWMA over one price stream, bundled into a row and printed as a live table. Demonstrates the opt-in `StatisticsOps` trait (kept out of the prelude). |

All five run with sane output. `cargo fmt --all --check`, `cargo build -p wingfoil-next --examples`, and `cargo clippy -p wingfoil-next --all-targets -- -D warnings` (default **and** `--all-features`) are clean.

### Already covered by pre-existing next examples

Several of the "aim for" targets were already present, so I didn't duplicate them — noting them for completeness:

- **basic map/filter/fold pipeline + historical-vs-realtime** → `hello_graph`
- **split/merge breadth-first DAG** → `odds_evens` (`graph!`, dual-engine)
- **stateful backtest (fold/join/filter)** → `ema_crossover`
- **async producer** → `async_source` / `produce_async_feed`

## Examples that do NOT port yet + the capability each needs

| Classic example | Missing capability |
|---|---|
| **dynamic** (`dynamic-group`, `demux`, `dynamic-manual`) | Runtime dynamic graphs — `graph_node` / `dynamic_group` and runtime-mutated topology. Not ported to next. |
| **order_book** (full fidelity) | **Multi-output `split()` / demux** — the classic node emits *both* a fills stream and a prices stream from one node; next ops are single-output. (Ported in simplified single-output form above.) Also relies on the CSV replay+write adapter (next has a `csv` feature, but the split is the blocker). |
| **statistics** (full fidelity) | **Variadic `combine`/`zip`** (packs N columns into one `Stream<Burst<f64>>` — next joins are fixed two-input) and a **time-weighted** aggregation family (`Weighting::Time` / TWAP). Ported without those two columns above. |
| **threading** | Cross-thread **sub-graph composition** — the `producer(graph_fn)` / `mapper(graph_fn)` helpers that run a whole sub-graph on another thread and bridge via channel, plus `logged`. (The `channel` / `external` sources exist, but not the whole-sub-graph-per-thread composition API.) |
| **latency**, **latency_e2e** | **Networked adapters** (ZMQ pub/sub, etc.) — not available on next. |
| **codegen**, **tracing**, **telemetry**, adapter examples (kafka/kdb/redis/postgres/etcd/fix/web/aeron/iceoryx2/fluvio/augurs/zmq) | Their respective **I/O adapters** are not ported to next. |

## Verification

```
cargo fmt --all -- --check          # clean
cargo build -p wingfoil-next --examples
cargo clippy -p wingfoil-next --all-targets -- -D warnings              # clean
cargo clippy -p wingfoil-next --all-targets --all-features -- -D warnings  # clean
cargo run -p wingfoil-next --example breadth_first   # value 170141183460469231731687303715884105728 (2^127), 1 tick
cargo run -p wingfoil-next --example feedback        # converges 10 → 19.922 toward setpoint 20
cargo run -p wingfoil-next --example run_mode -- historical   # last price: 105
cargo run -p wingfoil-next --example run_mode -- realtime     # last price: 105
cargo run -p wingfoil-next --example order_book      # streaming top-of-book
cargo run -p wingfoil-next --example statistics      # live rolling-stats table
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_