### PR TITLE
feat(wingfoil-next): port augurs adapter (forecast + outlier)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7673,6 +7673,7 @@ name = "wingfoil-next"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "augurs",
  "criterion",
  "csv",
  "futures",

--- a/wingfoil-next/Cargo.toml
+++ b/wingfoil-next/Cargo.toml
@@ -35,6 +35,19 @@ csv = { version = "1.4", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-aux = { version = "4.7.0", optional = true }
 
+# `augurs` feature: on-graph time-series forecasting + outlier detection. A
+# pure-Rust compute library (no external service), so — like the classic
+# `wingfoil` augurs adapter — coverage lives behind `--features augurs` with no
+# integration-test split. Pinned and default-features-off, mirroring the classic
+# crate; only the `ets`, `mstl`, and `outlier` sub-features are enabled, matching
+# the two ported ops (Prophet is deliberately excluded — it needs a bundled Stan
+# toolchain).
+augurs = { version = "0.10.2", default-features = false, features = [
+    "ets",
+    "mstl",
+    "outlier",
+], optional = true }
+
 [dev-dependencies]
 # Compile-fail tests pinning the `graph!` macro's key error paths.
 trybuild = "1"
@@ -44,6 +57,7 @@ criterion = "0.8.1"
 default = []
 async = ["dep:tokio", "dep:futures"]
 csv = ["dep:csv", "dep:serde", "dep:serde-aux"]
+augurs = ["dep:augurs"]
 
 [[example]]
 name = "async_source"

--- a/wingfoil-next/src/adapters/augurs.rs
+++ b/wingfoil-next/src/adapters/augurs.rs
@@ -1,0 +1,581 @@
+//! augurs adapter — on-graph time-series analysis powered by the
+//! [`augurs`](https://docs.rs/augurs) toolkit, ported to the Op pattern.
+//!
+//! Unlike a messaging adapter, augurs is a pure-Rust compute library: there is
+//! nothing to connect to and no service lifecycle. The adapter therefore
+//! exposes **transform ops** that maintain a sliding window of an input stream
+//! and apply augurs models on the graph thread each cycle — the same shape as
+//! the [`stats`](crate::stats) rolling-window ops, just with a heavier kernel.
+//!
+//! - [`AugursForecastOps::augurs_forecast`] — buffers a window of an `f64`
+//!   stream, fits a forecasting model ([`AutoETS`](augurs::ets::AutoETS) or
+//!   [MSTL](augurs::mstl)) and emits an [`AugursForecast`] (point forecast +
+//!   optional prediction intervals).
+//! - [`AugursOutlierOps::augurs_outlier`] — buffers a window of a `Vec<f64>`
+//!   stream (one value per series per tick), runs an outlier detector
+//!   ([MAD](augurs::outlier::MADDetector) or
+//!   [DBSCAN](augurs::outlier::DbscanDetector)) and emits an [`AugursOutliers`]
+//!   (which series are outlying + their latest scores).
+//!
+//! # Layering
+//!
+//! Following the [`stats`](crate::stats) module's pattern, the ops are *not*
+//! in the [`prelude`](crate::prelude): bring in the extension traits explicitly
+//! with `use wingfoil_next::adapters::augurs::{AugursForecastOps, AugursOutlierOps};`.
+//!
+//! Models are fitted inside `cycle()`. This is pure CPU work on the
+//! single-threaded engine (no locks, no I/O), but refitting is not free —
+//! throttle the input with [`throttle`](crate::fluent::StreamOps::throttle)
+//! upstream if you do not need a fresh fit on every tick.
+
+use std::collections::VecDeque;
+
+use anyhow::{Context, Result};
+use augurs::ets::AutoETS;
+use augurs::ets::trend::AutoETSTrendModel;
+use augurs::mstl::MSTLModel;
+use augurs::outlier::{DbscanDetector, MADDetector, OutlierDetector, OutlierOutput};
+use augurs::{Fit, Predict};
+use wingfoil_next_macros::op;
+
+use crate::fluent::Stream;
+use crate::op::{Activation, Ctx, Op, Tick};
+
+// -------------------------------------------------------------------------
+// Shared windowing helpers (ported from the classic adapter's `mod.rs`).
+// -------------------------------------------------------------------------
+
+/// Push `value` onto a sliding-window buffer, evicting the oldest samples until
+/// at most `window` remain.
+fn push_windowed<T>(buffer: &mut VecDeque<T>, value: T, window: usize) {
+    buffer.push_back(value);
+    while buffer.len() > window {
+        buffer.pop_front();
+    }
+}
+
+/// Transpose a window of per-tick multi-series samples (one value per series
+/// per tick) into aligned per-series columns of equal length. Short samples are
+/// forward-filled with the series' previous value so every column spans the
+/// full window. A series that first appears part-way through the window has its
+/// leading gap back-filled with its own first observed value — never a
+/// fabricated `0.0`, which would read as a large deviation to the outlier
+/// detector for the rest of the window.
+fn transpose_window(buffer: &VecDeque<Vec<f64>>) -> Vec<Vec<f64>> {
+    let n_series = buffer.iter().map(Vec::len).max().unwrap_or(0);
+    let mut series: Vec<Vec<Option<f64>>> = vec![Vec::with_capacity(buffer.len()); n_series];
+    for sample in buffer {
+        for (j, col) in series.iter_mut().enumerate() {
+            // Forward-fill a short sample from the series' previous value; a
+            // series that has not appeared yet stays `None` and is back-filled
+            // below.
+            let value = sample
+                .get(j)
+                .copied()
+                .or_else(|| col.last().copied().flatten());
+            col.push(value);
+        }
+    }
+    series
+        .into_iter()
+        .map(|col| {
+            let first = col.iter().copied().flatten().next().unwrap_or(0.0);
+            col.into_iter().map(|v| v.unwrap_or(first)).collect()
+        })
+        .collect()
+}
+
+// -------------------------------------------------------------------------
+// Value types.
+// -------------------------------------------------------------------------
+
+/// A forecast produced by [`AugursForecastOps::augurs_forecast`].
+///
+/// `point` holds the n-ahead point forecasts (length = `horizon`). `lower` /
+/// `upper` hold the prediction-interval bounds when a confidence level was
+/// requested, and are empty otherwise.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursForecast {
+    /// Point forecasts, one per step of the horizon.
+    pub point: Vec<f64>,
+    /// Lower prediction-interval bounds (empty when no level was requested).
+    pub lower: Vec<f64>,
+    /// Upper prediction-interval bounds (empty when no level was requested).
+    pub upper: Vec<f64>,
+}
+
+impl AugursForecast {
+    /// The one-step-ahead point forecast, if any.
+    #[must_use]
+    pub fn next(&self) -> Option<f64> {
+        self.point.first().copied()
+    }
+}
+
+/// The result of [`AugursOutlierOps::augurs_outlier`] for one cycle.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursOutliers {
+    /// Indices of the series flagged as outlying over the current window.
+    pub outlying: Vec<usize>,
+    /// The most recent outlier score for each series (higher = more outlying).
+    pub scores: Vec<f64>,
+}
+
+impl AugursOutliers {
+    /// Whether the series at `index` is currently flagged as an outlier.
+    #[must_use]
+    pub fn is_outlier(&self, index: usize) -> bool {
+        self.outlying.contains(&index)
+    }
+}
+
+// -------------------------------------------------------------------------
+// Forecasting.
+// -------------------------------------------------------------------------
+
+/// The forecasting model used by [`AugursForecastOps::augurs_forecast`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum AugursForecastModel {
+    /// Non-seasonal [`AutoETS`]. Fast and a good default for data without a
+    /// fixed seasonal period.
+    #[default]
+    Ets,
+    /// [MSTL](augurs::mstl) seasonal-trend decomposition with an [`AutoETS`]
+    /// trend, using the given seasonal `periods` (in samples). Choose this when
+    /// the data has one or more known seasonalities (e.g. `[24]` for hourly
+    /// data with a daily cycle). Needs a window of at least a couple of full
+    /// periods.
+    Mstl {
+        /// Seasonal period lengths, in samples.
+        periods: Vec<usize>,
+    },
+}
+
+/// Configuration for [`AugursForecastOps::augurs_forecast`].
+#[derive(Debug, Clone)]
+pub struct AugursForecastConfig {
+    /// Maximum number of recent points retained as training history. Older
+    /// points are dropped once the window is full.
+    pub window: usize,
+    /// Minimum number of buffered points before the model is fitted. Until this
+    /// many points have arrived the node does not tick. `AutoETS` needs more
+    /// than ~8 points, so values below `12` are raised to `12`.
+    pub min_points: usize,
+    /// Number of steps to forecast ahead.
+    pub horizon: usize,
+    /// Confidence level for prediction intervals (between 0 and 1). When `None`,
+    /// only point forecasts are produced and `lower`/`upper` stay empty.
+    pub level: Option<f64>,
+    /// Which forecasting model to fit each cycle.
+    pub model: AugursForecastModel,
+}
+
+impl AugursForecastConfig {
+    /// A config that keeps the last `window` points and forecasts `horizon`
+    /// steps ahead with no prediction intervals.
+    #[must_use]
+    pub fn new(window: usize, horizon: usize) -> Self {
+        Self {
+            window,
+            min_points: 12,
+            horizon,
+            level: None,
+            model: AugursForecastModel::Ets,
+        }
+    }
+
+    /// Request prediction intervals at the given confidence `level` (0..1).
+    #[must_use]
+    pub fn with_level(mut self, level: f64) -> Self {
+        self.level = Some(level);
+        self
+    }
+
+    /// Use MSTL seasonal-trend forecasting with the given seasonal `periods`
+    /// (in samples) instead of the default non-seasonal ETS model.
+    #[must_use]
+    pub fn mstl(mut self, periods: Vec<usize>) -> Self {
+        self.model = AugursForecastModel::Mstl { periods };
+        self
+    }
+
+    /// Select the forecasting model explicitly.
+    #[must_use]
+    pub fn with_model(mut self, model: AugursForecastModel) -> Self {
+        self.model = model;
+        self
+    }
+
+    /// Set the minimum number of points required before fitting begins.
+    #[must_use]
+    pub fn with_min_points(mut self, min_points: usize) -> Self {
+        self.min_points = min_points;
+        self
+    }
+
+    /// The effective minimum. Never below the `AutoETS` floor (~12 points), and
+    /// for MSTL never below two full seasonal periods (STL cannot decompose
+    /// fewer than two periods).
+    fn effective_min_points(&self) -> usize {
+        let floor = match &self.model {
+            AugursForecastModel::Ets => 12,
+            AugursForecastModel::Mstl { periods } => {
+                let max_period = periods.iter().copied().max().unwrap_or(1);
+                (2 * max_period + 1).max(12)
+            }
+        };
+        self.min_points.max(floor)
+    }
+}
+
+impl From<(usize, usize)> for AugursForecastConfig {
+    /// `(window, horizon)`.
+    fn from((window, horizon): (usize, usize)) -> Self {
+        Self::new(window, horizon)
+    }
+}
+
+/// Resolved forecast config: the user config plus the warm-up floor and
+/// effective window, computed once at wiring time and held as the op's `Cfg`.
+#[derive(Debug, Clone)]
+pub struct ForecastCfg {
+    config: AugursForecastConfig,
+    /// Effective window: the configured `window` grown to the model's warm-up
+    /// floor so a `window` smaller than the floor still lets the node fill up
+    /// and emit rather than never ticking.
+    window: usize,
+    /// Resolved warm-up floor (`effective_min_points`).
+    min_points: usize,
+}
+
+impl ForecastCfg {
+    fn resolve(config: AugursForecastConfig) -> Self {
+        let min_points = config.effective_min_points();
+        let window = config.window.max(min_points);
+        Self {
+            config,
+            window,
+            min_points,
+        }
+    }
+}
+
+/// Forecast op: buffers a window of an `f64` stream and fits an augurs
+/// forecasting model each cycle. `Cfg` = resolved config, `State` = the sliding
+/// window buffer.
+pub struct AugursForecastOp;
+
+#[op(build = augurs_forecast)]
+impl Op for AugursForecastOp {
+    type Cfg = ForecastCfg;
+    type State = VecDeque<f64>;
+    type In<'a> = (&'a f64,);
+    type Out = AugursForecast;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut ForecastCfg,
+        buffer: &mut VecDeque<f64>,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<AugursForecast>> {
+        push_windowed(buffer, *input.0, cfg.window);
+        if buffer.len() < cfg.min_points {
+            return Ok(Tick::Quiet);
+        }
+
+        let data: Vec<f64> = buffer.iter().copied().collect();
+        let forecast = match &cfg.config.model {
+            AugursForecastModel::Ets => {
+                let fitted = AutoETS::non_seasonal()
+                    .fit(&data)
+                    .context("augurs_forecast: ETS fit failed")?;
+                fitted
+                    .predict(cfg.config.horizon, cfg.config.level)
+                    .context("augurs_forecast: ETS predict failed")?
+            }
+            AugursForecastModel::Mstl { periods } => {
+                // STL cannot decompose an empty period set or a period below 2;
+                // catch it here with a clear message rather than letting augurs
+                // fail deep inside the fit with an opaque error.
+                if periods.is_empty() || periods.iter().any(|&p| p < 2) {
+                    anyhow::bail!(
+                        "augurs_forecast: MSTL periods must be non-empty and each >= 2, got {periods:?}"
+                    );
+                }
+                let trend = AutoETSTrendModel::from(AutoETS::non_seasonal());
+                let fitted = MSTLModel::new(periods.clone(), trend)
+                    .fit(&data)
+                    .context("augurs_forecast: MSTL fit failed")?;
+                fitted
+                    .predict(cfg.config.horizon, cfg.config.level)
+                    .context("augurs_forecast: MSTL predict failed")?
+            }
+        };
+
+        let (lower, upper) = match forecast.intervals {
+            Some(intervals) => (intervals.lower, intervals.upper),
+            None => (Vec::new(), Vec::new()),
+        };
+        Ok(Tick::Value(AugursForecast {
+            point: forecast.point,
+            lower,
+            upper,
+        }))
+    }
+}
+
+/// Adds the [`augurs_forecast`](AugursForecastOps::augurs_forecast) op to
+/// `f64` streams. Bring it into scope with
+/// `use wingfoil_next::adapters::augurs::AugursForecastOps;`.
+pub trait AugursForecastOps {
+    /// Maintain a sliding window of this stream and, once `min_points` have
+    /// arrived, emit an [`AugursForecast`] each tick by fitting a forecasting
+    /// model and predicting `horizon` steps ahead.
+    fn augurs_forecast(&self, config: impl Into<AugursForecastConfig>) -> Stream<AugursForecast>;
+}
+
+impl AugursForecastOps for Stream<f64> {
+    fn augurs_forecast(&self, config: impl Into<AugursForecastConfig>) -> Stream<AugursForecast> {
+        let cfg = ForecastCfg::resolve(config.into());
+        self.wire(|b, h| b.augurs_forecast(h, cfg))
+    }
+}
+
+// -------------------------------------------------------------------------
+// Outlier detection.
+// -------------------------------------------------------------------------
+
+/// Which outlier-detection algorithm [`AugursOutlierOps::augurs_outlier`] uses.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AugursOutlierDetector {
+    /// Median absolute deviation. Flags series whose values sit far from the
+    /// rolling median of the group. Works with any number of series (including
+    /// one) and is robust to a few out-of-sync members.
+    #[default]
+    Mad,
+    /// DBSCAN density clustering. Flags series that fall outside the main
+    /// cluster of similarly-behaving series. Needs **at least three** series to
+    /// form a cluster; with fewer it reports nothing.
+    Dbscan,
+}
+
+/// Configuration for [`AugursOutlierOps::augurs_outlier`].
+#[derive(Debug, Clone)]
+pub struct AugursOutlierConfig {
+    /// Number of recent samples retained as the detection window.
+    pub window: usize,
+    /// Detector sensitivity, strictly between 0 and 1. Higher is more
+    /// sensitive. Used to derive a detection threshold from the scale of the
+    /// data.
+    pub sensitivity: f64,
+    /// Which detector to run.
+    pub detector: AugursOutlierDetector,
+}
+
+impl AugursOutlierConfig {
+    /// Detect over the last `window` samples at the given `sensitivity` (must be
+    /// in `(0, 1)`) using the default [MAD](AugursOutlierDetector::Mad)
+    /// detector.
+    #[must_use]
+    pub fn new(window: usize, sensitivity: f64) -> Self {
+        Self {
+            window,
+            sensitivity,
+            detector: AugursOutlierDetector::Mad,
+        }
+    }
+
+    /// A MAD-detector config (same as [`new`](Self::new); reads clearer at call
+    /// sites that also use [`dbscan`](Self::dbscan)).
+    #[must_use]
+    pub fn mad(window: usize, sensitivity: f64) -> Self {
+        Self::new(window, sensitivity)
+    }
+
+    /// A [DBSCAN](AugursOutlierDetector::Dbscan)-detector config. Needs at least
+    /// three series to report anything.
+    #[must_use]
+    pub fn dbscan(window: usize, sensitivity: f64) -> Self {
+        Self {
+            window,
+            sensitivity,
+            detector: AugursOutlierDetector::Dbscan,
+        }
+    }
+}
+
+impl From<(usize, f64)> for AugursOutlierConfig {
+    /// `(window, sensitivity)` using the default MAD detector.
+    fn from((window, sensitivity): (usize, f64)) -> Self {
+        Self::new(window, sensitivity)
+    }
+}
+
+/// A constructed detector. `OutlierDetector` has an associated
+/// `PreprocessedData` type so it is not object-safe; this enum dispatches over
+/// the two concrete implementations instead.
+enum Detector {
+    Mad(MADDetector),
+    Dbscan(DbscanDetector),
+}
+
+impl Detector {
+    /// Build the detector for the given choice and `sensitivity`.
+    /// `with_sensitivity` fails on a sensitivity outside `(0, 1)`; that error is
+    /// surfaced through `anyhow` (aborting the run on the first cycle with a
+    /// clear message) rather than panicking at wiring time. The construction is
+    /// cheap and deterministic, so doing it per cycle does not change results.
+    fn build(detector: AugursOutlierDetector, sensitivity: f64) -> Result<Self> {
+        match detector {
+            AugursOutlierDetector::Mad => {
+                let d = MADDetector::with_sensitivity(sensitivity).map_err(|e| {
+                    anyhow::anyhow!("augurs_outlier: invalid sensitivity {sensitivity}: {e}")
+                })?;
+                Ok(Detector::Mad(d))
+            }
+            AugursOutlierDetector::Dbscan => {
+                let d = DbscanDetector::with_sensitivity(sensitivity).map_err(|e| {
+                    anyhow::anyhow!("augurs_outlier: invalid sensitivity {sensitivity}: {e}")
+                })?;
+                Ok(Detector::Dbscan(d))
+            }
+        }
+    }
+
+    fn run(&self, series: &[&[f64]]) -> Result<OutlierOutput> {
+        // augurs' outlier `Error` is not `Send + Sync`, so it cannot flow
+        // through `anyhow::Context`; render it into an `anyhow::Error` instead.
+        match self {
+            Detector::Mad(d) => {
+                let pre = d
+                    .preprocess(series)
+                    .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD preprocess failed: {e}"))?;
+                d.detect(&pre)
+                    .map_err(|e| anyhow::anyhow!("augurs_outlier: MAD detect failed: {e}"))
+            }
+            Detector::Dbscan(d) => {
+                let pre = d.preprocess(series).map_err(|e| {
+                    anyhow::anyhow!("augurs_outlier: DBSCAN preprocess failed: {e}")
+                })?;
+                d.detect(&pre)
+                    .map_err(|e| anyhow::anyhow!("augurs_outlier: DBSCAN detect failed: {e}"))
+            }
+        }
+    }
+}
+
+/// Resolved outlier config: the detector choice, sensitivity, and effective
+/// window (floored at 2), held as the op's `Cfg`.
+#[derive(Debug, Clone)]
+pub struct OutlierCfg {
+    detector: AugursOutlierDetector,
+    sensitivity: f64,
+    window: usize,
+}
+
+/// Outlier op: buffers a window of per-series readings and runs an augurs
+/// outlier detector each cycle. `Cfg` = resolved config, `State` = the sliding
+/// window of per-tick multi-series samples.
+pub struct AugursOutlierOp;
+
+#[op(build = augurs_outlier)]
+impl Op for AugursOutlierOp {
+    type Cfg = OutlierCfg;
+    type State = VecDeque<Vec<f64>>;
+    type In<'a> = (&'a Vec<f64>,);
+    type Out = AugursOutliers;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut OutlierCfg,
+        buffer: &mut VecDeque<Vec<f64>>,
+        input: (&Vec<f64>,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<AugursOutliers>> {
+        push_windowed(buffer, input.0.clone(), cfg.window);
+        // Need at least two timestamps to have any spread to measure.
+        if buffer.len() < 2 {
+            return Ok(Tick::Quiet);
+        }
+
+        // Transpose the buffered samples (one value per series per tick) into
+        // aligned per-series time series.
+        let series = transpose_window(buffer);
+        if series.is_empty() {
+            return Ok(Tick::Quiet);
+        }
+        let refs: Vec<&[f64]> = series.iter().map(Vec::as_slice).collect();
+        let detector = Detector::build(cfg.detector, cfg.sensitivity)?;
+        let output = detector.run(&refs)?;
+
+        Ok(Tick::Value(AugursOutliers {
+            outlying: output.outlying_series.iter().copied().collect(),
+            scores: output
+                .series_results
+                .iter()
+                .map(|s| s.scores.last().copied().unwrap_or(0.0))
+                .collect(),
+        }))
+    }
+}
+
+/// Adds the [`augurs_outlier`](AugursOutlierOps::augurs_outlier) op to streams
+/// of per-series readings. Bring it into scope with
+/// `use wingfoil_next::adapters::augurs::AugursOutlierOps;`.
+pub trait AugursOutlierOps {
+    /// Maintain a sliding window of per-series readings (one `f64` per series
+    /// per tick) and emit an [`AugursOutliers`] each tick once at least two
+    /// samples have arrived, flagging series that deviate from the group via the
+    /// configured detector.
+    ///
+    /// A `sensitivity` outside `(0, 1)` aborts the run on the first cycle with a
+    /// clear error (rather than panicking at wiring time).
+    fn augurs_outlier(&self, config: impl Into<AugursOutlierConfig>) -> Stream<AugursOutliers>;
+}
+
+impl AugursOutlierOps for Stream<Vec<f64>> {
+    fn augurs_outlier(&self, config: impl Into<AugursOutlierConfig>) -> Stream<AugursOutliers> {
+        let config = config.into();
+        let cfg = OutlierCfg {
+            detector: config.detector,
+            sensitivity: config.sensitivity,
+            window: config.window.max(2),
+        };
+        self.wire(|b, h| b.augurs_outlier(h, cfg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A series that only appears part-way through the window has its leading
+    /// gap back-filled with its own first value, not a fabricated `0.0`.
+    #[test]
+    fn transpose_backfills_late_series_with_first_value() {
+        let mut buffer = VecDeque::new();
+        buffer.push_back(vec![1.0, 2.0]);
+        buffer.push_back(vec![1.0, 2.0]);
+        buffer.push_back(vec![1.0, 2.0, 3.0]);
+        let cols = transpose_window(&buffer);
+        assert_eq!(
+            cols,
+            vec![
+                vec![1.0, 1.0, 1.0],
+                vec![2.0, 2.0, 2.0],
+                vec![3.0, 3.0, 3.0],
+            ]
+        );
+    }
+
+    /// A short sample forward-fills each missing series from its previous value.
+    #[test]
+    fn transpose_forward_fills_short_samples() {
+        let mut buffer = VecDeque::new();
+        buffer.push_back(vec![1.0, 2.0]);
+        buffer.push_back(vec![5.0]);
+        let cols = transpose_window(&buffer);
+        assert_eq!(cols, vec![vec![1.0, 5.0], vec![2.0, 2.0]]);
+    }
+}

--- a/wingfoil-next/src/adapters/mod.rs
+++ b/wingfoil-next/src/adapters/mod.rs
@@ -13,7 +13,12 @@
 //!   demonstration of an I/O edge in both directions.
 //! - [`csv`] — a serde-typed CSV file adapter (historical replay source + file
 //!   sink) behind the `csv` feature, the parsing cousin of [`lines`].
+//! - [`augurs`] — on-graph time-series analysis (forecasting + outlier
+//!   detection) over sliding windows, behind the `augurs` feature. A pure-Rust
+//!   compute adapter (no service), so it is transform ops, not a source/sink.
 
+#[cfg(feature = "augurs")]
+pub mod augurs;
 #[cfg(feature = "csv")]
 pub mod csv;
 pub mod lines;

--- a/wingfoil-next/tests/augurs_adapter.rs
+++ b/wingfoil-next/tests/augurs_adapter.rs
@@ -1,0 +1,239 @@
+//! augurs adapter parity tests — ports the classic
+//! `wingfoil::adapters::augurs` forecast + outlier unit tests to the
+//! wingfoil-next Op-pattern engine. augurs models are deterministic given their
+//! input (AutoETS/MSTL are optimizers with no RNG; MAD/DBSCAN are deterministic
+//! detectors), so the same known input series yields the same output on every
+//! run — the assertions match the classic ones (thresholds on the forecast /
+//! flagged-series, not brittle bit-exact values). Everything runs in historical
+//! mode for reproducibility.
+
+#![cfg(feature = "augurs")]
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::augurs::{
+    AugursForecastConfig, AugursForecastOps, AugursOutlierConfig, AugursOutlierOps,
+};
+use wingfoil_next::prelude::*;
+
+// -------------------------------------------------------------------------
+// Forecasting.
+// -------------------------------------------------------------------------
+
+/// Classic `forecast_ramp_predicts_ahead`: a clean upward ramp with mild
+/// seasonality forecasts values above the last observed point, and the
+/// prediction intervals bracket the point forecast.
+#[test]
+fn forecast_ramp_predicts_ahead() {
+    let g = GraphBuilder::new();
+    let source = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| n as f64 + (n as f64 * 0.5).sin());
+    let forecast = source.augurs_forecast(AugursForecastConfig::new(48, 3).with_level(0.9));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+        .unwrap();
+
+    let last = r.value(&forecast);
+    assert_eq!(last.point.len(), 3, "horizon == 3 point forecasts");
+    assert_eq!(last.lower.len(), 3);
+    assert_eq!(last.upper.len(), 3);
+    // The ramp is still rising, so the next forecast should exceed ~30.
+    assert!(
+        last.next().unwrap() > 30.0,
+        "expected forecast to continue the ramp, got {:?}",
+        last.point
+    );
+    // Intervals must bracket the point forecast.
+    for i in 0..3 {
+        assert!(last.lower[i] <= last.point[i]);
+        assert!(last.upper[i] >= last.point[i]);
+    }
+}
+
+/// Classic `forecast_waits_for_min_points`: the node stays silent until
+/// `min_points` have arrived.
+#[test]
+fn forecast_waits_for_min_points() {
+    let g = GraphBuilder::new();
+    let source = g.ticker(Duration::from_secs(1)).count().map(|&n| n as f64);
+    let forecast = source.augurs_forecast(AugursForecastConfig::new(64, 1).with_min_points(20));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(15))
+        .unwrap();
+    // 15 cycles < 20 min_points → never ticked, slot holds the default.
+    assert!(r.value(&forecast).point.is_empty());
+}
+
+/// Classic `forecast_mstl_captures_season`: MSTL with a seasonal period
+/// reproduces the seasonal swing rather than a flat line.
+#[test]
+fn forecast_mstl_captures_season() {
+    let g = GraphBuilder::new();
+    // Period-12 sine wave riding on a gentle ramp.
+    let source = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let t = n as f64;
+        0.1 * t + 5.0 * (t * std::f64::consts::TAU / 12.0).sin()
+    });
+    let forecast = source.augurs_forecast(AugursForecastConfig::new(120, 12).mstl(vec![12]));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(80))
+        .unwrap();
+
+    let last = r.value(&forecast);
+    assert_eq!(last.point.len(), 12, "horizon == 12 point forecasts");
+    // A seasonal forecast should swing by a meaningful fraction of the
+    // amplitude (10.0 peak-to-peak).
+    let max = last.point.iter().cloned().fold(f64::MIN, f64::max);
+    let min = last.point.iter().cloned().fold(f64::MAX, f64::min);
+    assert!(
+        max - min > 2.0,
+        "expected a seasonal swing, got range {:.3} for {:?}",
+        max - min,
+        last.point
+    );
+}
+
+/// Classic `forecast_window_below_floor_still_emits`: a `window` smaller than
+/// the model's warm-up floor still warms up and emits.
+#[test]
+fn forecast_window_below_floor_still_emits() {
+    let g = GraphBuilder::new();
+    let source = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| n as f64 + (n as f64 * 0.5).sin());
+    // window 10 is below the ETS floor of 12.
+    let forecast = source.augurs_forecast(AugursForecastConfig::new(10, 2));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+        .unwrap();
+    assert_eq!(
+        r.value(&forecast).point.len(),
+        2,
+        "should emit despite window < floor"
+    );
+}
+
+/// Classic `forecast_mstl_rejects_invalid_period`: an MSTL period below 2 is
+/// rejected with a clear error at run time.
+#[test]
+fn forecast_mstl_rejects_invalid_period() {
+    let g = GraphBuilder::new();
+    let source = g.ticker(Duration::from_secs(1)).count().map(|&n| n as f64);
+    let _forecast = source.augurs_forecast(AugursForecastConfig::new(64, 2).mstl(vec![1]));
+    let mut r = g.build();
+    let result = r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30));
+    let err = result.expect_err("period < 2 should fail the run");
+    assert!(
+        format!("{err:#}").contains("MSTL periods"),
+        "expected a clear MSTL period error, got {err:#}"
+    );
+}
+
+/// Classic `forecast_accepts_tuple_config`: `(window, horizon)` tuples convert
+/// into a config.
+#[test]
+fn forecast_accepts_tuple_config() {
+    let g = GraphBuilder::new();
+    let source = g.ticker(Duration::from_secs(1)).count().map(|&n| n as f64);
+    let forecast = source.augurs_forecast((32, 2));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+        .unwrap();
+    assert_eq!(r.value(&forecast).point.len(), 2);
+}
+
+// -------------------------------------------------------------------------
+// Outlier detection.
+// -------------------------------------------------------------------------
+
+/// Classic `outlier_mad_flags_diverging_series`: three series move together
+/// except one, which jumps away part-way through — flagged by MAD.
+#[test]
+fn outlier_mad_flags_diverging_series() {
+    let g = GraphBuilder::new();
+    // Per tick: [series0, series1, series2]. Series 2 spikes after a while.
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let base = 100.0 + (n as f64 * 0.4).sin();
+        let series2 = if n > 20 { base + 80.0 } else { base + 0.2 };
+        vec![base, base + 0.1, series2]
+    });
+    let outliers = readings.augurs_outlier(AugursOutlierConfig::new(40, 0.5));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+        .unwrap();
+
+    let last = r.value(&outliers);
+    assert_eq!(last.scores.len(), 3, "one score per series");
+    assert!(
+        last.is_outlier(2),
+        "series 2 diverged and should be flagged, got {last:?}"
+    );
+    assert!(!last.is_outlier(0));
+    assert!(!last.is_outlier(1));
+}
+
+/// Classic `outlier_dbscan_flags_diverging_series`: DBSCAN flags a series
+/// diverging from a cluster of similar series.
+#[test]
+fn outlier_dbscan_flags_diverging_series() {
+    let g = GraphBuilder::new();
+    // Four series: three cluster together, series 3 diverges.
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let base = 100.0 + (n as f64 * 0.4).sin();
+        let series3 = if n > 15 { base + 90.0 } else { base + 0.3 };
+        vec![base, base + 0.1, base - 0.1, series3]
+    });
+    let outliers = readings.augurs_outlier(AugursOutlierConfig::dbscan(40, 0.5));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+        .unwrap();
+
+    let last = r.value(&outliers);
+    assert_eq!(last.scores.len(), 4);
+    assert!(
+        last.is_outlier(3),
+        "series 3 diverged and should be flagged by DBSCAN, got {last:?}"
+    );
+}
+
+/// Classic `outlier_quiet_when_aligned`: with all series moving together,
+/// nothing is flagged.
+#[test]
+fn outlier_quiet_when_aligned() {
+    let g = GraphBuilder::new();
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let base = 50.0 + (n as f64 * 0.3).sin();
+        vec![base, base + 0.05, base - 0.05]
+    });
+    let outliers = readings.augurs_outlier((30, 0.5));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+        .unwrap();
+    let last = r.value(&outliers);
+    assert!(
+        last.outlying.is_empty(),
+        "aligned series should produce no outliers, got {last:?}"
+    );
+}
+
+/// Classic `outlier_waits_for_two_samples`: the node stays silent until it has
+/// at least two samples.
+#[test]
+fn outlier_waits_for_two_samples() {
+    let g = GraphBuilder::new();
+    let readings = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| vec![n as f64, n as f64 + 1.0]);
+    let outliers = readings.augurs_outlier((8, 0.5));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+        .unwrap();
+    // One cycle → fewer than two samples → never ticked, slot holds default.
+    let last = r.value(&outliers);
+    assert!(last.outlying.is_empty() && last.scores.is_empty());
+}


### PR DESCRIPTION
## Summary

Ports the classic `wingfoil::adapters::augurs` forecasting and outlier-detection ops to the **wingfoil-next** Op-pattern engine. augurs (grafana/augurs) is a pure-Rust time-series toolkit — no external service, no connection lifecycle — so the adapter is a set of on-graph **transform ops** that buffer a sliding window of an input stream and run the model on the graph thread each cycle. This is the same shape as the existing `stats` rolling-window ops, not a source/sink adapter.

## Ops ported

| Op | Input | Emits |
|---|---|---|
| `augurs_forecast` | `Stream<f64>` | `AugursForecast` (point + optional intervals); AutoETS or MSTL |
| `augurs_outlier` | `Stream<Vec<f64>>` | `AugursOutliers` (flagged series + latest scores); MAD or DBSCAN |

Both are single-active-input ops, so they use the `#[op(build = …)]` attribute to single-source the interpreted `Builder` wiring method (over `register_op1`), fronted by an opt-in extension trait (`AugursForecastOps` on `Stream<f64>`, `AugursOutlierOps` on `Stream<Vec<f64>>`). Kept out of the `prelude` and registered in `adapters/mod.rs` behind the feature gate, mirroring the `stats` / `lines` / `csv` layering. No `graph!`/compiled `OpKind` table changes are needed (adapter ops are interpreted-only, like the `rolling_*` stats ops).

Scope: the two ops named in the task. The classic adapter also has `changepoint`/`seasons`/`dtw`/`cluster`; those are not ported here and their augurs sub-features are omitted.

## Window / model mapping (faithful to classic)

- **Forecast** — same warm-up floors: ETS floored at 12 points; MSTL at `2·max_period + 1` (STL needs two full periods). A `window` below the floor grows to the floor so the node still warms up and emits. Same `AutoETS::non_seasonal()` fit and `MSTLModel::new(periods, AutoETSTrendModel)` config; MSTL periods `< 2` (or empty) are rejected with a clear run-time error. `min_points` / `horizon` / `level` / `(window, horizon)` tuple config all preserved.
- **Outlier** — same window-buffering, same `transpose_window` (forward-fill short samples, back-fill a late series with its own first value, never a fabricated `0.0`), same `≥ 2` samples gate, same MAD/DBSCAN dispatch and `outlying_series` / last-score outputs.
- **Deviation from classic (intentional):** the classic outlier operator builds the detector at wiring time and `panic!`s on an out-of-range sensitivity. Here detector construction moved into `cycle()` and surfaces an invalid sensitivity through `anyhow` (aborts the run on the first cycle with a clear message) instead of panicking. Construction is cheap and deterministic, so results on valid input are identical. No `.unwrap()` outside `#[cfg(test)]`.

## Feature gate

New `augurs` feature → `augurs = { version = "0.10.2", default-features = false, features = ["ets", "mstl", "outlier"], optional = true }` — pin mirrors the classic crate; only the three sub-features the two ported ops use are enabled (Prophet deliberately excluded — it needs a bundled Stan toolchain).

## Tests

`tests/augurs_adapter.rs` (gated `#[cfg(feature = "augurs")]`) ports the classic unit tests as historical-mode parity tests. augurs models are deterministic given their input (AutoETS/MSTL are optimizers with no RNG; MAD/DBSCAN are deterministic), so the same known input series yields the same output every run — assertions are the classic threshold-based checks (forecast continues the ramp, intervals bracket the point, MSTL swings, the diverging series is flagged, aligned series stay quiet, warm-up gating), not brittle bit-exact values. Two `transpose_window` unit tests live in the module.

## Verification

- `cargo fmt --all` — clean
- `cargo build -p wingfoil-next --features augurs` — ok
- `cargo build -p wingfoil-next` (default, no feature) — ok
- `cargo test -p wingfoil-next --features augurs` — 10 integration + 2 unit augurs tests pass (full suite green)
- `cargo clippy -p wingfoil-next --all-targets --features augurs -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_