### PR TITLE
next: add augurs adapter example and run wingfoil-next tests in CI

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -75,6 +75,17 @@ jobs:
         env:
           RUST_LOG: INFO
 
+      - name: Run wingfoil-next tests
+        # The coverage run above is scoped to `-p wingfoil`, so the next-engine
+        # crate's tests — the adapter parity suites (lines/csv/augurs) and the
+        # trybuild cases — would otherwise never execute in CI. Run them here
+        # with all features so the feature-gated csv/augurs adapters are
+        # exercised. `--lib --tests` skips the example binaries (already
+        # compile-checked by the workspace clippy step below).
+        run: cargo test -p wingfoil-next --all-features --lib --tests
+        env:
+          RUST_LOG: INFO
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         continue-on-error: true

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -79,6 +79,10 @@ harness = false
 name = "csv_adapter"
 required-features = ["csv"]
 
+[[example]]
+name = "augurs_adapter"
+required-features = ["augurs"]
+
 # Ports of the classic `wingfoil/examples/` onto the next engine's fluent API.
 # Each lives in its own directory with a README, mirroring the classic layout.
 [[example]]

--- a/next/crates/wingfoil-next/examples/augurs_adapter.rs
+++ b/next/crates/wingfoil-next/examples/augurs_adapter.rs
@@ -1,0 +1,84 @@
+//! augurs adapter example — on-graph forecasting and outlier detection.
+//!
+//! Run with the `augurs` feature:
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --features augurs --example augurs_adapter
+//! ```
+//!
+//! augurs is a pure-Rust time-series toolkit, so there is no service to start.
+//! wingfoil-next currently ports two of the classic adapter's operators —
+//! forecasting and outlier detection. (Seasonality and changepoint detection
+//! remain classic-only for now; see `next/docs/port-plan.md`.) This example
+//! drives a synthetic stream through each op, on the graph clock:
+//!
+//! 1. a noisy upward ramp fed to `augurs_forecast`, printing the 5-step-ahead
+//!    forecast and its 90% prediction interval each tick; and
+//! 2. four monitored series — three moving together and one that diverges
+//!    half-way through — fed to `augurs_outlier`, printing which series the MAD
+//!    detector flags.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::augurs::{
+    AugursForecastConfig, AugursForecastOps, AugursOutlierConfig, AugursOutlierOps,
+};
+use wingfoil_next::prelude::*;
+
+fn forecasting() -> anyhow::Result<()> {
+    println!("== forecasting (ETS, 5 steps ahead, 90% interval) ==");
+
+    let g = GraphBuilder::new();
+
+    // A rising series with mild seasonality: n + sin(n/2).
+    let forecast = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| *n as f64 + (*n as f64 * 0.5).sin())
+        .augurs_forecast(AugursForecastConfig::new(48, 5).with_level(0.90));
+
+    let _sink = forecast.with_time().for_each(|(time, forecast)| {
+        let point: Vec<String> = forecast.point.iter().map(|v| format!("{v:.1}")).collect();
+        println!("  {time}  next 5: [{}]", point.join(", "));
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(36))?;
+    Ok(())
+}
+
+fn outlier_detection() -> anyhow::Result<()> {
+    println!("\n== outlier detection (MAD over 4 series) ==");
+
+    let g = GraphBuilder::new();
+
+    // Per tick: four readings. Series 3 jumps away from the pack after tick 20.
+    let outliers = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| {
+            let base = 100.0 + (*n as f64 * 0.4).sin();
+            let diverging = if *n > 20 { base + 75.0 } else { base + 0.3 };
+            vec![base, base + 0.1, base - 0.1, diverging]
+        })
+        .augurs_outlier(AugursOutlierConfig::new(40, 0.5));
+
+    let _sink = outliers.with_time().for_each(|(time, outliers)| {
+        if !outliers.outlying.is_empty() {
+            println!("  {time}  outlying series: {:?}", outliers.outlying);
+        }
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(36))?;
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    forecasting()?;
+    outlier_detection()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

A compliance review of the **wingfoil-next** I/O adapters (`lines`, `csv`, `augurs`) against the `new-adapter-next` skill. Under that skill's rules the three adapters are compliant on nearly everything — the `src/adapters/mod.rs` doc list is the adapters index, per-adapter `CLAUDE.md` isn't required, and file/compute adapters need no integration CI. Two real gaps remained, fixed here.

## Changes

### 1. `augurs` was missing its example (skill step 11)
The classic `wingfoil` tree ships an `augurs` example; step 11 requires porting it. Added `next/crates/wingfoil-next/examples/augurs_adapter.rs`, registered with `required-features = ["augurs"]`.

- Ports the classic example's forecasting + outlier-detection demos, built strictly on the next fluent API (`g.ticker().count().map().augurs_forecast(...)`, `.with_time().for_each(...)`).
- Restricted to the two ops next currently ships — seasonality/changepoint remain classic-only, matching the next adapter's documented op surface.
- Verified it runs: the forecast tracks the rising ramp and the MAD detector flags series 3 exactly after tick 20.

### 2. `wingfoil-next` tests never ran in CI
`rust-test.yml`'s coverage job is scoped to `-p wingfoil`, so the next crate's adapter parity suites (`lines`/`csv`/`augurs`) and trybuild cases were only linted (via the `--workspace` clippy step), never executed. Added a `Run wingfoil-next tests` step running `cargo test -p wingfoil-next --all-features --lib --tests` on every push/PR.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo test -p wingfoil-next --all-features --lib --tests` — all binaries `0 failed`, trybuild green
- `cargo clippy -p wingfoil-next --all-features --all-targets -- -D warnings` — clean
- `cargo run -p wingfoil-next --features augurs --example augurs_adapter` — expected output

## Not included

- **Python bindings** — the `new-adapter-next` skill (step 12) defers next bindings to the facade/cutover phase (`next/docs/port-plan.md`, Phase 6); `wingfoil-python` binds the legacy crate only. Not added here by design.
- **`port-plan.md` per-adapter status** — the Phase 4 list has no per-adapter checkbox convention yet (`csv`/`lines` aren't marked done either), so I left it rather than reshape a planning doc mid-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJpExofKyQ9cPsvpNw58on

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJpExofKyQ9cPsvpNw58on)_