### PR TITLE
Fix type inference in tiers bench closures (unbreaks Build/Test/Lint on next)

### DIFF
--- a/wingfoil-next/benches/tiers.rs
+++ b/wingfoil-next/benches/tiers.rs
@@ -46,8 +46,8 @@ const STEP: Duration = Duration::from_nanos(100);
 wingfoil_next::graph! {
     fn dense_chain(g: &GraphBuilder) -> Stream<u64> {
         let src = g.ticker(STEP).count();
-        let chained = src.map_n(32, |i| std::hint::black_box(i.wrapping_add(1)));
-        let keep = chained.map(|i| i.is_multiple_of(2));
+        let chained = src.map_n(32, |i: &u64| std::hint::black_box(i.wrapping_add(1)));
+        let keep = chained.map(|i: &u64| i.is_multiple_of(2));
         let filtered = chained.filter(&keep);
         let sum = filtered.fold(0u64, |acc, v| *acc += v);
         sum


### PR DESCRIPTION
## Problem

`cargo clippy --all-targets` (equivalently `cargo bench --no-run`) fails on plain `origin/next` with a type-inference error, breaking the `test.rust` "Build, Test, & Lint" CI job branch-wide — every open PR against `next` goes red:

```
error[E0282]: type annotations needed for `&_`
  --> wingfoil-next/benches/tiers.rs:49:38
   |
49 |         let chained = src.map_n(32, |i| std::hint::black_box(i.wrapping_add(1)));
   |                                      ^                       - type must be known at this point
```

(A second identical error follows on line 50.)

The `map_n`/macro change on `next` removed the inference that let these closures compile without explicit parameter types when the bench merged (#493). `i.wrapping_add(1)` and `i.is_multiple_of(2)` are ambiguous across integer types, so the compiler can no longer infer the closure parameter.

## Fix

Annotate the two `dense_chain` closure parameters with their actual element type (`&u64`, since `src` is `g.ticker(STEP).count()` → `Stream<u64>`):

```rust
let chained = src.map_n(32, |i: &u64| std::hint::black_box(i.wrapping_add(1)));
let keep = chained.map(|i: &u64| i.is_multiple_of(2));
```

Two closures needed the annotation. The rest of the file (and the `include!`d `fanout_10x10.rs` wiring) already compiles — its `black_box(*i)` closures are identity passthroughs whose type flows from the `u64` source, so they were never ambiguous. Bench logic and reported numbers are unchanged — only closure parameter types were added.

## Verification

- `cargo clippy -p wingfoil-next --all-targets -- -D warnings` now exits 0.
- `cargo bench -p wingfoil-next --no-run` compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhAbF1xfre134JZ6wB7GEU)_