### PR TITLE
Port classic `threading` and `async` examples to wingfoil-next

### DIFF
--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -67,6 +67,13 @@ required-features = ["async"]
 name = "produce_async_feed"
 required-features = ["async"]
 
+# Port of the classic `async` example: an async `produce_async` producer driving
+# the graph (the graph itself is the consumer). Needs tokio + futures.
+[[example]]
+name = "async"
+path = "examples/async/main.rs"
+required-features = ["async"]
+
 [[bench]]
 name = "tiers"
 harness = false
@@ -104,3 +111,10 @@ path = "examples/order_book/main.rs"
 [[example]]
 name = "statistics"
 path = "examples/statistics/main.rs"
+
+# Multi-threaded execution: a producer sub-graph on a worker thread feeds the
+# main graph through the channel layer (next's take on classic `producer()` /
+# `mapper()`). Uses only default features.
+[[example]]
+name = "threading"
+path = "examples/threading/main.rs"

--- a/next/crates/wingfoil-next/examples/async/README.md
+++ b/next/crates/wingfoil-next/examples/async/README.md
@@ -1,0 +1,49 @@
+## async / tokio integration
+
+An async producer of **timestamped** values driving a wingfoil-next graph — the
+classic `produce_async` model, ported to next.
+
+Async streams are a natural fit for IO but an awkward one for business logic:
+their execution is implicit and depth-first. Wingfoil's is explicit,
+breadth-first and time-aware — with first-class historical *and* realtime
+modes, so strategies backtest and run live off the same wiring. The
+`produce_async` bridge keeps the best of both worlds: IO lives in the async
+producer, business logic lives in the graph, and the boundary between them is a
+single typed edge. That separation is exactly what tends to blur in
+async-oriented systems.
+
+The key call is **`produce_async`**, which maps an async `futures::Stream` of
+`(NanoTime, T)` onto a graph source. The graph itself is the consumer: classic
+hands the stream to an async `consume_async` closure, whereas on next an
+on-graph `for_each` plays that role — keeping the consumer in the
+explicitly-timed, breadth-first world. The producer runs on the caller's tokio
+runtime and each yielded value wakes the kernel.
+
+`produce_async` also carries the two guarantees classic gives for free:
+**back-pressure** (`produce_async_bounded` bounds how far a realtime producer
+may run ahead of the graph) and **`RunParams` validation** (a historical
+`start_time` that disagrees with the actual run is rejected rather than
+silently replaying against a bogus timeline). See the `async_source` module
+docs for details, and `produce_async_feed` for the historical-replay variant.
+
+## Running
+
+Gated behind the `async` feature (tokio + futures):
+
+```sh
+RUST_LOG=info cargo run -p wingfoil-next --features async --example async
+```
+
+```
+0
+10
+20
+30
+40
+50
+60
+70
+```
+
+The producer awaits between yields (simulating socket reads), emits eight
+timestamped values, then ends — closing the stream, which stops the graph.

--- a/next/crates/wingfoil-next/examples/async/main.rs
+++ b/next/crates/wingfoil-next/examples/async/main.rs
@@ -1,0 +1,72 @@
+//! async / tokio integration: an async producer of *timestamped* values driving
+//! a wingfoil-next graph — the classic `produce_async` model, ported to next.
+//!
+//! Async streams are a natural fit for IO but an awkward one for business
+//! logic: their execution is implicit and depth-first. Wingfoil's is explicit,
+//! breadth-first and time-aware (historical *and* realtime). The
+//! [`produce_async`] bridge keeps the best of both: IO lives in the async
+//! producer, business logic lives in the graph, and the boundary between them
+//! is a single typed edge.
+//!
+//! [`produce_async`] maps an async [`futures::Stream`] of `(NanoTime, T)` onto
+//! a graph source; the graph itself is the consumer (classic hands the stream
+//! to an async `consume_async` closure — on next, an on-graph `for_each` plays
+//! that role, keeping the consumer in the explicitly-timed world). The producer
+//! runs on the caller's tokio runtime and each value wakes the kernel.
+//!
+//! Gated behind the `async` feature (tokio + futures):
+//!
+//! ```sh
+//! RUST_LOG=info cargo run -p wingfoil-next --features async --example async
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::async_source::{RunParams, produce_async};
+use wingfoil_next::prelude::*;
+
+fn main() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+
+    let period = Duration::from_millis(10);
+
+    // The params describe the run we are about to drive (they must match the
+    // `run(..)` below; a historical `start_time` mismatch is rejected at run
+    // time — see the `produce_async` docs).
+    let params = RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Forever,
+        start_time: NanoTime::ZERO,
+    };
+
+    // The async producer: it awaits between yields (as a socket read would),
+    // emitting timestamped values. A finite feed of 8 values that ends —
+    // closing the stream, which stops the graph.
+    let quotes = produce_async(&g, rt.handle(), params, move |_p| async move {
+        Ok(futures::stream::unfold(0u32, move |i| async move {
+            if i >= 8 {
+                return None;
+            }
+            tokio::time::sleep(period).await; // simulate waiting IO
+            let value = i * 10;
+            // In realtime the timestamp is informational (the value ticks on
+            // arrival); a historical producer would drive replay off it.
+            Some((Ok((NanoTime::now(), value)), i + 1))
+        }))
+    });
+
+    // The consumer, on the graph: print every value in each arriving burst.
+    let _printed = quotes.for_each(|burst: &Burst<u32>| {
+        for value in burst.iter() {
+            println!("{value}");
+        }
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner
+        .run(RunMode::RealTime, RunFor::Forever)
+        .expect("run graph");
+}

--- a/next/crates/wingfoil-next/examples/threading/README.md
+++ b/next/crates/wingfoil-next/examples/threading/README.md
@@ -1,0 +1,47 @@
+## Threading
+
+Multi-threaded graph execution: a **producer** sub-graph runs on its own worker
+thread and feeds the **main** graph through the channel layer.
+
+This is the wingfoil-next port of the classic `threading` example. Classic
+provides `producer()` / `mapper()` combinators that run a sub-graph on a
+dedicated thread and shuttle values over channels. Next deliberately keeps those
+combinators out of the fluent vocabulary and instead exposes the primitive they
+were built on directly (see the capability matrix in `docs/port-plan.md` —
+external / channel sources are `THREADED`, the sugar is not):
+
+- **`GraphBuilder::channel()`** returns a source `Stream<Burst<T>>` plus a
+  clonable, `Send` `ChannelSender<T>`.
+- A worker thread builds and runs its **own** graph and forwards each value
+  through the sender.
+- The main graph receives a **burst** of everything that arrived since its last
+  cycle — never latest-wins, never dropped.
+
+Each graph stays single-threaded and lock-free; they touch only at the channel.
+This mirrors next's rule of thumb: *no locks on the execution path — use the
+channel layer to talk to background threads.* Additional stages chain the same
+way: each is a worker thread whose graph has a channel *in* and a
+`ChannelSender` *out*. Here the "mapper" stage (scale ×10) needs no thread of its
+own, so it is just an op on the receiving main graph.
+
+## Both run modes
+
+- **Realtime** — the worker paces at its ticker `period`; whatever arrived since
+  the last cycle rides one burst, so the grouping is wall-clock dependent.
+- **Historical** — the worker sends timestamped values (`send_at`) and the
+  receiver replays them **deterministically** at those graph times. Same
+  topology, reproducible timeline: `[[10], [20], [30], [40], [50], [60]]`.
+
+## Running
+
+```sh
+cargo run -p wingfoil-next --example threading
+```
+
+```
+realtime:   [[10], [20], [30], [40], [50], [60]]
+historical: [[10], [20], [30], [40], [50], [60]]
+```
+
+(Under load the realtime line may coalesce consecutive values into a single
+burst, e.g. `[[10, 20], [30], ...]` — the historical line never varies.)

--- a/next/crates/wingfoil-next/examples/threading/main.rs
+++ b/next/crates/wingfoil-next/examples/threading/main.rs
@@ -1,0 +1,96 @@
+//! Multi-threaded graph execution: a producer sub-graph runs on its own
+//! worker thread and feeds the main graph through the channel layer.
+//!
+//! This is the wingfoil-next port of the classic `threading` example. Classic
+//! offers `producer()` / `mapper()` combinators that run a sub-graph on a
+//! dedicated thread and shuttle values over channels. Next does not put those
+//! combinators in the fluent vocabulary — instead it exposes the primitive they
+//! were built on directly: a [`channel`](wingfoil_next::fluent::SourceOps::channel)
+//! source plus a `Send` [`ChannelSender`]. A worker thread builds and runs its
+//! *own* graph and forwards each value through the sender; the main graph
+//! receives a [`Burst`] of everything that arrived since its last cycle. The
+//! graphs stay single-threaded and lock-free; they touch only at the channel.
+//!
+//! A second, third, … stage chains the same way: each is a worker thread whose
+//! graph has a channel *in* and a `ChannelSender` *out*. Here the "mapper"
+//! stage (scale ×10) runs as an ordinary op on the receiving main graph.
+//!
+//! It runs in **both** modes. In realtime, values arrive whenever the worker
+//! produces them, so a cycle may carry a burst of several. In a historical
+//! replay the worker sends timestamped values ([`ChannelSender::send_at`]) and
+//! the receiver replays them **deterministically** at those graph times — same
+//! topology, reproducible timeline.
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example threading
+//! ```
+
+use std::thread;
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::channel::ChannelSender;
+use wingfoil_next::prelude::*;
+
+/// Run the producer-on-a-worker-thread pipeline in `run_mode` and return the
+/// scaled values the main graph collected, burst by burst.
+fn pipeline(run_mode: RunMode, period: Duration, n: u32) -> Vec<Vec<u64>> {
+    let g = GraphBuilder::new();
+
+    // The main graph's inbound edge: a channel source fed from the worker.
+    let (counts, to_main): (Stream<Burst<u64>>, ChannelSender<u64>) = g.channel::<u64>();
+
+    // The "mapper" stage, on the main graph: scale every value in each burst
+    // ×10 (classic runs this on its own thread via `mapper()`; on next a stage
+    // that needs no thread of its own is just an op on the receiving graph).
+    let scaled = counts.map(|b: &Burst<u64>| b.iter().map(|x| x * 10).collect::<Vec<u64>>());
+    let collected = scaled.accumulate();
+
+    let mut runner = g.build();
+
+    // The "producer" stage, on a worker thread: it builds and runs its OWN
+    // wingfoil-next graph (a ticker → running count) and forwards every value
+    // over the channel — next's replacement for classic `producer()`.
+    let worker = thread::spawn(move || {
+        let wg = GraphBuilder::new();
+        // `with_time` stamps each value: `send_at` replays deterministically at
+        // graph time in a historical run and is treated as a plain `send` (the
+        // stamp ignored) in realtime.
+        let ticks = wg.ticker(period).count().with_time();
+        let send = to_main.clone();
+        let _forward = ticks.for_each(move |tv: &(NanoTime, u64)| {
+            send.send_at(tv.1, tv.0);
+            Ok(())
+        });
+        let mut wrunner = wg.build();
+        wrunner
+            .run(run_mode, RunFor::Cycles(n))
+            .expect("run producer sub-graph");
+        // End-of-stream: the main graph stops once it drains the final burst.
+        to_main.close();
+    });
+
+    // `Forever` + the worker's `close()` bounds the run: the channel source ends
+    // it on end-of-stream rather than a fixed cycle count (which realtime burst
+    // coalescing would make unreliable).
+    runner
+        .run(run_mode, RunFor::Forever)
+        .expect("run main graph");
+    worker.join().expect("producer worker thread");
+    runner.value(&collected)
+}
+
+fn main() {
+    let period = Duration::from_millis(20);
+    let n = 6;
+
+    // Realtime: the worker paces at `period`; a cycle may carry a burst of
+    // several values, so the grouping is wall-clock dependent.
+    let realtime = pipeline(RunMode::RealTime, period, n);
+    println!("realtime:   {realtime:?}");
+
+    // Historical: timestamped replay — one value per instant, fully
+    // deterministic: [[10], [20], [30], [40], [50], [60]].
+    let historical = pipeline(RunMode::HistoricalFrom(NanoTime::ZERO), period, n);
+    println!("historical: {historical:?}");
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -363,9 +363,16 @@ values and tick times.
   classic. `tests/produce_async.rs` (deterministic historical replay,
   same-time-one-burst, mid-stream error abort) + `produce_async_feed`
   example.
-- ⬜ Re-implement classic `threading`/`async` examples on next; bounded-buffer
-  back-pressure; the `RunParams` are snapshotted at wiring (classic passes
-  them at setup) — align if a producer needs run-time bounds.
+- ✅ Classic `threading`/`async` examples re-implemented on next. `threading`
+  (`examples/threading/`) offloads a producer sub-graph to a worker thread that
+  feeds the main graph over the channel layer — next's take on classic
+  `producer()`/`mapper()`, which stay out of the fluent vocabulary (the channel
+  primitive replaces the sugar) — and runs in both modes (realtime bursts,
+  deterministic historical replay). `async` (`examples/async/`, gated on the
+  `async` feature) drives the graph from a `produce_async` producer with the
+  graph as consumer. Bounded-buffer back-pressure (`produce_async_bounded`) and
+  wiring-time `RunParams` (validated against the real run in historical mode)
+  landed with the `produce_async` ergonomic above.
 
 ## Phase 4 — adapters, easiest-first
 


### PR DESCRIPTION
Completes the example porting work by implementing the `threading` and `async` examples on wingfoil-next, demonstrating multi-threaded graph execution and async/tokio integration respectively.

## Summary

This PR ports two foundational examples from classic wingfoil to wingfoil-next, showcasing how to integrate background threads and async producers with the graph execution model. Rather than providing high-level combinators (`producer()`, `mapper()`), next exposes the primitives directly — allowing users to build their own patterns while keeping graphs single-threaded and lock-free.

## Key Changes

- **`threading` example** (`examples/threading/main.rs` + README):
  - Demonstrates a producer sub-graph running on a worker thread that feeds the main graph via `GraphBuilder::channel()`
  - Shows both realtime (wall-clock dependent bursts) and historical (deterministic timestamped replay) execution modes
  - Illustrates next's threading philosophy: no locks on the execution path, use the channel layer to talk to background threads
  - Replaces classic's `producer()` / `mapper()` combinators with explicit channel primitives (`ChannelSender`, `send_at`)

- **`async` example** (`examples/async/main.rs` + README):
  - Ports classic's `produce_async` model: an async tokio producer of timestamped values driving a wingfoil-next graph
  - The graph itself acts as the consumer (via `for_each`), keeping business logic in the explicitly-timed, breadth-first world
  - Demonstrates the separation of concerns: IO in async producer, business logic in the graph, boundary is a single typed edge
  - Gated behind the `async` feature (tokio + futures)

- **`Cargo.toml` updates**:
  - Added `[[example]]` entries for both `threading` and `async` with appropriate feature gates
  - `threading` uses default features only
  - `async` requires the `async` feature

- **`docs/port-plan.md` update**:
  - Marked the threading/async example porting task as complete (✅)
  - Documented that `RunParams` validation and bounded-buffer back-pressure landed with the `produce_async` ergonomic work

## Implementation Details

Both examples demonstrate wingfoil-next's core design principle: **explicit, breadth-first, time-aware execution**. The `threading` example shows how to compose multiple single-threaded graphs via channels, while the `async` example shows how to bridge the implicit, depth-first async world with the explicit graph world at a single typed boundary. Both support deterministic historical replay alongside realtime execution.

https://claude.ai/code/session_01FVYsyWD7UVxgd24mY6MmJw