### PR TITLE
next: sync port plan with landed dirty-list; freeze slot boundary (SlotRef) + baseline bench

### DIFF
--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -75,6 +75,10 @@ harness = false
 name = "custom_op"
 harness = false
 
+[[bench]]
+name = "store_baseline"
+harness = false
+
 [[example]]
 name = "csv_adapter"
 required-features = ["csv"]

--- a/next/crates/wingfoil-next/benches/store_baseline.rs
+++ b/next/crates/wingfoil-next/benches/store_baseline.rs
@@ -1,0 +1,145 @@
+//! Pre-arena baseline: the two measurements the arena / SoA value-store
+//! decision hinges on (see `next/docs/port-plan.md`, Phase 4.5).
+//!
+//! The arena is a deferred perf follow-on. Before committing to it, we want the
+//! go/no-go driven by numbers, not the ~1.1–1.5× estimate. This suite
+//! establishes the interpreted-engine baseline so a future arena PR can show
+//! its delta against these same graphs.
+//!
+//! Two workloads, each targeting a distinct question:
+//!
+//! 1. `sparse_dispatch` — the standing gate for the *already-landed* dirty-list
+//!    scheduler: per-cycle work must track the *active* node count, not the
+//!    graph size `N`. A tiny hot chain (fires every cycle) sits in a graph
+//!    padded with many cold branches (slow tickers that almost never fire).
+//!    `Dispatch::Sparse` (default) should be roughly flat as the cold padding
+//!    grows; `Dispatch::FullSweep` (the retained `O(N)` oracle) should scale
+//!    with it. The arena does *not* change this relationship — it's here as the
+//!    perf-parity gate the plan owes, and as the sparse baseline.
+//!
+//! 2. `forward_clone` — the ceiling on what the arena + zero-copy passthrough
+//!    could recover. A large payload is forwarded through a chain of `filter`
+//!    hops; each hop republishes its input by **clone** today. Running the
+//!    identical graph with a `Vec<u64>` payload (a deep 8 KiB memcpy per hop)
+//!    versus an `Rc<Vec<u64>>` payload (a refcount bump per hop) brackets the
+//!    cost: the `Vec` − `Rc<Vec>` gap is the clone tax that slot-aliasing would
+//!    remove. If that gap is small, the aliasing work isn't worth it; if it's
+//!    large, it is. Neither payload changes the result — only the copy cost.
+
+use std::hint::black_box;
+use std::rc::Rc;
+use std::time::Duration;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::interp::Dispatch;
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const STEP: Duration = Duration::from_nanos(100);
+/// Cold-branch tickers fire this many times slower than the hot chain, so over
+/// a bounded run they effectively never fire — they only pad the node count.
+const COLD_STEP: Duration = Duration::from_millis(100);
+
+// --- Workload 1: sparse dispatch — work should track active nodes, not N ----
+
+/// One hot chain that fires every cycle, plus `cold` branches hung off slow
+/// tickers that almost never fire. Returns the built runner and the hot output;
+/// `dispatch` selects the sparse dirty-list (default) or the full-sweep oracle.
+fn run_sparse(cold: usize, cycles: u32, dispatch: Dispatch) {
+    let g = GraphBuilder::new();
+
+    // Hot path: fires every cycle (~8 active nodes).
+    let mut hot = g.ticker(STEP).count();
+    for _ in 0..6 {
+        hot = hot.map(|i: &u64| black_box(i.wrapping_add(1)));
+    }
+    let out = hot.fold(0u64, |acc, v| *acc = acc.wrapping_add(*v));
+
+    // Cold padding: present in the graph (so FullSweep scans them) but seeded
+    // only when due (so Sparse skips them) — the whole point of the contrast.
+    for _ in 0..cold {
+        let mut branch = g.ticker(COLD_STEP).count();
+        for _ in 0..3 {
+            branch = branch.map(|i: &u64| black_box(i.wrapping_add(1)));
+        }
+        black_box(&branch);
+    }
+
+    let mut runner = g.build().with_dispatch(dispatch);
+    runner.run(HISTORICAL, RunFor::Cycles(cycles)).unwrap();
+    black_box(runner.value(&out));
+}
+
+fn sparse_dispatch(c: &mut Criterion) {
+    const CYCLES: u32 = 20_000;
+    const COLD: usize = 256; // ~256*4 = 1024 cold nodes padding an ~8-node hot path
+
+    let mut g = c.benchmark_group("sparse_dispatch");
+    g.sample_size(20);
+    g.throughput(Throughput::Elements(CYCLES as u64));
+
+    // Default engine: work ∝ active nodes — should be near-flat vs the padding.
+    g.bench_function("sparse", |b| {
+        b.iter(|| run_sparse(COLD, CYCLES, Dispatch::Sparse))
+    });
+    // Retained O(N) oracle: work ∝ N — should pay for every cold node each cycle.
+    g.bench_function("full_sweep", |b| {
+        b.iter(|| run_sparse(COLD, CYCLES, Dispatch::FullSweep))
+    });
+
+    g.finish();
+}
+
+// --- Workload 2: large-payload forwarding clone — the aliasing ceiling -------
+
+const VEC_LEN: usize = 1024; // 8 KiB per payload
+const HOPS: usize = 16; // forwarding filters, one clone each per cycle
+const FWD_CYCLES: u32 = 5_000;
+
+fn forward_clone(c: &mut Criterion) {
+    let mut g = c.benchmark_group("forward_clone");
+    g.sample_size(20);
+    // Throughput = clones performed on the forwarding path (cycles * hops).
+    g.throughput(Throughput::Elements(FWD_CYCLES as u64 * HOPS as u64));
+
+    // Owned Vec payload: each filter hop deep-copies the whole vector.
+    g.bench_function("vec", |b| {
+        b.iter(|| {
+            let g = GraphBuilder::new();
+            let src = g.ticker(STEP).count();
+            let keep = src.map(|_: &u64| true);
+            let mut cur = src.map(|i: &u64| vec![*i; VEC_LEN]);
+            for _ in 0..HOPS {
+                cur = cur.filter(&keep);
+            }
+            let out = cur.fold(0u64, |acc, v| *acc = acc.wrapping_add(v.len() as u64));
+            let mut runner = g.build();
+            runner.run(HISTORICAL, RunFor::Cycles(FWD_CYCLES)).unwrap();
+            black_box(runner.value(&out));
+        })
+    });
+
+    // Rc<Vec> payload: identical graph, but each hop's clone is a refcount bump.
+    // The vec − rc gap is the clone tax slot-aliasing would eliminate.
+    g.bench_function("rc_vec", |b| {
+        b.iter(|| {
+            let g = GraphBuilder::new();
+            let src = g.ticker(STEP).count();
+            let keep = src.map(|_: &u64| true);
+            let mut cur = src.map(|i: &u64| Rc::new(vec![*i; VEC_LEN]));
+            for _ in 0..HOPS {
+                cur = cur.filter(&keep);
+            }
+            let out = cur.fold(0u64, |acc, v| *acc = acc.wrapping_add(v.len() as u64));
+            let mut runner = g.build();
+            runner.run(HISTORICAL, RunFor::Cycles(FWD_CYCLES)).unwrap();
+            black_box(runner.value(&out));
+        })
+    });
+
+    g.finish();
+}
+
+criterion_group!(benches, sparse_dispatch, forward_clone);
+criterion_main!(benches);

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -31,7 +31,7 @@ use wingfoil::NanoTime;
 
 use crate::Burst;
 use crate::channel::ChannelSender;
-use crate::interp::{AsHandle, Builder, ExternalSource, FeedbackSink, Handle, Runner};
+use crate::interp::{AsHandle, Builder, ExternalSource, FeedbackSink, Handle, Runner, SlotRef};
 
 /// A graph under construction. Cheap to clone; all clones share the same
 /// underlying builder.
@@ -282,9 +282,11 @@ impl<T> Stream<T> {
     }
 
     /// The shared value slot backing this stream. Used by the `graph!`
-    /// macro's `nested` expansion to read composite inputs.
+    /// macro's `nested` expansion to read composite inputs. Returns a
+    /// [`SlotRef`] — the frozen access boundary — not the concrete cell, so the
+    /// value store can move to an arena later without changing this hook.
     #[doc(hidden)]
-    pub fn __slot(&self) -> Rc<RefCell<T>>
+    pub fn __slot(&self) -> SlotRef<T>
     where
         T: 'static,
     {

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -23,15 +23,18 @@
 //! full-index sweep it replaces), but per-cycle work is proportional to the
 //! nodes that actually fire, not the graph size `N`.
 //!
-//! Value slots are individual `Rc<RefCell<T>>`s; the arena/SoA store is a
-//! deliberately separate follow-on (the slot boundary is frozen here so the
-//! catalog and adapter ports are not touched twice — see the Phase 4.5
-//! coupling note in the port plan). `run` is fallible — it returns the first
+//! Value slots are reached only through [`SlotRef<T>`] — the frozen access
+//! boundary between ops and the value store. Each `SlotRef` wraps an individual
+//! `Rc<RefCell<T>>` today, but ops only `borrow()`/`borrow_mut()` it, never the
+//! concrete cell, so the store can move to a contiguous arena/SoA later as an
+//! internal swap without touching a single capture site (the Phase 4.5
+//! "freeze the slot boundary" mitigation, made *by type* not just convention;
+//! see the port plan). `run` is fallible — it returns the first
 //! `start`/`cycle`/`stop`/`teardown` error (with node context) and still runs
 //! cleanup afterwards, matching the classic engine.
 
 use std::any::Any;
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, VecDeque};
 use std::fmt::Debug;
@@ -110,6 +113,58 @@ impl Builder {
             builder_id: self.id,
             _t: PhantomData,
         }
+    }
+}
+
+/// The frozen access boundary between an op and the value store.
+///
+/// Every op registration closure reads and writes its slots **only** through a
+/// `SlotRef` — `borrow()` for a shared read of the current value, `borrow_mut()`
+/// for the write — never through the concrete backing cell. Today a `SlotRef`
+/// wraps one `Rc<RefCell<T>>`, but because no capture site names that type, the
+/// store can move to a contiguous arena / structure-of-arrays later (Phase 4.5)
+/// as an internal swap of this struct's innards, without touching a single
+/// registration or emission path. This is the "freeze the slot API boundary"
+/// mitigation from the port plan, made *by type* rather than by convention.
+///
+/// Cheap to clone (clones the underlying handle), so a `move` cycle closure
+/// captures its own `SlotRef` by value, exactly as it captured an `Rc` before.
+///
+/// `pub` + `#[doc(hidden)]` (like [`Stream::__slot`](crate::fluent::Stream::__slot)
+/// and the other codegen hooks): the `graph!` macro's `nested` expansion, which
+/// lands in downstream crates, reads island inputs through `SlotRef::borrow`.
+#[doc(hidden)]
+pub struct SlotRef<T> {
+    cell: Rc<RefCell<T>>,
+}
+
+// Hand-written `Clone` (not `#[derive]`) for the same reason as `Handle`: a
+// `SlotRef` shares a handle to storage, so it is cloneable for *every* `T`,
+// with no spurious `T: Clone` bound.
+impl<T> Clone for SlotRef<T> {
+    fn clone(&self) -> Self {
+        Self {
+            cell: self.cell.clone(),
+        }
+    }
+}
+
+impl<T> SlotRef<T> {
+    fn new(cell: Rc<RefCell<T>>) -> Self {
+        Self { cell }
+    }
+
+    /// Shared read of the slot's current value. `pub` (doc-hidden) because the
+    /// `graph!` `nested` expansion calls it from downstream crates.
+    #[doc(hidden)]
+    pub fn borrow(&self) -> Ref<'_, T> {
+        self.cell.borrow()
+    }
+
+    /// Exclusive write access to the slot. Crate-internal — only op
+    /// registration writes a slot; downstream codegen only ever reads.
+    pub(crate) fn borrow_mut(&self) -> RefMut<'_, T> {
+        self.cell.borrow_mut()
     }
 }
 
@@ -471,21 +526,23 @@ impl Builder {
         (self.make_handle(idx), sender)
     }
 
-    pub(crate) fn slot<T: 'static>(&self, h: Handle<T>) -> Rc<RefCell<T>> {
+    pub(crate) fn slot<T: 'static>(&self, h: Handle<T>) -> SlotRef<T> {
         debug_assert_eq!(
             h.builder_id, self.id,
             "Handle used with a different Builder than the one that minted it"
         );
-        self.slots[h.idx]
-            .clone()
-            .downcast::<RefCell<T>>()
-            .expect("invariant: Handle<T> indexes a slot of type T")
+        SlotRef::new(
+            self.slots[h.idx]
+                .clone()
+                .downcast::<RefCell<T>>()
+                .expect("invariant: Handle<T> indexes a slot of type T"),
+        )
     }
 
-    fn new_slot<T: 'static>(&mut self, init: T) -> Rc<RefCell<T>> {
-        let slot = Rc::new(RefCell::new(init));
-        self.slots.push(slot.clone() as Rc<dyn Any>);
-        slot
+    fn new_slot<T: 'static>(&mut self, init: T) -> SlotRef<T> {
+        let cell = Rc::new(RefCell::new(init));
+        self.slots.push(cell.clone() as Rc<dyn Any>);
+        SlotRef::new(cell)
     }
 
     /// Register a node: its slot must already have been pushed (so slot and

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -4,8 +4,9 @@ Status: **porting in progress** — the Phase 0 contract spikes have landed and
 several later phases are underway (see the ✅/🟡 markers throughout the body).
 The `wingfoil-next` and `wingfoil-next-macros` crates now live on this branch
 (with tests and lints passing) and implement the target pattern: `Op` trait
-(pure semantics, engine-owned state), an
-interpreted engine, a fully monomorphized `compiled()` expansion, compiled
+(pure semantics, engine-owned state), a sparse dirty-list
+interpreted engine (Phase 4.5 scheduling landed), a fully monomorphized
+`compiled()` expansion, compiled
 islands (`nested()`) mountable in interpreted graphs, busy-spin `poll`
 sources, and the `graph!` macro deriving all of it from one fluent wiring
 function. This document plans the port of the entire classic codebase onto
@@ -38,31 +39,36 @@ What each execution path supports, per wingfoil pattern. Legend: ✅ works ·
 🟡 partial · 📅 planned · ❌ not supported **by design** (not a missing
 feature — the path's value depends on the constraint).
 
-Classic is the reference the next engine converges toward: the two
-interpreted columns aim to *match* it, while compiled/island add new fast
+Classic is the reference the next engine converges toward: the interpreted
+engine aims to *match* it, while compiled/island add new fast
 paths that trade generality for speed (the ❌s are by-design, not gaps).
 
-| Pattern / capability | Classic wingfoil | Interpreted (today) | Interpreted + dirty-list (4.5) | Compiled | Island |
-|---|:--:|:--:|:--:|:--:|:--:|
-| Static DAG (map/filter/fold/sample/merge/join/…) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Shared nodes / fan-out | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Split + glitch-free recombine (single-fire) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Delay & self-scheduling (`SCHEDULES`) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Feedback / cycles | ✅ | ✅¹ | ✅ | ❌ | ❌ |
-| Busy-poll ingest (`ALWAYS`) | ✅ | ✅ | ✅ | ❌ | ❌ |
-| External / channel / async sources (`THREADED`) | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Bursts (never latest-wins) | ✅ | ✅ | ✅ | ❌² | ❌² |
-| Historical replay | ✅ | ✅ | ✅ | ✅³ | ✅ |
-| Realtime | ✅ | ✅ | ✅ | 🟡³ | ✅ |
-| Fallible ops / error propagation | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Lifecycle start/stop/teardown | ✅ | ✅ | ✅ | 🟡⁴ | 🟡⁴ |
-| Observe arbitrary intermediate streams | ✅ | ✅ | ✅ | ❌⁵ | ❌⁵ |
-| Runtime-valued config (params/captures from caller) | ✅ | ✅ | ✅ | ❌⁶ | ❌⁶ |
-| Mutable per-node state | ✅⁷ | ✅⁷ | ✅⁷ | ✅⁷ | ✅⁷ |
-| Re-run (independent repeated runs) | ✅⁸ | ❌⁸ | 📅⁸ | ✅⁹ | ✅⁹ |
-| Dynamic graph (runtime add/remove) | ✅ | ❌ | 📅 | ❌ | 🟡¹⁰ |
-| Sparse-graph efficiency (work ∝ *active* nodes) | ✅¹¹ | ❌¹² | ✅ | 🟡¹³ | ✅¹⁴ |
-| Dense hot-path speed (measured) | 1× | 1× | ~1× | 3–4×¹⁵ | interior 3–4×¹⁵ |
+The two former interpreted columns ("today" vs "+ dirty-list (4.5)") have
+collapsed into one: the **sparse dirty-list scheduler has landed** as the
+default interpreted dispatch (see Phase 4.5), so what was the 4.5 column *is*
+today's interpreted engine.
+
+| Pattern / capability | Classic wingfoil | Interpreted | Compiled | Island |
+|---|:--:|:--:|:--:|:--:|
+| Static DAG (map/filter/fold/sample/merge/join/…) | ✅ | ✅ | ✅ | ✅ |
+| Shared nodes / fan-out | ✅ | ✅ | ✅ | ✅ |
+| Split + glitch-free recombine (single-fire) | ✅ | ✅ | ✅ | ✅ |
+| Delay & self-scheduling (`SCHEDULES`) | ✅ | ✅ | ✅ | ✅ |
+| Feedback / cycles | ✅ | ✅¹ | ❌ | ❌ |
+| Busy-poll ingest (`ALWAYS`) | ✅ | ✅ | ❌ | ❌ |
+| External / channel / async sources (`THREADED`) | ✅ | ✅ | ❌ | ❌ |
+| Bursts (never latest-wins) | ✅ | ✅ | ❌² | ❌² |
+| Historical replay | ✅ | ✅ | ✅³ | ✅ |
+| Realtime | ✅ | ✅ | 🟡³ | ✅ |
+| Fallible ops / error propagation | ✅ | ✅ | ✅ | ✅ |
+| Lifecycle start/stop/teardown | ✅ | ✅ | 🟡⁴ | 🟡⁴ |
+| Observe arbitrary intermediate streams | ✅ | ✅ | ❌⁵ | ❌⁵ |
+| Runtime-valued config (params/captures from caller) | ✅ | ✅ | ❌⁶ | ❌⁶ |
+| Mutable per-node state | ✅⁷ | ✅⁷ | ✅⁷ | ✅⁷ |
+| Re-run (independent repeated runs) | ✅⁸ | ❌⁸ | ✅⁹ | ✅⁹ |
+| Dynamic graph (runtime add/remove) | ✅ | 📅¹⁰ | ❌ | 🟡¹⁰ |
+| Sparse-graph efficiency (work ∝ *active* nodes) | ✅¹¹ | ✅¹² | 🟡¹³ | ✅¹⁴ |
+| Dense hot-path speed (measured) | 1× | ~1×¹² | 3–4×¹⁵ | interior 3–4×¹⁵ |
 
 ¹ Fluent layer only (engine-level `+1` edge); not expressible inside `graph!`.
 ² No burst *sources* exist in the macro vocabulary; the pattern is about IO
@@ -85,12 +91,18 @@ paths that trade generality for speed (the ❌s are by-design, not gaps).
   `setup`. next's v1 Runner is single-run (spike 0.4); matching classic's
   re-run needs the per-node reset hook (planned).
 ⁹ `compiled()` is a plain fn — each call is a fresh independent run.
-¹⁰ Island interior is fixed at compile time, but the island *itself* can be
-  wired dynamically into the interpreted graph once 4.5 lands.
+¹⁰ The sparse dirty-list engine — the mutable-frontier *enabler* for runtime
+  add/remove — has landed, but graph *mutation* itself (`Runner::extend`) is
+  not yet built (📅). The compiled/island interior stays fixed by design, but
+  an island can be wired dynamically into the interpreted graph.
 ¹¹ Classic propagates breadth-first through a dirty-list (work ∝ active
   nodes) — though it still carries an `O(N)` per-cycle reset/scan floor the
-  4.5 arena rework can also improve on.
-¹² `O(N)` topological sweep every cycle — the Phase 4.5 gap.
+  deferred 4.5 arena rework can also improve on.
+¹² Sparse dirty-list dispatch (classic's `dirty_nodes_by_layer` model) has
+  landed as the default: per-cycle work ∝ active nodes, results byte-identical
+  to classic and to the old full sweep (retained as `Dispatch::FullSweep`, an
+  executable oracle). The arena/SoA value store — the remaining dense-path
+  speedup — is a deferred follow-on with the slot boundary frozen (Phase 4.5).
 ¹³ Straight-line per-node `if cond` checks (cheap, but every node); region
   gating (skip quiet sub-graphs) is the planned compiled counterpart.
 ¹⁴ A quiet island isn't cycled — islands already give coarse region gating.
@@ -403,83 +415,78 @@ untouched (still shipping) until Phase 7.
 
 ## Phase 4.5 — engine execution model: breadth-first dirty-list parity
 
-**Gap (must close):** the interpreted engine currently sweeps **all** nodes in
-wiring (topological) order every cycle, testing each node's dispatch condition.
-Classic wingfoil instead propagates **breadth-first from the ticked source
-nodes through a dirty-list / layered schedule**, touching only nodes that can
-actually fire this cycle. The two are *observably identical* — both are
-glitch-free and fire each node exactly once after its upstreams (macro-parity
-tests confirm byte-identical output) — but the mechanisms differ, and the
-`O(N)`-per-cycle sweep does not match classic's sparse-graph performance: a
-large graph where only a handful of nodes tick still pays for a full node scan
-each cycle.
+**Scheduling: ✅ landed.** The interpreted engine now runs a sparse dirty-list
+by default (`interp.rs`, `Dispatch::Sparse`), reproducing classic wingfoil's
+`dirty_nodes_by_layer` model. Each cycle seeds a work set from the frontier —
+`always` busy-poll ops plus kernel-marked callback-activated ops (tickers,
+`delay` pops, the feedback source, channel replay) — then propagates the tick
+frontier forward: a node that ticks marks its active downstream neighbours
+dirty. The work set drains in ascending node-index order (a valid topological
+order, since the fluent API forces a stream to exist before it is referenced),
+so each node fires exactly once after everything it reads — glitch-free, and
+with per-cycle work proportional to the nodes that *actually fire*, not the
+graph size `N`. Results are **byte-identical** to classic and to the old
+`O(N)` full-index sweep, which is retained as `Dispatch::FullSweep` — an
+executable reference oracle (`runner.with_dispatch(Dispatch::FullSweep)`) the
+parity suite can cross-check against. This closes the sparse-graph performance
+gap against classic (pending the benchmark below as the standing gate).
 
-**Target:** reproduce classic's execution model in the interpreted engine —
-source-driven breadth-first propagation over a dirty-list (or layer-ordered
-work set), so per-cycle work is proportional to the nodes that actually fire,
-not the graph size. Concretely:
+**Two follow-ons remain, both deliberately separated from the scheduler:**
 
-- Assign each node a layer (longest path from a source) at `build()`, or keep
-  an explicit ready/dirty set; either way process in an order that preserves
-  the existing glitch-free single-fire guarantee (a recombine node fires once,
-  after every upstream that fires this cycle).
-- Seed each cycle's work set from the kernel's due callbacks
-  (`schedules`/`threaded`/`always` sources) and the tick-propagation frontier,
-  then expand breadth-first through active downstream edges only.
-- Preserve everything already correct: burst delivery, feedback's `+1`
-  scheduled edge, `Activation`-driven dispatch (callback-activated / always),
-  passive edges (read-not-triggering), and the `is_last_cycle` boundary flush.
+### Arena / SoA value store — deferred perf follow-on (boundary frozen)
+
+Value slots are still individual `Rc<RefCell<T>>`s. Moving them to a
+contiguous arena / structure-of-arrays store is a **pure memory/throughput
+optimisation** (semantics unchanged) that lands the "dense hot-path speed"
+number and enables the post-v1 zero-copy passthrough (a node that provably
+forwards its input aliases the upstream slot handle instead of cloning).
+
+The rework-trap the review flagged — every `Builder` registration closure and
+every macro emission captures the concrete `Rc<RefCell<T>>` today, so a naive
+swap touches the whole ported catalog + adapters **twice** — is **resolved by
+option (b): freeze the slot API boundary now** (`interp.rs:26`). Ops touch
+slots only through `Handle<T>` + the `slot()`/`new_slot()` accessors and the
+`.borrow()`/`.borrow_mut()` access shape, so the arena becomes an internal swap
+behind those accessors and the ported catalog survives unchanged. This is no
+longer a sequencing risk — the bulk catalog/adapter port can proceed against
+the frozen boundary and the arena lands whenever the dense-path speedup is
+wanted.
+
+⚠️ **Frozen by convention, not yet by type.** `slot()`/`new_slot()` still
+*return* `Rc<RefCell<T>>`, and closures call `.borrow_mut()` on that concrete
+type. Before starting the arena, confirm one of: (a) the accessor already
+hands out an opaque guard an arena can re-implement, or (b) a small guard
+newtype (`SlotRef<T>`) goes in first so the swap stays internal. Cheap now;
+avoids a mechanical type-swap across every capture site later.
+
+### Dynamic graphs (runtime add/remove) — enabler landed, feature not built
+
+The sparse dirty-list maintains a mutable frontier of active nodes — the
+natural home for classic's `graph_node` / `dynamic_group` (add/remove nodes
+and sub-graphs mid-run), which the old all-nodes sweep could not cleanly
+express. The **enabler is now in place**; the feature itself (a
+`Runner::extend` appending nodes + slots and splicing edges at runtime, with
+layer/dirty bookkeeping updated for the affected region) is **not yet built**.
+This is the one open *decision*, not just execution: **is runtime mutation a
+cutover blocker under the superset objective, or a documented v1 deviation?**
+Classic `graph_node` users force the call. The compiled and island paths stay
+static by design (their whole value is a fixed monomorphized schedule);
+dynamism is an interpreted-engine capability, matching classic.
 
 **Scope notes:**
-- Pure mechanism/performance change — observable results must stay identical,
-  so the full existing parity suite (catalog, macro, feedback, channel) is the
-  regression gate, plus a new large-sparse-graph benchmark asserting per-cycle
-  cost tracks the *active* node count, not `N`.
-- The value store is orthogonal but naturally paired: individual
-  `Rc<RefCell<T>>` slots → a contiguous arena/SoA (the other prototype
-  simplification the interp module doc flags), which the dirty-list rework is
-  the right moment to land. **⚠ Coupling / rework trap:** the arena/SoA change
-  alters the slot representation that *every* `Builder` registration closure
-  and *every* macro emission path captures today (`Rc<RefCell<T>>` handed into
-  the emitted `cycle`). Porting the ~40-node catalog and the adapters against
-  the current slot shape first, then landing the arena, means touching all of
-  that code **twice**. Two ways out, pick one before the Phase 2/4 volume
-  ramps: **(a)** land Phase 4.5 (at least the value-store half) *before* the
-  bulk catalog/adapter port, or **(b)** freeze the slot API boundary now — a
-  stable handle/accessor that registrations and emissions target — so the
-  arena swap is internal and registrations survive it unchanged. This coupling
-  is real work either way; do not treat the store swap as a free rider on the
-  dirty-list pass.
+- The scheduler change was pure mechanism/performance — observable results
+  stayed identical, so the full existing parity suite (catalog, macro,
+  feedback, channel) plus the `FullSweep` oracle guard it. Still owed: a
+  large-sparse-graph benchmark asserting per-cycle cost tracks the *active*
+  node count, not `N`, as the standing gate for the perf-parity claim.
 - The **compiled**/island path is unaffected in shape (it already emits
   straight-line per-node dispatch, the static-schedule analogue), but this is
   where branch-1's *region gating* idea (skip whole quiet sub-graphs) becomes
-  the compiled counterpart of the dirty-list — worth doing in the same pass.
+  the compiled counterpart of the dirty-list — worth doing alongside the
+  arena/perf pass.
 - Bench gate ties to Phase 6: `next-interpreted ≥ classic-interpreted` on the
-  sparse workloads is only achievable **after** this phase; until then next's
-  interpreted engine is knowingly slower on large sparse graphs.
-
-**Dynamism rides on this.** A dirty-list engine that already maintains a
-mutable frontier of active nodes is the natural home for **runtime graph
-mutation** — classic's `graph_node` / `dynamic_group` (add/remove nodes and
-sub-graphs mid-run) live on exactly this machinery, which the topological
-all-nodes sweep cannot cleanly express. So the dynamic-graph capability
-(previously fenced out of v1) folds in here: once the engine propagates from
-a mutable ready-set instead of scanning a fixed node vector, appending nodes
-+ slots and splicing edges at runtime becomes tractable, with layer/dirty
-bookkeeping updated for the affected region. The compiled and island paths
-stay static by design (their whole value is a fixed monomorphized schedule);
-dynamism is an interpreted-engine capability, matching classic.
-
-Sequencing: the *dirty-list mechanism* is observably independent of the
-catalog/adapter volume (Phases 2/4) and must land before claiming
-interpreted-engine performance parity with classic. But the **arena/SoA value
-store bundled into this phase is not schedule-independent** — it changes the
-slot shape the whole catalog and adapter port captures (see the coupling
-warning above). So this phase does *not* "land any time before Phase 6": either
-its value-store half lands before the Phase 2/4 bulk, or the slot API boundary
-is frozen first so registrations survive the arena swap unchanged. The
-dirty-list scheduling change proper, and dynamic-graph support, can still be
-follow-on increments once that boundary question is settled.
+  sparse workloads is now achievable in principle (the mechanism has landed);
+  the benchmark confirms it.
 
 ## Phase 5 — infrastructure
 
@@ -561,23 +568,24 @@ follow-on increments once that boundary question is settled.
 | Risk | Impact | Mitigation |
 |---|---|---|
 | Engine-owned init / evaluation-timing drift across the three emission paths | silent wrong values — the macro crate's interpreted/compiled/nested paths are the biggest drift surface; op-`cycle` semantics agree but engine-owned *seeding* and *timing* do not (fold init, closure-factory re-eval) | table-driven three-engine parity test (one micro-graph per macro-supported combinator, `interpreted == compiled == nested`); seed with the known divergences; single seed/init field per op so all three paths read one source |
-| Interpreted engine slower than classic on sparse graphs | perf parity claim; `O(N)`/cycle sweep vs classic's dirty-list | **Phase 4.5** breadth-first dirty-list rework; sparse-graph benchmark as gate; results already parity-identical, so it's mechanism/perf only |
-| Arena/SoA slot swap forces a second pass over the ported catalog | rework cost — every `Builder` registration + macro emission captures `Rc<RefCell<T>>` today | land Phase 4.5's value-store half before the Phase 2/4 bulk, **or** freeze the slot API boundary now so registrations survive the swap unchanged (see Phase 4.5 coupling warning) |
+| Interpreted engine slower than classic on sparse graphs | perf parity claim | ✅ **Phase 4.5 dirty-list landed** (`Dispatch::Sparse`, classic's `dirty_nodes_by_layer` model; `FullSweep` retained as oracle) — results byte-identical, work ∝ active nodes; remaining: the sparse-graph benchmark as the standing gate |
+| Arena/SoA slot swap forces a second pass over the ported catalog | rework cost — every `Builder` registration + macro emission captures `Rc<RefCell<T>>` today | ✅ **resolved: slot API boundary frozen** (option b, `interp.rs:26`) — ops go through `Handle<T>` + `slot()`/`new_slot()`, so the arena is an internal follow-on. Caveat: frozen by convention, not yet by type (accessor still returns `Rc<RefCell<T>>`) — add a `SlotRef<T>` guard first if needed (see Phase 4.5) |
 | Burst/replay semantics drift | backtest determinism is the product | Phase 0.3 spike; classic tests as oracle; fallback design named in advance |
 | Feedback timing mismatch | correctness of feedback graphs | engine-level edge + classic's 4 feedback tests; fluent-only v1 |
 | Fallibility retrofit cost | touches every emitter | do it first (0.1); never retrofit later |
-| Dynamic graph expectations | `graph_node` users | **Phase 4.5** dirty-list engine is the enabler (mutable frontier); islands cover static composition today |
+| Dynamic graph expectations | `graph_node` users | dirty-list engine (the mutable-frontier enabler) has landed; the mutation feature (`Runner::extend`) is **not yet built** — open decision: cutover blocker vs documented v1 deviation. Islands cover static composition today |
 | Python API drift | downstream breakage | facade keeps bindings stable; pytest as gate |
 | Statistics adapter size | schedule risk, not design risk | it's first in Phase 4 precisely to surface state-porting friction early |
 
 ## Explicitly out of scope (v1)
 
 - Feedback inside `graph!` / islands (fluent only).
-- Runtime graph mutation — now targeted at **Phase 4.5** (the dirty-list
-  engine is its enabler), not a permanent exclusion.
-- Arena value store for the interpreted engine — now folded into **Phase
-  4.5** (the dirty-list rework is the right moment to land it), no longer
-  indefinitely deferred.
+- Runtime graph mutation — the **Phase 4.5** dirty-list enabler has landed;
+  the mutation feature itself is still to be built (open blocker-vs-deviation
+  decision), not a permanent exclusion.
+- Arena value store for the interpreted engine — a deferred **Phase 4.5** perf
+  follow-on with the slot boundary frozen so it stays internal; no longer
+  indefinitely deferred and no longer a sequencing risk.
 - wingfoil-wasm / wingfoil-js changes (protocol-level, engine-agnostic).
 
 ### Nice-to-have (post-v1)

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -433,31 +433,42 @@ gap against classic (pending the benchmark below as the standing gate).
 
 **Two follow-ons remain, both deliberately separated from the scheduler:**
 
-### Arena / SoA value store — deferred perf follow-on (boundary frozen)
+### Arena / SoA value store — deferred perf follow-on (boundary frozen by type)
 
-Value slots are still individual `Rc<RefCell<T>>`s. Moving them to a
-contiguous arena / structure-of-arrays store is a **pure memory/throughput
-optimisation** (semantics unchanged) that lands the "dense hot-path speed"
-number and enables the post-v1 zero-copy passthrough (a node that provably
-forwards its input aliases the upstream slot handle instead of cloning).
+**Decision: do the arena later, not now.** It's a pure perf follow-on; the
+interpreted engine is already at parity with classic (the dirty-list did that),
+and nothing correctness- or cutover-related depends on it. The critical path to
+cutover is *breadth* — catalog, adapters, facade, python — so the arena waits
+for a measured need. Two cheap de-risking steps were done now instead (below),
+so "later" stays free and evidence-driven.
 
-The rework-trap the review flagged — every `Builder` registration closure and
-every macro emission captures the concrete `Rc<RefCell<T>>` today, so a naive
-swap touches the whole ported catalog + adapters **twice** — is **resolved by
-option (b): freeze the slot API boundary now** (`interp.rs:26`). Ops touch
-slots only through `Handle<T>` + the `slot()`/`new_slot()` accessors and the
-`.borrow()`/`.borrow_mut()` access shape, so the arena becomes an internal swap
-behind those accessors and the ported catalog survives unchanged. This is no
-longer a sequencing risk — the bulk catalog/adapter port can proceed against
-the frozen boundary and the arena lands whenever the dense-path speedup is
-wanted.
+Moving the per-slot `Rc<RefCell<T>>`s to a contiguous arena / structure-of-arrays
+store is a **pure memory/throughput optimisation** (semantics unchanged) that
+lands the "dense hot-path speed" number and enables the zero-copy passthrough
+(a node that provably forwards its input aliases the upstream slot handle
+instead of cloning — see the ref/aliasing note below).
 
-⚠️ **Frozen by convention, not yet by type.** `slot()`/`new_slot()` still
-*return* `Rc<RefCell<T>>`, and closures call `.borrow_mut()` on that concrete
-type. Before starting the arena, confirm one of: (a) the accessor already
-hands out an opaque guard an arena can re-implement, or (b) a small guard
-newtype (`SlotRef<T>`) goes in first so the swap stays internal. Cheap now;
-avoids a mechanical type-swap across every capture site later.
+The rework-trap the review flagged — every `Builder` registration closure
+captures the concrete slot type, so a naive swap touches the whole ported
+catalog + adapters **twice** — is **resolved: the slot API boundary is now
+frozen by type.** ✅ `SlotRef<T>` (`interp.rs`) is the sole access boundary:
+`slot()`/`new_slot()` return it, and every registration closure reads/writes
+only through `SlotRef::borrow`/`borrow_mut`, never the concrete cell. Today it
+wraps an `Rc<RefCell<T>>`; the arena becomes an internal swap of that innards
+with **zero capture sites touched**. Audited: the macro crate never names the
+slot type (compiled uses locals), and the one other hook —
+`Stream::__slot` for `nested` islands — now returns `SlotRef<T>` too. So the
+bulk catalog/adapter port proceeds against the frozen boundary and the arena
+lands whenever a measured need appears.
+
+**Measured baseline** (`benches/store_baseline.rs`, added now): on a large
+forwarding graph (8 KiB `Vec` payload through 16 `filter` hops), the owned-`Vec`
+run is ~5× an `Rc<Vec>` run of the identical graph — i.e. the per-hop clone tax
+that slot-aliasing would remove is *large* for big-payload forwarding, so the
+arena+aliasing has real teeth there (ratio is machine-dependent; regenerate
+before deciding). The same bench's `sparse_dispatch` group is the standing gate
+for the dirty-list: `Dispatch::Sparse` runs ~8× faster than the `FullSweep`
+oracle on a graph padded with cold nodes, confirming work ∝ active, not `N`.
 
 ### Dynamic graphs (runtime add/remove) — enabler landed, feature not built
 
@@ -569,7 +580,7 @@ dynamism is an interpreted-engine capability, matching classic.
 |---|---|---|
 | Engine-owned init / evaluation-timing drift across the three emission paths | silent wrong values — the macro crate's interpreted/compiled/nested paths are the biggest drift surface; op-`cycle` semantics agree but engine-owned *seeding* and *timing* do not (fold init, closure-factory re-eval) | table-driven three-engine parity test (one micro-graph per macro-supported combinator, `interpreted == compiled == nested`); seed with the known divergences; single seed/init field per op so all three paths read one source |
 | Interpreted engine slower than classic on sparse graphs | perf parity claim | ✅ **Phase 4.5 dirty-list landed** (`Dispatch::Sparse`, classic's `dirty_nodes_by_layer` model; `FullSweep` retained as oracle) — results byte-identical, work ∝ active nodes; remaining: the sparse-graph benchmark as the standing gate |
-| Arena/SoA slot swap forces a second pass over the ported catalog | rework cost — every `Builder` registration + macro emission captures `Rc<RefCell<T>>` today | ✅ **resolved: slot API boundary frozen** (option b, `interp.rs:26`) — ops go through `Handle<T>` + `slot()`/`new_slot()`, so the arena is an internal follow-on. Caveat: frozen by convention, not yet by type (accessor still returns `Rc<RefCell<T>>`) — add a `SlotRef<T>` guard first if needed (see Phase 4.5) |
+| Arena/SoA slot swap forces a second pass over the ported catalog | rework cost — registrations capture the slot type | ✅ **resolved: boundary frozen by type.** `SlotRef<T>` (`interp.rs`) is the sole access path (`slot()`/`new_slot()` return it; ops only `borrow`/`borrow_mut`); the arena is an internal swap of its innards, zero capture sites touched. Macro uses locals; `Stream::__slot` returns `SlotRef` too |
 | Burst/replay semantics drift | backtest determinism is the product | Phase 0.3 spike; classic tests as oracle; fallback design named in advance |
 | Feedback timing mismatch | correctness of feedback graphs | engine-level edge + classic's 4 feedback tests; fluent-only v1 |
 | Fallibility retrofit cost | touches every emitter | do it first (0.1); never retrofit later |
@@ -593,11 +604,35 @@ dynamism is an interpreted-engine capability, matching classic.
 - **Emit-by-reference / zero-copy passthrough.** Today an op reads its
   upstreams by reference (`In<'a> = (&'a A,)`, no clone to inspect) but must
   *produce* an owned value into its own slot — a passthrough or a big-value
-  forward costs a clone (cheap only if the element is `Rc`/`Arc`). A future
-  optimisation could let a node that provably forwards its input unchanged
-  *alias* the upstream slot instead of owning a copy (or, with the Phase 4.5
-  arena, hand out a slot handle rather than a value). Purely a memory/throughput
-  win — semantics are unchanged — so it stays out of the correctness-first path.
+  forward costs a clone (cheap only if the element is `Rc`/`Arc`; `store_baseline`
+  measures the tax). A node that provably forwards its input unchanged could
+  *alias* the upstream slot instead of owning a copy. Purely a memory/throughput
+  win — semantics unchanged — so it stays off the correctness-first path.
+
+  **Shape (decided): op-declared aliasing on the frozen slot handle, *not* a
+  threaded `'cycle` lifetime.** The clean encoding is a per-op fact —
+  `Aliases(input_k)` vs `Owns` — that both engines honour identically:
+  interpreted redirects the output `SlotRef` (or arena handle) to the upstream
+  slot; compiled reuses the upstream local. The materialize/alias boundary falls
+  out correctly: structural passthroughs (`filter`/`sample`/`merge`, and
+  `fold`'s publish) alias; retainers (`delay`/`buffer`/`window`) and producers
+  (`map`) own — `map` is the case `Rc` could never have helped anyway (it's new
+  data). **Soundness rides on the single-fire guarantee**: each node writes its
+  slot once per cycle before its readers run, so a within-cycle alias can't be
+  mutated out from under a reader; the feature would be unsound in a re-fire
+  engine. The alias fact must be a property of the *op* (structurally a
+  passthrough), never inferred from a user `map` closure the engine can't see
+  into — that keeps the two engines in agreement.
+
+  The type-level alternative — a `'cycle` lifetime threaded through `Op::Out`
+  so the borrow checker enforces "can't retain a `&'cycle T`" — was considered
+  and **set aside**: it collides with the interpreted engine's `Rc<dyn Any>` /
+  `Box<dyn Fn>` erasure (neither is `'static`-free), needs GAT-over-HRTB
+  gymnastics, and — worst — an op written with a borrowing `Out<'cycle>` may not
+  be expressible identically on both engines, cracking the single-source /
+  dual-execution invariant. The op-declared form gets ~all the benefit with
+  none of that. Rides on the Phase 4.5 arena (the slot-handle boundary is its
+  natural home).
 
 ## Sequencing and parallelism
 


### PR DESCRIPTION
## Summary

Two commits on the Wingfoil Next port plan / interpreted engine:

1. **Docs sync** — update `next/docs/port-plan.md` to reflect that the sparse dirty-list scheduler has already landed as the default interpreted dispatch (the plan still described it as an open Phase 4.5 gap).
2. **De-risk the deferred arena** — freeze the value-store boundary *by type* (`SlotRef<T>`) and add a baseline benchmark, so the arena/SoA work can be done later as a zero-touch internal swap, with a go/no-go driven by measured numbers rather than an estimate.

No behaviour change: results stay byte-identical (guarded by the full parity suite + the `FullSweep` oracle); `SlotRef` is a pure access-boundary refactor.

## Commit 1 — port-plan sync

- **Scheduler status**: mark Phase 4.5 scheduling ✅ landed (`Dispatch::Sparse`, reproducing classic's `dirty_nodes_by_layer`); per-cycle work ∝ active nodes, not graph size `N`; byte-identical to classic and to the old `O(N)` full sweep (retained as the `Dispatch::FullSweep` oracle).
- **Capability matrix**: collapse the two former interpreted columns ("today" vs "+ dirty-list (4.5)") into one; update rows and footnotes to the new baseline.
- **Dynamic graphs**: the mutable-frontier enabler has landed, but the mutation feature (`Runner::extend`) is not yet built — flagged as the open decision (cutover blocker vs documented v1 deviation).
- **Risk register / out-of-scope**: updated to reflect the landed scheduler and the resolved arena sequencing risk.

## Commit 2 — `SlotRef<T>` + `store_baseline` bench

- **`SlotRef<T>` (`interp.rs`)** — the value store is now reached *only* through this handle: `slot()`/`new_slot()` return it, and every op registration reads/writes via `SlotRef::borrow`/`borrow_mut`, never the concrete `Rc<RefCell<T>>`. Audited the surface: the macro crate never names the slot type (compiled uses locals), and the one other hook — `Stream::__slot` (nested islands) — now returns `SlotRef` too. So a future arena is an internal swap of `SlotRef`'s innards with **zero capture sites touched** — the boundary is now frozen by type, not just convention (this resolves the earlier "frozen by convention" caveat).
- **`benches/store_baseline.rs`** — the pre-arena measurements the decision needs:
  - `sparse_dispatch`: `Dispatch::Sparse` vs the `FullSweep` oracle on a cold-node-padded graph — the standing gate that work tracks active nodes, not `N` (~8× on the dev machine).
  - `forward_clone`: an 8 KiB `Vec` vs `Rc<Vec>` forwarded through 16 `filter` hops — brackets the per-hop clone tax that slot-aliasing would remove (~5× here), so the aliasing win has measured teeth for big payloads.
- **Plan updates**: arena marked "do it later" with the boundary-frozen-by-type resolution and the measured baseline; the zero-copy passthrough nice-to-have now specifies the decided shape (op-declared `Aliases(k)` on the slot handle, sound under single-fire) and why the `'cycle`-lifetime alternative was set aside.

## Checks

`cargo fmt --all -- --check`, workspace default clippy, `cargo clippy -p wingfoil-next --all-targets --all-features`, and `cargo test -p wingfoil-next --all-features` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dcwadLLityFnxD8Gt5scu