### PR TITLE
Fix npm Dependabot advisories (seroval + postcss) failing security-audit on next

### DIFF
--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -76,7 +76,10 @@
       "svelte": ">=5.55.7",
       "devalue": ">=5.8.1",
       "esbuild": ">=0.25.0",
-      "@babel/core": ">=7.29.6"
+      "@babel/core": ">=7.29.6",
+      "postcss": ">=8.5.18",
+      "seroval": ">=1.5.3",
+      "seroval-plugins": ">=1.5.3"
     }
   }
 }

--- a/wingfoil-js/pnpm-lock.yaml
+++ b/wingfoil-js/pnpm-lock.yaml
@@ -9,6 +9,9 @@ overrides:
   devalue: '>=5.8.1'
   esbuild: '>=0.25.0'
   '@babel/core': '>=7.29.6'
+  postcss: '>=8.5.18'
+  seroval: '>=1.5.3'
+  seroval-plugins: '>=1.5.3'
 
 importers:
 
@@ -803,14 +806,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  seroval-plugins@1.5.2:
-    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+  seroval-plugins@1.5.6:
+    resolution: {integrity: sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      seroval: ^1.0
+      seroval: '>=1.5.3'
 
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   siginfo@2.0.0:
@@ -1663,19 +1666,19 @@ snapshots:
 
   semver@7.8.5: {}
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
+  seroval-plugins@1.5.6(seroval@1.5.6):
     dependencies:
-      seroval: 1.5.2
+      seroval: 1.5.6
 
-  seroval@1.5.2: {}
+  seroval@1.5.6: {}
 
   siginfo@2.0.0: {}
 
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.6
+      seroval-plugins: 1.5.6(seroval@1.5.6)
 
   solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:


### PR DESCRIPTION
## Problem

The `security.audit` CI workflow (`.github/workflows/security-audit.yml`) runs `pnpm audit --audit-level moderate` in `wingfoil-js/` and has been failing on PRs targeting `next`. `pnpm audit` reports three transitive-dependency advisories in the committed lockfile:

| Package | Vulnerable | Patched | Severity | Advisory | Path |
|---------|-----------|---------|----------|----------|------|
| `seroval` | `<=1.5.2` | `>=1.5.3` | critical | [GHSA-mv8w-475r-vwqw](https://github.com/advisories/GHSA-mv8w-475r-vwqw) | `. > solid-js > seroval` |
| `postcss` | `<=8.5.11` | `>=8.5.12` | high | [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q) | `. > vite > postcss`, `. > vue > @vue/compiler-sfc > postcss` |
| `postcss` | `<=8.5.17` | `>=8.5.18` | high | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) | same |

All three are **transitive** dependencies — not direct deps and unrelated to any Rust code.

## Fix

Two pnpm overrides plus the regenerated lockfile, alongside the existing supply-chain overrides in `wingfoil-js/package.json`:

```json
"pnpm": {
  "overrides": {
    ...
    "postcss": ">=8.5.18",
    "seroval": ">=1.5.3",
    "seroval-plugins": ">=1.5.3"
  }
}
```

Regenerating `pnpm-lock.yaml` resolves `seroval` 1.5.2 → 1.5.6, `seroval-plugins` 1.5.2 → 1.5.6, and `postcss` 8.5.10 → 8.5.22 (all patched). No other dependencies are touched.

## Verification

- `pnpm audit --audit-level moderate` (the exact CI command, run from `wingfoil-js/`) now reports **"No known vulnerabilities found"** and exits 0.
- `pnpm install --lockfile-only` succeeds against the updated lockfile.

## Note

This supersedes #497, which fixed only the `seroval` advisory; this PR additionally clears the two `postcss` high-severity advisories. Consistent with the existing pinned `svelte` / `devalue` / `esbuild` / `@babel/core` overrides in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnTN64zGLz3fo8bXB36BX9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnTN64zGLz3fo8bXB36BX9)_