### PR TITLE
Port etcd adapter to next engine with snapshot→watch source and PUT sink

### DIFF
--- a/.github/workflows/etcd-next-integration.yml
+++ b/.github/workflows/etcd-next-integration.yml
@@ -1,0 +1,53 @@
+name: test.integration.etcd-next
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'next/crates/wingfoil-next/src/adapters/etcd**'
+      - 'next/crates/wingfoil-next/tests/etcd_integration.rs'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  etcd-next-integration:
+    name: etcd (next) Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
+
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Pre-pull etcd image
+        # testcontainers pulls the image lazily on first use, which is
+        # vulnerable to transient registry flakes (e.g. "bytes remaining
+        # on stream"). Pull once up front with retries so every test
+        # reuses the cached image.
+        run: |
+          for i in 1 2 3; do
+            docker pull gcr.io/etcd-development/etcd:v3.5.0 && exit 0
+            echo "pull attempt $i failed, retrying..."
+            sleep 5
+          done
+          echo "failed to pull etcd image after 3 attempts" && exit 1
+
+      - name: Run etcd (next) integration tests
+        run: |
+          cargo test --features etcd-integration-test -p wingfoil-next \
+            -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,11 @@ jobs:
     uses: ./.github/workflows/etcd-integration.yml
     secrets: inherit
 
+  etcd-next-integration:
+    name: etcd (next) Integration Tests
+    uses: ./.github/workflows/etcd-next-integration.yml
+    secrets: inherit
+
   redis-integration:
     name: redis Integration Tests
     uses: ./.github/workflows/redis-integration.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7673,12 +7673,16 @@ name = "wingfoil-next"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "augurs",
  "criterion",
  "csv",
+ "etcd-client",
  "futures",
  "serde",
  "serde-aux",
+ "testcontainers",
+ "tinyvec",
  "tokio",
  "trybuild",
  "wingfoil",

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -16,6 +16,10 @@ workspace = true
 wingfoil = { path = "../../../wingfoil" }
 wingfoil-next-macros = { path = "../wingfoil-next-macros" }
 anyhow = { workspace = true }
+# `Burst<T>` is `tinyvec::TinyVec<[T; 1]>`, and the re-exported `burst!` macro
+# expands to `::tinyvec::tiny_vec!` — so the crate needs `tinyvec` in scope for
+# that macro to resolve. Version mirrors the classic `wingfoil` crate.
+tinyvec = { version = "1.10.0", features = ["alloc"] }
 
 # `async` feature: the `produce_async` ergonomic source (async closure →
 # timestamped burst stream) over the channel. Optional so the core engine
@@ -48,6 +52,18 @@ augurs = { version = "0.10.2", default-features = false, features = [
     "outlier",
 ], optional = true }
 
+# `etcd` feature: streaming key-prefix snapshot + watch source and a key-value
+# PUT sink for the etcd key-value store. Built on the `async` `produce_async`
+# ergonomic (`etcd-client` is a tokio client). Versions mirror the classic
+# `wingfoil` crate's etcd adapter so the two trees don't drift. `testcontainers`
+# (used only by the integration tests) is an optional [dependencies] entry
+# because feature flags cannot gate dev-dependencies.
+etcd-client = { version = "0.18", optional = true }
+async-stream = { version = "0.3.6", optional = true }
+testcontainers = { version = "0.27", features = [
+    "blocking",
+], optional = true }
+
 [dev-dependencies]
 # Compile-fail tests pinning the `graph!` macro's key error paths.
 trybuild = "1"
@@ -58,6 +74,8 @@ default = []
 async = ["dep:tokio", "dep:futures"]
 csv = ["dep:csv", "dep:serde", "dep:serde-aux"]
 augurs = ["dep:augurs"]
+etcd = ["dep:etcd-client", "dep:async-stream", "async"]
+etcd-integration-test = ["etcd", "dep:testcontainers"]
 
 [[example]]
 name = "async_source"
@@ -93,6 +111,10 @@ required-features = ["csv"]
 [[example]]
 name = "augurs_adapter"
 required-features = ["augurs"]
+
+[[example]]
+name = "etcd_adapter"
+required-features = ["etcd"]
 
 # Ports of the classic `wingfoil/examples/` onto the next engine's fluent API.
 # Each lives in its own directory with a README, mirroring the classic layout.

--- a/next/crates/wingfoil-next/examples/etcd_adapter.rs
+++ b/next/crates/wingfoil-next/examples/etcd_adapter.rs
@@ -1,0 +1,93 @@
+//! etcd adapter example — watch a key prefix, transform values, write back.
+//!
+//! A port of the classic `wingfoil/examples/etcd` example onto the next engine.
+//! Two independent graph roots share one [`GraphBuilder`]:
+//!
+//! - `seed`       — writes source keys once via `constant` + `etcd_pub`.
+//! - `round_trip` — watches the source prefix, uppercases each value, and writes
+//!   the result to a destination prefix.
+//!
+//! Unlike classic, the runtime is the caller's: we build a tokio runtime and
+//! hand its `handle()` to `etcd_sub` / `etcd_pub` (see the module docs).
+//!
+//! # Prerequisites
+//!
+//! A running etcd instance:
+//! ```sh
+//! docker run --rm -p 2379:2379 \
+//!   -e ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379 \
+//!   -e ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379 \
+//!   gcr.io/etcd-development/etcd:v3.5.0
+//! ```
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example etcd_adapter --features etcd
+//! ```
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::etcd::{EtcdConnection, EtcdEntry, EtcdSinkOps, etcd_sub};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+const ENDPOINT: &str = "http://localhost:2379";
+const SOURCE_PREFIX: &str = "/example/source/";
+const DEST_PREFIX: &str = "/example/dest/";
+
+fn main() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    let handle = rt.handle();
+    let conn = EtcdConnection::new(ENDPOINT);
+
+    let g = GraphBuilder::new();
+
+    // Seed the source prefix with two keys, once.
+    let _seed = g
+        .constant(burst![
+            EtcdEntry {
+                key: format!("{SOURCE_PREFIX}greeting"),
+                value: b"hello".to_vec(),
+            },
+            EtcdEntry {
+                key: format!("{SOURCE_PREFIX}subject"),
+                value: b"world".to_vec(),
+            },
+        ])
+        .etcd_pub(handle, conn.clone(), None, true)?;
+
+    // Watch the source prefix, uppercase each value, write to the dest prefix.
+    let params = RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Cycles(3),
+        start_time: NanoTime::ZERO,
+    };
+    let _round_trip = etcd_sub(&g, handle, params, conn.clone(), SOURCE_PREFIX)
+        .map(|burst: &Burst<_>| {
+            burst
+                .iter()
+                .map(|event: &wingfoil_next::adapters::etcd::EtcdEvent| {
+                    let dest_key = event.entry.key.replacen(SOURCE_PREFIX, DEST_PREFIX, 1);
+                    let upper = event
+                        .entry
+                        .value_str()
+                        .unwrap_or("")
+                        .to_uppercase()
+                        .into_bytes();
+                    println!(
+                        "  {} → {}",
+                        event.entry.key,
+                        String::from_utf8_lossy(&upper)
+                    );
+                    EtcdEntry {
+                        key: dest_key,
+                        value: upper,
+                    }
+                })
+                .collect::<Burst<EtcdEntry>>()
+        })
+        .etcd_pub(handle, conn, None, true)?;
+
+    g.build().run(RunMode::RealTime, RunFor::Cycles(3))?;
+    Ok(())
+}

--- a/next/crates/wingfoil-next/src/adapters/etcd.rs
+++ b/next/crates/wingfoil-next/src/adapters/etcd.rs
@@ -1,0 +1,510 @@
+//! etcd adapter — a streaming key-prefix snapshot + live watch **source**
+//! (`etcd_sub`) and a key-value PUT **sink** (`EtcdSinkOps::etcd_pub`) for the
+//! etcd key-value store. It ports the classic `wingfoil::adapters::etcd` module
+//! onto the Op model.
+//!
+//! # Layering
+//!
+//! Following the [`lines`](crate::adapters::lines) / [`stats`](crate::stats)
+//! pattern, the adapter is *not* in the [`prelude`](crate::prelude). Bring in
+//! what you need explicitly:
+//!
+//! - **Source** — the free builder function [`etcd_sub`] on a
+//!   [`GraphBuilder`]: a consistent key-prefix snapshot followed by live watch
+//!   events, emitting `Stream<Burst<EtcdEvent>>`.
+//! - **Sink** — the [`EtcdSinkOps`] extension trait on `Stream<Burst<EtcdEntry>>`
+//!   (and, for convenience, `Stream<EtcdEntry>`), enabled with
+//!   `use wingfoil_next::adapters::etcd::EtcdSinkOps;`.
+//!
+//! # Deviations from classic
+//!
+//! Every classic *capability* (snapshot→watch, deletes, leases with keepalive
+//! and revoke-on-shutdown, the `force` conditional write) is preserved. The
+//! surface differs in three deliberate ways:
+//!
+//! 1. **The tokio runtime is the caller's.** Classic `etcd_sub`/`etcd_pub` hide
+//!    a global runtime inside `produce_async`/`consume_async`. Next has no
+//!    `consume_async`, and its
+//!    [`produce_async`](crate::async_source::produce_async) takes the runtime
+//!    [`Handle`](tokio::runtime::Handle) and [`RunParams`] explicitly (the
+//!    producer task is spawned at wiring time, before the run). Both functions
+//!    here follow that convention: the caller owns a `tokio::runtime::Runtime`
+//!    and hands in its `handle()`.
+//! 2. **The sink connects eagerly, at wiring time.** `etcd_pub` returns
+//!    `Result` and a connection (or `lease_grant`) failure surfaces *before* the
+//!    run, whereas classic connected lazily inside the async consumer so the
+//!    error surfaced *during* the run. (Skill step 8 prefers wiring-time I/O
+//!    errors; a lazily-connecting client still surfaces the failure on the first
+//!    PUT.)
+//! 3. **The sink is a trait only.** Classic exposed both a free `etcd_pub`
+//!    function and an `EtcdPubOperators` trait; next folds the single public
+//!    entry point into the [`EtcdSinkOps`] trait (renamed for the sink-as-trait
+//!    convention shared with [`lines`](crate::adapters::lines) /
+//!    [`csv`](crate::adapters::csv)).
+//!
+//! ## Runtime requirement (a `block_on` footgun)
+//!
+//! Because the sink drives its writes with [`Handle::block_on`] on the graph
+//! thread (and the [`LeaseGuard`] revokes on `Drop` the same way), **the graph
+//! must be built, run, and dropped from a non-async thread** — the ordinary
+//! case (`main`, a `#[test]` fn). Driving it from *inside* an async context
+//! (e.g. `rt.block_on(async { g.build().run(..) })`) makes those `block_on`
+//! calls panic, and a panic in the `Drop` revoke during unwinding would abort.
+//! The producer and keepalive tasks, by contrast, run on the runtime's own
+//! workers via [`Handle::spawn`] and have no such constraint.
+//!
+//! # Subscribing to a key prefix (the snapshot→watch handoff)
+//!
+//! [`etcd_sub`] first emits a snapshot of all keys matching the prefix as
+//! [`EtcdEventKind::Put`] events, then streams live watch events (puts and
+//! deletes). The watch is opened **before** the GET so no write is missed in
+//! the handoff window; any event already covered by the snapshot
+//! (`mod_revision <= snapshot_rev`) is filtered out as a duplicate. Snapshot and
+//! live events are stamped with `NanoTime::now()`, so — like classic — the
+//! source is designed for `RunMode::RealTime`; a `HistoricalFrom` run replays
+//! them at wall-clock instants rather than a historical timeline.
+//!
+//! # Sink
+//!
+//! [`EtcdSinkOps::etcd_pub`] connects at wiring time (a connection error surfaces
+//! before the run) and issues one PUT per [`EtcdEntry`] in each burst, blocking
+//! the graph thread on the runtime for the write so any failure aborts the run
+//! deterministically with context — matching the classic consumer's ordering
+//! guarantees.
+//!
+//! - `lease_ttl: None` writes plain keys that persist until deleted.
+//! - `lease_ttl: Some(ttl)` attaches an etcd lease with a background keepalive
+//!   task that renews it every `ttl/3`; the lease is **revoked** when the sink
+//!   is dropped at graph teardown, so leased keys vanish immediately rather than
+//!   waiting out the TTL (presence/heartbeat pattern).
+//! - `force: true` silently overwrites an existing key; `force: false` issues a
+//!   conditional transaction (`create_revision == 0`) and aborts the run,
+//!   naming the key, if it already exists.
+//!
+//! # Setup
+//!
+//! ```sh
+//! docker run --rm -p 2379:2379 \
+//!   -e ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379 \
+//!   -e ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379 \
+//!   gcr.io/etcd-development/etcd:v3.5.0
+//! ```
+
+use std::cell::RefCell;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use etcd_client::{Client, Compare, CompareOp, GetOptions, PutOptions, Txn, TxnOp, WatchOptions};
+use futures::StreamExt;
+use tokio::runtime::Handle;
+use wingfoil::NanoTime;
+
+use crate::Burst;
+use crate::async_source::{RunParams, produce_async};
+use crate::burst;
+use crate::fluent::{GraphBuilder, Stream, StreamOps};
+
+/// Connection configuration for etcd.
+#[derive(Debug, Clone)]
+pub struct EtcdConnection {
+    /// etcd endpoints, e.g. `["http://localhost:2379"]`.
+    pub endpoints: Vec<String>,
+}
+
+impl EtcdConnection {
+    /// Create a connection config with a single endpoint.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoints: vec![endpoint.into()],
+        }
+    }
+
+    /// Create a connection config with multiple endpoints (for an etcd cluster).
+    pub fn with_endpoints(endpoints: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            endpoints: endpoints.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<&str> for EtcdConnection {
+    fn from(endpoint: &str) -> Self {
+        Self::new(endpoint)
+    }
+}
+
+impl From<String> for EtcdConnection {
+    fn from(endpoint: String) -> Self {
+        Self::new(endpoint)
+    }
+}
+
+impl From<&String> for EtcdConnection {
+    fn from(endpoint: &String) -> Self {
+        Self::new(endpoint.clone())
+    }
+}
+
+/// A single key-value pair from etcd.
+#[derive(Debug, Clone, Default)]
+pub struct EtcdEntry {
+    pub key: String,
+    pub value: Vec<u8>,
+}
+
+impl EtcdEntry {
+    /// Interpret the value as a UTF-8 string.
+    pub fn value_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.value)
+    }
+}
+
+/// The type of change represented by an [`EtcdEvent`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum EtcdEventKind {
+    /// A key was created or updated.
+    #[default]
+    Put,
+    /// A key was deleted.
+    ///
+    /// The associated [`EtcdEvent::entry`] carries the deleted key but an
+    /// **empty value** (`value == vec![]`). Use [`EtcdEventKind::Put`] events if
+    /// you need the value.
+    Delete,
+}
+
+/// An event from an etcd watch stream.
+///
+/// Snapshot events (from the initial GET) are always [`EtcdEventKind::Put`].
+/// Subsequent watch events reflect the actual change type from etcd.
+#[derive(Debug, Clone, Default)]
+pub struct EtcdEvent {
+    pub kind: EtcdEventKind,
+    pub entry: EtcdEntry,
+    /// The etcd cluster revision at which this event was observed.
+    pub revision: i64,
+}
+
+/// Stream all current KVs under `prefix` as [`EtcdEvent`]s, then stream live
+/// updates, as a `Burst<EtcdEvent>` source.
+///
+/// Always starts with a consistent snapshot (via GET), then seamlessly
+/// transitions to a live watch. The watch is opened **before** the GET so no
+/// writes are missed in the handoff window; any watch event with
+/// `mod_revision <= snapshot_rev` is filtered out as a duplicate of the
+/// snapshot.
+///
+/// `handle` is the caller's tokio runtime handle and `params` describes the run
+/// the graph will be driven with (see [`produce_async`] and the module docs).
+/// Use `.collapse()` for single-event processing.
+#[must_use]
+pub fn etcd_sub(
+    g: &GraphBuilder,
+    handle: &Handle,
+    params: RunParams,
+    conn: impl Into<EtcdConnection>,
+    prefix: impl Into<String>,
+) -> Stream<Burst<EtcdEvent>> {
+    let conn = conn.into();
+    let prefix = prefix.into();
+    produce_async(g, handle, params, move |_p: RunParams| async move {
+        let mut client = Client::connect(&conn.endpoints, None)
+            .await
+            .with_context(|| format!("etcd_sub: connecting to etcd at {:?}", conn.endpoints))?;
+
+        // 1. Open the watch BEFORE the GET to prevent the snapshot/watch race.
+        let watch_opts = WatchOptions::new().with_prefix();
+        let mut watch_stream = client
+            .watch(prefix.as_bytes(), Some(watch_opts))
+            .await
+            .map_err(|e| anyhow::anyhow!("etcd watch failed: {e}"))?;
+
+        // 2. Read the snapshot and capture its revision.
+        let get_opts = GetOptions::new().with_prefix();
+        let get_resp = client
+            .get(prefix.as_bytes(), Some(get_opts))
+            .await
+            .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
+        let snapshot_rev = get_resp.header().map(|h| h.revision()).unwrap_or(0);
+
+        // 3. Collect snapshot KVs into owned data to move into the stream.
+        let snapshot: Vec<EtcdEvent> = get_resp
+            .kvs()
+            .iter()
+            .map(|kv| EtcdEvent {
+                kind: EtcdEventKind::Put,
+                entry: EtcdEntry {
+                    key: String::from_utf8_lossy(kv.key()).into_owned(),
+                    value: kv.value().to_vec(),
+                },
+                revision: snapshot_rev,
+            })
+            .collect();
+
+        // 4. Return the combined snapshot + live stream. `watch_stream` is moved
+        //    in and kept alive for the stream's lifetime so the watch stays open.
+        Ok(async_stream::stream! {
+            // Phase 1: emit snapshot events.
+            for event in snapshot {
+                yield Ok((NanoTime::now(), event));
+            }
+
+            // Phase 2: drain the watch stream, deduplicating against the snapshot.
+            loop {
+                match watch_stream.next().await {
+                    Some(Ok(resp)) => {
+                        // Skip the initial "watch created" confirmation (no events).
+                        if resp.created() {
+                            continue;
+                        }
+                        if resp.canceled() {
+                            yield Err(anyhow::anyhow!(
+                                "etcd watch cancelled: {}",
+                                resp.cancel_reason()
+                            ));
+                            break;
+                        }
+                        for event in resp.events() {
+                            let kv = match event.kv() {
+                                Some(kv) => kv,
+                                None => continue,
+                            };
+                            let mod_rev = kv.mod_revision();
+                            // Skip events already covered by the snapshot.
+                            if mod_rev <= snapshot_rev {
+                                continue;
+                            }
+                            let kind = match event.event_type() {
+                                etcd_client::EventType::Put => EtcdEventKind::Put,
+                                etcd_client::EventType::Delete => EtcdEventKind::Delete,
+                            };
+                            yield Ok((NanoTime::now(), EtcdEvent {
+                                kind,
+                                entry: EtcdEntry {
+                                    key: String::from_utf8_lossy(kv.key()).into_owned(),
+                                    value: kv.value().to_vec(),
+                                },
+                                revision: mod_rev,
+                            }));
+                        }
+                    }
+                    Some(Err(e)) => {
+                        yield Err(anyhow::anyhow!("etcd watch error: {e}"));
+                        break;
+                    }
+                    None => {
+                        yield Err(anyhow::anyhow!("etcd watch stream closed unexpectedly"));
+                        break;
+                    }
+                }
+            }
+        })
+    })
+}
+
+/// Holds a granted lease alive and revokes it on drop.
+///
+/// Moved into the sink's `for_each` closure, so it is dropped when the sink (and
+/// with it the whole graph) is torn down: the keepalive task is aborted and the
+/// lease revoked, matching classic's "leased keys vanish on clean shutdown".
+struct LeaseGuard {
+    handle: Handle,
+    client: Client,
+    lease_id: i64,
+    keepalive: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for LeaseGuard {
+    fn drop(&mut self) {
+        let keepalive = self.keepalive.take();
+        let mut client = self.client.clone();
+        let lease_id = self.lease_id;
+        // Best-effort revoke on teardown; a failure here (e.g. the connection is
+        // already gone) is not worth aborting a shutting-down graph over.
+        let _ = self.handle.block_on(async move {
+            // Stop keepalive fully before revoking (as classic does), so a
+            // renewal can't race the revoke. Awaiting an aborted handle resolves
+            // immediately with a Cancelled error, which we ignore.
+            if let Some(ka) = keepalive {
+                ka.abort();
+                let _ = ka.await;
+            }
+            client.lease_revoke(lease_id).await
+        });
+    }
+}
+
+/// Extension trait providing a fluent API for writing streams to etcd via PUT.
+///
+/// Implemented for both `Stream<Burst<EtcdEntry>>` (multi-item) and
+/// `Stream<EtcdEntry>` (single-item, auto-wrapped into one-element bursts), so
+/// burst wrapping is never required in user code.
+pub trait EtcdSinkOps {
+    /// Write this stream to etcd via PUT. Returns the sink `Stream<()>`.
+    ///
+    /// - `handle`: the caller's tokio runtime handle (see the module docs).
+    /// - `lease_ttl`: `None` for plain writes; `Some(duration)` to attach a lease
+    ///   with automatic keepalive renewal (keys vanish on sink teardown via
+    ///   revoke).
+    /// - `force`: `true` silently overwrites existing keys; `false` aborts the
+    ///   run, naming the key, if it already exists (a conditional transaction).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error at wiring time if the etcd connection (or, when a lease
+    /// is requested, the `lease_grant`) fails. A per-write failure (including a
+    /// `force: false` conflict) aborts the run with context.
+    fn etcd_pub(
+        &self,
+        handle: &Handle,
+        conn: impl Into<EtcdConnection>,
+        lease_ttl: Option<Duration>,
+        force: bool,
+    ) -> Result<Stream<()>>;
+}
+
+impl EtcdSinkOps for Stream<Burst<EtcdEntry>> {
+    fn etcd_pub(
+        &self,
+        handle: &Handle,
+        conn: impl Into<EtcdConnection>,
+        lease_ttl: Option<Duration>,
+        force: bool,
+    ) -> Result<Stream<()>> {
+        let conn = conn.into();
+        // Connect at wiring time so a connection error surfaces before the run.
+        let mut client = handle
+            .block_on(Client::connect(&conn.endpoints, None))
+            .with_context(|| format!("etcd_pub: connecting to etcd at {:?}", conn.endpoints))?;
+
+        // Optionally grant a lease and start a background keepalive task.
+        let guard = match lease_ttl {
+            None => None,
+            Some(ttl) => {
+                // etcd's minimum TTL is 1 second; sub-second durations round up.
+                let ttl_secs = ttl.as_secs().max(1) as i64;
+                let lease_id = handle
+                    .block_on(client.lease_grant(ttl_secs, None))
+                    .context("etcd_pub: lease_grant failed")?
+                    .id();
+
+                // Keepalive runs on a clone so the sink's client stays free for
+                // PUTs; it renews at ttl/3 (>= 1s) until the task is aborted.
+                let mut ka_client = client.clone();
+                let renew_interval = (ttl / 3).max(Duration::from_secs(1));
+                let keepalive = handle.spawn(async move {
+                    let (mut keeper, mut ka_stream) =
+                        match ka_client.lease_keep_alive(lease_id).await {
+                            Ok(pair) => pair,
+                            Err(_) => return,
+                        };
+                    loop {
+                        tokio::time::sleep(renew_interval).await;
+                        if keeper.keep_alive().await.is_err() {
+                            break;
+                        }
+                        // Drain the server ack to keep the stream healthy.
+                        match ka_stream.message().await {
+                            Ok(Some(_)) => {}
+                            _ => break,
+                        }
+                    }
+                });
+
+                Some(LeaseGuard {
+                    handle: handle.clone(),
+                    client: client.clone(),
+                    lease_id,
+                    keepalive: Some(keepalive),
+                })
+            }
+        };
+
+        let lease_id = guard.as_ref().map(|g| g.lease_id);
+        let handle = handle.clone();
+        // `for_each` takes an `Fn`; the etcd `Client` needs `&mut` per PUT, so it
+        // lives behind a `RefCell`. The lease guard is moved in so its revoke
+        // fires when the sink is dropped at graph teardown.
+        let client = RefCell::new(client);
+        Ok(self.for_each(move |burst: &Burst<EtcdEntry>| {
+            // Load-bearing: referencing `guard` is what makes this `move` closure
+            // capture (and thus own) it, so the lease is revoked only when the
+            // sink is dropped at teardown — not immediately at the end of wiring.
+            let _lease = &guard;
+            let mut client = client.borrow_mut();
+            handle.block_on(async {
+                for entry in burst.iter() {
+                    let opts = lease_id.map(|id| PutOptions::new().with_lease(id));
+                    if force {
+                        client
+                            .put(entry.key.clone(), entry.value.clone(), opts)
+                            .await
+                            .with_context(|| format!("etcd_pub: PUT {} failed", entry.key))?;
+                    } else {
+                        // Conditional put: succeed only if the key is absent.
+                        // create_revision == 0 is etcd's canonical "key absent".
+                        let key_absent = vec![Compare::create_revision(
+                            entry.key.as_bytes(),
+                            CompareOp::Equal,
+                            0,
+                        )];
+                        let put_op =
+                            vec![TxnOp::put(entry.key.as_bytes(), entry.value.as_slice(), opts)];
+                        let txn = Txn::new().when(key_absent).and_then(put_op);
+                        let resp = client
+                            .txn(txn)
+                            .await
+                            .with_context(|| format!("etcd_pub: conditional PUT {} failed", entry.key))?;
+                        if !resp.succeeded() {
+                            anyhow::bail!(
+                                "etcd_pub: conditional write failed: key already exists (use force=true to overwrite): {}",
+                                entry.key
+                            );
+                        }
+                    }
+                }
+                anyhow::Ok(())
+            })?;
+            Ok(())
+        }))
+    }
+}
+
+impl EtcdSinkOps for Stream<EtcdEntry> {
+    fn etcd_pub(
+        &self,
+        handle: &Handle,
+        conn: impl Into<EtcdConnection>,
+        lease_ttl: Option<Duration>,
+        force: bool,
+    ) -> Result<Stream<()>> {
+        self.map(|entry: &EtcdEntry| burst![entry.clone()])
+            .etcd_pub(handle, conn, lease_ttl, force)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EtcdConnection, EtcdEntry};
+
+    #[test]
+    fn value_str_reads_utf8() {
+        let entry = EtcdEntry {
+            key: "/foo".to_string(),
+            value: b"bar".to_vec(),
+        };
+        assert_eq!(entry.value_str().unwrap(), "bar");
+    }
+
+    #[test]
+    fn connection_from_str_and_endpoints() {
+        let one = EtcdConnection::from("http://localhost:2379");
+        assert_eq!(one.endpoints, vec!["http://localhost:2379".to_string()]);
+
+        let many = EtcdConnection::with_endpoints(["http://a:2379", "http://b:2379"]);
+        assert_eq!(
+            many.endpoints,
+            vec!["http://a:2379".to_string(), "http://b:2379".to_string()]
+        );
+    }
+}

--- a/next/crates/wingfoil-next/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next/src/adapters/mod.rs
@@ -16,9 +16,15 @@
 //! - [`augurs`] — on-graph time-series analysis (forecasting + outlier
 //!   detection) over sliding windows, behind the `augurs` feature. A pure-Rust
 //!   compute adapter (no service), so it is transform ops, not a source/sink.
+//! - [`etcd`] — a streaming key-prefix snapshot + watch source (`etcd_sub`) and
+//!   a key-value PUT sink (`EtcdSinkOps::etcd_pub`) for the etcd key-value
+//!   store, behind the `etcd` feature (built on the async `produce_async`
+//!   ergonomic).
 
 #[cfg(feature = "augurs")]
 pub mod augurs;
 #[cfg(feature = "csv")]
 pub mod csv;
+#[cfg(feature = "etcd")]
+pub mod etcd;
 pub mod lines;

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -796,7 +796,7 @@ impl Builder {
     ) -> Handle<Burst<T>> {
         let idx = self.nodes.len();
         let indices: Vec<usize> = srcs.iter().map(|h| h.idx).collect();
-        let slots: Vec<Rc<RefCell<T>>> = srcs.iter().map(|h| self.slot(*h)).collect();
+        let slots: Vec<SlotRef<T>> = srcs.iter().map(|h| self.slot(*h)).collect();
         let out = self.new_slot(Burst::<T>::new());
         let ticked = self.ticked.clone();
         self.push_node(

--- a/next/crates/wingfoil-next/tests/etcd_adapter.rs
+++ b/next/crates/wingfoil-next/tests/etcd_adapter.rs
@@ -1,0 +1,60 @@
+//! etcd adapter tests that need no running service.
+//!
+//! The container-backed parity tests live in `tests/etcd_integration.rs` behind
+//! the `etcd-integration-test` feature. Run these with:
+//! ```sh
+//! cargo test -p wingfoil-next --features etcd
+//! ```
+#![cfg(feature = "etcd")]
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::etcd::{EtcdConnection, EtcdEntry, EtcdSinkOps, etcd_sub};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+/// An unreachable endpoint must abort the source's run rather than hang or panic
+/// — the parity of classic `test_connection_refused`.
+#[test]
+fn sub_connection_refused_aborts_the_run() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let params = RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Cycles(1),
+        start_time: NanoTime::ZERO,
+    };
+    let conn = EtcdConnection::new("http://127.0.0.1:59999");
+    let _events = etcd_sub(&g, rt.handle(), params, conn, "/x/").collapse_accumulate();
+
+    let mut runner = g.build();
+    let result = runner.run(RunMode::RealTime, RunFor::Cycles(1));
+    assert!(
+        result.is_err(),
+        "an unreachable etcd endpoint must abort the run"
+    );
+}
+
+/// The sink must surface a connection failure — at wiring (eager connect) or, if
+/// the client connects lazily, on the first PUT during the run. Either way the
+/// caller sees an error rather than a silent success.
+#[test]
+fn pub_connection_refused_surfaces_an_error() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let source = g.constant(burst![EtcdEntry {
+        key: "/x/k".to_string(),
+        value: b"v".to_vec(),
+    }]);
+    let conn = EtcdConnection::new("http://127.0.0.1:59999");
+
+    let outcome = match source.etcd_pub(rt.handle(), conn, None, true) {
+        // Errored at wiring (eager connect) — acceptable.
+        Err(_) => return,
+        // Connected lazily: the failure must surface when the first PUT runs.
+        Ok(_sink) => g.build().run(RunMode::RealTime, RunFor::Cycles(1)),
+    };
+    assert!(
+        outcome.is_err(),
+        "an unreachable etcd endpoint must surface an error at wiring or during the run"
+    );
+}

--- a/next/crates/wingfoil-next/tests/etcd_integration.rs
+++ b/next/crates/wingfoil-next/tests/etcd_integration.rs
@@ -1,0 +1,455 @@
+//! Integration tests for the etcd adapter — parity port of the classic
+//! `wingfoil/src/adapters/etcd/integration_tests.rs`.
+//!
+//! Requires Docker. Run with:
+//! ```sh
+//! cargo test -p wingfoil-next --features etcd-integration-test \
+//!   -- --test-threads=1 --nocapture
+//! ```
+#![cfg(feature = "etcd-integration-test")]
+
+use std::time::Duration;
+
+use etcd_client::Client;
+use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::SyncRunner};
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::etcd::{
+    EtcdConnection, EtcdEntry, EtcdEvent, EtcdEventKind, EtcdSinkOps, etcd_sub,
+};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+const ETCD_PORT: u16 = 2379;
+const ETCD_IMAGE: &str = "gcr.io/etcd-development/etcd";
+const ETCD_TAG: &str = "v3.5.0";
+
+/// Start an etcd container and return the host endpoint. The returned container
+/// must be kept alive for the duration of the test.
+fn start_etcd() -> anyhow::Result<(impl Drop, String)> {
+    let container = GenericImage::new(ETCD_IMAGE, ETCD_TAG)
+        .with_wait_for(WaitFor::message_on_stderr(
+            "now serving peer/client/metrics",
+        ))
+        .with_env_var("ETCD_LISTEN_CLIENT_URLS", "http://0.0.0.0:2379")
+        .with_env_var("ETCD_ADVERTISE_CLIENT_URLS", "http://0.0.0.0:2379")
+        .start()?;
+    let port = container.get_host_port_ipv4(ETCD_PORT)?;
+    let endpoint = format!("http://127.0.0.1:{port}");
+    Ok((container, endpoint))
+}
+
+/// A realtime run description for the source (start time is ignored in realtime).
+fn realtime(cycles: u32) -> RunParams {
+    RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Cycles(cycles),
+        start_time: NanoTime::ZERO,
+    }
+}
+
+/// Seed key-value pairs directly into etcd via the client.
+fn seed_keys(endpoint: &str, pairs: &[(&str, &str)]) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let mut client = Client::connect(&[endpoint], None).await?;
+        for (k, v) in pairs {
+            client.put(*k, *v, None).await?;
+        }
+        Ok(())
+    })
+}
+
+/// Delete a key directly via the client.
+fn delete_key(endpoint: &str, key: &str) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let mut client = Client::connect(&[endpoint], None).await?;
+        client.delete(key, None).await?;
+        Ok(())
+    })
+}
+
+/// Read a key from etcd, returning `None` if it doesn't exist.
+fn get_key(endpoint: &str, key: &str) -> anyhow::Result<Option<Vec<u8>>> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let mut client = Client::connect(&[endpoint], None).await?;
+        let resp = client.get(key, None).await?;
+        Ok(resp.kvs().first().map(|kv| kv.value().to_vec()))
+    })
+}
+
+fn entry(key: &str, value: &[u8]) -> EtcdEntry {
+    EtcdEntry {
+        key: key.to_string(),
+        value: value.to_vec(),
+    }
+}
+
+// ---- Source tests ----
+
+#[test]
+fn test_sub_empty_snapshot_then_live_write() -> anyhow::Result<()> {
+    // An empty prefix yields no snapshot events; a subsequent live write arrives
+    // as a Put.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+
+    let g = GraphBuilder::new();
+    let events = etcd_sub(
+        &g,
+        rt.handle(),
+        realtime(1),
+        EtcdConnection::new(&endpoint),
+        "/empty/",
+    )
+    .collapse_accumulate();
+
+    let endpoint_clone = endpoint.clone();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(200));
+        seed_keys(&endpoint_clone, &[("/empty/probe", "1")]).unwrap();
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+    writer.join().unwrap();
+
+    let events: Vec<EtcdEvent> = runner.value(&events);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].kind, EtcdEventKind::Put);
+    assert_eq!(events[0].entry.key, "/empty/probe");
+    Ok(())
+}
+
+#[test]
+fn test_sub_snapshot_with_existing_keys() -> anyhow::Result<()> {
+    // Pre-seeded keys appear as Put events in the snapshot phase (one burst).
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+    seed_keys(&endpoint, &[("/snap/a", "1"), ("/snap/b", "2")])?;
+
+    let g = GraphBuilder::new();
+    let events = etcd_sub(
+        &g,
+        rt.handle(),
+        realtime(1),
+        EtcdConnection::new(&endpoint),
+        "/snap/",
+    )
+    .collapse_accumulate();
+
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let events: Vec<EtcdEvent> = runner.value(&events);
+    assert_eq!(events.len(), 2);
+    assert!(events.iter().all(|e| e.kind == EtcdEventKind::Put));
+
+    let keys: std::collections::BTreeSet<String> =
+        events.iter().map(|e| e.entry.key.clone()).collect();
+    assert!(keys.contains("/snap/a"));
+    assert!(keys.contains("/snap/b"));
+    Ok(())
+}
+
+#[test]
+fn test_sub_live_updates() -> anyhow::Result<()> {
+    // Live watch events arrive after the (empty) snapshot phase.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+
+    let endpoint_clone = endpoint.clone();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(150));
+        seed_keys(&endpoint_clone, &[("/live/x", "hello")]).unwrap();
+    });
+
+    let g = GraphBuilder::new();
+    let events = etcd_sub(
+        &g,
+        rt.handle(),
+        realtime(1),
+        EtcdConnection::new(&endpoint),
+        "/live/",
+    )
+    .collapse_accumulate();
+
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+    writer.join().unwrap();
+
+    let events: Vec<EtcdEvent> = runner.value(&events);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].kind, EtcdEventKind::Put);
+    assert_eq!(events[0].entry.key, "/live/x");
+    assert_eq!(events[0].entry.value, b"hello");
+    Ok(())
+}
+
+#[test]
+fn test_sub_delete_events() -> anyhow::Result<()> {
+    // A DELETE in etcd produces an EtcdEventKind::Delete event.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+    seed_keys(&endpoint, &[("/del/k", "v")])?;
+
+    let endpoint_clone = endpoint.clone();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(150));
+        delete_key(&endpoint_clone, "/del/k").unwrap();
+    });
+
+    let g = GraphBuilder::new();
+    // Cycles(2): 1 snapshot Put + 1 live Delete.
+    let events = etcd_sub(
+        &g,
+        rt.handle(),
+        realtime(2),
+        EtcdConnection::new(&endpoint),
+        "/del/",
+    )
+    .collapse_accumulate();
+
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(2))?;
+    writer.join().unwrap();
+
+    let events: Vec<EtcdEvent> = runner.value(&events);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].kind, EtcdEventKind::Put);
+    assert_eq!(events[1].kind, EtcdEventKind::Delete);
+    assert_eq!(events[1].entry.key, "/del/k");
+    Ok(())
+}
+
+#[test]
+fn test_sub_no_race_between_snapshot_and_watch() -> anyhow::Result<()> {
+    // A pre-seeded key and a second key written just before the graph starts
+    // must each appear exactly once — no missed events, no duplicates.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+    seed_keys(&endpoint, &[("/race/existing", "old")])?;
+
+    let endpoint_clone = endpoint.clone();
+    let writer = std::thread::spawn(move || {
+        seed_keys(&endpoint_clone, &[("/race/new", "new")]).unwrap();
+    });
+    writer.join().unwrap();
+
+    let g = GraphBuilder::new();
+    let events = etcd_sub(
+        &g,
+        rt.handle(),
+        realtime(1),
+        EtcdConnection::new(&endpoint),
+        "/race/",
+    )
+    .collapse_accumulate();
+
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let events: Vec<EtcdEvent> = runner.value(&events);
+    let keys: std::collections::HashSet<String> =
+        events.iter().map(|e| e.entry.key.clone()).collect();
+    assert!(keys.contains("/race/existing"), "existing key missing");
+    assert!(keys.contains("/race/new"), "concurrent key missing");
+    assert_eq!(keys.len(), 2, "duplicate events detected");
+    Ok(())
+}
+
+// ---- Sink tests ----
+
+#[test]
+fn test_pub_round_trip() -> anyhow::Result<()> {
+    // etcd_pub writes keys; verify via a direct client read.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g.constant(burst![entry("/rt/key1", b"value1")]).etcd_pub(
+            rt.handle(),
+            EtcdConnection::new(&endpoint),
+            None,
+            true,
+        )?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    assert_eq!(
+        get_key(&endpoint, "/rt/key1")?.as_deref(),
+        Some(&b"value1"[..])
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pub_no_lease_keys_persist() -> anyhow::Result<()> {
+    // Without a lease, keys remain after the consumer stops.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![entry("/nolease/k1", b"persist")])
+            .etcd_pub(rt.handle(), EtcdConnection::new(&endpoint), None, true)?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    assert_eq!(
+        get_key(&endpoint, "/nolease/k1")?.as_deref(),
+        Some(&b"persist"[..])
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pub_lease_keys_expire_after_revoke() -> anyhow::Result<()> {
+    // Keys written with a lease are revoked (deleted) when the sink is dropped
+    // at graph teardown.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+
+    {
+        let g = GraphBuilder::new();
+        // A 30s TTL — the key must still vanish on revoke, not wait 30s.
+        let _sink = g.constant(burst![entry("/lease/k1", b"hello")]).etcd_pub(
+            rt.handle(),
+            EtcdConnection::new(&endpoint),
+            Some(Duration::from_secs(30)),
+            true,
+        )?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+    // Sink dropped → lease revoked → key must be gone.
+    assert!(
+        get_key(&endpoint, "/lease/k1")?.is_none(),
+        "key should be gone after lease revoke"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pub_lease_keepalive_extends_ttl() -> anyhow::Result<()> {
+    // While the sink is running, keepalive prevents key expiry.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+
+    // TTL 3s, keepalive renews every 1s, graph runs 10s (> TTL). The check
+    // thread polls until the key appears, then waits past the raw TTL.
+    let endpoint_check = endpoint.clone();
+    let checker = std::thread::spawn(move || -> anyhow::Result<()> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            if get_key(&endpoint_check, "/lease/heartbeat")?.is_some() {
+                break;
+            }
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "key never appeared within 15s"
+            );
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        // Sleep past the raw TTL (3s) — the key must still be alive via keepalive.
+        std::thread::sleep(Duration::from_secs(4));
+        assert!(
+            get_key(&endpoint_check, "/lease/heartbeat")?.is_some(),
+            "key should still exist; keepalive should have renewed the lease"
+        );
+        Ok(())
+    });
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![entry("/lease/heartbeat", b"alive")])
+            .etcd_pub(
+                rt.handle(),
+                EtcdConnection::new(&endpoint),
+                Some(Duration::from_secs(3)),
+                true,
+            )?;
+        g.build()
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(10)))?;
+    }
+
+    checker.join().unwrap()?;
+    Ok(())
+}
+
+#[test]
+fn test_pub_force_true_overwrites() -> anyhow::Result<()> {
+    // force: true silently overwrites an existing key.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+    seed_keys(&endpoint, &[("/force/k", "original")])?;
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g.constant(burst![entry("/force/k", b"updated")]).etcd_pub(
+            rt.handle(),
+            EtcdConnection::new(&endpoint),
+            None,
+            true,
+        )?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    assert_eq!(
+        get_key(&endpoint, "/force/k")?.as_deref(),
+        Some(&b"updated"[..])
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pub_force_false_fails_if_exists() -> anyhow::Result<()> {
+    // force: false aborts the run, naming the key, when it already exists.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+    seed_keys(&endpoint, &[("/noforce/k", "original")])?;
+
+    let g = GraphBuilder::new();
+    let _sink = g
+        .constant(burst![entry("/noforce/k", b"should-not-overwrite")])
+        .etcd_pub(rt.handle(), EtcdConnection::new(&endpoint), None, false)?;
+    let result = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
+
+    assert!(result.is_err(), "expected error when key already exists");
+    let err = result.unwrap_err();
+    assert!(
+        err.chain().any(|e| e.to_string().contains("/noforce/k")),
+        "error chain should name the key: {err:#}"
+    );
+
+    // Original value must be unchanged.
+    assert_eq!(
+        get_key(&endpoint, "/noforce/k")?.as_deref(),
+        Some(&b"original"[..])
+    );
+    Ok(())
+}
+
+#[test]
+fn test_pub_force_false_succeeds_if_absent() -> anyhow::Result<()> {
+    // force: false writes successfully when the key does not exist.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, endpoint) = start_etcd()?;
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![entry("/noforce/new", b"value")])
+            .etcd_pub(rt.handle(), EtcdConnection::new(&endpoint), None, false)?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    assert_eq!(
+        get_key(&endpoint, "/noforce/new")?.as_deref(),
+        Some(&b"value"[..])
+    );
+    Ok(())
+}

--- a/next/crates/wingfoil-next/tests/etcd_integration.rs
+++ b/next/crates/wingfoil-next/tests/etcd_integration.rs
@@ -364,8 +364,16 @@ fn test_pub_lease_keepalive_extends_ttl() -> anyhow::Result<()> {
 
     {
         let g = GraphBuilder::new();
+        // Drive the write from a ticker rather than a bare `constant`: under
+        // `RunFor::Duration` a `constant` source emits no wake, so the graph
+        // would never run the cycle that fires the PUT. Re-writing the same key
+        // under the lease every 500ms is idempotent — and it is keepalive, not
+        // the re-write, that holds the lease open past its 3s TTL (a PUT does not
+        // reset the lease timer; if keepalive stalled the lease would expire and
+        // the next PUT with the dead lease id would abort the run).
         let _sink = g
-            .constant(burst![entry("/lease/heartbeat", b"alive")])
+            .ticker(Duration::from_millis(500))
+            .map(|_: &()| burst![entry("/lease/heartbeat", b"alive")])
             .etcd_pub(
                 rt.handle(),
                 EtcdConnection::new(&endpoint),

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -416,6 +416,21 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
 3. **csv** — replay source + sink; exercises 0.3 historical bursts.
 4. **redis, postgres, etcd** — request/response shaped; fallible cycle +
    lifecycle hooks.
+   ✅ **etcd** *(done)*: snapshot→watch source (`etcd_sub`) on `produce_async`
+   and a key-value PUT sink (`EtcdSinkOps::etcd_pub`) with leases (background
+   keepalive + revoke-on-teardown via a `Drop` guard) and the `force`
+   conditional write, behind the `etcd` feature. Parity port of the classic
+   adapter's tests as `tests/etcd_integration.rs` (testcontainers, gated on
+   `etcd-integration-test`) plus no-service tests in `tests/etcd_adapter.rs`.
+   **Deviations** (capabilities all preserved): (a) the tokio runtime is the
+   caller's — `etcd_sub`/`etcd_pub` take a `&tokio::runtime::Handle` (and
+   `etcd_sub` a `RunParams`), matching next's `produce_async` convention rather
+   than classic's hidden global runtime; (b) the sink connects eagerly at wiring
+   and returns `Result`, so a connection error surfaces before the run rather
+   than during it (classic connected lazily inside the consumer); (c) the sink
+   is the `EtcdSinkOps` trait only (classic's free `etcd_pub` fn folded into the
+   trait, per next's sink-as-trait convention). The sink drives writes with
+   `Handle::block_on`, so the graph must be driven from a non-async thread.
 5. **zmq, kafka, kdb** — streaming; `poll`/`external` + lifecycle.
 6. **fix** — codec-heavy; fallibility with context.
 7. **web** (+ wingfoil-wire-types, wingfoil-wasm, wingfoil-js untouched —


### PR DESCRIPTION
## Summary

Ports the classic `wingfoil::adapters::etcd` module onto the next engine (`wingfoil-next`), providing a streaming key-prefix snapshot + live watch **source** (`etcd_sub`) and a key-value PUT **sink** (`EtcdSinkOps::etcd_pub`) for the etcd key-value store.

## Key Changes

- **New etcd adapter module** (`src/adapters/etcd.rs`, 510 lines):
  - `etcd_sub()` — free builder function on `GraphBuilder` that emits `Stream<Burst<EtcdEvent>>`. Opens the watch **before** the GET to prevent snapshot/watch race; deduplicates events by `mod_revision <= snapshot_rev`.
  - `EtcdSinkOps` trait — extension on `Stream<Burst<EtcdEntry>>` and `Stream<EtcdEntry>` providing `etcd_pub()` method for writing via PUT.
  - Lease support with background keepalive task (renews every `ttl/3`) and revoke-on-teardown via `LeaseGuard` drop guard.
  - Conditional write support (`force: false` aborts run if key exists; `force: true` silently overwrites).
  - Eager connection at wiring time so errors surface before the run.

- **Integration tests** (`tests/etcd_integration.rs`, 455 lines):
  - Parity port of classic `wingfoil/src/adapters/etcd/integration_tests.rs`.
  - Tests snapshot consistency, live updates, delete events, snapshot/watch race prevention, lease keepalive, and conditional writes.
  - Uses `testcontainers` to spawn etcd v3.5.0 on demand; runs with `--test-threads=1` to serialize container lifecycle.

- **Unit tests** (`tests/etcd_adapter.rs`, 60 lines):
  - Connection failure handling (source and sink).
  - No Docker required; runs in CI without the `etcd-integration-test` feature.

- **Example** (`examples/etcd_adapter.rs`, 93 lines):
  - Demonstrates two independent graph roots sharing one `GraphBuilder`: seed source keys once, then watch and transform them.

- **CI workflow** (`.github/workflows/etcd-next-integration.yml`):
  - Runs etcd integration tests on push to etcd adapter files.
  - Pre-pulls etcd image with retries to avoid transient registry flakes.

- **Feature flags and dependencies**:
  - `etcd` feature (default-off) — enables the adapter and its dependencies (`etcd-client`, `async-stream`).
  - `etcd-integration-test` feature (default-off) — enables integration tests and `testcontainers`.
  - Added `tinyvec` to main dependencies (required for `burst!` macro expansion).

- **Documentation updates**:
  - Comprehensive module-level docs covering layering, deviations from classic, runtime requirements (non-async thread constraint for `block_on`), snapshot→watch handoff, sink behavior, and setup instructions.
  - Updated `port-plan.md` to mark etcd as complete.

## Notable Implementation Details

1. **Runtime ownership**: The caller provides a `tokio::runtime::Handle` to both `etcd_sub` and `etcd_pub`, following the next engine convention. No hidden global runtime.

2. **Snapshot→watch race prevention**: Watch is opened before GET; any event with `mod_revision <= snapshot_rev` is filtered as a duplicate.

3. **Lease lifecycle**: `LeaseGuard` holds the lease ID and keepalive task. On drop (at graph teardown), it aborts the keepalive task and revokes the lease, ensuring leased keys vanish immediately rather than waiting out the TTL.

4. **Eager connection**: Sink connects at wiring time via `handle.block_on()`, so connection errors surface before the run (unlike classic's lazy connect inside the consumer).

5. **Conditional writes**: `force: false` uses etcd transactions with `create_revision == 0` comparison to ensure atomicity.

6. **Block-on

https://claude.ai/code/session_01ApjX2yRPnYXVvxv2NvPEzb