### PR TITLE
Implement per-node reset hook for re-runnable graphs

### DIFF
--- a/next/crates/wingfoil-next-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-macros/src/lib.rs
@@ -1649,7 +1649,9 @@ fn expand_op(args: &OpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
                         ::core::any::type_name::<#self_ty>(),
                         <#self_ty as crate::op::Op>::ACTIVATION,
                         #cfg_arg,
-                        ::core::default::Default::default(),
+                        // A factory, not a value, so the interpreted engine can
+                        // re-seed the op's state on a re-run (see `ResetFn`).
+                        || ::core::default::Default::default(),
                         |__cfg, __state, __a, __ctx| {
                             <#self_ty as crate::op::Op>::cycle(__cfg, __state, (__a,), __ctx)
                         },

--- a/next/crates/wingfoil-next/benches/custom_op.rs
+++ b/next/crates/wingfoil-next/benches/custom_op.rs
@@ -93,9 +93,14 @@ trait IncrOps {
 impl IncrOps for Stream<f64> {
     fn incr(&self) -> Stream<f64> {
         self.wire(|b, h| {
-            b.register_op1(h, "incr", Incr::ACTIVATION, (), (), |c, s, a, ctx| {
-                <Incr as Op>::cycle(c, s, (a,), ctx)
-            })
+            b.register_op1(
+                h,
+                "incr",
+                Incr::ACTIVATION,
+                (),
+                || (),
+                |c, s, a, ctx| <Incr as Op>::cycle(c, s, (a,), ctx),
+            )
         })
     }
 }

--- a/next/crates/wingfoil-next/src/async_source.rs
+++ b/next/crates/wingfoil-next/src/async_source.rs
@@ -162,7 +162,7 @@ where
             "produce_async::validate",
             Activation::NONE,
             (),
-            (),
+            || (),
             move |_cfg: &mut (), _state: &mut (), input: &Burst<T>, ctx| {
                 if !checked {
                     checked = true;

--- a/next/crates/wingfoil-next/src/compat.rs
+++ b/next/crates/wingfoil-next/src/compat.rs
@@ -124,24 +124,21 @@ impl<T: 'static> Signal<T> {
 
     /// Run the graph to its bound, storing the runner for `peek_value`.
     ///
-    /// Re-running is not supported: the shared [`GraphBuilder`] is consumed by
-    /// the first `run`, so a second call would build — and silently run — an
-    /// empty graph, then read a now-dangling handle out of bounds. Until re-run
-    /// support lands (deferred — see `next/docs/fable-review.md`, plan point 3) a
-    /// second call is a *reachable* user error, not an unreachable invariant,
-    /// so it is surfaced as an error rather than a panic. The first run's
-    /// runner is left in place, so `peek_value` keeps working.
+    /// **Re-runnable**: the graph is built once (on the first call) and the
+    /// [`Runner`] is retained, so a second `run` reuses it —
+    /// [`Runner::run`](crate::interp::Runner::run) restores every node's state
+    /// and value slot to its wiring-time initial value first, giving each run
+    /// independent, reproducible results (classic's setup-per-run semantics).
+    /// This is what the wingfoil-python pytest suite — and any classic-idiom
+    /// code that runs a stream more than once — depends on.
     pub fn run(&self, run_mode: RunMode, run_for: RunFor) -> Result<()> {
-        if self.runner.borrow().is_some() {
-            anyhow::bail!(
-                "Signal::run called more than once: re-running a graph is not \
-                 supported (the builder is consumed by the first run)"
-            );
+        let mut slot = self.runner.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(self.graph.build());
         }
-        let mut runner = self.graph.build();
-        let result = runner.run(run_mode, run_for);
-        *self.runner.borrow_mut() = Some(runner);
-        result
+        slot.as_mut()
+            .expect("runner just built")
+            .run(run_mode, run_for)
     }
 
     /// The stream's current value after a [`run`](Signal::run).

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -429,6 +429,22 @@ pub trait StreamOps<T>: Sized {
     where
         T: Clone + Default + 'static;
 
+    /// Merge this stream with every stream in `others` into one — the n-ary
+    /// `merge`. On a same-cycle tie the earliest-supplied ticked input wins:
+    /// this stream first, then `others` in slice order. `merge_all(&[])` is
+    /// just this stream.
+    ///
+    /// This unrolls to a left-associated chain of 2-ary
+    /// [`merge`](StreamOps::merge)s (`self.merge(a).merge(b)…`), which is
+    /// exactly equivalent — 2-ary merge's earliest-wins tie-break is
+    /// associative, so the chain and a single n-ary node fire identically. It
+    /// closes the n-ary-merge vocabulary gap without a bespoke variadic op (the
+    /// same sugar-over-primitive approach as [`fan`](StreamOps::fan) /
+    /// [`map_n`](StreamOps::map_n)).
+    fn merge_all(&self, others: &[&Stream<T>]) -> Stream<T>
+    where
+        T: Clone + Default + 'static;
+
     /// Chain the same endomorphic `map` `n` times. `map_n(0, f)` is the
     /// identity (a pass-through). Bounded repetition sugar for a straight deep
     /// chain; inside `graph!` the count must be a literal so the DAG stays
@@ -686,6 +702,17 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
     {
         let other = other.handle();
         self.wire(|b, h| b.merge2(h, other))
+    }
+
+    fn merge_all(&self, others: &[&Stream<T>]) -> Stream<T>
+    where
+        T: Clone + Default + 'static,
+    {
+        let mut merged = self.clone();
+        for other in others {
+            merged = merged.merge(other);
+        }
+        merged
     }
 
     fn map_n<F>(&self, n: usize, f: F) -> Stream<T>

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -860,8 +860,9 @@ impl Builder {
     ) -> Handle<Burst<T>> {
         let idx = self.nodes.len();
         let indices: Vec<usize> = srcs.iter().map(|h| h.idx).collect();
-        let slots: Vec<Rc<RefCell<T>>> = srcs.iter().map(|h| self.slot(*h)).collect();
+        let slots: Vec<SlotRef<T>> = srcs.iter().map(|h| self.slot(*h)).collect();
         let out = self.new_slot(Burst::<T>::new());
+        let out_reset = out.clone();
         let ticked = self.ticked.clone();
         self.push_node(
             indices.clone(),
@@ -886,6 +887,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = Burst::new();
+        }));
         self.make_handle(idx)
     }
 
@@ -1478,6 +1482,7 @@ impl Builder {
         let ticked = self.ticked.clone();
         let (is, it) = (src.idx, trigger.idx);
         let cs = Self::cell(delay, DelayWithResetState::<T>::default());
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx, trigger.idx],
             DelayWithReset::<T>::ACTIVATION,
@@ -1508,6 +1513,10 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = DelayWithResetState::<T>::default();
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -181,6 +181,15 @@ pub(crate) fn short_type_name(s: &'static str) -> &'static str {
 type CycleFn = Box<dyn FnMut(&mut Kernel) -> Result<bool>>;
 /// Start / stop / teardown all share this shape.
 type LifecycleFn = Box<dyn FnMut(&mut Kernel) -> Result<()>>;
+/// A node's re-run hook: restore its engine-owned state and value slot to
+/// their **wiring-time initial values**, so a second [`Runner::run`] starts
+/// from a clean slate (the kernel is rebuilt from `t=0` each run, and each
+/// node's `start` re-seeds its schedules, so this closure need only reset
+/// per-node state — never the kernel). Takes no [`Kernel`]: reset happens
+/// *between* runs, when no kernel exists. Restoring a stored value is
+/// infallible, so unlike the other hooks it returns nothing. Defaults to a
+/// no-op (a stateless node with no persistent slot needs no reset).
+type ResetFn = Box<dyn FnMut()>;
 
 /// One node's **r**un**t**ime record: everything the engine needs to schedule
 /// and drive that node, kept in parallel `Vec`s indexed by node position (its
@@ -206,6 +215,10 @@ struct NodeRt {
     start: LifecycleFn,
     stop: LifecycleFn,
     teardown: LifecycleFn,
+    /// Re-run hook — restores this node's state + value slot to their
+    /// wiring-time initial values before a second [`Runner::run`]. See
+    /// [`ResetFn`]. Defaults to a no-op; stateful nodes overwrite it.
+    reset: ResetFn,
 }
 
 /// The producer half of an [`external`](Builder::external) source: send a
@@ -289,6 +302,14 @@ pub struct Builder {
     /// `finished` flag (here one shared flag ends the run on any channel
     /// close, which is the single-channel realtime case the fix targets).
     finished: Rc<Cell<bool>>,
+    /// True while every node in the graph can restore itself for a re-run
+    /// (see [`ResetFn`]). Cleared by nodes that hold state the engine cannot
+    /// reset — `external`/`poll`/`channel` sources (their producer channels
+    /// and wakers are consumed by the first run) and `composite` islands
+    /// (their interior owns a private runtime with no reset hook). A
+    /// [`Runner`] built from such a graph is single-run; a pure historical
+    /// graph (tickers/constants + combinators + feedback) re-runs.
+    re_runnable: bool,
     /// Process-unique id (see [`NEXT_BUILDER_ID`]), stamped on every [`Handle`]
     /// this builder mints and carried into its [`Runner`], so a handle used
     /// with a *different* runner is caught by a `debug_assert`.
@@ -308,6 +329,7 @@ impl Default for Builder {
             has_always: false,
             has_channel: false,
             finished: Rc::new(Cell::new(false)),
+            re_runnable: true,
             id: NEXT_BUILDER_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
@@ -330,6 +352,8 @@ impl Builder {
         let out = self.new_slot(Burst::<T>::new());
         let (tx, rx) = std::sync::mpsc::channel::<T>();
         self.has_external = true;
+        // The producer channel + waker are consumed by the first run.
+        self.re_runnable = false;
         self.push_node(
             Vec::new(),
             Activation::THREADED,
@@ -380,6 +404,9 @@ impl Builder {
         let out = self.new_slot(Burst::<T>::new());
         let (tx, rx) = std::sync::mpsc::channel::<Message<T>>();
         self.has_channel = true;
+        // The receiver is drained (historical) or waker-driven (realtime) by
+        // the first run; a second run would see an empty channel.
+        self.re_runnable = false;
         // Shared between the cycle and start adapters: the receiver, plus the
         // time-grouped bursts the historical `start` fills.
         let cs = Self::cell(rx, VecDeque::<(NanoTime, Burst<T>)>::new());
@@ -564,8 +591,20 @@ impl Builder {
             start,
             stop: Box::new(|_| Ok(())),
             teardown: Box::new(|_| Ok(())),
+            reset: Box::new(|| {}),
         });
         self.ticked.borrow_mut().push(false);
+    }
+
+    /// Attach a re-run hook to the node most recently pushed. Called by the
+    /// registration methods right after `push_node`, so a second
+    /// [`Runner::run`] restores that node's state and value slot. See
+    /// [`ResetFn`].
+    fn set_reset(&mut self, reset: ResetFn) {
+        self.nodes
+            .last_mut()
+            .expect("invariant: set_reset called immediately after push_node")
+            .reset = reset;
     }
 
     /// Shared cfg+state cell, used by both the cycle and start adapters.
@@ -583,13 +622,18 @@ impl Builder {
     /// calls `Op::cycle`) is the only monomorphic piece, so this primitive
     /// stays free of the GAT-over-HRTB gymnastics a fully generic version would
     /// need. `label` is `type_name::<Op>()`; it is shortened for error context.
-    pub fn register_op1<A, C, S, Out, Step>(
+    ///
+    /// `state_init` is a *factory* (not a value) so the engine can re-run it
+    /// on a second [`Runner::run`], restoring the op's state to its
+    /// wiring-time initial value (see [`ResetFn`]). The `#[op]`-generated
+    /// wrapper passes `|| Default::default()`.
+    pub fn register_op1<A, C, S, Out, Step, SInit>(
         &mut self,
         src: Handle<A>,
         label: &'static str,
         activation: Activation,
         cfg: C,
-        state: S,
+        state_init: SInit,
         mut step: Step,
     ) -> Handle<Out>
     where
@@ -597,12 +641,14 @@ impl Builder {
         C: 'static,
         S: 'static,
         Out: Default + 'static,
+        SInit: Fn() -> S + 'static,
         Step: FnMut(&mut C, &mut S, &A, &mut Ctx<'_>) -> Result<Tick<Out>> + 'static,
     {
         let idx = self.nodes.len();
         let src_slot = self.slot(src);
         let out = self.new_slot(Out::default());
-        let cs = Rc::new(RefCell::new((cfg, state)));
+        let cs = Rc::new(RefCell::new((cfg, state_init())));
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             activation,
@@ -627,6 +673,10 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = state_init();
+            *out_reset.borrow_mut() = Out::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -640,14 +690,14 @@ impl Builder {
     // arguments mirror `register_op1` plus the second input handle — grouping
     // them into a struct would only move the eight names one level down.
     #[allow(clippy::too_many_arguments)]
-    pub fn register_op2<A, B, C, S, Out, Step>(
+    pub fn register_op2<A, B, C, S, Out, Step, SInit>(
         &mut self,
         a: Handle<A>,
         b: Handle<B>,
         label: &'static str,
         activation: Activation,
         cfg: C,
-        state: S,
+        state_init: SInit,
         mut step: Step,
     ) -> Handle<Out>
     where
@@ -656,13 +706,15 @@ impl Builder {
         C: 'static,
         S: 'static,
         Out: Default + 'static,
+        SInit: Fn() -> S + 'static,
         Step: FnMut(&mut C, &mut S, &A, &B, &mut Ctx<'_>) -> Result<Tick<Out>> + 'static,
     {
         let idx = self.nodes.len();
         let a_slot = self.slot(a);
         let b_slot = self.slot(b);
         let out = self.new_slot(Out::default());
-        let cs = Rc::new(RefCell::new((cfg, state)));
+        let cs = Rc::new(RefCell::new((cfg, state_init())));
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![a.idx, b.idx],
             activation,
@@ -690,6 +742,10 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = state_init();
+            *out_reset.borrow_mut() = Out::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -698,6 +754,7 @@ impl Builder {
         let out = self.new_slot(());
         let cs = Self::cell(period, TickerState::default());
         let cs2 = cs.clone();
+        let cs_reset = cs.clone();
         self.push_node(
             Vec::new(),
             Ticker::ACTIVATION,
@@ -723,6 +780,9 @@ impl Builder {
                 Ticker::start(cfg, state, &mut ctx)
             }),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = TickerState::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -731,6 +791,7 @@ impl Builder {
         let out = self.new_slot(T::default());
         let cs = Self::cell(value, ());
         let cs2 = cs.clone();
+        let out_reset = out.clone();
         self.push_node(
             Vec::new(),
             Const::<T>::ACTIVATION,
@@ -756,6 +817,9 @@ impl Builder {
                 Const::<T>::start(cfg, state, &mut ctx)
             }),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -832,6 +896,7 @@ impl Builder {
         let idx = self.nodes.len();
         let src_slot = self.slot(src);
         let out = self.new_slot((NanoTime::ZERO, src_slot.borrow().clone()));
+        let (src_reset, out_reset) = (src_slot.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             WithTime::<T>::ACTIVATION,
@@ -855,6 +920,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = (NanoTime::ZERO, src_reset.borrow().clone());
+        }));
         self.make_handle(idx)
     }
 
@@ -868,6 +936,7 @@ impl Builder {
         let src_slot = self.slot(src);
         let out = self.new_slot(T::default());
         let cs = Self::cell(interval, None::<NanoTime>);
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             Throttle::<T>::ACTIVATION,
@@ -892,6 +961,10 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = None;
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -907,6 +980,7 @@ impl Builder {
         let out = self.new_slot(Vec::<T>::new());
         let cs = Self::cell(interval, WindowState::<T>::default());
         let cs2 = cs.clone();
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             Window::<T>::ACTIVATION,
@@ -935,6 +1009,10 @@ impl Builder {
                 Window::<T>::start(cfg, state, &mut ctx)
             }),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = WindowState::<T>::default();
+            *out_reset.borrow_mut() = Vec::new();
+        }));
         self.make_handle(idx)
     }
 
@@ -964,6 +1042,7 @@ impl Builder {
         let c_slot = self.slot(c);
         let out = self.new_slot(D::default());
         let cs = Self::cell(f, ());
+        let out_reset = out.clone();
         let mut active = Vec::with_capacity(3);
         if a_active {
             active.push(a.idx);
@@ -1000,6 +1079,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = D::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1030,6 +1112,7 @@ impl Builder {
         let c_slot = self.slot(c);
         let out = self.new_slot(D::default());
         let cs = Self::cell(f, ());
+        let out_reset = out.clone();
         let mut active = Vec::with_capacity(3);
         if a_active {
             active.push(a.idx);
@@ -1066,6 +1149,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = D::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1078,6 +1164,7 @@ impl Builder {
         let src_slot = self.slot(src);
         let cond_slot = self.slot(condition);
         let out = self.new_slot(T::default());
+        let out_reset = out.clone();
         self.push_node(
             vec![src.idx, condition.idx],
             Filter::<T>::ACTIVATION,
@@ -1102,6 +1189,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1113,8 +1203,10 @@ impl Builder {
     {
         let idx = self.nodes.len();
         let src_slot = self.slot(src);
+        let init_reset = init.clone();
         let out = self.new_slot(init.clone());
         let cs = Self::cell(f, init);
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             Fold::<A, B, F>::ACTIVATION,
@@ -1139,6 +1231,10 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = init_reset.clone();
+            *out_reset.borrow_mut() = init_reset.clone();
+        }));
         self.make_handle(idx)
     }
 
@@ -1151,6 +1247,7 @@ impl Builder {
         let idx = self.nodes.len();
         let src_slot = self.slot(src);
         let out = self.new_slot(T::default());
+        let out_reset = out.clone();
         self.push_node(
             vec![trigger.idx],
             Sample::<T>::ACTIVATION,
@@ -1174,6 +1271,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1211,6 +1311,7 @@ impl Builder {
         let b_slot = self.slot(b);
         let out = self.new_slot(C::default());
         let cs = Self::cell(f, ());
+        let out_reset = out.clone();
         let mut active = Vec::with_capacity(2);
         if a_active {
             active.push(a.idx);
@@ -1245,6 +1346,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = C::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1270,6 +1374,7 @@ impl Builder {
         let b_slot = self.slot(b);
         let out = self.new_slot(C::default());
         let cs = Self::cell(f, ());
+        let out_reset = out.clone();
         let mut active = Vec::with_capacity(2);
         if a_active {
             active.push(a.idx);
@@ -1304,6 +1409,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = C::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1319,6 +1427,7 @@ impl Builder {
         let ticked = self.ticked.clone();
         let is = src.idx;
         let cs = Self::cell(delay, DelayState::<T>::default());
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             Delay::<T>::ACTIVATION,
@@ -1345,6 +1454,10 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = DelayState::<T>::default();
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1408,6 +1521,7 @@ impl Builder {
         let a_slot = self.slot(a);
         let b_slot = self.slot(b);
         let out = self.new_slot(T::default());
+        let out_reset = out.clone();
         let ticked = self.ticked.clone();
         let (ia, ib) = (a.idx, b.idx);
         self.push_node(
@@ -1440,6 +1554,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1456,6 +1573,8 @@ impl Builder {
         let out = self.new_slot(T::default());
         let cs = Self::cell(f, ());
         self.has_always = true;
+        // A busy-poll source is inherently single-run (realtime only).
+        self.re_runnable = false;
         self.push_node(
             Vec::new(),
             Poll::<T, F>::ACTIVATION,
@@ -1494,6 +1613,7 @@ impl Builder {
         let out = self.new_slot(());
         let cs = Self::cell(f, A::default());
         let cs2 = cs.clone();
+        let cs_reset = cs.clone();
         self.push_node(
             vec![src.idx],
             Finally::<A, F>::ACTIVATION,
@@ -1528,6 +1648,9 @@ impl Builder {
             let mut ctx = Ctx::new(k, idx);
             Finally::<A, F>::teardown(cfg, state, &mut ctx)
         });
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = A::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1540,6 +1663,7 @@ impl Builder {
         let out = self.new_slot(T::default());
         let cs = Self::cell((), Vec::<T>::new());
         let cs2 = cs.clone();
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             Print::<T>::ACTIVATION,
@@ -1574,6 +1698,10 @@ impl Builder {
             let mut ctx = Ctx::new(k, idx);
             Print::<T>::teardown(cfg, state, &mut ctx)
         });
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = Vec::new();
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1588,6 +1716,7 @@ impl Builder {
         let cs = Self::cell((), TimedState::<T>::default());
         let cs_start = cs.clone();
         let cs_stop = cs.clone();
+        let (cs_reset, out_reset) = (cs.clone(), out.clone());
         self.push_node(
             vec![src.idx],
             Timed::<T>::ACTIVATION,
@@ -1626,6 +1755,10 @@ impl Builder {
             let mut ctx = Ctx::new(k, idx);
             Timed::<T>::stop(cfg, state, &mut ctx)
         });
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = TimedState::<T>::default();
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1643,6 +1776,7 @@ impl Builder {
         let out = self.new_slot(T::default());
         let queue: Rc<RefCell<TimeQueue<T>>> = Rc::new(RefCell::new(TimeQueue::new()));
         let q = queue.clone();
+        let (q_reset, out_reset) = (queue.clone(), out.clone());
         self.push_node(
             Vec::new(),
             Activation::SCHEDULES,
@@ -1658,6 +1792,10 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *q_reset.borrow_mut() = TimeQueue::new();
+            *out_reset.borrow_mut() = T::default();
+        }));
         (self.make_handle(idx), FeedbackSink { queue, source: idx })
     }
 
@@ -1674,6 +1812,7 @@ impl Builder {
         let out = self.new_slot(T::default());
         let queue = sink.queue.clone();
         let source = sink.source;
+        let out_reset = out.clone();
         self.push_node(
             vec![src.idx],
             Activation::NONE,
@@ -1688,6 +1827,9 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = T::default();
+        }));
         self.make_handle(idx)
     }
 
@@ -1712,6 +1854,10 @@ impl Builder {
     {
         let idx = self.nodes.len();
         let out = self.new_slot(T::default());
+        // A mounted island owns a private interior runtime with no reset hook,
+        // so a graph containing one is single-run for now (see the re-run note
+        // in the port plan).
+        self.re_runnable = false;
         let cell = Rc::new(RefCell::new(node));
         let cell_start = cell.clone();
         let cell_stop = cell.clone();
@@ -1815,6 +1961,8 @@ impl Builder {
             active_downs,
             seed_nodes,
             dispatch: Dispatch::default(),
+            re_runnable: self.re_runnable,
+            has_run: false,
         }
     }
 }
@@ -1868,12 +2016,43 @@ pub struct Runner {
     seed_nodes: Vec<usize>,
     /// Which dispatch loop `run` uses. `Sparse` by default; see [`Dispatch`].
     dispatch: Dispatch,
+    /// Whether every node can restore itself for a re-run (see
+    /// [`Builder::re_runnable`](Builder)). A graph with `external`/`poll`/
+    /// `channel` sources or `composite` islands is single-run.
+    re_runnable: bool,
+    /// Set after the first [`run`](Runner::run); a subsequent run first calls
+    /// [`reset`](Runner::reset) to restore state.
+    has_run: bool,
 }
 
 impl Runner {
     /// Run the graph to its bound. Returns the first error from any node's
     /// `start`/`cycle`/`stop`/`teardown` (with node context), or `Ok(())`.
+    ///
+    /// A [`Runner`] may be run **repeatedly** as long as its graph is
+    /// re-runnable — tickers/constants + combinators + feedback, the
+    /// deterministic historical subset. A second `run` first restores every
+    /// node's state and value slot to its wiring-time initial value (via
+    /// [`reset`](Runner::reset)), so each run is independent and reproduces a
+    /// fresh graph exactly (spike 0.4's "setup-per-run" semantics). A graph
+    /// with `external`/`poll`/`channel` sources or `composite` islands is
+    /// single-run — its producer channels, wakers, and island interiors are
+    /// consumed by the first run — and a second `run` returns an error rather
+    /// than silently producing wrong values.
     pub fn run(&mut self, run_mode: RunMode, run_for: RunFor) -> Result<()> {
+        if self.has_run {
+            if self.re_runnable {
+                self.reset();
+            } else {
+                bail!(
+                    "this Runner is single-run: its graph contains external/poll/channel \
+                     sources or a nested island whose state cannot be reset — build a fresh \
+                     graph to run again (a historical graph of tickers/constants + combinators \
+                     re-runs)"
+                );
+            }
+        }
+        self.has_run = true;
         let realtime = matches!(run_mode, RunMode::RealTime);
         // `external`/`poll` are wall-clock (realtime-only); `channel` carries
         // timestamps and runs in both modes. These are reachable user errors
@@ -1953,6 +2132,30 @@ impl Runner {
             Some(e) => Err(e),
             None => Ok(()),
         }
+    }
+
+    /// Restore every node's engine-owned state and value slot to its
+    /// wiring-time initial value, so the next [`run`](Runner::run) starts from
+    /// a clean slate — spike 0.4's per-run reset semantics. Called
+    /// automatically by `run` on a re-run; exposed so a caller can reset
+    /// explicitly. The kernel is rebuilt from `t=0` on each `run` and each
+    /// node's `start` re-seeds its schedules, so this only touches per-node
+    /// state (accumulators, buffers, delay queues), never the clock.
+    ///
+    /// Only meaningful for a re-runnable graph; on a single-run graph
+    /// (external/poll/channel/island) the per-node reset closures still run but
+    /// cannot restore a consumed producer channel, so [`run`](Runner::run)
+    /// still refuses a second call.
+    pub fn reset(&mut self) {
+        for node in &mut self.nodes {
+            (node.reset)();
+        }
+        // Defensive: every run leaves `ticked` all-false (each cycle clears the
+        // nodes it fired), but clear it anyway so reset is self-contained.
+        for t in self.ticked.borrow_mut().iter_mut() {
+            *t = false;
+        }
+        self.finished.set(false);
     }
 
     /// Select the dispatch strategy for subsequent [`run`](Runner::run)s.

--- a/next/crates/wingfoil-next/tests/compat.rs
+++ b/next/crates/wingfoil-next/tests/compat.rs
@@ -62,26 +62,26 @@ fn peek_before_run_panics_with_a_clear_message() {
     let _ = counted.peek_value();
 }
 
-/// Re-running is deferred: the builder is consumed by the first run, so a
-/// second `run` must surface a clear error instead of silently running an
-/// empty graph and then panicking out-of-bounds in `peek_value`. The first
-/// run's result stays readable afterwards.
+/// Re-running is supported (spike 0.4's setup-per-run reset): the graph is
+/// built once and the runner retained, and each `run` restores every node's
+/// state and value slot first, so two runs of the *same* `Signal` produce
+/// identical results — never the accumulator-continues bug (a count that would
+/// go 5 → 10). This is the wingfoil-python re-run gate.
 #[test]
-fn second_run_errors_and_leaves_first_result_intact() {
+fn second_run_matches_the_first() {
     let counted = ticker(Duration::from_nanos(100)).count();
+
     counted.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
     assert_eq!(5, counted.peek_value());
 
-    let err = counted
-        .run(HISTORICAL, RunFor::Cycles(5))
-        .expect_err("a second run must error, not silently run an empty graph");
-    assert!(
-        err.to_string().contains("called more than once"),
-        "unexpected error message: {err}"
-    );
-
-    // The first run's runner is untouched, so peek still returns its value.
+    // A second run reproduces the first exactly — the count restarts from the
+    // fold's wiring-time seed rather than continuing at 5.
+    counted.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
     assert_eq!(5, counted.peek_value());
+
+    // A different bound on the retained runner still gives fresh-graph results.
+    counted.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(3, counted.peek_value());
 }
 
 // --- Expanded operator surface, all in the classic idiom -------------------

--- a/next/crates/wingfoil-next/tests/custom_op.rs
+++ b/next/crates/wingfoil-next/tests/custom_op.rs
@@ -428,9 +428,14 @@ trait CustomOps {
 impl CustomOps for Stream<f64> {
     fn scale(&self, factor: f64) -> Stream<f64> {
         self.wire(|b, h| {
-            b.register_op1(h, "scale", Scale::ACTIVATION, factor, (), |c, s, a, ctx| {
-                <Scale as Op>::cycle(c, s, (a,), ctx)
-            })
+            b.register_op1(
+                h,
+                "scale",
+                Scale::ACTIVATION,
+                factor,
+                || (),
+                |c, s, a, ctx| <Scale as Op>::cycle(c, s, (a,), ctx),
+            )
         })
     }
 
@@ -441,7 +446,7 @@ impl CustomOps for Stream<f64> {
                 "delta",
                 <Delta<f64> as Op>::ACTIVATION,
                 (),
-                None,
+                || None,
                 |c, s, a, ctx| <Delta<f64> as Op>::cycle(c, s, (a,), ctx),
             )
         })
@@ -454,7 +459,7 @@ impl CustomOps for Stream<f64> {
                 "apply",
                 <Apply<F> as Op>::ACTIVATION,
                 f,
-                (),
+                || (),
                 |c, s, a, ctx| <Apply<F> as Op>::cycle(c, s, (a,), ctx),
             )
         })
@@ -469,7 +474,7 @@ impl CustomOps for Stream<f64> {
                 "spread",
                 Spread::ACTIVATION,
                 (),
-                (),
+                || (),
                 |c, s, a, b, ctx| <Spread as Op>::cycle(c, s, (a, b), ctx),
             )
         })
@@ -488,7 +493,7 @@ impl CustomOps for Stream<f64> {
                 "combine",
                 <Combine<f64, f64, f64, F> as Op>::ACTIVATION,
                 f,
-                (),
+                || (),
                 |c, s, a, b, ctx| <Combine<f64, f64, f64, F> as Op>::cycle(c, s, (a, b), ctx),
             )
         })

--- a/next/crates/wingfoil-next/tests/rerun.rs
+++ b/next/crates/wingfoil-next/tests/rerun.rs
@@ -1,0 +1,213 @@
+//! Re-run / runner-lifecycle parity (spike 0.4 → Phase 1 contract).
+//!
+//! A [`Runner`](wingfoil_next::interp::Runner) for a *re-runnable* graph
+//! (tickers/constants + combinators + feedback — the deterministic historical
+//! subset) may be run repeatedly. Each `run` first restores every node's
+//! engine-owned state and value slot to its wiring-time initial value, so two
+//! runs of the same runner are independent and reproduce a freshly-built graph
+//! exactly — classic wingfoil's setup-per-run semantics. This is the contract
+//! the Phase 6 compat facade (and the wingfoil-python re-run) depends on; spike
+//! 0.4 deferred it to Phase 1, and here it is.
+//!
+//! Single-run graphs (external/poll/channel sources, nested islands) hold state
+//! the engine cannot reset — their producer channels, wakers, and island
+//! interiors are consumed by the first run — so a second `run` errors rather
+//! than silently producing wrong values.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const TEN: Duration = Duration::from_nanos(10);
+
+/// A graph exercising stateful ops whose state *must* reset between runs: a
+/// `count` (fold), a `map`, a running `fold`, a `delay` (self-scheduling queue),
+/// and a `merge`. Returns the accumulated merged output.
+fn wire(g: &GraphBuilder) -> Stream<Vec<u64>> {
+    let count = g.ticker(TEN).count(); // 1, 2, 3, ...
+    let doubled = count.map(|i| i * 2); // 2, 4, 6, ...
+    let running = doubled.fold(0u64, |acc, x| *acc += *x); // 2, 6, 12, ...
+    let delayed = count.delay(Duration::from_nanos(25)); // count, shifted later
+    running.merge(&delayed).accumulate()
+}
+
+/// The core contract: a second `run` of the same runner reproduces the first
+/// exactly (state resets — the running fold restarts from its seed rather than
+/// continuing), and both equal a freshly-built graph run once.
+#[test]
+fn rerun_matches_fresh_graph() {
+    let g = GraphBuilder::new();
+    let acc = wire(&g);
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    let first = r.value(&acc);
+
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    let second = r.value(&acc);
+
+    // A freshly-built identical graph is the parity oracle.
+    let g2 = GraphBuilder::new();
+    let acc2 = wire(&g2);
+    let mut r2 = g2.build();
+    r2.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    let fresh = r2.value(&acc2);
+
+    assert_eq!(
+        first, second,
+        "a re-run must reproduce the first run exactly"
+    );
+    assert_eq!(first, fresh, "a re-run must match a freshly-built graph");
+    assert!(
+        !first.is_empty(),
+        "sanity: the graph actually produced values"
+    );
+}
+
+/// Without the reset, a running fold would *continue* across runs (spike 0.4's
+/// "counter goes 3 → 6"). Assert it restarts instead.
+#[test]
+fn fold_accumulator_restarts_not_continues() {
+    let g = GraphBuilder::new();
+    let sum = g.ticker(TEN).count().fold(0u64, |acc, x| *acc += *x);
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(1 + 2 + 3, r.value(&sum)); // 6
+
+    // If state leaked, the second run would end at 6 + (1+2+3) = 12.
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(1 + 2 + 3, r.value(&sum)); // 6 again, not 12
+}
+
+/// The buffering / scheduling / passive-read ops (`window`, `throttle`,
+/// `sample`, `with_time`) each reset their state and value slot between runs.
+#[test]
+fn buffering_and_sampling_ops_reset() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(TEN).count();
+    let windowed = count.window(Duration::from_nanos(30)).accumulate();
+    let throttled = count.throttle(Duration::from_nanos(30)).accumulate();
+    let sampled = count
+        .sample(&g.ticker(Duration::from_nanos(20)))
+        .accumulate();
+    let timed = count.with_time().accumulate();
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(8)).unwrap();
+    let (w1, t1, s1, ts1) = (
+        r.value(&windowed),
+        r.value(&throttled),
+        r.value(&sampled),
+        r.value(&timed),
+    );
+
+    r.run(HISTORICAL, RunFor::Cycles(8)).unwrap();
+    assert_eq!(w1, r.value(&windowed), "window must reset");
+    assert_eq!(t1, r.value(&throttled), "throttle must reset");
+    assert_eq!(s1, r.value(&sampled), "sample must reset");
+    assert_eq!(ts1, r.value(&timed), "with_time must reset");
+}
+
+/// Feedback graphs re-run: the shared time-queue is cleared and the source slot
+/// reset, so the classic `1, 11, 111, ...` sequence reproduces on every run.
+#[test]
+fn feedback_reruns() {
+    let g = GraphBuilder::new();
+    let (fed_back, sink) = g.feedback::<u64>();
+    let one = g.constant(1u64);
+    let sum = one.join(&fed_back, |a, b| a + b * 10);
+    let writer = sum.feedback(&sink);
+    let acc = writer.accumulate();
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1, 11, 111, 1111, 11111], r.value(&acc));
+
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![1, 11, 111, 1111, 11111], r.value(&acc));
+}
+
+/// An explicit [`Runner::reset`] restores state without running; a subsequent
+/// `run` then starts clean, same as the auto-reset a re-run performs.
+#[test]
+fn explicit_reset_restores_state() {
+    let g = GraphBuilder::new();
+    let sum = g.ticker(TEN).count().fold(0u64, |acc, x| *acc += *x);
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(1 + 2 + 3 + 4, r.value(&sum)); // 10
+    r.reset();
+    // After reset (before any re-run) the slot is back to the fold seed.
+    assert_eq!(0, r.value(&sum));
+
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(10, r.value(&sum));
+}
+
+/// A single-run graph (here a busy-poll source) cannot reset — its producer
+/// channel is consumed by the first run — so a second `run` errors with a
+/// clear message rather than silently producing wrong values.
+#[test]
+fn single_run_graph_errors_on_second_run() {
+    let g = GraphBuilder::new();
+    let polled = g.poll(|| None::<u64>);
+    let _acc = polled.accumulate();
+    let mut r = g.build();
+
+    r.run(RunMode::RealTime, RunFor::Cycles(4)).unwrap();
+    let err = r
+        .run(RunMode::RealTime, RunFor::Cycles(4))
+        .expect_err("a single-run graph must refuse a second run");
+    assert!(
+        err.to_string().contains("single-run"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `merge_all` (the n-ary merge sugar) is exactly the left-associated chain of
+/// 2-ary merges — same values, same earliest-wins tie-break — and both match a
+/// fresh graph.
+#[test]
+fn merge_all_matches_chained_merge() {
+    fn wire_nary(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let base = g.ticker(TEN).count();
+        let a = base.map(|i| i * 10);
+        let b = base.map(|i| i * 100);
+        let c = base.map(|i| i * 1000);
+        a.merge_all(&[&b, &c]).accumulate()
+    }
+    fn wire_chained(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let base = g.ticker(TEN).count();
+        let a = base.map(|i| i * 10);
+        let b = base.map(|i| i * 100);
+        let c = base.map(|i| i * 1000);
+        a.merge(&b).merge(&c).accumulate()
+    }
+
+    let gn = GraphBuilder::new();
+    let nary = wire_nary(&gn);
+    let mut rn = gn.build();
+    rn.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+
+    let gc = GraphBuilder::new();
+    let chained = wire_chained(&gc);
+    let mut rc = gc.build();
+    rc.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+
+    assert_eq!(rn.value(&nary), rc.value(&chained));
+    assert!(!rn.value(&nary).is_empty());
+
+    // `merge_all(&[])` is just the stream itself.
+    let g0 = GraphBuilder::new();
+    let base = g0.ticker(TEN).count();
+    let lone = base.map(|i| i * 10);
+    let empty = lone.merge_all(&[]).accumulate();
+    let direct = lone.accumulate();
+    let mut r0 = g0.build();
+    r0.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(r0.value(&direct), r0.value(&empty));
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -65,7 +65,7 @@ today's interpreted engine.
 | Observe arbitrary intermediate streams | ✅ | ✅ | ❌⁵ | ❌⁵ |
 | Runtime-valued config (params/captures from caller) | ✅ | ✅ | ❌⁶ | ❌⁶ |
 | Mutable per-node state | ✅⁷ | ✅⁷ | ✅⁷ | ✅⁷ |
-| Re-run (independent repeated runs) | ✅⁸ | ❌⁸ | ✅⁹ | ✅⁹ |
+| Re-run (independent repeated runs) | ✅⁸ | ✅⁸ | ✅⁹ | ✅⁹ |
 | Dynamic graph (runtime add/remove) | ✅ | 📅¹⁰ | ❌ | 🟡¹⁰ |
 | Sparse-graph efficiency (work ∝ *active* nodes) | ✅¹¹ | ✅¹² | 🟡¹³ | ✅¹⁴ |
 | Dense hot-path speed (measured) | 1× | ~1×¹² | 3–4×¹⁵ | interior 3–4×¹⁵ |
@@ -88,8 +88,13 @@ today's interpreted engine.
   would drift between the interpreted and compiled engines) is a compile
   error. Both express arbitrary per-node state, by different idioms.
 ⁸ Classic is the reference — a fresh `Graph::run` re-initialises via
-  `setup`. next's v1 Runner is single-run (spike 0.4); matching classic's
-  re-run needs the per-node reset hook (planned).
+  `setup`. The interpreted engine now matches it: the per-node `reset` hook
+  (Phase 1, landed) restores each node's state + value slot to its wiring-time
+  initial value, so `Runner::run` re-runs for the deterministic historical
+  subset (tickers/constants + combinators + feedback). Graphs with
+  external/poll/channel sources or nested islands stay single-run by
+  construction (consumed producer channels/wakers/interiors) — a second `run`
+  errors rather than misbehaving.
 ⁹ `compiled()` is a plain fn — each call is a fresh independent run.
 ¹⁰ The sparse dirty-list engine — the mutable-frontier *enabler* for runtime
   add/remove — has landed, but graph *mutation* itself (`Runner::extend`) is
@@ -243,23 +248,61 @@ on re-run working. Rather than discovering this at the facade, the per-node
 plumbing (it slots into the existing lifecycle machinery). This closes the
 last Phase-0 spike by decision.
 
+**Update — delivered in Phase 1.** The `reset` hook has since landed (see the
+Phase 1 bullet): the interpreted `Runner` re-runs the deterministic historical
+subset, restoring per-node state + slots to their wiring-time values, and
+`compat::Signal::run` is re-runnable. Single-run graphs (external/poll/channel/
+island) error on a second `run` rather than misbehaving.
+
 **Gate 0:** all four spikes land with classic-parity tests green.
 
 ## Phase 1 — contract completion
 
 - Fold spike results into `op.rs` + all three engines + macro.
-- Variadic gaps: `Join3` (trimap), n-ary merge, `try_map`/`try_bimap`/
-  `try_trimap` (trivial once cycle is fallible — the closure returns
-  `Result`, the op `?`s it).
-- Multi-output islands via projection nodes (or explicitly re-defer with a
-  written rationale).
+- Variadic gaps: `Join3` (trimap) ✅, n-ary merge ✅, `try_map`/`try_bimap`/
+  `try_trimap` ✅ (trivial once cycle is fallible — the closure returns
+  `Result`, the op `?`s it). **n-ary merge** landed as `StreamOps::merge_all`
+  (`fluent.rs`) — sugar that unrolls to a left-associated chain of 2-ary
+  `merge`s. 2-ary merge's earliest-wins tie-break is associative, so the chain
+  and a single variadic node fire identically; the sugar-over-primitive
+  approach matches `fan`/`map_n`, and a dedicated variadic op would add engine
+  complexity for zero observable difference (`tests/rerun.rs::
+  merge_all_matches_chained_merge`).
+- **Multi-output islands — re-deferred (written rationale).** An `Op`/island
+  produces a single `Out`; classic multi-output nodes (`demux`,
+  `dynamic_group`) would need projection nodes that fan a tuple output into N
+  slots. Re-deferred for v1 because: (a) nothing in the catalog *ported so far*
+  needs it — every Phase 2 op landed is single-output, and the two classic
+  multi-output nodes are in the "Structural / deferred" group that also awaits
+  the dynamic-graph decision (Phase 4.5); (b) an island already exposes its one
+  output cleanly, and a caller wanting K outputs can mount K islands over the
+  same inputs (wasteful only if the shared interior is expensive — none is
+  today); (c) the honest projection design is coupled to the Phase 4.5 arena
+  slot representation (a projection writes several slots from one cycle), so
+  building it against today's `Rc<RefCell<T>>` slots risks the exact
+  touch-it-twice rework the Phase 4.5 coupling note warns against. Decision:
+  revisit alongside `demux`/`dynamic_group` in the Phase 4.5 dynamic-graph
+  pass, not as isolated Phase 1 work.
 - Debug labels on nodes (needed by 0.1 error reports; also unlocks GML
   export in Phase 5).
-- **Per-node `reset`/`setup` hook** (from spike 0.4) — restores each op's
-  state to its wiring-time initial value and re-seeds schedules, giving
-  well-defined re-run. It is contract work, not a facade detail: the Phase 6
-  compat facade re-runs classic streams and `compat::Signal` already breaks
-  without it (see 0.4). Same plumbing shape as `stop`/`teardown`.
+- **Per-node `reset`/`setup` hook** ✅ **landed** (from spike 0.4) — the
+  interpreted engine now restores each node's engine-owned state and value slot
+  to its wiring-time initial value before a re-run, giving well-defined
+  repeated runs. `register_op1`/`register_op2` take a *state factory*
+  (`Fn() -> S`, not a value) so the engine can re-seed; the `#[op]` macro emits
+  `|| Default::default()`. `NodeRt` carries a `reset` closure (same plumbing
+  shape as `stop`/`teardown`), set by every registration. `Runner::run`
+  auto-resets on a second call (and `Runner::reset()` is public); the kernel is
+  rebuilt from `t=0` each run and each node's `start` re-seeds its schedules, so
+  reset only touches per-node state. Graphs with `external`/`poll`/`channel`
+  sources or `composite` islands are single-run by construction (their producer
+  channels, wakers, and island interiors are consumed by the first run) and a
+  second `run` errors clearly. This unblocks the Phase 6 compat facade:
+  `compat::Signal::run` is now re-runnable, the wingfoil-python re-run gate.
+  Covered by `tests/rerun.rs` (re-run == fresh graph; fold restarts not
+  continues; buffering/sampling ops reset; feedback re-runs; explicit reset;
+  single-run guard) and the rewritten `tests/compat.rs::
+  second_run_matches_the_first`.
 - **`Tick::Silent` (update-value-without-ticking) contract decision** — the
   `Tick` contract today cannot express "store a new value but don't tick,"
   which classic relies on (e.g. `Delay`'s first-value seeding, so passive


### PR DESCRIPTION
## Summary

Implements the Phase 1 per-node `reset` hook to enable re-runnable graphs in the interpreted engine. This restores each node's engine-owned state and value slot to their wiring-time initial values before a second `Runner::run`, giving independent, reproducible runs that match classic wingfoil's setup-per-run semantics.

## Key Changes

- **New `ResetFn` type and `NodeRt.reset` field**: Added a reset closure to every node's runtime record, defaulting to a no-op for stateless nodes. Documented the contract: reset happens *between* runs when no kernel exists, and restores state to wiring-time initial values.

- **State factory pattern in `register_op1`/`register_op2`**: Changed the `state` parameter to `state_init: SInit where SInit: Fn() -> S`, allowing the engine to re-seed state on re-run. The `#[op]` macro now emits `|| Default::default()`. All call sites updated (custom ops, benches, async sources).

- **Reset hooks on all stateful ops**: Every registration method (`ticker`, `constant`, `with_time`, `throttle`, `window`, `fold`, `delay`, `filter`, `merge`, `join`, `sample`, `finally`, etc.) now calls `set_reset()` to attach a closure that restores that node's state and output slot.

- **`Builder.re_runnable` flag**: Tracks whether the graph can reset. Set to `false` by `external()`, `channel()`, and `poll()` (their producer channels/wakers are consumed by the first run) and `composite()` (interior runtime has no reset hook). A `Runner` built from a single-run graph errors on a second `run` rather than misbehaving.

- **`Runner::reset()` method**: Explicit reset without running, restoring state before a subsequent `run`.

- **`compat::Signal::run` is now re-runnable**: Builds the graph once and retains the runner, so repeated calls re-run with fresh state. Removed the "called more than once" error; the runner now handles re-runs correctly.

- **`StreamOps::merge_all` (n-ary merge)**: Sugar that unrolls to a left-associated chain of 2-ary `merge`s. Closes the variadic-merge vocabulary gap without a bespoke op (same approach as `fan`/`map_n`).

- **Comprehensive test suite** (`tests/rerun.rs`): Validates that re-runs reproduce the first run exactly, fold accumulators restart (not continue), buffering/sampling ops reset, feedback graphs re-run, explicit reset works, and single-run graphs error on a second run.

## Implementation Details

- The reset closure captures clones of the state cell and output slot, re-initializing them to their wiring-time values. For ops with config + state, only state is reset (config is immutable).
- `Runner::run` calls `reset()` on every node before executing the graph, ensuring a clean slate each time.
- The `re_runnable` flag is a compile-time property of the graph shape — determined during wiring, not at runtime — so the error on a second run of a single-run graph is caught eagerly.
- Updated `port-plan.md` to reflect Phase 1 completion: re-run is now ✅ for the interpreted engine (deterministic historical subset), with single-run graphs (external/poll/channel/island) erroring rather than misbehaving.

## Testing

All existing tests pass. New `tests/rerun.rs` validates:
- Re-runs match fresh graphs exactly
- Fold accumulators restart, not continue
- Buffering/sampling ops reset state
- Feedback graphs re-run
- Explicit `reset()` restores state
- Single-run graphs error on second run
- `merge_all` matches chained 2-ary merges

https://claude.ai/code/session_014RPNsRk6v7rtxznETdMCBJ