### PR TITLE
Fix seroval critical advisory failing security.audit on next PRs

### DIFF
--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -73,6 +73,7 @@
   },
   "pnpm": {
     "overrides": {
+      "seroval": ">=1.5.3",
       "svelte": ">=5.55.7",
       "devalue": ">=5.8.1",
       "esbuild": ">=0.25.0",

--- a/wingfoil-js/pnpm-lock.yaml
+++ b/wingfoil-js/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  seroval: '>=1.5.3'
   svelte: '>=5.55.7'
   devalue: '>=5.8.1'
   esbuild: '>=0.25.0'
@@ -807,10 +808,10 @@ packages:
     resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
     engines: {node: '>=10'}
     peerDependencies:
-      seroval: ^1.0
+      seroval: '>=1.5.3'
 
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   siginfo@2.0.0:
@@ -1663,19 +1664,19 @@ snapshots:
 
   semver@7.8.5: {}
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
+  seroval-plugins@1.5.2(seroval@1.5.6):
     dependencies:
-      seroval: 1.5.2
+      seroval: 1.5.6
 
-  seroval@1.5.2: {}
+  seroval@1.5.6: {}
 
   siginfo@2.0.0: {}
 
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.6
+      seroval-plugins: 1.5.2(seroval@1.5.6)
 
   solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:


### PR DESCRIPTION
## Problem

The `security.audit` CI workflow (`.github/workflows/security-audit.yml`) runs `pnpm audit --audit-level moderate` in `wingfoil-js/` and has been **failing on every PR targeting `next`** with 1 CRITICAL advisory:

| Package | Vulnerable | Patched | Advisory |
|---------|-----------|---------|----------|
| `seroval` | `<=1.5.2` | `>=1.5.3` | [GHSA-mv8w-475r-vwqw](https://github.com/advisories/GHSA-mv8w-475r-vwqw) |

`seroval` is a **transitive** dependency — path `. > solid-js > seroval`, pulled in via the solid-js reactive binding in the `@wingfoil/client` package. It is **not a direct dependency** and is **unrelated to any Rust code or the port work**. It began failing CI when `security.audit` was recently enabled on the `next` branch, so this is a pre-existing red that blocks all `next` PRs.

## Fix

Minimal and targeted — a single pnpm override plus the regenerated lockfile, alongside the existing supply-chain overrides in `wingfoil-js/package.json`:

```json
"pnpm": {
  "overrides": {
    "seroval": ">=1.5.3",
    ...
  }
}
```

Regenerating `pnpm-lock.yaml` resolves **seroval 1.5.2 → 1.5.6** (patched). No other dependencies are touched.

## Verification

- `pnpm audit --audit-level moderate` (the exact CI command, run from `wingfoil-js/`) now reports **"No known vulnerabilities found"** and exits **0**.
- `pnpm install --frozen-lockfile` succeeds against the updated lockfile.
- The `tracing` test suite passes (15/15). The `burst`/`reconnect` suites fail only because they import the WASM module (`src/wasm/wingfoil_wasm.js`), which is a gitignored build artifact not generated in this environment (`pnpm build:wasm`); this is pre-existing and independent of the override.

## Supply-chain backlog

This is another transitive advisory resolved via a pinned pnpm override, consistent with the existing `svelte` / `devalue` / `esbuild` / `@babel/core` overrides in this package.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_