### PR TITLE
Document next/ branching workflow and conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance for Claude Code when working with this codebase.
 
+> **Working under `next/`? Read [`next/CLAUDE.md`](next/CLAUDE.md) first.**
+> Wingfoil Next is the Op-pattern engine we are building in the `next/`
+> folder to stage the replacement for the legacy tree — when it is ready we
+> swap it in wholesale. All of that work has its own conventions and, most
+> importantly, a **different branching workflow: branches are cut from and
+> pull requests merge into the `next` branch, never `main`** (see
+> [next/CLAUDE.md](next/CLAUDE.md#branching-all-next-work-merges-into-next-not-main)).
+> This root file still applies (error-handling policy, pre-commit checklist,
+> etc.); `next/CLAUDE.md` adds and overrides on top of it.
+
 ## Project Overview
 
 Wingfoil is a Rust stream processing library for building directed acyclic graphs (DAGs) of data transformations. It supports both real-time and historical (backtesting) execution modes.

--- a/next/CLAUDE.md
+++ b/next/CLAUDE.md
@@ -55,10 +55,22 @@ legacy capability, example, or test case.
 
 ## Branching: all next work merges into `next`, not `main`
 
-Cut branches from the `next` branch (`git checkout next && git pull origin
-next && git checkout -b <branch-name>`) and open pull requests with **base
-`next`** — never `main`. `main` only receives the eventual next→main
-cutover/sync PRs.
+Everything under `next/` is built up on the long-lived **`next` branch** to
+stage the replacement engine in one place; when it reaches parity we swap it
+in for the legacy tree wholesale. Until that cutover, `next` is the
+integration branch for all next work — treat it the way you would treat
+`main` for legacy work.
+
+So the workflow for any change under `next/` is:
+
+1. Cut a feature branch **from `next`**:
+   `git checkout next && git pull origin next && git checkout -b <branch-name>`.
+2. Do the work, commit, and push the feature branch.
+3. Open a pull request with **base `next`** — never `main`. The PR merges the
+   feature branch back into `next`.
+
+`main` only ever receives the eventual next→main cutover/sync PRs; no
+day-to-day next work targets `main`.
 
 ## Working conventions
 


### PR DESCRIPTION
## Summary

Add guidance to both root and `next/` CLAUDE.md files to clarify the branching workflow and conventions for work under the `next/` folder, where the Op-pattern replacement engine is being staged.

## Changes

- **`next/CLAUDE.md`**: Expanded the "Branching" section with a clearer explanation of the `next` branch as the integration point for all next-generation work, and detailed step-by-step workflow instructions (cut from `next`, open PRs with base `next`, never target `main`).
- **`CLAUDE.md`**: Added a prominent notice at the top directing developers working under `next/` to read `next/CLAUDE.md` first, explaining the different branching model and that `next/CLAUDE.md` adds to and overrides the root conventions.

## Rationale

The `next/` folder contains a wholesale replacement engine that will eventually swap in for the legacy tree. This requires a different branching strategy than the legacy codebase — all work integrates into the long-lived `next` branch rather than `main`. The updated documentation makes this clear upfront and provides explicit, step-by-step instructions to prevent accidental PRs against `main`.

https://claude.ai/code/session_01ScPRdWcpp2viVRhrdzhgBN