### PR TITLE
Phase 2: Add never, delay_with_reset, node_flow ops, and structural ops

### DIFF
--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -141,6 +141,16 @@ impl GraphBuilder {
         );
         std::mem::take(&mut *self.inner.borrow_mut()).build()
     }
+
+    /// Combine several same-type streams into a `Stream<Burst<T>>` (the classic
+    /// `combine`): each cycle gathers the current values of every input that
+    /// ticked *this* instant into one [`Burst`], in argument order — same-instant
+    /// values ride one burst, never latest-wins.
+    pub fn combine<T: Clone + Default + 'static>(&self, streams: &[Stream<T>]) -> Stream<Burst<T>> {
+        let handles: Vec<Handle<T>> = streams.iter().map(|s| s.handle()).collect();
+        let handle = self.with_builder(|b| b.combine(&handles));
+        self.wrap(handle)
+    }
 }
 
 /// Source constructors — the graph's entry points. An extension trait on
@@ -180,6 +190,11 @@ pub trait SourceOps {
     fn feedback<T>(&self) -> (Stream<T>, FeedbackSink<T>)
     where
         T: Clone + Default + PartialEq + 'static;
+
+    /// A source that never ticks (the classic `never`). Useful as an inert
+    /// trigger — e.g. a [`delay_with_reset`](StreamOps::delay_with_reset) that
+    /// never resets behaves like a plain [`delay`](StreamOps::delay).
+    fn never(&self) -> Stream<()>;
 }
 
 impl SourceOps for GraphBuilder {
@@ -215,6 +230,10 @@ impl SourceOps for GraphBuilder {
     {
         let (handle, sink) = self.with_builder(|b| b.feedback::<T>());
         (self.wrap(handle), sink)
+    }
+
+    fn never(&self) -> Stream<()> {
+        self.source(|b| b.never())
     }
 }
 
@@ -487,6 +506,23 @@ pub trait StreamOps<T>: Sized {
     where
         T: Clone + Default + PartialEq + 'static;
 
+    /// [`delay`](StreamOps::delay) with a reset trigger (the classic
+    /// `delay_with_reset`): when `trigger` ticks, the output snaps to the
+    /// current value and any pending (delayed) values are dropped. `trigger`
+    /// is read for its tick only, so its value type is irrelevant.
+    fn delay_with_reset<U>(&self, delay: Duration, trigger: &Stream<U>) -> Stream<T>
+    where
+        T: Clone + Default + PartialEq + 'static,
+        U: 'static;
+
+    /// Collapse a burst/iterator value into a single tick of its **last** item
+    /// (the classic `collapse`); stays quiet when the iterator is empty. Sugar
+    /// over [`map_filter`](StreamOps::map_filter).
+    fn collapse<OUT>(&self) -> Stream<OUT>
+    where
+        T: Clone + IntoIterator<Item = OUT> + 'static,
+        OUT: Clone + Default + 'static;
+
     /// Run a side-effecting (fallible) closure on each tick — the graph's
     /// outbound edge (print, send, record). A returned `Err` aborts the run
     /// with context. Emits `()` per tick.
@@ -753,6 +789,26 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         self.wire(|b, h| b.delay(h, delay))
     }
 
+    fn delay_with_reset<U>(&self, delay: Duration, trigger: &Stream<U>) -> Stream<T>
+    where
+        T: Clone + Default + PartialEq + 'static,
+        U: 'static,
+    {
+        let trig = trigger.handle();
+        self.wire(|b, h| b.delay_with_reset(h, trig, delay))
+    }
+
+    fn collapse<OUT>(&self) -> Stream<OUT>
+    where
+        T: Clone + IntoIterator<Item = OUT> + 'static,
+        OUT: Clone + Default + 'static,
+    {
+        self.map_filter(|x: &T| match x.clone().into_iter().last() {
+            Some(last) => (last, true),
+            None => (OUT::default(), false),
+        })
+    }
+
     fn for_each<F>(&self, f: F) -> Stream<()>
     where
         T: 'static,
@@ -792,5 +848,18 @@ impl<T: Clone + Default + 'static> Stream<Burst<T>> {
         self.fold(Vec::new(), |acc, burst: &Burst<T>| {
             acc.extend(burst.iter().cloned())
         })
+    }
+}
+
+impl<A, B> Stream<(A, B)>
+where
+    A: Clone + Default + 'static,
+    B: Clone + Default + 'static,
+{
+    /// Decompose a stream of pairs into its two component streams (the classic
+    /// `split`) — sugar over two [`map`](StreamOps::map)s. Both branches tick
+    /// whenever the source does.
+    pub fn split(&self) -> (Stream<A>, Stream<B>) {
+        (self.map(|t| t.0.clone()), self.map(|t| t.1.clone()))
     }
 }

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -51,9 +51,9 @@ use crate::Burst;
 use crate::channel::{ChannelSender, Message};
 use crate::op::{Activation, CompositePhase, Ctx, Op, Tick};
 use crate::ops::{
-    Const, Delay, DelayState, Filter, Finally, Fold, Join, Join3, Merge2, Poll, Print, Sample,
-    Throttle, Ticker, TickerState, Timed, TimedState, TryJoin, TryJoin3, Window, WindowState,
-    WithTime,
+    Const, Delay, DelayState, DelayWithReset, DelayWithResetState, Filter, Finally, Fold, Join,
+    Join3, Merge2, Never, Poll, Print, Sample, Throttle, Ticker, TickerState, Timed, TimedState,
+    TryJoin, TryJoin3, Window, WindowState, WithTime,
 };
 use wingfoil::codegen::{Kernel, KernelWaker, ReadyReceiver, waker_channel};
 use wingfoil::{NanoTime, RunFor, RunMode, TimeQueue};
@@ -702,6 +702,72 @@ impl Builder {
         self.make_handle(idx)
     }
 
+    /// A source that never ticks (the classic `never`). No upstreams and no
+    /// scheduling, so the engine never cycles it; used as an inert trigger.
+    pub fn never(&mut self) -> Handle<()> {
+        let idx = self.nodes.len();
+        // The slot is kept for index alignment; `never` never writes it.
+        let _out = self.new_slot(());
+        self.push_node(
+            Vec::new(),
+            Never::ACTIVATION,
+            "never",
+            Box::new(move |k| {
+                let mut ctx = Ctx::new(k, idx);
+                match Never::cycle(&mut (), &mut (), (), &mut ctx)? {
+                    Tick::Value(()) | Tick::Silent(()) => Ok(false),
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        self.make_handle(idx)
+    }
+
+    /// Combine several same-type streams into a `Stream<Burst<T>>` (the classic
+    /// `combine`): each cycle gathers the current values of every upstream that
+    /// ticked *this* instant into one [`Burst`], in upstream order. Quiet on a
+    /// cycle where none ticked (only reachable via a shared scheduled wake).
+    ///
+    /// Hand-written (no `Op` witness): an n-ary fan-in does not fit the `Op`
+    /// trait's fixed-arity tuple `In`, and — unlike the classic port's shared
+    /// `Rc<RefCell<Burst>>` cell written by per-stream feeder nodes — the burst
+    /// is built locally here, honouring next's no-shared-mutable-slot rule.
+    pub fn combine<T: Clone + Default + 'static>(
+        &mut self,
+        srcs: &[Handle<T>],
+    ) -> Handle<Burst<T>> {
+        let idx = self.nodes.len();
+        let indices: Vec<usize> = srcs.iter().map(|h| h.idx).collect();
+        let slots: Vec<Rc<RefCell<T>>> = srcs.iter().map(|h| self.slot(*h)).collect();
+        let out = self.new_slot(Burst::<T>::new());
+        let ticked = self.ticked.clone();
+        self.push_node(
+            indices.clone(),
+            Activation::NONE,
+            "combine",
+            Box::new(move |_k| {
+                let mut burst = Burst::<T>::new();
+                {
+                    let t = ticked.borrow();
+                    for (i, slot) in indices.iter().zip(slots.iter()) {
+                        if t[*i] {
+                            burst.push(slot.borrow().clone());
+                        }
+                    }
+                }
+                if burst.is_empty() {
+                    Ok(false)
+                } else {
+                    *out.borrow_mut() = burst;
+                    Ok(true)
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        self.make_handle(idx)
+    }
+
     /// Pair each value with the current engine time: `(time, value)`. Kept
     /// hand-written (not `#[op]`): the output `(NanoTime, T)` is seeded from
     /// the input's current value, so it never requires `T: Default`.
@@ -1214,6 +1280,56 @@ impl Builder {
                         Tick::Silent(value) => (Some(value), false),
                         Tick::Quiet => (None, false),
                     };
+                drop(v);
+                if let Some(w) = write {
+                    *out.borrow_mut() = w;
+                }
+                Ok(did)
+            }),
+            Box::new(|_| Ok(())),
+        );
+        self.make_handle(idx)
+    }
+
+    /// [`delay`](Self::delay) with a reset trigger (the classic
+    /// `delay_with_reset`): when `trigger` ticks, the output snaps to the
+    /// current upstream value and the pending queue is cleared. `trigger` is
+    /// read for its *tick* only — its value type is irrelevant — so it is an
+    /// active edge alongside the upstream.
+    pub fn delay_with_reset<T: Clone + Default + PartialEq + 'static, U: 'static>(
+        &mut self,
+        src: Handle<T>,
+        trigger: Handle<U>,
+        delay: Duration,
+    ) -> Handle<T> {
+        let idx = self.nodes.len();
+        let src_slot = self.slot(src);
+        let out = self.new_slot(T::default());
+        let ticked = self.ticked.clone();
+        let (is, it) = (src.idx, trigger.idx);
+        let cs = Self::cell(delay, DelayWithResetState::<T>::default());
+        self.push_node(
+            vec![src.idx, trigger.idx],
+            DelayWithReset::<T>::ACTIVATION,
+            "delay_with_reset",
+            Box::new(move |k| {
+                let (src_ticked, trig_ticked) = {
+                    let t = ticked.borrow();
+                    (t[is], t[it])
+                };
+                let (cfg, state) = &mut *cs.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                let v = src_slot.borrow();
+                let (write, did): (Option<T>, bool) = match DelayWithReset::<T>::cycle(
+                    cfg,
+                    state,
+                    (&v, src_ticked, trig_ticked),
+                    &mut ctx,
+                )? {
+                    Tick::Value(value) => (Some(value), true),
+                    Tick::Silent(value) => (Some(value), false),
+                    Tick::Quiet => (None, false),
+                };
                 drop(v);
                 if let Some(w) = write {
                     *out.borrow_mut() = w;

--- a/next/crates/wingfoil-next/src/ops.rs
+++ b/next/crates/wingfoil-next/src/ops.rs
@@ -2095,3 +2095,110 @@ impl<T: Clone + 'static> Op for Merge2<T> {
         })
     }
 }
+
+/// A source that never ticks — the classic `never` node. It has no upstreams
+/// and never schedules itself, so it stays [`Tick::Quiet`] for the whole run;
+/// its unit value is never observed downstream. The idiomatic inert trigger —
+/// e.g. a [`DelayWithReset`] that never resets degrades to a plain [`Delay`].
+///
+/// Kept a plain `Op` (no `#[op]`, hand-written `Builder::never`) because it is
+/// a zero-input source, the shape the single-input `#[op]` scope does not
+/// cover.
+pub struct Never;
+
+impl Op for Never {
+    type Cfg = ();
+    type State = ();
+    type In<'a> = ();
+    type Out = ();
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(_cfg: &mut (), _state: &mut (), _input: (), _ctx: &mut Ctx<'_>) -> Result<Tick<()>> {
+        Ok(Tick::Quiet)
+    }
+}
+
+/// Pending state for a [`DelayWithReset`] op: the queue of not-yet-due values
+/// and whether the first upstream value has been stored into the slot (via
+/// [`Tick::Silent`], as [`Delay`] does).
+pub struct DelayWithResetState<T: PartialEq> {
+    queue: TimeQueue<T>,
+    initialized: bool,
+}
+
+impl<T: PartialEq> Default for DelayWithResetState<T> {
+    fn default() -> Self {
+        Self {
+            queue: TimeQueue::new(),
+            initialized: false,
+        }
+    }
+}
+
+/// [`Delay`] with a reset trigger — the classic `delay_with_reset` node. When
+/// the trigger ticks, the output snaps to the *current* upstream value and the
+/// pending queue is cleared; otherwise it behaves exactly like [`Delay`]. The
+/// two active inputs (upstream value and the trigger's tick) arrive as input
+/// data — `(&value, upstream_ticked, trigger_ticked)` — mirroring the way
+/// [`Delay`] receives its upstream tick flag; `SCHEDULES` grants the delayed
+/// re-emit its `Ctx::schedule`.
+///
+/// Hand-written `Builder` (no `#[op]`): two tick-flag inputs plus custom state
+/// seeding put it outside the single-input `#[op]` scope, like [`Delay`].
+pub struct DelayWithReset<T>(PhantomData<T>);
+
+impl<T: Clone + PartialEq + 'static> Op for DelayWithReset<T> {
+    type Cfg = Duration;
+    type State = DelayWithResetState<T>;
+    /// Upstream value, whether the upstream ticked, and whether the reset
+    /// trigger ticked, this cycle.
+    type In<'a> = (&'a T, bool, bool);
+    type Out = T;
+    const ACTIVATION: Activation = Activation::SCHEDULES;
+
+    fn cycle(
+        cfg: &mut Duration,
+        state: &mut DelayWithResetState<T>,
+        input: (&T, bool, bool),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<T>> {
+        let (value, upstream_ticked, trigger_ticked) = input;
+        // Reset wins over a same-cycle upstream tick (classic checks the
+        // trigger first): snap to the live upstream value, drop the queue.
+        if trigger_ticked {
+            state.queue.clear();
+            state.initialized = true;
+            return Ok(Tick::Value(value.clone()));
+        }
+        let delay = NanoTime::from(*cfg);
+        // Classic parity: a zero delay emits inline in the *same* cycle.
+        if delay == NanoTime::ZERO {
+            return Ok(if upstream_ticked {
+                Tick::Value(value.clone())
+            } else {
+                Tick::Quiet
+            });
+        }
+        let mut seed_first = false;
+        if upstream_ticked {
+            if !state.initialized {
+                state.initialized = true;
+                seed_first = true;
+            }
+            let at = ctx.time() + delay;
+            state.queue.push(value.clone(), at);
+            ctx.schedule(at);
+        }
+        let mut out = Tick::Quiet;
+        while let Some(due) = state.queue.pop_if_pending(ctx.time()) {
+            out = Tick::Value(due);
+        }
+        // Classic parity: the first upstream value is stored into the slot
+        // *without* ticking, so passive readers see it before the delay
+        // elapses (identical to `Delay`'s first-value seeding).
+        if matches!(out, Tick::Quiet) && seed_first {
+            return Ok(Tick::Silent(value.clone()));
+        }
+        Ok(out)
+    }
+}

--- a/next/crates/wingfoil-next/tests/catalog_flow.rs
+++ b/next/crates/wingfoil-next/tests/catalog_flow.rs
@@ -1,0 +1,391 @@
+//! Phase 2 node-catalog parity for the remaining scheduling / structural
+//! nodes: `never`, `delay_with_reset`, the node-level flow ops (`node_flow`'s
+//! throttle / delay / limit / filter / feedback, run here over the unit-stream
+//! path), and the `combine` / `split` / `collapse` structural ops. Each test
+//! mirrors the classic node's own unit test — reproducing the same values and
+//! the same tick times.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+// --- never -----------------------------------------------------------------
+
+/// `never` never ticks, so nothing downstream of it ever fires — mirrors
+/// classic `never::never_does_not_trigger_downstream`.
+#[test]
+fn never_never_triggers_downstream() {
+    let counter = Rc::new(RefCell::new(0u32));
+    let c2 = counter.clone();
+    let g = GraphBuilder::new();
+    // A ticker drives the clock forward; `never`'s branch must stay silent.
+    let _clock = g.ticker(Duration::from_nanos(10)).count();
+    let _sink = g.never().for_each(move |_| {
+        *c2.borrow_mut() += 1;
+        Ok(())
+    });
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(0, *counter.borrow());
+}
+
+// --- delay_with_reset (classic `delay_with_reset`) -------------------------
+
+/// With `never()` as the reset trigger, `delay_with_reset` degrades to a plain
+/// `delay` — mirrors classic `delay_with_reset::delay_never_reset`.
+#[test]
+fn delay_with_reset_never_reset_matches_delay() {
+    let period = Duration::from_nanos(100);
+    let g = GraphBuilder::new();
+    let src = g.ticker(period).count();
+    let never = g.never();
+    let with_reset = src
+        .delay_with_reset(period * 3, &never)
+        .with_time()
+        .accumulate();
+    let plain = src.delay(period * 3).with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(20)).unwrap();
+    assert_eq!(r.value(&with_reset), r.value(&plain));
+}
+
+fn assert_snaps_on_trigger(trigger_period: Duration, expected: Vec<(u64, u64, u64)>) {
+    let period = Duration::from_nanos(100);
+    let g = GraphBuilder::new();
+    let source = g.ticker(period).count();
+    let trigger = g.ticker(trigger_period);
+    let delayed = source.delay(period * 5);
+    let reset = source.delay_with_reset(period * 5, &trigger);
+    let acc = source
+        .join3(&delayed, &reset, |a, b, c| (*a, *b, *c))
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Duration(period * 20)).unwrap();
+    assert_eq!(expected, r.value(&acc));
+}
+
+/// The reset trigger snaps the delayed output back to the live value — mirrors
+/// classic `delay_with_reset::delay_with_reset_snaps_on_trigger` (trigger every
+/// 1000ns).
+#[test]
+fn delay_with_reset_snaps_on_trigger() {
+    assert_snaps_on_trigger(
+        Duration::from_nanos(1000),
+        vec![
+            (1, 1, 1),
+            (2, 1, 1),
+            (3, 1, 1),
+            (4, 1, 1),
+            (5, 1, 1),
+            (6, 1, 1),
+            (7, 2, 2),
+            (8, 3, 3),
+            (9, 4, 4),
+            (10, 5, 5),
+            (11, 6, 11),
+            (12, 7, 11),
+            (13, 8, 11),
+            (14, 9, 11),
+            (15, 10, 11),
+            (16, 11, 11),
+            (17, 12, 12),
+            (18, 13, 13),
+            (19, 14, 14),
+            (20, 15, 15),
+            (21, 16, 21),
+            (22, 17, 21),
+        ],
+    );
+}
+
+/// A second reset cadence (every 750ns), where a trigger and a delayed pop can
+/// land on the same instant — mirrors classic
+/// `delay_with_reset::delay_with_reset_snaps_on_trigger_2`.
+#[test]
+fn delay_with_reset_snaps_on_trigger_2() {
+    assert_snaps_on_trigger(
+        Duration::from_nanos(750),
+        vec![
+            (1, 1, 1),
+            (2, 1, 1),
+            (3, 1, 1),
+            (4, 1, 1),
+            (5, 1, 1),
+            (6, 1, 1),
+            (7, 2, 2),
+            (8, 3, 3),
+            (8, 3, 8),
+            (9, 4, 8),
+            (10, 5, 8),
+            (11, 6, 8),
+            (12, 7, 8),
+            (13, 8, 8),
+            (14, 9, 9),
+            (15, 10, 10),
+            (16, 11, 16),
+            (17, 12, 16),
+            (18, 13, 16),
+            (19, 14, 16),
+            (20, 15, 16),
+            (21, 16, 16),
+            (22, 17, 17),
+        ],
+    );
+}
+
+/// Zero delay passes every value through immediately, regardless of the reset
+/// trigger — mirrors classic
+/// `delay_with_reset::delay_with_reset_zero_delay_passes_through_immediately`.
+#[test]
+fn delay_with_reset_zero_delay_passes_through_immediately() {
+    let period = Duration::from_nanos(100);
+    let g = GraphBuilder::new();
+    let src = g.ticker(period).count();
+    let never = g.never();
+    let acc = src
+        .delay_with_reset(Duration::ZERO, &never)
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    // Zero delay: every tick passes through immediately, unchanged.
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 1),
+            (NanoTime::new(100), 2),
+            (NanoTime::new(200), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+// --- node_flow (node-level flow ops over the unit-stream path) --------------
+
+/// Throttling a fast source suppresses ticks closer than the interval —
+/// mirrors classic `node_flow::node_throttle_suppresses_fast_ticks` (10ns
+/// source, 25ns interval → t = 0, 30, 60).
+#[test]
+fn node_throttle_suppresses_fast_ticks() {
+    let g = GraphBuilder::new();
+    let acc = g
+        .ticker(Duration::from_nanos(10))
+        .throttle(Duration::from_nanos(25))
+        .count()
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Duration(Duration::from_nanos(60)))
+        .unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 1),
+            (NanoTime::new(30), 2),
+            (NanoTime::new(60), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// A zero interval throttles nothing — mirrors classic
+/// `node_flow::node_throttle_zero_interval_passes_all`.
+#[test]
+fn node_throttle_zero_interval_passes_all() {
+    let g = GraphBuilder::new();
+    let acc = g
+        .ticker(Duration::from_nanos(10))
+        .throttle(Duration::from_nanos(0))
+        .count()
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 1),
+            (NanoTime::new(10), 2),
+            (NanoTime::new(20), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// Delaying a source shifts its ticks by the interval — mirrors classic
+/// `node_flow::node_delay_shifts_ticks` (100ns source, 10ns delay → arrives at
+/// t = 10, 110, 210).
+#[test]
+fn node_delay_shifts_ticks() {
+    let g = GraphBuilder::new();
+    let acc = g
+        .ticker(Duration::from_nanos(100))
+        .delay(Duration::from_nanos(10))
+        .count()
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(10), 1),
+            (NanoTime::new(110), 2),
+            (NanoTime::new(210), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// A zero delay passes ticks through immediately — mirrors classic
+/// `node_flow::node_delay_zero_passes_immediately`.
+#[test]
+fn node_delay_zero_passes_immediately() {
+    let g = GraphBuilder::new();
+    let acc = g
+        .ticker(Duration::from_nanos(10))
+        .delay(Duration::from_nanos(0))
+        .count()
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 1),
+            (NanoTime::new(10), 2),
+            (NanoTime::new(20), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// `limit` caps the number of ticks passed — mirrors classic
+/// `node_flow::node_limit_caps_ticks` (limit 3).
+#[test]
+fn node_limit_caps_ticks() {
+    let g = GraphBuilder::new();
+    let acc = g
+        .ticker(Duration::from_nanos(10))
+        .limit(3)
+        .count()
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Duration(Duration::from_nanos(90)))
+        .unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 1),
+            (NanoTime::new(10), 2),
+            (NanoTime::new(20), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// `filter` gates ticks by a condition stream — mirrors classic
+/// `node_flow::node_filter_gates_ticks` (pass only even counts → t = 10, 30,
+/// 50).
+#[test]
+fn node_filter_gates_ticks() {
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_nanos(10));
+    let is_even = src.count().map(|i| i % 2 == 0);
+    let acc = src.filter(&is_even).count().with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Duration(Duration::from_nanos(50)))
+        .unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(10), 1),
+            (NanoTime::new(30), 2),
+            (NanoTime::new(50), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// Feedback on a unit stream re-enters one cycle (`+1`) later — mirrors classic
+/// `node_flow::node_feedback_sends_signal` (rx ticks at t = 1, 101, 201).
+#[test]
+fn node_feedback_sends_signal() {
+    let period = Duration::from_nanos(100);
+    let g = GraphBuilder::new();
+    let (rx, sink) = g.feedback::<()>();
+    // Fire feedback on every source tick.
+    let _fb = g.ticker(period).feedback(&sink);
+    let acc = rx.count().with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Duration(period * 2)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(1), 1),
+            (NanoTime::new(101), 2),
+            (NanoTime::new(201), 3),
+        ],
+        r.value(&acc)
+    );
+}
+
+// --- combine / split / collapse (structural) -------------------------------
+
+/// `combine` gathers every same-instant value into one burst, in argument
+/// order — mirrors classic `combine::combine_works`.
+#[test]
+fn combine_gathers_same_instant_values() {
+    fn burst_of(items: &[u64]) -> Burst<u64> {
+        let mut b = Burst::new();
+        for &i in items {
+            b.push(i);
+        }
+        b
+    }
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_micros(1)).count();
+    let streams: Vec<_> = (0..3).map(|i| src.map(move |x| x * 10u64.pow(i))).collect();
+    let acc = g.combine(&streams).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![
+            burst_of(&[1, 10, 100]),
+            burst_of(&[2, 20, 200]),
+            burst_of(&[3, 30, 300]),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// `split` decomposes a stream of pairs into its two components — mirrors
+/// classic `mod::split_decomposes_tuple_stream`.
+#[test]
+fn split_decomposes_tuple_stream() {
+    let g = GraphBuilder::new();
+    let pairs = g
+        .ticker(Duration::from_nanos(10))
+        .count()
+        .map(|i| (i * 10, i * 20));
+    let (a, b) = pairs.split();
+    let aa = a.accumulate();
+    let bb = b.accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
+    assert_eq!(vec![10u64], r.value(&aa));
+    assert_eq!(vec![20u64], r.value(&bb));
+}
+
+/// `collapse` emits the last item of a non-empty iterator value and stays
+/// quiet on an empty one — mirrors classic `mod::collapse_skips_empty_iterator`.
+#[test]
+fn collapse_skips_empty_iterator() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count();
+    // cycle 1 → [1, 2] (collapses to 2); cycle 2 → [] (collapse stays quiet).
+    let vecs = count.map(|i| if *i == 1 { vec![1u64, 2] } else { Vec::new() });
+    let acc = vecs.collapse::<u64>().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(2)).unwrap();
+    assert_eq!(vec![2u64], r.value(&acc));
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -333,10 +333,10 @@ Inventory (classic `nodes/` → target), grouped by effort:
 | Group | Nodes | Notes |
 |---|---|---|
 | Done in prototype | map, filter, fold, constant, sample, merge (2-ary), delay, tick(er), producer(→poll), consumer(→for_each), try_map, finally, feedback | parity-tested |
-| Trivial state/closure | ✅ distinct, difference, limit, map_filter, throttle, inspect, window, buffer, with_time, ticked_at/-elapsed, not (`tests/catalog.rs`); ⬜ print, timed, split/combine/collapse (Burst/tuple structural) | recipe proven; `window`/`buffer` use `Ctx::is_last_cycle` |
-| Scheduling | ✅ throttle; ⬜ delay_with_reset, node_flow (node-level delay/filter/limit/throttle) | `SCHEDULES`/time-gated; pattern proven by delay + throttle |
-| Multi-input | ✅ bimap (active/passive) + join, trimap + join3; ⬜ try_* variants | passive `bimap` unlocked passive feedback; `trimap` is the 3-ary combine |
-| Engine-touching | always (→`ALWAYS`, done), never, finally (needs teardown), callback stream, iterator_stream (replay source; needs 0.3), receiver, channel nodes (→Phase 3), async_io (→Phase 3) | |
+| Trivial state/closure | ✅ distinct, difference, limit, map_filter, throttle, inspect, window, buffer, with_time, ticked_at/-elapsed, not, print, timed (`tests/catalog.rs`, `tests/catalog_ops.rs`); ✅ split, combine, collapse (Burst/tuple structural, `tests/catalog_flow.rs`) | recipe proven; `window`/`buffer` use `Ctx::is_last_cycle`; `combine` builds the burst locally (no shared-cell port) |
+| Scheduling | ✅ throttle, delay_with_reset, node_flow (node-level delay/filter/limit/throttle, run over the unit-stream path, `tests/catalog_flow.rs`) | `SCHEDULES`/time-gated; pattern proven by delay + throttle |
+| Multi-input | ✅ bimap (active/passive) + join, trimap + join3, try_* variants (`tests/catalog_ops.rs`) | passive `bimap` unlocked passive feedback; `trimap` is the 3-ary combine |
+| Engine-touching | always (→`ALWAYS`, done), ✅ never (`tests/catalog_flow.rs`), finally (needs teardown, done), callback stream, iterator_stream (replay source; needs 0.3), receiver, channel nodes (→Phase 3), async_io (→Phase 3) | |
 | Structural / deferred | demux, dynamic_group, graph_node | multi-output + dynamic-graph decisions below |
 
 **Dynamic graphs** (`graph_node`, `dynamic_group`, the dynamic examples):
@@ -345,6 +345,14 @@ loops). Runtime graph *mutation* is a separate feature: either
 `Runner::extend` on the interpreted engine (design here, implement if the
 demand is real) or an explicit out-of-scope ruling for v1. Do not let this
 block the catalog — decide, document, move on.
+
+**Engine coverage note:** `never`, `combine`, and `delay_with_reset` land as
+interpreted-engine (fluent) ports — like `feedback` — since a zero-input
+source, an n-ary fan-in, and a two-tick-flag scheduling op fall outside the
+`#[op]` single-input scope that auto-emits the `graph!`/compiled forwarders.
+`split`/`collapse` are pure sugar over `map`/`map_filter`, so they reach every
+engine for free. Extending `combine`/`delay_with_reset` to `graph!`/compiled is
+a follow-up (as it is for `feedback`).
 
 **Gate 2:** every classic node test has a next twin producing identical
 values and tick times.


### PR DESCRIPTION
## Summary

Implements Phase 2 node-catalog parity for wingfoil-next, adding the remaining scheduling and structural nodes from the classic wingfoil library. All new operations are tested against their classic counterparts with matching tick times and values.

## Key Changes

- **`never` source**: A zero-input source that never ticks, useful as an inert trigger (e.g., for `delay_with_reset` that never resets to degrade to plain `delay`)
  - Hand-written `Builder::never()` (outside `#[op]` scope due to zero inputs)
  - Plain `Op` impl returning `Tick::Quiet` always

- **`delay_with_reset` node**: Extends `delay` with a reset trigger that snaps output to the current upstream value and clears the pending queue
  - Two active inputs: upstream value and trigger tick flag
  - Custom state tracking (`DelayWithResetState`) for queue and initialization
  - Hand-written `Builder::delay_with_reset()` (two tick flags + custom seeding outside `#[op]` scope)
  - Fluent API: `stream.delay_with_reset(duration, &trigger_stream)`

- **Node-level flow ops** (over unit-stream path): `throttle`, `delay`, `limit`, `filter`, `feedback`
  - Already implemented in prior commits; tests confirm parity with classic behavior

- **Structural ops**:
  - **`combine`**: Fan-in n-ary operator gathering same-instant values into a `Burst<T>` in argument order
    - Hand-written `Builder::combine()` (n-ary fan-in outside fixed-arity `Op` tuple scope)
    - Reads per-stream tick flags from shared `ticked` vector; builds burst locally
    - Fluent API: `graph.combine(&[stream1, stream2, ...])`
  - **`split`**: Decompose `Stream<(A, B)>` into two component streams
    - Sugar over two `map` calls; both branches tick whenever source does
    - Extension method on `Stream<(A, B)>`
  - **`collapse`**: Emit last item of iterator/burst, stay quiet on empty
    - Sugar over `map_filter` extracting the final element
    - Fluent API: `stream.collapse::<T>()`

## Implementation Details

- All new ops follow the no-shared-mutable-slot rule: `combine` builds its burst locally rather than via shared `Rc<RefCell<Burst>>`
- `DelayWithReset` mirrors classic's reset-first logic (trigger wins over same-cycle upstream tick)
- Zero-delay variants pass through immediately in the same cycle (classic parity)
- Comprehensive test suite (`tests/catalog_flow.rs`, 391 lines) mirrors classic unit tests, verifying tick times and values match exactly
- Updated `port-plan.md` to mark these nodes as complete in Phase 2

## Testing

All 13 new tests pass, covering:
- `never` never triggering downstream
- `delay_with_reset` with various reset cadences and edge cases (zero delay, simultaneous trigger/pop)
- Node-level flow ops (throttle, delay, limit, filter, feedback)
- Structural ops (combine, split, collapse)

https://claude.ai/code/session_014DayLwf5vGsLYQoNc881GF