### PR TITLE
wingfoil-next: runtime graph dynamism (layered dispatch + run_dynamic/Extension, dynamic_group, demux)

### DIFF
--- a/next/crates/wingfoil-next-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-macros/src/lib.rs
@@ -2126,12 +2126,15 @@ fn expand_nested(def: &GraphDef) -> TokenStream2 {
             let mut __q = ::wingfoil_next::wingfoil::TimeQueue::<usize>::new();
             let mut __dirty = [false; #n];
             let mut __active: ::std::vec::Vec<usize> = ::std::vec::Vec::new();
+            let mut __passive: ::std::vec::Vec<usize> = ::std::vec::Vec::new();
             #(
                 if #input_active_exprs {
                     __active.push(#ix_ids);
+                } else {
+                    __passive.push(#ix_ids);
                 }
             )*
-            __g.__composite(__active, #callback_activated, move |__ctx, __phase| {
+            __g.__composite(__active, __passive, #callback_activated, move |__ctx, __phase| {
                 let __now = __ctx.time();
                 let __start_time = __ctx.start_time();
                 match __phase {

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -76,6 +76,12 @@ csv = ["dep:csv", "dep:serde", "dep:serde-aux"]
 augurs = ["dep:augurs"]
 etcd = ["dep:etcd-client", "dep:async-stream", "async"]
 etcd-integration-test = ["etcd", "dep:testcontainers"]
+# Runtime graph dynamism: append nodes and splice edges into a live graph
+# mid-run (`Runner::run_dynamic` + `Extension`). Mirrors classic wingfoil's
+# `dynamic-graph` feature; off the default hot path until wired in. The layered
+# `(layer, index)` dispatch it relies on is always on (it is byte-identical to
+# the old index order on static graphs).
+dynamic-graph = []
 
 [[example]]
 name = "async_source"

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -103,15 +103,16 @@ impl GraphBuilder {
     pub fn __composite<T: Clone + Default + 'static>(
         &self,
         active_ups: Vec<usize>,
+        passive_ups: Vec<usize>,
         callback_activated: bool,
         node: impl FnMut(&mut crate::op::Ctx, crate::op::CompositePhase) -> Result<crate::op::Tick<T>>
         + 'static,
     ) -> Stream<T> {
         self.assert_not_built();
-        let handle = self
-            .inner
-            .borrow_mut()
-            .composite(active_ups, callback_activated, node);
+        let handle =
+            self.inner
+                .borrow_mut()
+                .composite(active_ups, passive_ups, callback_activated, node);
         self.wrap(handle)
     }
 

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -2055,6 +2055,7 @@ impl Builder {
             id: self.id,
             active_downs,
             passive_downs,
+            removed: vec![false; n],
             seed_nodes,
             layer,
             dispatch: Dispatch::default(),
@@ -2115,6 +2116,15 @@ pub struct Runner {
     /// passive). Inert unless the graph is mutated at runtime.
     #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
     passive_downs: Vec<Vec<usize>>,
+    /// `removed[i]` — a tombstone set when a node is deleted at runtime
+    /// (`Extension::remove`). Its edges are unlinked and it is dropped from
+    /// `seed_nodes` so it never cycles again; the flag additionally stops the
+    /// end-of-run cleanup from calling its `stop`/`teardown` a second time
+    /// (they already ran at removal — classic parity, `graph.rs:1015-1028`).
+    /// Slots are tombstoned, never freed, so a `Handle` stays valid. Always
+    /// all-false on a static run.
+    #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
+    removed: Vec<bool>,
     /// Frontier sources seeded each cycle: `always` ops and callback-activated
     /// ops (the latter only fire when the kernel marks them dirty).
     seed_nodes: Vec<usize>,
@@ -2542,7 +2552,11 @@ impl Runner {
                 cycles += 1;
                 // Apply staged mutations at the boundary, matching classic's
                 // end-of-cycle `process_pending_*` (`graph.rs:934-939`).
-                let mut ext = Extension { runner: self };
+                let mut ext = Extension {
+                    runner: self,
+                    kernel: &mut kernel,
+                    appended: Vec::new(),
+                };
                 if let Err(e) = between(&mut ext, cycles) {
                     first_err = Some(e);
                     break;
@@ -2551,16 +2565,24 @@ impl Runner {
         }
 
         // Cleanup always runs; a stop/teardown error only surfaces if no
-        // earlier error already won.
-        for (i, node) in self.nodes.iter_mut().enumerate() {
-            if let Err(e) = (node.stop)(&mut kernel) {
-                let e = e.context(format!("node {i} ({}) stop", node.label));
+        // earlier error already won. A node removed mid-run already ran its
+        // `stop`/`teardown` at removal (classic parity), so the tombstone skips
+        // it here — no double call.
+        for i in 0..self.nodes.len() {
+            if self.removed[i] {
+                continue;
+            }
+            if let Err(e) = (self.nodes[i].stop)(&mut kernel) {
+                let e = e.context(format!("node {i} ({}) stop", self.nodes[i].label));
                 first_err.get_or_insert(e);
             }
         }
-        for (i, node) in self.nodes.iter_mut().enumerate() {
-            if let Err(e) = (node.teardown)(&mut kernel) {
-                let e = e.context(format!("node {i} ({}) teardown", node.label));
+        for i in 0..self.nodes.len() {
+            if self.removed[i] {
+                continue;
+            }
+            if let Err(e) = (self.nodes[i].teardown)(&mut kernel) {
+                let e = e.context(format!("node {i} ({}) teardown", self.nodes[i].label));
                 first_err.get_or_insert(e);
             }
         }
@@ -2632,6 +2654,7 @@ impl Runner {
         self.ticked.borrow_mut().push(false);
         self.active_downs.push(Vec::new());
         self.passive_downs.push(Vec::new());
+        self.removed.push(false);
         self.layer.push(lyr);
         if activation.always || activation.callback_activated() {
             self.seed_nodes.push(idx);
@@ -2686,6 +2709,91 @@ impl Runner {
             }
         }
     }
+
+    /// Unlink node `idx` from the live graph and run its lifecycle teardown.
+    /// Removes it from every upstream's down-list and every downstream's
+    /// up-list (both active and passive), drops it from `seed_nodes`, runs
+    /// `stop` then `teardown` once, and tombstones it (`removed[idx] = true`).
+    /// Because it no longer appears in any frontier or reverse-edge list it can
+    /// never be enqueued again. Port of classic's `process_pending_removals`
+    /// (`graph.rs:992-1028`). No-op if already removed.
+    fn remove_node(&mut self, idx: usize, kernel: &mut Kernel) -> Result<()> {
+        if self.removed[idx] {
+            return Ok(());
+        }
+        // Unlink from upstreams' down-lists.
+        let active_ups = std::mem::take(&mut self.nodes[idx].active_ups);
+        for &u in &active_ups {
+            self.active_downs[u].retain(|&x| x != idx);
+        }
+        let passive_ups = std::mem::take(&mut self.nodes[idx].passive_ups);
+        for &u in &passive_ups {
+            self.passive_downs[u].retain(|&x| x != idx);
+        }
+        // Unlink from downstreams' up-lists.
+        let active_downs = std::mem::take(&mut self.active_downs[idx]);
+        for &d in &active_downs {
+            self.nodes[d].active_ups.retain(|&x| x != idx);
+        }
+        let passive_downs = std::mem::take(&mut self.passive_downs[idx]);
+        for &d in &passive_downs {
+            self.nodes[d].passive_ups.retain(|&x| x != idx);
+        }
+        // Drop from the dispatch frontier so it is never seeded again.
+        self.seed_nodes.retain(|&x| x != idx);
+        self.removed[idx] = true;
+        // Lifecycle teardown, once, with node context — stop then teardown.
+        let label = self.nodes[idx].label;
+        (self.nodes[idx].stop)(kernel)
+            .map_err(|e| e.context(format!("node {idx} ({label}) stop (dynamic removal)")))?;
+        (self.nodes[idx].teardown)(kernel)
+            .map_err(|e| e.context(format!("node {idx} ({label}) teardown (dynamic removal)")))?;
+        Ok(())
+    }
+
+    /// Schedule the attachment points of a freshly appended region to fire at
+    /// `time + 1`, in dependency order — the `recycle` first-value guarantee.
+    /// Walks `new`'s upstream cone, bounded to nodes in `appended` (this
+    /// boundary's new nodes); a node is an *attachment point* if it reads a
+    /// pre-existing (non-`appended`) upstream or is a source. Each attachment
+    /// point is scheduled and, if not already a dispatch seed, added to
+    /// `seed_nodes` so the scheduled dirty flag actually fires it (a plain
+    /// `map`/`fold` is otherwise reached only by upstream propagation).
+    /// Downstream appended nodes then fire by normal tick propagation, so the
+    /// region evaluates in order and reads real values, not `Default`. Mirrors
+    /// classic's attachment-point walk (`graph.rs:1092-1115`).
+    fn recycle_schedule(&mut self, new: usize, appended: &[usize], kernel: &mut Kernel) {
+        let time = kernel.time() + 1;
+        let mut stack = vec![new];
+        let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        while let Some(ix) = stack.pop() {
+            if !visited.insert(ix) {
+                continue;
+            }
+            let has_preexisting = self.nodes[ix]
+                .active_ups
+                .iter()
+                .chain(self.nodes[ix].passive_ups.iter())
+                .any(|u| !appended.contains(u));
+            let is_source =
+                self.nodes[ix].active_ups.is_empty() && self.nodes[ix].passive_ups.is_empty();
+            if has_preexisting || is_source {
+                kernel.schedule(ix, time);
+                if !self.seed_nodes.contains(&ix) {
+                    self.seed_nodes.push(ix);
+                }
+            }
+            for &u in self.nodes[ix]
+                .active_ups
+                .iter()
+                .chain(self.nodes[ix].passive_ups.iter())
+            {
+                if appended.contains(&u) {
+                    stack.push(u);
+                }
+            }
+        }
+    }
 }
 
 /// A scoped mutation session over a *live* [`Runner`], handed to the
@@ -2695,6 +2803,13 @@ impl Runner {
 #[cfg(feature = "dynamic-graph")]
 pub struct Extension<'r> {
     runner: &'r mut Runner,
+    /// The live kernel, so `add_upstream(recycle = true)` can schedule the new
+    /// region's attachment points to fire at `time + 1`.
+    kernel: &'r mut Kernel,
+    /// Indices appended through *this* boundary scope, so a subsequent
+    /// `add_upstream(recycle = true)` knows which of `new`'s upstream cone is
+    /// freshly added (walk into) vs. pre-existing (an attachment point).
+    appended: Vec<usize>,
 }
 
 #[cfg(feature = "dynamic-graph")]
@@ -2739,6 +2854,7 @@ impl Extension<'_> {
             cycle,
             Box::new(|_| Ok(())),
         );
+        self.appended.push(idx);
         self.runner.rt_make_handle(idx)
     }
 
@@ -2781,6 +2897,7 @@ impl Extension<'_> {
             cycle,
             Box::new(|_| Ok(())),
         );
+        self.appended.push(idx);
         self.runner.rt_make_handle(idx)
     }
 
@@ -2788,15 +2905,37 @@ impl Extension<'_> {
     /// edge re-fires `caller` whenever `new` ticks and lifts `caller`'s layer
     /// above `new` (via `fix_layers`) so dispatch order stays correct even
     /// though `caller` has the lower index; a passive edge is read-only but
-    /// still raises the layer. Takes effect next cycle.
+    /// still raises the layer.
+    ///
+    /// With `recycle = true`, the newly appended region feeding `new` is
+    /// scheduled to fire at `time + 1` in dependency order (its attachment
+    /// points — nodes reading a pre-existing upstream, or new sources — are
+    /// seeded), so `caller` observes real current values on the next cycle
+    /// rather than the `Default` a not-yet-run node would hold. Mirrors classic
+    /// `add_upstream(recycle)` (`graph.rs:1092-1116`). Takes effect next cycle.
     pub fn add_upstream<C, N>(
         &mut self,
         caller: impl AsHandle<C>,
         new: impl AsHandle<N>,
         active: bool,
+        recycle: bool,
     ) {
         let caller = caller.as_handle();
         let new = new.as_handle();
         self.runner.splice_upstream(caller.idx, new.idx, active);
+        if recycle {
+            self.runner
+                .recycle_schedule(new.idx, &self.appended, self.kernel);
+        }
+    }
+
+    /// Remove a node from the live graph: unlink its edges, drop it from the
+    /// dispatch frontier so it never cycles again, and run its `stop` then
+    /// `teardown` exactly once (now, not at run end). The slot is tombstoned
+    /// (never freed), so the handle stays valid and its last value is still
+    /// readable — classic parity (`graph.rs:992-1028`). Idempotent: removing an
+    /// already-removed node is a no-op.
+    pub fn remove<T>(&mut self, node: impl AsHandle<T>) -> Result<()> {
+        self.runner.remove_node(node.as_handle().idx, self.kernel)
     }
 }

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -2018,6 +2018,7 @@ impl Builder {
         // the reorder index order alone cannot express.
         let n = self.nodes.len();
         let mut active_downs: Vec<Vec<usize>> = vec![Vec::new(); n];
+        let mut passive_downs: Vec<Vec<usize>> = vec![Vec::new(); n];
         let mut seed_nodes: Vec<usize> = Vec::new();
         let mut layer: Vec<usize> = vec![0; n];
         for i in 0..n {
@@ -2030,8 +2031,10 @@ impl Builder {
             // but still raise the layer: a passive reader must drain after the
             // value it reads, exactly as classic counts every upstream
             // (`graph.rs:794`). Index order is topological over all edges, so
-            // `layer[u]` is already final here.
+            // `layer[u]` is already final here. `passive_downs` is the reverse,
+            // used only by a dynamic `fix_layers`.
             for &u in &self.nodes[i].passive_ups {
+                passive_downs[u].push(i);
                 lyr = lyr.max(layer[u] + 1);
             }
             layer[i] = lyr;
@@ -2051,6 +2054,7 @@ impl Builder {
             finished: self.finished,
             id: self.id,
             active_downs,
+            passive_downs,
             seed_nodes,
             layer,
             dispatch: Dispatch::default(),
@@ -2104,6 +2108,13 @@ pub struct Runner {
     /// `active_ups`). Passive edges are deliberately absent — they are read but
     /// do not propagate ticks.
     active_downs: Vec<Vec<usize>>,
+    /// `passive_downs[i]` = nodes that *passively* read `i` (reverse of
+    /// `passive_ups`). Never used for tick propagation — only so a dynamic
+    /// `fix_layers` can raise a passive reader's layer when the node it reads is
+    /// relayered (classic propagates through every downstream, active or
+    /// passive). Inert unless the graph is mutated at runtime.
+    #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
+    passive_downs: Vec<Vec<usize>>,
     /// Frontier sources seeded each cycle: `always` ops and callback-activated
     /// ops (the latter only fire when the kernel marks them dirty).
     seed_nodes: Vec<usize>,
@@ -2296,56 +2307,78 @@ impl Runner {
         // waiting for the bound while a live sender clone keeps the waker
         // channel connected.
         while !self.finished.get() && kernel.begin_cycle(&mut dirty) {
-            // Seed the frontier: `always` ops fire unconditionally;
-            // callback-activated ops (tickers, `delay` pops, feedback source,
-            // channel replay) fire only when the kernel marked them dirty this
-            // cycle. Everything else reaches the queue by downstream
-            // propagation below.
-            for &i in &self.seed_nodes {
-                if (self.nodes[i].activation.always || dirty[i]) && !node_dirty[i] {
-                    node_dirty[i] = true;
-                    queue.push(Reverse((self.layer[i], i)));
-                }
-            }
-            // Drain in ascending `(layer, index)` order. A node that ticks marks
-            // its active downstream neighbours (all at strictly higher layers,
-            // so still ahead in the drain) dirty — propagating the tick
-            // frontier, each node firing once after everything it reads.
-            while let Some(Reverse((_layer, i))) = queue.pop() {
-                let did = match (self.nodes[i].cycle)(kernel) {
-                    Ok(did) => did,
-                    Err(e) => {
-                        let label = self.nodes[i].label;
-                        return Some(e.context(format!("node {i} ({label}) cycle")));
-                    }
-                };
-                // `ticked[i]` must be visible to downstreams that read it
-                // (`merge` tie-break, `delay` first-value seeding) before they
-                // fire; index order guarantees every node `i` reads has already
-                // set its flag.
-                self.ticked.borrow_mut()[i] = did;
-                fired.push(i);
-                if did {
-                    for &d in &self.active_downs[i] {
-                        if !node_dirty[d] {
-                            node_dirty[d] = true;
-                            queue.push(Reverse((self.layer[d], d)));
-                        }
-                    }
-                }
-            }
-            // Reset only the nodes we touched (the queue is already drained
-            // empty), keeping the per-cycle reset sparse.
+            if let Some(e) =
+                self.drain_cycle(kernel, &dirty, &mut queue, &mut node_dirty, &mut fired)
             {
-                let mut t = self.ticked.borrow_mut();
-                for &i in &fired {
-                    t[i] = false;
-                    node_dirty[i] = false;
-                }
+                return Some(e);
             }
-            fired.clear();
             kernel.end_cycle(&mut dirty);
         }
+        None
+    }
+
+    /// Seed, drain and reset a single already-begun cycle — the body shared by
+    /// [`run_cycles_sparse`](Runner::run_cycles_sparse) and (behind
+    /// `dynamic-graph`) [`run_dynamic`](Runner::run_dynamic). `dirty` was filled
+    /// by `kernel.begin_cycle`; the scratch buffers are reused across cycles and
+    /// must be empty (`queue`, `fired`) / sized to the node count and all-false
+    /// (`node_dirty`) on entry, and are restored to that state on a clean
+    /// return. On a cycle error the buffers are left as-is (the run aborts, so
+    /// they are not reused). Returns the first cycle error, or `None`.
+    fn drain_cycle(
+        &mut self,
+        kernel: &mut Kernel,
+        dirty: &[bool],
+        queue: &mut BinaryHeap<Reverse<(usize, usize)>>,
+        node_dirty: &mut [bool],
+        fired: &mut Vec<usize>,
+    ) -> Option<anyhow::Error> {
+        // Seed the frontier: `always` ops fire unconditionally; callback-
+        // activated ops (tickers, `delay` pops, feedback source, channel replay)
+        // fire only when the kernel marked them dirty this cycle. Everything
+        // else reaches the queue by downstream propagation below.
+        for &i in &self.seed_nodes {
+            if (self.nodes[i].activation.always || dirty[i]) && !node_dirty[i] {
+                node_dirty[i] = true;
+                queue.push(Reverse((self.layer[i], i)));
+            }
+        }
+        // Drain in ascending `(layer, index)` order. A node that ticks marks its
+        // active downstream neighbours (all at strictly higher layers, so still
+        // ahead in the drain) dirty — propagating the tick frontier, each node
+        // firing once after everything it reads.
+        while let Some(Reverse((_layer, i))) = queue.pop() {
+            let did = match (self.nodes[i].cycle)(kernel) {
+                Ok(did) => did,
+                Err(e) => {
+                    let label = self.nodes[i].label;
+                    return Some(e.context(format!("node {i} ({label}) cycle")));
+                }
+            };
+            // `ticked[i]` must be visible to downstreams that read it (`merge`
+            // tie-break, `delay` first-value seeding) before they fire; layer
+            // order guarantees every node `i` reads has already set its flag.
+            self.ticked.borrow_mut()[i] = did;
+            fired.push(i);
+            if did {
+                for &d in &self.active_downs[i] {
+                    if !node_dirty[d] {
+                        node_dirty[d] = true;
+                        queue.push(Reverse((self.layer[d], d)));
+                    }
+                }
+            }
+        }
+        // Reset only the nodes we touched (the queue is already drained empty),
+        // keeping the per-cycle reset sparse.
+        {
+            let mut t = self.ticked.borrow_mut();
+            for &i in &*fired {
+                t[i] = false;
+                node_dirty[i] = false;
+            }
+        }
+        fired.clear();
         None
     }
 
@@ -2399,5 +2432,371 @@ impl Runner {
             .expect("invariant: Handle<T> indexes a slot of type T")
             .borrow()
             .clone()
+    }
+}
+
+// ---- Runtime graph dynamism (feature `dynamic-graph`) ----------------------
+//
+// Runtime add/splice on the live interpreted graph. Built on the always-on
+// layered `(layer, index)` dispatch: because dispatch order is a `layer` key
+// (not raw node index), a new node can be appended at the end of the `nodes`
+// vec (highest index) and *spliced beneath* an existing lower-indexed caller —
+// `fix_layers` lifts the caller's layer above the new node so it still drains
+// after it, the reorder classic wingfoil does with its own `layer`/`fix_layers`
+// (`graph.rs:1149`) and index order alone cannot express.
+//
+// `run_dynamic` mirrors `run` but hands a mutation scope to a caller-supplied
+// hook at each cycle boundary — the exact point classic applies its staged
+// `pending_additions`/`pending_removals` (`graph.rs:934-939`), so a node added
+// after cycle N first fires in cycle N+1. This is the driver-thread surface;
+// the in-`cycle` node-driven path (what `DynamicGroup` needs) stages into the
+// same boundary apply and lands in a later increment.
+
+#[cfg(feature = "dynamic-graph")]
+impl Runner {
+    /// Longest-path dispatch layer of a node — the first component of the
+    /// `(layer, index)` sort key. Exposed for dynamism tests that assert
+    /// `fix_layers` re-sorted a spliced node correctly.
+    #[doc(hidden)]
+    pub fn layer_of<T>(&self, h: impl AsHandle<T>) -> usize {
+        self.layer[h.as_handle().index()]
+    }
+
+    /// Run the graph like [`run`](Runner::run), but call `between` at every
+    /// cycle boundary with a mutation scope ([`Extension`]) over the live graph
+    /// and the number of cycles completed so far. Nodes appended (or edges
+    /// spliced) through the scope take effect on the *next* cycle — classic
+    /// wingfoil's "requested in cycle N, live in N+1" contract.
+    pub fn run_dynamic<F>(
+        &mut self,
+        run_mode: RunMode,
+        run_for: RunFor,
+        mut between: F,
+    ) -> Result<()>
+    where
+        F: FnMut(&mut Extension<'_>, u32) -> Result<()>,
+    {
+        // Source/run-mode validation, identical to `run`.
+        let realtime = matches!(run_mode, RunMode::RealTime);
+        if !realtime && self.has_external {
+            bail!(
+                "graphs with external sources require RunMode::RealTime — untimestamped \
+                 external events have no place in a deterministic historical replay (use a \
+                 channel with timestamped sends for historical)"
+            );
+        }
+        if !realtime && self.has_always {
+            bail!(
+                "graphs with poll sources require RunMode::RealTime — there is nothing to \
+                 busy-poll in a deterministic historical replay"
+            );
+        }
+        let needs_waker = self.has_external || (self.has_channel && realtime);
+        let mut kernel = if needs_waker {
+            let Some(ready) = self.ready.take() else {
+                bail!(
+                    "a Runner with realtime sources (external/poll/realtime channel) supports \
+                     only a single run — the waker/ready channel is consumed by the first run"
+                );
+            };
+            Kernel::with_ready(run_mode, run_for, ready)
+        } else {
+            Kernel::new(run_mode, run_for)
+        };
+        if self.has_always {
+            kernel.set_spin(true);
+        }
+
+        let mut first_err: Option<anyhow::Error> = None;
+        for (i, node) in self.nodes.iter_mut().enumerate() {
+            if let Err(e) = (node.start)(&mut kernel) {
+                first_err = Some(e.context(format!("node {i} ({}) start", node.label)));
+                break;
+            }
+        }
+
+        if first_err.is_none() {
+            // Scratch is reused across cycles and regrown as nodes are appended.
+            // `dirty` is sized to the current node count each cycle (the kernel
+            // marks due callbacks into it by index).
+            let mut queue: BinaryHeap<Reverse<(usize, usize)>> = BinaryHeap::new();
+            let mut node_dirty: Vec<bool> = Vec::new();
+            let mut fired: Vec<usize> = Vec::new();
+            let mut cycles: u32 = 0;
+            loop {
+                let n = self.nodes.len();
+                if node_dirty.len() < n {
+                    node_dirty.resize(n, false);
+                }
+                let mut dirty = vec![false; n];
+                if self.finished.get() || !kernel.begin_cycle(&mut dirty) {
+                    break;
+                }
+                if let Some(e) =
+                    self.drain_cycle(&mut kernel, &dirty, &mut queue, &mut node_dirty, &mut fired)
+                {
+                    first_err = Some(e);
+                    break;
+                }
+                kernel.end_cycle(&mut dirty);
+                cycles += 1;
+                // Apply staged mutations at the boundary, matching classic's
+                // end-of-cycle `process_pending_*` (`graph.rs:934-939`).
+                let mut ext = Extension { runner: self };
+                if let Err(e) = between(&mut ext, cycles) {
+                    first_err = Some(e);
+                    break;
+                }
+            }
+        }
+
+        // Cleanup always runs; a stop/teardown error only surfaces if no
+        // earlier error already won.
+        for (i, node) in self.nodes.iter_mut().enumerate() {
+            if let Err(e) = (node.stop)(&mut kernel) {
+                let e = e.context(format!("node {i} ({}) stop", node.label));
+                first_err.get_or_insert(e);
+            }
+        }
+        for (i, node) in self.nodes.iter_mut().enumerate() {
+            if let Err(e) = (node.teardown)(&mut kernel) {
+                let e = e.context(format!("node {i} ({}) teardown", node.label));
+                first_err.get_or_insert(e);
+            }
+        }
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    fn rt_slot<T: 'static>(&self, h: Handle<T>) -> Rc<RefCell<T>> {
+        debug_assert_eq!(
+            h.builder_id, self.id,
+            "Handle used with a different Runner than the Builder that minted it"
+        );
+        self.slots[h.idx]
+            .clone()
+            .downcast::<RefCell<T>>()
+            .expect("invariant: Handle<T> indexes a slot of type T")
+    }
+
+    fn rt_new_slot<T: 'static>(&mut self, init: T) -> Rc<RefCell<T>> {
+        let slot = Rc::new(RefCell::new(init));
+        self.slots.push(slot.clone() as Rc<dyn Any>);
+        slot
+    }
+
+    fn rt_make_handle<T>(&self, idx: usize) -> Handle<T> {
+        Handle {
+            idx,
+            builder_id: self.id,
+            _t: PhantomData,
+        }
+    }
+
+    /// Append a node to the *live* graph, growing every parallel structure the
+    /// sparse engine keeps (`nodes`, `ticked`, `active_downs`, `passive_downs`,
+    /// `layer`, and `seed_nodes` if the node self-activates) and wiring its
+    /// reverse edges + layer. `active_ups`/`passive_ups` reference existing
+    /// (lower-index) nodes, so no existing node's order changes — pure append.
+    fn rt_append_node(
+        &mut self,
+        active_ups: Vec<usize>,
+        passive_ups: Vec<usize>,
+        activation: Activation,
+        label: &'static str,
+        cycle: CycleFn,
+        start: LifecycleFn,
+    ) -> usize {
+        let idx = self.nodes.len();
+        let mut lyr = 0usize;
+        for &u in &active_ups {
+            self.active_downs[u].push(idx);
+            lyr = lyr.max(self.layer[u] + 1);
+        }
+        for &u in &passive_ups {
+            self.passive_downs[u].push(idx);
+            lyr = lyr.max(self.layer[u] + 1);
+        }
+        self.nodes.push(NodeRt {
+            active_ups,
+            passive_ups,
+            activation,
+            label,
+            cycle,
+            start,
+            stop: Box::new(|_| Ok(())),
+            teardown: Box::new(|_| Ok(())),
+        });
+        self.ticked.borrow_mut().push(false);
+        self.active_downs.push(Vec::new());
+        self.passive_downs.push(Vec::new());
+        self.layer.push(lyr);
+        if activation.always || activation.callback_activated() {
+            self.seed_nodes.push(idx);
+        }
+        idx
+    }
+
+    /// Splice an edge from existing `new` into existing `caller`, then
+    /// re-establish layer order. An active edge (`active`) records
+    /// `caller`→`active_ups` + the reverse `active_downs[new]` so `new`'s tick
+    /// re-fires `caller`; a passive edge records `passive_ups`/`passive_downs`
+    /// only. `caller` may now depend on a *higher-indexed* `new`, so
+    /// `fix_layers` lifts its layer above `new` — the reorder only the
+    /// `(layer, index)` key can dispatch.
+    fn splice_upstream(&mut self, caller: usize, new: usize, active: bool) {
+        if active {
+            self.nodes[caller].active_ups.push(new);
+            self.active_downs[new].push(caller);
+        } else {
+            self.nodes[caller].passive_ups.push(new);
+            self.passive_downs[new].push(caller);
+        }
+        self.fix_layers(caller);
+    }
+
+    /// Recompute `start`'s layer from its upstreams (active *and* passive) and
+    /// propagate any increase to every node that reads it (active *and*
+    /// passive downstreams), iterative BFS. Port of classic's `fix_layers`
+    /// (`graph.rs:1149`): after splicing a new upstream into an existing
+    /// caller, this lifts the caller — and anything reading it — above the new
+    /// node so `(layer, index)` dispatch still drains each node after
+    /// everything it reads.
+    fn fix_layers(&mut self, start: usize) {
+        let mut queue: VecDeque<usize> = VecDeque::new();
+        queue.push_back(start);
+        while let Some(node) = queue.pop_front() {
+            let required = self.nodes[node]
+                .active_ups
+                .iter()
+                .chain(self.nodes[node].passive_ups.iter())
+                .map(|&u| self.layer[u])
+                .max()
+                .map_or(0, |m| m + 1);
+            if required > self.layer[node] {
+                self.layer[node] = required;
+                for &d in self.active_downs[node]
+                    .iter()
+                    .chain(self.passive_downs[node].iter())
+                {
+                    queue.push_back(d);
+                }
+            }
+        }
+    }
+}
+
+/// A scoped mutation session over a *live* [`Runner`], handed to the
+/// [`run_dynamic`](Runner::run_dynamic) boundary hook. Every node appended or
+/// edge spliced here takes effect on the next cycle. Handles it mints carry the
+/// runner's `builder_id`, so cross-runner misuse stays caught.
+#[cfg(feature = "dynamic-graph")]
+pub struct Extension<'r> {
+    runner: &'r mut Runner,
+}
+
+#[cfg(feature = "dynamic-graph")]
+impl Extension<'_> {
+    /// Append a `map` of an existing `src` onto the live graph. It ticks from
+    /// the next cycle whenever `src` ticks; its value is observable via
+    /// [`Runner::value`].
+    pub fn map<A, B, F>(&mut self, src: impl AsHandle<A>, f: F) -> Handle<B>
+    where
+        A: 'static,
+        B: Clone + Default + 'static,
+        F: Fn(&A) -> B + 'static,
+    {
+        let src = src.as_handle();
+        let idx = self.runner.nodes.len();
+        let src_slot = self.runner.rt_slot(src);
+        let out = self.runner.rt_new_slot(B::default());
+        let cs = Rc::new(RefCell::new((f, ())));
+        let cycle: CycleFn = Box::new(move |k| {
+            let (cfg, state) = &mut *cs.borrow_mut();
+            let mut ctx = Ctx::new(k, idx);
+            let a = src_slot.borrow();
+            match crate::ops::Map::<A, B, F>::cycle(cfg, state, (&a,), &mut ctx)? {
+                Tick::Value(v) => {
+                    drop(a);
+                    *out.borrow_mut() = v;
+                    Ok(true)
+                }
+                Tick::Silent(v) => {
+                    drop(a);
+                    *out.borrow_mut() = v;
+                    Ok(false)
+                }
+                Tick::Quiet => Ok(false),
+            }
+        });
+        self.runner.rt_append_node(
+            vec![src.idx],
+            Vec::new(),
+            crate::ops::Map::<A, B, F>::ACTIVATION,
+            "map",
+            cycle,
+            Box::new(|_| Ok(())),
+        );
+        self.runner.rt_make_handle(idx)
+    }
+
+    /// Append a `fold` of an existing `src` onto the live graph — a running
+    /// accumulator seeded with `init`, updated each time `src` ticks.
+    pub fn fold<A, B, F>(&mut self, src: impl AsHandle<A>, init: B, f: F) -> Handle<B>
+    where
+        A: 'static,
+        B: Clone + 'static,
+        F: Fn(&mut B, &A) + 'static,
+    {
+        let src = src.as_handle();
+        let idx = self.runner.nodes.len();
+        let src_slot = self.runner.rt_slot(src);
+        let out = self.runner.rt_new_slot(init.clone());
+        let cs = Rc::new(RefCell::new((f, init)));
+        let cycle: CycleFn = Box::new(move |k| {
+            let (cfg, state) = &mut *cs.borrow_mut();
+            let mut ctx = Ctx::new(k, idx);
+            let a = src_slot.borrow();
+            match Fold::<A, B, F>::cycle(cfg, state, (&a,), &mut ctx)? {
+                Tick::Value(v) => {
+                    drop(a);
+                    *out.borrow_mut() = v;
+                    Ok(true)
+                }
+                Tick::Silent(v) => {
+                    drop(a);
+                    *out.borrow_mut() = v;
+                    Ok(false)
+                }
+                Tick::Quiet => Ok(false),
+            }
+        });
+        self.runner.rt_append_node(
+            vec![src.idx],
+            Vec::new(),
+            Fold::<A, B, F>::ACTIVATION,
+            "fold",
+            cycle,
+            Box::new(|_| Ok(())),
+        );
+        self.runner.rt_make_handle(idx)
+    }
+
+    /// Splice `new` in as an upstream of the existing `caller`. An `active`
+    /// edge re-fires `caller` whenever `new` ticks and lifts `caller`'s layer
+    /// above `new` (via `fix_layers`) so dispatch order stays correct even
+    /// though `caller` has the lower index; a passive edge is read-only but
+    /// still raises the layer. Takes effect next cycle.
+    pub fn add_upstream<C, N>(
+        &mut self,
+        caller: impl AsHandle<C>,
+        new: impl AsHandle<N>,
+        active: bool,
+    ) {
+        let caller = caller.as_handle();
+        let new = new.as_handle();
+        self.runner.splice_upstream(caller.idx, new.idx, active);
     }
 }

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -203,6 +203,16 @@ struct NodeRt {
     /// edges). A cycle runs when any of these ticked — see the dispatch loop
     /// in [`Runner::run`].
     active_ups: Vec<usize>,
+    /// Indices of upstream nodes this node **reads but is not triggered by**
+    /// (the passive edges — `sample`'s data leg, a `bimap`/`trimap` inactive
+    /// input). They never appear in `active_downs` (no tick propagates along
+    /// them), but they *do* count toward the node's dispatch `layer`: a passive
+    /// reader must run after the value it reads, exactly as an active one must.
+    /// Classic tracks the same fact (every upstream, active or passive, raises
+    /// the layer — `graph.rs:794`, `fix_layers` at `graph.rs:1153`); the
+    /// index-order engine got this for free from wiring order, but the layered
+    /// engine (and dynamic `fix_layers`) needs it explicit.
+    passive_ups: Vec<usize>,
     /// The op's `ACTIVATION` — this contract drives dispatch: nodes without
     /// `callback_activated()` skip the dirty check entirely, and `always`
     /// nodes are cycled unconditionally (busy-poll sources).
@@ -585,6 +595,7 @@ impl Builder {
     ) {
         self.nodes.push(NodeRt {
             active_ups,
+            passive_ups: Vec::new(),
             activation,
             label,
             cycle,
@@ -605,6 +616,17 @@ impl Builder {
             .last_mut()
             .expect("invariant: set_reset called immediately after push_node")
             .reset = reset;
+    }
+
+    /// Record the passive upstream edges of the node at `idx` (the node just
+    /// pushed by [`push_node`](Self::push_node)). Passive edges are read but do
+    /// not trigger, so they stay out of `active_ups`/`active_downs`; they are
+    /// tracked only so `build()` (and dynamic `fix_layers`) can raise the
+    /// node's dispatch `layer` above every value it reads. Called by the
+    /// handful of passive-capable builders (`sample`, `bimap`, `trimap`, and
+    /// their `try_` variants); all-active shapes leave it empty.
+    fn set_passive_ups(&mut self, idx: usize, passive_ups: Vec<usize>) {
+        self.nodes[idx].passive_ups = passive_ups;
     }
 
     /// Shared cfg+state cell, used by both the cycle and start adapters.
@@ -1048,14 +1070,21 @@ impl Builder {
         let cs = Self::cell(f, ());
         let out_reset = out.clone();
         let mut active = Vec::with_capacity(3);
+        let mut passive = Vec::with_capacity(3);
         if a_active {
             active.push(a.idx);
+        } else {
+            passive.push(a.idx);
         }
         if b_active {
             active.push(b.idx);
+        } else {
+            passive.push(b.idx);
         }
         if c_active {
             active.push(c.idx);
+        } else {
+            passive.push(c.idx);
         }
         self.push_node(
             active,
@@ -1086,6 +1115,7 @@ impl Builder {
         self.set_reset(Box::new(move || {
             *out_reset.borrow_mut() = D::default();
         }));
+        self.set_passive_ups(idx, passive);
         self.make_handle(idx)
     }
 
@@ -1118,14 +1148,21 @@ impl Builder {
         let cs = Self::cell(f, ());
         let out_reset = out.clone();
         let mut active = Vec::with_capacity(3);
+        let mut passive = Vec::with_capacity(3);
         if a_active {
             active.push(a.idx);
+        } else {
+            passive.push(a.idx);
         }
         if b_active {
             active.push(b.idx);
+        } else {
+            passive.push(b.idx);
         }
         if c_active {
             active.push(c.idx);
+        } else {
+            passive.push(c.idx);
         }
         self.push_node(
             active,
@@ -1156,6 +1193,7 @@ impl Builder {
         self.set_reset(Box::new(move || {
             *out_reset.borrow_mut() = D::default();
         }));
+        self.set_passive_ups(idx, passive);
         self.make_handle(idx)
     }
 
@@ -1278,6 +1316,10 @@ impl Builder {
         self.set_reset(Box::new(move || {
             *out_reset.borrow_mut() = T::default();
         }));
+        // `src` is read passively (only `trigger` activates the sample), so it
+        // does not appear in `active_ups`; record it as a passive edge so the
+        // sample's layer sits above the value it samples.
+        self.set_passive_ups(idx, vec![src.idx]);
         self.make_handle(idx)
     }
 
@@ -1317,11 +1359,16 @@ impl Builder {
         let cs = Self::cell(f, ());
         let out_reset = out.clone();
         let mut active = Vec::with_capacity(2);
+        let mut passive = Vec::with_capacity(2);
         if a_active {
             active.push(a.idx);
+        } else {
+            passive.push(a.idx);
         }
         if b_active {
             active.push(b.idx);
+        } else {
+            passive.push(b.idx);
         }
         self.push_node(
             active,
@@ -1353,6 +1400,7 @@ impl Builder {
         self.set_reset(Box::new(move || {
             *out_reset.borrow_mut() = C::default();
         }));
+        self.set_passive_ups(idx, passive);
         self.make_handle(idx)
     }
 
@@ -1380,11 +1428,16 @@ impl Builder {
         let cs = Self::cell(f, ());
         let out_reset = out.clone();
         let mut active = Vec::with_capacity(2);
+        let mut passive = Vec::with_capacity(2);
         if a_active {
             active.push(a.idx);
+        } else {
+            passive.push(a.idx);
         }
         if b_active {
             active.push(b.idx);
+        } else {
+            passive.push(b.idx);
         }
         self.push_node(
             active,
@@ -1416,6 +1469,7 @@ impl Builder {
         self.set_reset(Box::new(move || {
             *out_reset.borrow_mut() = C::default();
         }));
+        self.set_passive_ups(idx, passive);
         self.make_handle(idx)
     }
 
@@ -1854,6 +1908,7 @@ impl Builder {
     pub fn composite<T, F>(
         &mut self,
         active_ups: Vec<usize>,
+        passive_ups: Vec<usize>,
         callback_activated: bool,
         node: F,
     ) -> Handle<T>
@@ -1918,6 +1973,10 @@ impl Builder {
             (cell_teardown.borrow_mut())(&mut ctx, CompositePhase::Teardown)?;
             Ok(())
         });
+        // An island can read outer streams passively (a `graph!` input marked
+        // `passive`); those edges do not trigger the composite but must still
+        // raise its layer above the values it reads.
+        self.set_passive_ups(idx, passive_ups);
         self.make_handle(idx)
     }
 
@@ -1945,13 +2004,37 @@ impl Builder {
         // every node after everything it reads. That is what lets passive
         // reads (e.g. `sample` of a `delay`ed slot) observe the same value the
         // old full-index sweep produced, without tracking passive edges here.
+        //
+        // The work set drains by ascending **`(layer, index)`** (see
+        // `Runner::run`), where `layer[i]` is the longest path to `i` over
+        // *all* upstream edges — active and passive. This is classic wingfoil's
+        // layer-order dispatch (`dirty_nodes_by_layer`, `graph.rs:205`); for a
+        // statically wired graph index order is already a valid layer order, so
+        // `(layer, index)` is a linear extension of the read relation identical
+        // to the old pure-index order (the `Dispatch::FullSweep` oracle pins
+        // this). The explicit `layer` is what lets *dynamic* additions splice a
+        // new node beneath an existing lower-indexed caller: `fix_layers` bumps
+        // the caller's layer above the new node so it still drains after it —
+        // the reorder index order alone cannot express.
         let n = self.nodes.len();
         let mut active_downs: Vec<Vec<usize>> = vec![Vec::new(); n];
         let mut seed_nodes: Vec<usize> = Vec::new();
+        let mut layer: Vec<usize> = vec![0; n];
         for i in 0..n {
+            let mut lyr = 0usize;
             for &u in &self.nodes[i].active_ups {
                 active_downs[u].push(i);
+                lyr = lyr.max(layer[u] + 1);
             }
+            // Passive edges do not propagate ticks (absent from `active_downs`)
+            // but still raise the layer: a passive reader must drain after the
+            // value it reads, exactly as classic counts every upstream
+            // (`graph.rs:794`). Index order is topological over all edges, so
+            // `layer[u]` is already final here.
+            for &u in &self.nodes[i].passive_ups {
+                lyr = lyr.max(layer[u] + 1);
+            }
+            layer[i] = lyr;
             let act = self.nodes[i].activation;
             if act.always || act.callback_activated() {
                 seed_nodes.push(i);
@@ -1969,6 +2052,7 @@ impl Builder {
             id: self.id,
             active_downs,
             seed_nodes,
+            layer,
             dispatch: Dispatch::default(),
             re_runnable: self.re_runnable,
             has_run: false,
@@ -2023,6 +2107,11 @@ pub struct Runner {
     /// Frontier sources seeded each cycle: `always` ops and callback-activated
     /// ops (the latter only fire when the kernel marks them dirty).
     seed_nodes: Vec<usize>,
+    /// `layer[i]` = longest path to `i` over all upstream edges (active and
+    /// passive); the primary sparse-dispatch sort key. `(layer, index)` is a
+    /// valid topological order that survives dynamic edge splices (which index
+    /// order alone cannot — see [`build`](Builder::build) and `fix_layers`).
+    layer: Vec<usize>,
     /// Which dispatch loop `run` uses. `Sparse` by default; see [`Dispatch`].
     dispatch: Dispatch,
     /// Whether every node can restore itself for a re-run (see
@@ -2186,17 +2275,20 @@ impl Runner {
         let n = self.nodes.len();
         let mut dirty = vec![false; n];
         // Sparse dirty-list scratch, allocated once and reused every cycle:
-        //   * `queue` — the dirty work set, a min-heap on node index so it
-        //     drains in ascending (wiring/topological) order. Every active
-        //     downstream has a higher index than its upstream, so a node
-        //     enqueued while processing `i` is always popped after `i` — the
-        //     heap never revisits a processed node.
+        //   * `queue` — the dirty work set, a min-heap on `(layer, index)` so it
+        //     drains in ascending layer order (ties broken by index — classic's
+        //     within-layer wiring order). Every active downstream has a strictly
+        //     greater layer than its upstream, so a node enqueued while
+        //     processing `i` is always popped after `i` — the heap never
+        //     revisits a processed node. Keying on `layer` (not raw index) is
+        //     what keeps this invariant after a dynamic splice bumps a caller's
+        //     layer above a newly added upstream.
         //   * `node_dirty[i]` — guards a recombine node against being enqueued
         //     twice, so it fires exactly once per cycle.
         //   * `fired` — every node cycled this tick; the per-cycle `ticked` and
         //     `node_dirty` resets touch only these, not all `N`, so per-cycle
         //     work stays proportional to the active node count.
-        let mut queue: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
+        let mut queue: BinaryHeap<Reverse<(usize, usize)>> = BinaryHeap::new();
         let mut node_dirty = vec![false; n];
         let mut fired: Vec<usize> = Vec::new();
         // Check `finished` *before* `begin_cycle` parks: a channel that received
@@ -2212,14 +2304,14 @@ impl Runner {
             for &i in &self.seed_nodes {
                 if (self.nodes[i].activation.always || dirty[i]) && !node_dirty[i] {
                     node_dirty[i] = true;
-                    queue.push(Reverse(i));
+                    queue.push(Reverse((self.layer[i], i)));
                 }
             }
-            // Drain in ascending index order. A node that ticks marks its
-            // active downstream neighbours (all at higher indices, so still
-            // ahead in the drain) dirty — propagating the tick frontier, each
-            // node firing once after everything it reads.
-            while let Some(Reverse(i)) = queue.pop() {
+            // Drain in ascending `(layer, index)` order. A node that ticks marks
+            // its active downstream neighbours (all at strictly higher layers,
+            // so still ahead in the drain) dirty — propagating the tick
+            // frontier, each node firing once after everything it reads.
+            while let Some(Reverse((_layer, i))) = queue.pop() {
                 let did = match (self.nodes[i].cycle)(kernel) {
                     Ok(did) => did,
                     Err(e) => {
@@ -2237,7 +2329,7 @@ impl Runner {
                     for &d in &self.active_downs[i] {
                         if !node_dirty[d] {
                             node_dirty[d] = true;
-                            queue.push(Reverse(d));
+                            queue.push(Reverse((self.layer[d], d)));
                         }
                     }
                 }

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -340,6 +340,16 @@ pub struct Builder {
     /// node at wiring time; empty and inert on a static graph.
     #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
     pending: Rc<RefCell<Vec<PendingMut>>>,
+    /// Same-cycle "mark this node dirty" requests from a routing node (a
+    /// [`demux`](Builder::demux) parent), drained *within* the current cycle by
+    /// the dispatch loop. Shared (`Rc`) with the routing node. Distinct from
+    /// `pending` (next-cycle structural mutation) — this is fixed-topology
+    /// dynamic *routing*: a node enqueues a chosen, already-wired downstream to
+    /// fire this cycle. `has_marks` gates the drain off the hot path.
+    marks: Rc<RefCell<Vec<usize>>>,
+    /// Set when any [`demux`](Builder::demux) node is wired, so the dispatch
+    /// loop knows to drain `marks`. Off (and the drain skipped) otherwise.
+    has_marks: bool,
 }
 
 impl Default for Builder {
@@ -358,6 +368,8 @@ impl Default for Builder {
             re_runnable: true,
             id: NEXT_BUILDER_ID.fetch_add(1, Ordering::Relaxed),
             pending: Rc::new(RefCell::new(Vec::new())),
+            marks: Rc::new(RefCell::new(Vec::new())),
+            has_marks: false,
         }
     }
 }
@@ -2074,6 +2086,8 @@ impl Builder {
             passive_downs,
             removed: vec![false; n],
             pending: self.pending,
+            marks: self.marks,
+            has_marks: self.has_marks,
             seed_nodes,
             layer,
             dispatch: Dispatch::default(),
@@ -2149,6 +2163,11 @@ pub struct Runner {
     /// static graph.
     #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
     pending: Rc<RefCell<Vec<PendingMut>>>,
+    /// Same-cycle mark-dirty requests from routing nodes ([`demux`](Builder::demux)),
+    /// drained by the dispatch loop within the current cycle. See [`Builder::marks`].
+    marks: Rc<RefCell<Vec<usize>>>,
+    /// Whether any routing node exists; gates the `marks` drain off the hot path.
+    has_marks: bool,
     /// Frontier sources seeded each cycle: `always` ops and callback-activated
     /// ops (the latter only fire when the kernel marks them dirty).
     seed_nodes: Vec<usize>,
@@ -2399,6 +2418,18 @@ impl Runner {
                     if !node_dirty[d] {
                         node_dirty[d] = true;
                         queue.push(Reverse((self.layer[d], d)));
+                    }
+                }
+            }
+            // Same-cycle routing: a `demux` parent marks a chosen, already-wired
+            // child (higher `(layer, index)`, so still ahead in the drain) to
+            // fire this cycle — even though the parent itself did not tick.
+            if self.has_marks {
+                let mut marks = self.marks.borrow_mut();
+                for target in marks.drain(..) {
+                    if !node_dirty[target] {
+                        node_dirty[target] = true;
+                        queue.push(Reverse((self.layer[target], target)));
                     }
                 }
             }
@@ -3150,5 +3181,89 @@ impl Builder {
             Box::new(|_| Ok(())),
         );
         self.make_handle(idx)
+    }
+
+    /// Fixed-topology dynamic *routing* — the next twin of classic `demux`
+    /// (`nodes/demux.rs`). Pre-wires `size` child streams plus one overflow
+    /// child; each cycle the parent reads `source`, calls `route(value)` for a
+    /// slot, and marks **only** the chosen child to fire this cycle (via the
+    /// engine's same-cycle mark-dirty). A slot `< size` selects that child;
+    /// anything `>= size` routes to the overflow child. The selected child
+    /// re-emits the source's current value; the others stay quiet. No nodes are
+    /// added or removed — the graph shape is fixed, only the tick is routed.
+    ///
+    /// Returns `(children, overflow)`. Unlike classic's `DemuxMap`, key→slot
+    /// assignment and slot release (`DemuxEvent::Close`) are the caller's
+    /// concern here (a deliberately thinner surface over the routing primitive);
+    /// classic's auto-assigning map is a convenience that can layer on top.
+    pub fn demux<T, F>(
+        &mut self,
+        source: Handle<T>,
+        size: usize,
+        route: F,
+    ) -> (Vec<Handle<T>>, Handle<T>)
+    where
+        T: Clone + Default + 'static,
+        F: Fn(&T) -> usize + 'static,
+    {
+        self.has_marks = true;
+        let source_slot = self.slot(source);
+
+        // Parent: reads `source`, routes, and marks the chosen child. It never
+        // ticks itself (`Ok(false)`) — it publishes the value for the child to
+        // read and hands the tick to that one child via the mark-dirty buffer.
+        let parent_idx = self.nodes.len();
+        let parent_out = self.new_slot(T::default());
+        let child_indices: Rc<RefCell<Vec<usize>>> = Rc::new(RefCell::new(Vec::new()));
+        let marks = self.marks.clone();
+        let idxs_cycle = child_indices.clone();
+        let publish = parent_out.clone();
+        let cycle: CycleFn = Box::new(move |_k| {
+            let value = source_slot.borrow().clone();
+            *publish.borrow_mut() = value.clone();
+            let slot = route(&value).min(size); // `>= size` → overflow (last entry)
+            let target = idxs_cycle.borrow()[slot];
+            marks.borrow_mut().push(target);
+            Ok(false)
+        });
+        self.push_node(
+            vec![source.idx],
+            Activation::NONE,
+            "demux",
+            cycle,
+            Box::new(|_| Ok(())),
+        );
+
+        // `size` children + 1 overflow. Each reads the parent's published value
+        // passively (so its layer sits above the parent and it drains *after*
+        // the mark) but is never triggered by it — only the mark fires it.
+        let mut children = Vec::with_capacity(size);
+        let mut overflow = None;
+        for slot in 0..=size {
+            let child_idx = self.nodes.len();
+            let read = parent_out.clone();
+            let out = self.new_slot(T::default());
+            let cycle: CycleFn = Box::new(move |_k| {
+                let v = read.borrow().clone();
+                *out.borrow_mut() = v;
+                Ok(true)
+            });
+            self.push_node(
+                Vec::new(),
+                Activation::NONE,
+                "demux_child",
+                cycle,
+                Box::new(|_| Ok(())),
+            );
+            self.set_passive_ups(child_idx, vec![parent_idx]);
+            child_indices.borrow_mut().push(child_idx);
+            let handle = self.make_handle::<T>(child_idx);
+            if slot < size {
+                children.push(handle);
+            } else {
+                overflow = Some(handle);
+            }
+        }
+        (children, overflow.expect("overflow child built"))
     }
 }

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -191,6 +191,16 @@ type LifecycleFn = Box<dyn FnMut(&mut Kernel) -> Result<()>>;
 /// no-op (a stateless node with no persistent slot needs no reset).
 type ResetFn = Box<dyn FnMut()>;
 
+/// A graph mutation staged by an in-graph node during its `cycle` (where it
+/// cannot borrow the `Runner`), applied by [`Runner::run_dynamic`] at the next
+/// cycle boundary. This is how a self-contained dynamic node (e.g. a
+/// [`dynamic_group`](Builder::dynamic_group)) grows or shrinks the graph from
+/// inside its own logic — mirroring classic's `pending_additions` /
+/// `pending_removals` (`graph.rs:369-392`). Shared via `Rc` between the staging
+/// node and the runner.
+#[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
+type PendingMut = Box<dyn FnOnce(&mut Runner, &mut Kernel) -> Result<()>>;
+
 /// One node's **r**un**t**ime record: everything the engine needs to schedule
 /// and drive that node, kept in parallel `Vec`s indexed by node position (its
 /// [`Handle`] index). It is the erased, uniform counterpart to a typed [`Op`]
@@ -324,6 +334,12 @@ pub struct Builder {
     /// this builder mints and carried into its [`Runner`], so a handle used
     /// with a *different* runner is caught by a `debug_assert`.
     id: u64,
+    /// Mutations staged by in-graph dynamic nodes (e.g. a
+    /// [`dynamic_group`](Builder::dynamic_group)) during a cycle, applied at the
+    /// cycle boundary by [`Runner::run_dynamic`]. Shared (`Rc`) with any such
+    /// node at wiring time; empty and inert on a static graph.
+    #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
+    pending: Rc<RefCell<Vec<PendingMut>>>,
 }
 
 impl Default for Builder {
@@ -341,6 +357,7 @@ impl Default for Builder {
             finished: Rc::new(Cell::new(false)),
             re_runnable: true,
             id: NEXT_BUILDER_ID.fetch_add(1, Ordering::Relaxed),
+            pending: Rc::new(RefCell::new(Vec::new())),
         }
     }
 }
@@ -2056,6 +2073,7 @@ impl Builder {
             active_downs,
             passive_downs,
             removed: vec![false; n],
+            pending: self.pending,
             seed_nodes,
             layer,
             dispatch: Dispatch::default(),
@@ -2125,6 +2143,12 @@ pub struct Runner {
     /// all-false on a static run.
     #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
     removed: Vec<bool>,
+    /// Mutations staged by in-graph dynamic nodes during a cycle, drained and
+    /// applied at each cycle boundary by [`run_dynamic`](Runner::run_dynamic).
+    /// Shares the `Rc` the [`Builder`] handed to any staging node. Empty on a
+    /// static graph.
+    #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
+    pending: Rc<RefCell<Vec<PendingMut>>>,
     /// Frontier sources seeded each cycle: `always` ops and callback-activated
     /// ops (the latter only fire when the kernel marks them dirty).
     seed_nodes: Vec<usize>,
@@ -2550,8 +2574,20 @@ impl Runner {
                 }
                 kernel.end_cycle(&mut dirty);
                 cycles += 1;
-                // Apply staged mutations at the boundary, matching classic's
-                // end-of-cycle `process_pending_*` (`graph.rs:934-939`).
+                // Apply mutations staged by in-graph dynamic nodes during this
+                // cycle (e.g. a `dynamic_group`'s insert/remove), matching
+                // classic's end-of-cycle `process_pending_*` (`graph.rs:934-939`).
+                let staged = std::mem::take(&mut *self.pending.borrow_mut());
+                for apply in staged {
+                    if let Err(e) = apply(self, &mut kernel) {
+                        first_err = Some(e);
+                        break;
+                    }
+                }
+                if first_err.is_some() {
+                    break;
+                }
+                // Then the caller-driven mutation scope (driver-thread surface).
                 let mut ext = Extension {
                     runner: self,
                     kernel: &mut kernel,
@@ -2650,6 +2686,10 @@ impl Runner {
             start,
             stop: Box::new(|_| Ok(())),
             teardown: Box::new(|_| Ok(())),
+            // Dynamically-added nodes default to a no-op reset — re-run
+            // (a second `run`) is a static-graph capability; a graph mutated
+            // via `run_dynamic` rebuilds its dynamic region on the next run.
+            reset: Box::new(|| {}),
         });
         self.ticked.borrow_mut().push(false);
         self.active_downs.push(Vec::new());
@@ -2901,6 +2941,42 @@ impl Extension<'_> {
         self.runner.rt_make_handle(idx)
     }
 
+    /// Append a value-predicate filter of an existing `src` onto the live graph:
+    /// it re-emits `src`'s value on the cycles `pred` holds and stays quiet
+    /// otherwise — the per-key selector a `dynamic_group` factory typically
+    /// builds over a shared feed.
+    pub fn filter_value<A, F>(&mut self, src: impl AsHandle<A>, pred: F) -> Handle<A>
+    where
+        A: Clone + Default + 'static,
+        F: Fn(&A) -> bool + 'static,
+    {
+        let src = src.as_handle();
+        let idx = self.runner.nodes.len();
+        let src_slot = self.runner.rt_slot(src);
+        let out = self.runner.rt_new_slot(A::default());
+        let cycle: CycleFn = Box::new(move |_k| {
+            let v = src_slot.borrow();
+            if pred(&v) {
+                let val = v.clone();
+                drop(v);
+                *out.borrow_mut() = val;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        });
+        self.runner.rt_append_node(
+            vec![src.idx],
+            Vec::new(),
+            Activation::NONE,
+            "filter_value",
+            cycle,
+            Box::new(|_| Ok(())),
+        );
+        self.appended.push(idx);
+        self.runner.rt_make_handle(idx)
+    }
+
     /// Splice `new` in as an upstream of the existing `caller`. An `active`
     /// edge re-fires `caller` whenever `new` ticks and lifts `caller`'s layer
     /// above `new` (via `fix_layers`) so dispatch order stays correct even
@@ -2937,5 +3013,142 @@ impl Extension<'_> {
     /// already-removed node is a no-op.
     pub fn remove<T>(&mut self, node: impl AsHandle<T>) -> Result<()> {
         self.runner.remove_node(node.as_handle().idx, self.kernel)
+    }
+}
+
+/// One live per-key stream a [`dynamic_group`](Builder::dynamic_group) tracks:
+/// its output value slot and its node index (to read its per-cycle tick flag).
+#[cfg(feature = "dynamic-graph")]
+struct LiveStream<T> {
+    slot: Rc<RefCell<T>>,
+    idx: usize,
+}
+
+#[cfg(feature = "dynamic-graph")]
+impl Builder {
+    /// A keyed collection of dynamically-wired sub-graphs, kept in sync with the
+    /// graph — the next twin of classic `dynamic_group_stream`
+    /// (`nodes/dynamic_group.rs`). A single in-graph node reacts to two key
+    /// streams and folds its live members into an output value `V`:
+    ///
+    /// - when `add` ticks, `factory` builds a per-key sub-graph (via an
+    ///   [`Extension`]) whose output is wired in as an **active** upstream with
+    ///   `recycle` (so it observes real current values); its handle is tracked
+    ///   under the key;
+    /// - when `del` ticks, `on_remove` runs and the key's output node is removed;
+    /// - every cycle, `on_tick` folds each tracked member **that ticked this
+    ///   cycle** into `V`. Because each member is an active upstream, the layered
+    ///   engine drains the group *after* them, so those reads are the members'
+    ///   current values — the fresh-read guarantee dynamic groups depend on.
+    ///
+    /// Runs under [`Runner::run_dynamic`] (its boundary is where the staged
+    /// insert/remove mutations apply). The store is a `BTreeMap`, so `K: Ord`;
+    /// the pluggable-`StreamStore` backends of classic are a deliberate
+    /// ergonomic omission, not a semantic one.
+    #[allow(clippy::too_many_arguments)]
+    pub fn dynamic_group<K, T, V, Factory, OnTick, OnRemove>(
+        &mut self,
+        add: Handle<K>,
+        del: Handle<K>,
+        factory: Factory,
+        init: V,
+        on_tick: OnTick,
+        on_remove: OnRemove,
+    ) -> Handle<V>
+    where
+        K: Clone + Default + Ord + 'static,
+        T: Clone + Default + 'static,
+        V: Clone + Default + 'static,
+        Factory: Fn(&mut Extension<'_>, K) -> Handle<T> + 'static,
+        OnTick: Fn(&mut V, &K, &T) + 'static,
+        OnRemove: Fn(&mut V, &K) + 'static,
+    {
+        let idx = self.nodes.len();
+        let add_slot = self.slot(add);
+        let del_slot = self.slot(del);
+        let out = self.new_slot(init.clone());
+        let ticked = self.ticked.clone();
+        let pending = self.pending.clone();
+        let (add_idx, del_idx) = (add.idx, del.idx);
+
+        let store: Rc<RefCell<std::collections::BTreeMap<K, LiveStream<T>>>> =
+            Rc::new(RefCell::new(std::collections::BTreeMap::new()));
+        let factory = Rc::new(factory);
+        let mut value = init;
+
+        let cycle: CycleFn = Box::new(move |_k| {
+            let (add_t, del_t) = {
+                let t = ticked.borrow();
+                (t[add_idx], t[del_idx])
+            };
+            // Add: stage the factory build + active/recycle splice for the
+            // boundary (the store insert happens there too, once it has a slot).
+            if add_t {
+                let key: K = add_slot.borrow().clone();
+                let f = factory.clone();
+                let store_ins = store.clone();
+                pending.borrow_mut().push(Box::new(
+                    move |runner: &mut Runner, kernel: &mut Kernel| {
+                        let mut ext = Extension {
+                            runner,
+                            kernel,
+                            appended: Vec::new(),
+                        };
+                        let h = f(&mut ext, key.clone());
+                        let slot = ext.runner.rt_slot(h);
+                        let caller = ext.runner.rt_make_handle::<V>(idx);
+                        ext.add_upstream(caller, h, true, true);
+                        store_ins.borrow_mut().insert(
+                            key,
+                            LiveStream {
+                                slot,
+                                idx: h.index(),
+                            },
+                        );
+                        Ok(())
+                    },
+                ));
+            }
+            // Delete: run `on_remove` and drop from the store now (so it stops
+            // aggregating immediately); stage the node removal for the boundary.
+            if del_t {
+                let key: K = del_slot.borrow().clone();
+                on_remove(&mut value, &key);
+                let removed = store.borrow_mut().remove(&key);
+                if let Some(live) = removed {
+                    pending.borrow_mut().push(Box::new(
+                        move |runner: &mut Runner, kernel: &mut Kernel| {
+                            runner.remove_node(live.idx, kernel)
+                        },
+                    ));
+                }
+            }
+            // Aggregate the members that ticked this cycle. `ticked[live.idx]`
+            // and `live.slot` are the member's current tick/value: the member is
+            // an active upstream, so it drained before this node (layer order).
+            let mut ticked_any = false;
+            {
+                let t = ticked.borrow();
+                let members = store.borrow();
+                for (key, live) in members.iter() {
+                    if t[live.idx] {
+                        let v = live.slot.borrow().clone();
+                        on_tick(&mut value, key, &v);
+                        ticked_any = true;
+                    }
+                }
+            }
+            *out.borrow_mut() = value.clone();
+            Ok(ticked_any)
+        });
+
+        self.push_node(
+            vec![add_idx, del_idx],
+            Activation::NONE,
+            "dynamic_group",
+            cycle,
+            Box::new(|_| Ok(())),
+        );
+        self.make_handle(idx)
     }
 }

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -2659,21 +2659,26 @@ impl Runner {
         }
     }
 
-    fn rt_slot<T: 'static>(&self, h: Handle<T>) -> Rc<RefCell<T>> {
+    // Dynamic node registration reaches the value store through the same
+    // `SlotRef` boundary as static wiring (`Builder::slot`/`new_slot`), so a
+    // future arena/SoA swap need not special-case dynamically-added slots.
+    fn rt_slot<T: 'static>(&self, h: Handle<T>) -> SlotRef<T> {
         debug_assert_eq!(
             h.builder_id, self.id,
             "Handle used with a different Runner than the Builder that minted it"
         );
-        self.slots[h.idx]
-            .clone()
-            .downcast::<RefCell<T>>()
-            .expect("invariant: Handle<T> indexes a slot of type T")
+        SlotRef::new(
+            self.slots[h.idx]
+                .clone()
+                .downcast::<RefCell<T>>()
+                .expect("invariant: Handle<T> indexes a slot of type T"),
+        )
     }
 
-    fn rt_new_slot<T: 'static>(&mut self, init: T) -> Rc<RefCell<T>> {
-        let slot = Rc::new(RefCell::new(init));
-        self.slots.push(slot.clone() as Rc<dyn Any>);
-        slot
+    fn rt_new_slot<T: 'static>(&mut self, init: T) -> SlotRef<T> {
+        let cell = Rc::new(RefCell::new(init));
+        self.slots.push(cell.clone() as Rc<dyn Any>);
+        SlotRef::new(cell)
     }
 
     fn rt_make_handle<T>(&self, idx: usize) -> Handle<T> {
@@ -3051,7 +3056,7 @@ impl Extension<'_> {
 /// its output value slot and its node index (to read its per-cycle tick flag).
 #[cfg(feature = "dynamic-graph")]
 struct LiveStream<T> {
-    slot: Rc<RefCell<T>>,
+    slot: SlotRef<T>,
     idx: usize,
 }
 

--- a/next/crates/wingfoil-next/tests/dynamic_graph.rs
+++ b/next/crates/wingfoil-next/tests/dynamic_graph.rs
@@ -1,0 +1,144 @@
+//! Runtime graph dynamism (feature `dynamic-graph`): appending nodes and
+//! splicing edges onto a *live* interpreted graph mid-run. Each test is a next
+//! twin of a classic wingfoil `dynamic-graph` oracle (`wingfoil/src/graph.rs`
+//! `#[cfg(test)]`), reproducing its value/timing behaviour on the layered
+//! `(layer, index)` engine.
+#![cfg(feature = "dynamic-graph")]
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// Twin of classic's `add_upstream_dynamically_fires_only_after_wired`
+/// (`graph.rs:2102`): a node appended at the end of cycle 3 must first fire on
+/// cycle 4, so across a 6-cycle run it fires exactly 3 times (cycles 4, 5, 6).
+///
+/// The appended node is a `fold` counting its own activations, so its final
+/// value is the number of times it fired — the direct analogue of classic's
+/// `extra_ticks` counter. It reads the shared per-cycle counter (`src`), which
+/// ticks every cycle, so once wired it fires every subsequent cycle.
+#[test]
+fn append_node_fires_only_from_next_cycle() {
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_nanos(1)).count().handle();
+    let mut runner = g.build();
+
+    // Wire the counter at the end of cycle 3; capture its handle out of the hook.
+    let mut appended: Option<_> = None;
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(6), |ext, cycle| {
+            if cycle == 3 {
+                appended = Some(ext.fold(src, 0u64, |acc, _| *acc += 1));
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    let appended = appended.expect("node appended at cycle 3");
+    // Fired on cycles 4, 5, 6 only → 3 activations.
+    assert_eq!(runner.value(appended), 3, "fires only after it was wired");
+    // The pre-existing counter ran all 6 cycles.
+    assert_eq!(runner.value(src), 6);
+}
+
+/// The appended node observes the *current* value of its source from the cycle
+/// it goes live — not a stale or default value. Appended at end of cycle 2, a
+/// `map` of the counter should read 3 on cycle 3, 4 on cycle 4, ….
+#[test]
+fn appended_node_reads_live_source_value() {
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_nanos(1)).count().handle();
+    let mut runner = g.build();
+
+    let mut mapped = None;
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(5), |ext, cycle| {
+            if cycle == 2 {
+                mapped = Some(ext.map(src, |v: &u64| v * 10));
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    // Counter reaches 5; the map last fired on cycle 5 reading src=5 → 50.
+    assert_eq!(runner.value(src), 5);
+    assert_eq!(runner.value(mapped.unwrap()), 50);
+}
+
+/// Twin of classic's `layer_resort_after_deep_upstream_addition`
+/// (`graph.rs:2371`): splicing a *deep* node in as an active upstream of a
+/// *shallow* caller must lift the caller's layer above the deep node via
+/// `fix_layers`, even though the caller has the lower node index.
+#[test]
+fn add_upstream_deep_resorts_caller_layer() {
+    let g = GraphBuilder::new();
+    let ticker = g.ticker(Duration::from_nanos(1));
+    let depth1 = ticker.count(); // layer above the ticker
+    let deep = depth1.map(|v: &u64| v * 2).map(|v: &u64| v + 1).handle(); // two layers deeper
+    // A shallow caller triggered directly by the ticker.
+    let caller = ticker.map(|_| 0u64).handle();
+    let mut runner = g.build();
+
+    let deep_layer_before = runner.layer_of(deep);
+    let caller_layer_before = runner.layer_of(caller);
+    assert!(
+        caller_layer_before <= deep_layer_before,
+        "precondition: caller starts at or below the deep node's layer \
+         (caller={caller_layer_before}, deep={deep_layer_before})"
+    );
+
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(2), |ext, cycle| {
+            if cycle == 1 {
+                ext.add_upstream(caller, deep, true);
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    // After the splice the caller must sit strictly above the deep node.
+    assert!(
+        runner.layer_of(caller) > runner.layer_of(deep),
+        "fix_layers must lift the caller above the deep upstream \
+         (caller={}, deep={})",
+        runner.layer_of(caller),
+        runner.layer_of(deep),
+    );
+}
+
+/// Twin of classic's `add_upstream_passive_does_not_trigger` (`graph.rs:2227`):
+/// a node spliced in as a *passive* upstream is read but never triggers the
+/// caller. Here the caller is a `fold` counting its activations; adding a
+/// passive upstream must not increase that count — it keeps firing only on its
+/// own active trigger.
+#[test]
+fn add_upstream_passive_does_not_trigger() {
+    let g = GraphBuilder::new();
+    // Two independent tickers at the same period so both fire every cycle.
+    let trigger = g.ticker(Duration::from_nanos(1));
+    let other = g.ticker(Duration::from_nanos(1)).count().handle();
+    // Caller counts how often it fires; active upstream is `trigger` only.
+    let caller = trigger.fold(0u64, |acc, _| *acc += 1).handle();
+    let mut runner = g.build();
+
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(6), |ext, cycle| {
+            if cycle == 2 {
+                // Passive splice: caller reads `other` but is not triggered by it.
+                ext.add_upstream(caller, other, false);
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    // Caller fired once per cycle on its own trigger — 6 times — regardless of
+    // the passive edge added mid-run.
+    assert_eq!(
+        runner.value(caller),
+        6,
+        "a passive upstream must not add activations"
+    );
+}

--- a/next/crates/wingfoil-next/tests/dynamic_graph.rs
+++ b/next/crates/wingfoil-next/tests/dynamic_graph.rs
@@ -93,7 +93,7 @@ fn add_upstream_deep_resorts_caller_layer() {
     runner
         .run_dynamic(HISTORICAL, RunFor::Cycles(2), |ext, cycle| {
             if cycle == 1 {
-                ext.add_upstream(caller, deep, true);
+                ext.add_upstream(caller, deep, true, false);
             }
             Ok(())
         })
@@ -128,7 +128,7 @@ fn add_upstream_passive_does_not_trigger() {
         .run_dynamic(HISTORICAL, RunFor::Cycles(6), |ext, cycle| {
             if cycle == 2 {
                 // Passive splice: caller reads `other` but is not triggered by it.
-                ext.add_upstream(caller, other, false);
+                ext.add_upstream(caller, other, false, false);
             }
             Ok(())
         })
@@ -140,5 +140,153 @@ fn add_upstream_passive_does_not_trigger() {
         runner.value(caller),
         6,
         "a passive upstream must not add activations"
+    );
+}
+
+/// Twin of classic's `remove_node_stops_firing_and_calls_lifecycle`
+/// (`graph.rs:2064`): a node removed mid-run stops cycling immediately, and its
+/// value freezes at whatever it last held.
+///
+/// A `fold` counter appended at cycle 1 fires on cycles 2, 3, 4 (→ 3), then is
+/// removed at the cycle-4 boundary; over the remaining cycles it must not fire
+/// again, so its final value stays 3 (not the 7 it would reach unremoved).
+#[test]
+fn removed_node_stops_firing_and_value_freezes() {
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_nanos(1)).count().handle();
+    let mut runner = g.build();
+
+    let mut counter = None;
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(8), |ext, cycle| {
+            if cycle == 1 {
+                counter = Some(ext.fold(src, 0u64, |acc, _| *acc += 1));
+            }
+            if cycle == 4 {
+                ext.remove(counter.expect("counter appended at cycle 1"))?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    let counter = counter.unwrap();
+    // Fired on cycles 2, 3, 4 → 3; removed at the cycle-4 boundary, frozen after.
+    // Its slot is tombstoned (not freed), so the value is still readable.
+    assert_eq!(
+        runner.value(counter),
+        3,
+        "removed node stops firing; value freezes"
+    );
+}
+
+/// The lifecycle half of the removal oracle: a removed node runs its `stop`
+/// then `teardown` exactly once, at removal — not again at run shutdown. Uses a
+/// `finally` node (whose whole purpose is an observable teardown hook) and
+/// checks the count both immediately after removal and after the run ends.
+#[test]
+fn remove_runs_teardown_once_at_removal() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let teardowns = Rc::new(Cell::new(0u64));
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_nanos(1)).count().handle();
+    let tc = teardowns.clone();
+    // `finally`'s closure runs at teardown; count how many times.
+    let fin = g.with_builder(|b| {
+        b.finally(src, move |_| {
+            tc.set(tc.get() + 1);
+            Ok(())
+        })
+    });
+    let mut runner = g.build();
+
+    let mut teardowns_at_removal = None;
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(6), |ext, cycle| {
+            if cycle == 3 {
+                ext.remove(fin)?;
+                teardowns_at_removal = Some(teardowns.get());
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    // Teardown ran once, *at* removal (observed mid-run) …
+    assert_eq!(
+        teardowns_at_removal,
+        Some(1),
+        "teardown runs when the node is removed"
+    );
+    // … and was not called a second time by the end-of-run cleanup.
+    assert_eq!(
+        teardowns.get(),
+        1,
+        "teardown is not called again at shutdown"
+    );
+}
+
+/// Twin of classic's `add_upstream_with_recycle_delivers_first_value`
+/// (`graph.rs:2164`): with `recycle = true`, a node appended over a *quiet*
+/// source is scheduled to fire at `time + 1`, so it observes the source's real
+/// current value rather than the `Default` it would otherwise hold.
+///
+/// The source is a `constant`, which ticks once at t=0 then stays quiet. A `map`
+/// of it spliced in at cycle 3 would never fire on its own (the constant never
+/// ticks again); recycle forces one evaluation, delivering `42 + 1 = 43`.
+#[test]
+fn recycle_delivers_first_value_from_quiet_source() {
+    let g = GraphBuilder::new();
+    let c = g.constant(42u64).handle(); // ticks once at t=0, then quiet
+    let trigger = g.ticker(Duration::from_nanos(1));
+    let caller = trigger.fold(0u64, |acc, _| *acc += 1).handle();
+    let mut runner = g.build();
+
+    let mut mapped = None;
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(6), |ext, cycle| {
+            if cycle == 3 {
+                let m = ext.map(c, |v: &u64| v + 1);
+                ext.add_upstream(caller, m, true, true); // recycle = true
+                mapped = Some(m);
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(
+        runner.value(mapped.unwrap()),
+        43,
+        "recycle scheduled the appended node to observe the constant's value"
+    );
+}
+
+/// The negative control for recycle: without it, a node appended over the same
+/// *quiet* source never fires and keeps its `Default` — proving the previous
+/// test's `43` is the recycle schedule at work, not natural propagation.
+#[test]
+fn without_recycle_quiet_source_stays_default() {
+    let g = GraphBuilder::new();
+    let c = g.constant(42u64).handle();
+    let trigger = g.ticker(Duration::from_nanos(1));
+    let caller = trigger.fold(0u64, |acc, _| *acc += 1).handle();
+    let mut runner = g.build();
+
+    let mut mapped = None;
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(6), |ext, cycle| {
+            if cycle == 3 {
+                let m = ext.map(c, |v: &u64| v + 1);
+                ext.add_upstream(caller, m, true, false); // recycle = false
+                mapped = Some(m);
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(
+        runner.value(mapped.unwrap()),
+        0,
+        "without recycle the quiet source never re-ticks the appended node"
     );
 }

--- a/next/crates/wingfoil-next/tests/dynamic_graph.rs
+++ b/next/crates/wingfoil-next/tests/dynamic_graph.rs
@@ -357,3 +357,49 @@ fn dynamic_group_maintains_a_live_price_book() {
         "final price book"
     );
 }
+
+/// `demux` fixed-topology routing (twin of classic `demux`, `nodes/demux.rs`):
+/// the parent marks exactly the routed child each cycle — same-cycle, via the
+/// engine's mark-dirty primitive — and each child re-emits the source's current
+/// value only on the cycles it was selected, staying quiet otherwise. Routes a
+/// counter (1..=6) by parity: even → child 0, odd → child 1.
+#[test]
+fn demux_routes_each_value_to_its_child() {
+    let g = GraphBuilder::new();
+    let n = g.ticker(Duration::from_nanos(1)).count().handle(); // 1, 2, …, 6
+    let (children, _overflow) = g.with_builder(|b| b.demux(n, 2, |v: &u64| (*v % 2) as usize));
+    let c0 = g.wrap(children[0]).accumulate();
+    let c1 = g.wrap(children[1]).accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+
+    // Child 0 saw the even values, child 1 the odd ones — each only on its
+    // selected cycles (accumulate collects only ticked values).
+    assert_eq!(runner.value(&c0), vec![2u64, 4, 6], "child 0 (even)");
+    assert_eq!(runner.value(&c1), vec![1u64, 3, 5], "child 1 (odd)");
+}
+
+/// `demux` overflow: a routed slot `>= size` lands on the overflow child.
+/// Routing `value - 1` with `size = 2` sends 1 → child 0, 2 → child 1, and
+/// 3, 4, 5, 6 → overflow.
+#[test]
+fn demux_routes_excess_to_overflow() {
+    let g = GraphBuilder::new();
+    let n = g.ticker(Duration::from_nanos(1)).count().handle();
+    let (children, overflow) = g.with_builder(|b| b.demux(n, 2, |v: &u64| (*v - 1) as usize));
+    let c0 = g.wrap(children[0]).accumulate();
+    let c1 = g.wrap(children[1]).accumulate();
+    let ov = g.wrap(overflow).accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+
+    assert_eq!(runner.value(&c0), vec![1u64], "slot 0");
+    assert_eq!(runner.value(&c1), vec![2u64], "slot 1");
+    assert_eq!(
+        runner.value(&ov),
+        vec![3u64, 4, 5, 6],
+        "overflow (slots >= size)"
+    );
+}

--- a/next/crates/wingfoil-next/tests/dynamic_graph.rs
+++ b/next/crates/wingfoil-next/tests/dynamic_graph.rs
@@ -8,6 +8,7 @@
 use std::time::Duration;
 
 use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::interp::Extension;
 use wingfoil_next::prelude::*;
 
 const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
@@ -288,5 +289,71 @@ fn without_recycle_quiet_source_stays_default() {
         runner.value(mapped.unwrap()),
         0,
         "without recycle the quiet source never re-ticks the appended node"
+    );
+}
+
+/// End-to-end twin of the `dynamic-group` example (`examples/dynamic`): a keyed
+/// price book maintained by an in-graph `dynamic_group` node that wires per-key
+/// filter sub-graphs on `add`, tears them down on `del`, and folds each live
+/// member's current price into a `BTreeMap` — all driven from *inside* the graph
+/// (no driver-hook mutation). Exercises the whole stack: in-cycle staging,
+/// active/recycle splicing, removal, and the fresh-read guarantee (each member
+/// is an active upstream, so the group reads its current value).
+///
+/// A shared feed emits `(key, price)` alternating key 1/0 each cycle with
+/// `price = cycle * 10`. Key 0 is added at cycle 1, key 1 at cycle 2, and key 0
+/// is deleted at cycle 4.
+#[test]
+fn dynamic_group_maintains_a_live_price_book() {
+    use std::collections::BTreeMap;
+
+    let g = GraphBuilder::new();
+    let n = g.ticker(Duration::from_nanos(1)).count(); // 1, 2, 3, …
+    // Shared feed: (key, price) with key alternating 1,0,1,0,… and price = 10*cycle.
+    let feed = n.map(|c: &u64| (c % 2, c * 10)).handle();
+    // `add` fires key 0 at cycle 1 and key 1 at cycle 2. `del` fires key 0 at
+    // cycle 4, and a no-op delete of a non-existent key at cycle 5 — the latter
+    // exists to trigger the group *early* (via its `del` edge) on a cycle where
+    // key 1's member also fires. Without `fix_layers` re-sorting the group above
+    // its members, that early trigger drains the group before key 1's member,
+    // so it would miss the cycle-5 price (50) and the book would hold a stale 30.
+    let add = n
+        .map_filter(|c: &u64| ((if *c == 1 { 0u64 } else { 1 }), *c == 1 || *c == 2))
+        .handle();
+    let del = n
+        .map_filter(|c: &u64| ((if *c == 4 { 0u64 } else { 99 }), *c == 4 || *c == 5))
+        .handle();
+
+    let book = g.with_builder(|b| {
+        b.dynamic_group(
+            add,
+            del,
+            // Factory: per-key subgraph = filter the feed to this key, take price.
+            move |ext: &mut Extension<'_>, k: u64| {
+                let selected = ext.filter_value(feed, move |(i, _): &(u64, u64)| *i == k);
+                ext.map(selected, |(_, px): &(u64, u64)| *px)
+            },
+            BTreeMap::<u64, u64>::new(),
+            |book: &mut BTreeMap<u64, u64>, key: &u64, price: &u64| {
+                book.insert(*key, *price);
+            },
+            |book: &mut BTreeMap<u64, u64>, key: &u64| {
+                book.remove(key);
+            },
+        )
+    });
+
+    let mut runner = g.build();
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(6), |_ext, _cycle| Ok(()))
+        .unwrap();
+
+    // key0 tracked prices on cycles 2 (20), removed at cycle 4; key1 tracked on
+    // cycles 3 (30) and 5 (50). Final book holds only the live key 1 at 50.
+    let final_book = runner.value(book);
+    assert_eq!(
+        final_book,
+        BTreeMap::from([(1u64, 50u64)]),
+        "final price book"
     );
 }

--- a/next/crates/wingfoil-next/tests/sparse_graph.rs
+++ b/next/crates/wingfoil-next/tests/sparse_graph.rs
@@ -229,3 +229,63 @@ fn wide_fanout_is_correct() {
         );
     }
 }
+
+/// Regression guard for the layered dispatch key: a node that reads a value
+/// **passively** must still drain *after* that value updates, even when the
+/// passive source sits **deeper** than the node's own active trigger.
+///
+/// `trigger.sample(deep_chain)` is the minimal case — the sample's only active
+/// edge is a shallow trigger (layer 1), yet it passively reads a layer-4 chain.
+/// A dispatch `layer` computed from *active* edges alone would sort the sample
+/// (layer 1) ahead of the chain (layers 2..4) and read a **stale** value; the
+/// layer must count passive edges too, matching classic wingfoil where every
+/// upstream — active or passive — raises the layer (`graph.rs:794`, and
+/// `fix_layers` at `graph.rs:1153`). The random-graph oracle only hits this
+/// probabilistically; this pins it deterministically.
+#[test]
+fn passive_read_of_deeper_node_sees_current_value() {
+    // Returns (sampled series, deep series). Both tickers run at the same 1ns
+    // period, so they fire on the same instants: every cycle the deep chain
+    // updates *and* the trigger fires, so a correct sample sees the current
+    // deep value and the two series are identical.
+    fn wire(g: &GraphBuilder) -> (Stream<Vec<u64>>, Stream<Vec<u64>>) {
+        let src = g.ticker(Duration::from_nanos(1)).count();
+        let deep = src
+            .map(|v| v.wrapping_mul(2)) // layer 2
+            .map(|v| v.wrapping_add(1)) // layer 3
+            .map(|v| v.wrapping_mul(10)); // layer 4
+        let trigger = g.ticker(Duration::from_nanos(1));
+        let sampled = deep.sample(&trigger);
+        (sampled.accumulate(), deep.accumulate())
+    }
+
+    // Differential: the layered sparse engine vs the index-order full-sweep
+    // oracle must agree.
+    let g_sparse = GraphBuilder::new();
+    let (sampled_sparse, _deep_sparse) = wire(&g_sparse);
+    let mut r_sparse = g_sparse.build();
+    r_sparse.run(HISTORICAL, RunFor::Cycles(20)).unwrap();
+
+    let g_full = GraphBuilder::new();
+    let (sampled_full, _deep_full) = wire(&g_full);
+    let mut r_full = g_full.build().with_dispatch(Dispatch::FullSweep);
+    r_full.run(HISTORICAL, RunFor::Cycles(20)).unwrap();
+
+    assert_eq!(
+        r_sparse.value(&sampled_sparse),
+        r_full.value(&sampled_full),
+        "layered sparse and full-sweep disagree on a passive read of a deeper node"
+    );
+
+    // Direct freshness check: the sampled series must equal the deep series —
+    // i.e. the sample observed the *current* (not lagged) deep value each cycle.
+    let g = GraphBuilder::new();
+    let (sampled, deep) = wire(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(20)).unwrap();
+    assert_eq!(
+        r.value(&sampled),
+        r.value(&deep),
+        "sample read a stale deep value — the passive edge did not raise its layer"
+    );
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -533,6 +533,27 @@ routing on a same-cycle mark-dirty primitive — no add/remove). Removed slots a
 tombstoned, not freed (classic parity). Parity tests in
 `tests/dynamic_graph.rs`.
 
+**Known parity gaps (for the cutover audit).** The runtime *behaviour* is a
+faithful twin (values + tick times match classic's oracles); what next omits so
+far is ergonomic surface, not mechanism:
+
+- **`StreamStore` (pluggable `dynamic_group` backing store).** next's
+  `dynamic_group` hardcodes a `BTreeMap` (so `K: Ord`); classic is generic over
+  a `StreamStore` trait with `BTreeMap`/`HashMap` blanket impls. This is
+  deliberately deferred, not just unfinished. The only capability it actually
+  unlocks is a key type that is `Hash + Eq` but **not** `Ord` (the container
+  choice is otherwise near-irrelevant to cost — the per-cycle work is iterating
+  *live* members, O(members), regardless of backing store). And `HashMap`'s
+  nondeterministic iteration order is a mild footgun against backtest
+  determinism, so `BTreeMap`-only is arguably the *safer* default, not merely a
+  smaller one. Re-add the trait (a mechanical ~20-min change: one trait param +
+  two blanket impls, touching no engine/staging code) if the cutover requires
+  strict signature parity or a real non-`Ord` key appears — not speculatively.
+- **`DemuxMap` key lifecycle + `demux_it`.** next's `demux` exposes the raw
+  routing primitive (`route(value) -> slot` + overflow); classic's
+  auto-assigning/`Close`-releasing `DemuxMap` and the `Burst` `demux_it` variant
+  layer on top of it and can be added without engine changes.
+
 **Two follow-ons remain, both deliberately separated from the scheduler:**
 
 ### Arena / SoA value store — deferred perf follow-on (boundary frozen by type)

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -66,7 +66,7 @@ today's interpreted engine.
 | Runtime-valued config (params/captures from caller) | ✅ | ✅ | ❌⁶ | ❌⁶ |
 | Mutable per-node state | ✅⁷ | ✅⁷ | ✅⁷ | ✅⁷ |
 | Re-run (independent repeated runs) | ✅⁸ | ✅⁸ | ✅⁹ | ✅⁹ |
-| Dynamic graph (runtime add/remove) | ✅ | 📅¹⁰ | ❌ | 🟡¹⁰ |
+| Dynamic graph (runtime add/remove) | ✅ | ✅¹⁰ | ❌ | 🟡¹⁰ |
 | Sparse-graph efficiency (work ∝ *active* nodes) | ✅¹¹ | ✅¹² | 🟡¹³ | ✅¹⁴ |
 | Dense hot-path speed (measured) | 1× | ~1×¹² | 3–4×¹⁵ | interior 3–4×¹⁵ |
 
@@ -96,10 +96,17 @@ today's interpreted engine.
   construction (consumed producer channels/wakers/interiors) — a second `run`
   errors rather than misbehaving.
 ⁹ `compiled()` is a plain fn — each call is a fresh independent run.
-¹⁰ The sparse dirty-list engine — the mutable-frontier *enabler* for runtime
-  add/remove — has landed, but graph *mutation* itself (`Runner::extend`) is
-  not yet built (📅). The compiled/island interior stays fixed by design, but
-  an island can be wired dynamically into the interpreted graph.
+¹⁰ **Landed** behind the `dynamic-graph` cargo feature. The layered
+  `(layer, index)` dispatch (always on) makes it possible: a node appended at
+  the highest index can be spliced beneath an existing lower-indexed caller,
+  `fix_layers` lifting the caller above it. Surfaces: `Runner::run_dynamic` with
+  an `Extension` scope (`map`/`fold`/`filter_value`/`add_upstream`/`remove`,
+  active/passive + `recycle`), and an in-graph `Builder::dynamic_group`
+  (classic's `dynamic_group_stream` twin) that stages insert/remove from its own
+  `cycle`. Parity tests in `tests/dynamic_graph.rs`; removed slots are
+  tombstoned, not freed (classic parity). The compiled/island interior stays
+  fixed by design, but an island can be wired dynamically into the interpreted
+  graph. See the Phase 4.5 note.
 ¹¹ Classic propagates breadth-first through a dirty-list (work ∝ active
   nodes) — though it still carries an `O(N)` per-cycle reset/scan floor the
   deferred 4.5 arena rework can also improve on.
@@ -112,7 +119,6 @@ today's interpreted engine.
   gating (skip quiet sub-graphs) is the planned compiled counterpart.
 ¹⁴ A quiet island isn't cycled — islands already give coarse region gating.
 ¹⁵ Measured on dense chains; standalone LLVM-fuses trivial chains to near-free.
-
 ## Phase 0 — design spikes
 
 Four contract questions, each resolved with a spike + parity test before any
@@ -502,15 +508,27 @@ by default (`interp.rs`, `Dispatch::Sparse`), reproducing classic wingfoil's
 `always` busy-poll ops plus kernel-marked callback-activated ops (tickers,
 `delay` pops, the feedback source, channel replay) — then propagates the tick
 frontier forward: a node that ticks marks its active downstream neighbours
-dirty. The work set drains in ascending node-index order (a valid topological
-order, since the fluent API forces a stream to exist before it is referenced),
-so each node fires exactly once after everything it reads — glitch-free, and
-with per-cycle work proportional to the nodes that *actually fire*, not the
-graph size `N`. Results are **byte-identical** to classic and to the old
-`O(N)` full-index sweep, which is retained as `Dispatch::FullSweep` — an
+dirty. The work set drains in ascending **`(layer, index)`** order — `layer[i]`
+is the longest path to `i` over active *and* passive edges (classic's layer
+order); it collapses to plain index order on a static graph (a valid
+topological order, since the fluent API forces a stream to exist before it is
+referenced), so each node fires exactly once after everything it reads —
+glitch-free, and with per-cycle work proportional to the nodes that *actually
+fire*, not the graph size `N`. Results are **byte-identical** to classic and to
+the old `O(N)` full-index sweep, which is retained as `Dispatch::FullSweep` — an
 executable reference oracle (`runner.with_dispatch(Dispatch::FullSweep)`) the
 parity suite can cross-check against. This closes the sparse-graph performance
 gap against classic (pending the benchmark below as the standing gate).
+
+**Dynamism: ✅ landed** (behind the `dynamic-graph` feature). The `(layer,
+index)` key is what makes runtime mutation possible — a node appended at the
+highest index can be spliced beneath an existing lower-indexed caller, with
+`fix_layers` lifting the caller's layer above the new upstream (the reorder
+plain index order cannot express). Surfaces: `Runner::run_dynamic` + an
+`Extension` scope (append / active-passive splice / remove / recycle) and an
+in-graph `Builder::dynamic_group` (classic's `dynamic_group_stream` twin) that
+stages insert/remove from its own `cycle`. Removed slots are tombstoned, not
+freed (classic parity). Parity tests in `tests/dynamic_graph.rs`.
 
 **Two follow-ons remain, both deliberately separated from the scheduler:**
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -101,12 +101,13 @@ today's interpreted engine.
   the highest index can be spliced beneath an existing lower-indexed caller,
   `fix_layers` lifting the caller above it. Surfaces: `Runner::run_dynamic` with
   an `Extension` scope (`map`/`fold`/`filter_value`/`add_upstream`/`remove`,
-  active/passive + `recycle`), and an in-graph `Builder::dynamic_group`
-  (classic's `dynamic_group_stream` twin) that stages insert/remove from its own
-  `cycle`. Parity tests in `tests/dynamic_graph.rs`; removed slots are
-  tombstoned, not freed (classic parity). The compiled/island interior stays
-  fixed by design, but an island can be wired dynamically into the interpreted
-  graph. See the Phase 4.5 note.
+  active/passive + `recycle`), an in-graph `Builder::dynamic_group` (classic's
+  `dynamic_group_stream` twin) that stages insert/remove from its own `cycle`,
+  and `Builder::demux` (fixed-topology dynamic *routing* on a same-cycle
+  mark-dirty primitive — no add/remove). Parity tests in
+  `tests/dynamic_graph.rs`; removed slots are tombstoned, not freed (classic
+  parity). The compiled/island interior stays fixed by design, but an island
+  can be wired dynamically into the interpreted graph. See the Phase 4.5 note.
 ¹¹ Classic propagates breadth-first through a dirty-list (work ∝ active
   nodes) — though it still carries an `O(N)` per-cycle reset/scan floor the
   deferred 4.5 arena rework can also improve on.
@@ -525,10 +526,12 @@ index)` key is what makes runtime mutation possible — a node appended at the
 highest index can be spliced beneath an existing lower-indexed caller, with
 `fix_layers` lifting the caller's layer above the new upstream (the reorder
 plain index order cannot express). Surfaces: `Runner::run_dynamic` + an
-`Extension` scope (append / active-passive splice / remove / recycle) and an
+`Extension` scope (append / active-passive splice / remove / recycle), an
 in-graph `Builder::dynamic_group` (classic's `dynamic_group_stream` twin) that
-stages insert/remove from its own `cycle`. Removed slots are tombstoned, not
-freed (classic parity). Parity tests in `tests/dynamic_graph.rs`.
+stages insert/remove from its own `cycle`, and `Builder::demux` (fixed-topology
+routing on a same-cycle mark-dirty primitive — no add/remove). Removed slots are
+tombstoned, not freed (classic parity). Parity tests in
+`tests/dynamic_graph.rs`.
 
 **Two follow-ons remain, both deliberately separated from the scheduler:**
 


### PR DESCRIPTION
Implements runtime graph dynamism for the `wingfoil-next` interpreted engine — issue #500, "solution B" (the layered engine) from the design spike (`docs/dynamism-design.md`, PR #485). Behind a new `dynamic-graph` cargo feature, mirroring classic wingfoil.

## What this adds

**Layered `(layer, index)` dispatch (always on).** The sparse work-heap now keys on `(layer, index)` instead of raw node index, where `layer[i]` is the longest path to `i` over active **and passive** edges — classic's `dirty_nodes_by_layer` order. On a static graph this collapses to plain index order, so results stay **byte-identical** to before (verified against the retained `Dispatch::FullSweep` oracle). It's the foundation dynamism needs: a node appended at the highest index can be spliced *beneath* an existing lower-indexed caller, with `fix_layers` lifting the caller above the new upstream — a reorder plain index order cannot express.

**Runtime mutation** (`dynamic-graph` feature):
- `Runner::run_dynamic(mode, for, hook)` — runs like `run` but hands an `Extension` mutation scope to a caller hook at each cycle boundary (the point classic applies its staged `pending_*`), giving the "requested in cycle N, live in N+1" contract.
- `Extension`: `map` / `fold` / `filter_value` (append), `add_upstream` (active/passive splice, with `recycle` for first-value delivery), `remove` (tombstone + `stop`/`teardown` once, never a double call).
- In-graph dynamism via a shared pending-mutation buffer, so a node can grow/shrink the graph from inside its own `cycle` (no `Ctx` widening — it stays narrow).
- `Builder::dynamic_group` — next twin of classic's `dynamic_group_stream`: one in-graph node wires per-key subgraphs on `add`, tears them down on `del`, and folds each live member into its output, reading them **fresh** (members are active upstreams, so the layered engine drains the group after them).
- `Builder::demux` — fixed-topology dynamic *routing* on a same-cycle mark-dirty primitive (route each source value to a chosen pre-wired child; no add/remove).

## Design notes

- **Passive-edge layering**: the dispatch key must count passive edges, or a node passively reading a *deeper* value (e.g. `trigger.sample(deep_chain)`) would drain too early and read stale. This drove tracking `passive_ups`/`passive_downs` (faithful to classic's `fix_layers`, which raises layer over all upstreams).
- `Ctx` stays narrow — in-graph nodes capture the pending/marks buffers directly rather than widening `Ctx::request_extend`.
- Removed slots are tombstoned, not freed (classic parity).
- All dynamic value-slot access goes through the `SlotRef` boundary (#512), so the future arena/SoA swap need not special-case dynamically-added slots.

## Testing

`tests/dynamic_graph.rs` — 11 tests, each a next twin of a classic `dynamic-graph` oracle (`+1`-cycle timing, `fix_layers` resort, passive-non-trigger, removal + lifecycle, recycle first-value + negative control, an end-to-end `dynamic_group` price book, and `demux` routing + overflow). Plus a deterministic passive-deeper-than-active regression test in `tests/sparse_graph.rs`.

Three of these are verified to have teeth (fail when the mechanism is disabled): the passive-layer contribution, `fix_layers` structural resort, and — the key correctness proof — the **runtime fresh-read** (the `dynamic_group` book holds a stale `{1:30}` instead of `{1:50}` if `fix_layers` is disabled).

Full `wingfoil-next` suite green in both feature configs; `fmt` + `clippy` clean (default and all-features).

## Documented parity gaps (for the cutover audit)

The runtime *behaviour* is a faithful twin; what's deferred is ergonomic surface, recorded in `port-plan.md`:
- **`StreamStore`** — `dynamic_group` hardcodes `BTreeMap` (so `K: Ord`) rather than being generic over classic's pluggable-store trait. The only capability that omits is a non-`Ord` key; `BTreeMap`-only iteration is also the safer default for backtest determinism.
- **`DemuxMap` key lifecycle + `demux_it`** — `demux` exposes the raw routing primitive; classic's auto-assigning/`Close`-releasing map and the `Burst` `demux_it` variant layer on top without engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZ4j5nzyx6ytSKWaGQv3DS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZ4j5nzyx6ytSKWaGQv3DS)_