### PR TITLE
Document web adapter control plane requirements for v2 port

### DIFF
--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -493,6 +493,17 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
 6. **fix** — codec-heavy; fallibility with context.
 7. **web** (+ wingfoil-wire-types, wingfoil-wasm, wingfoil-js untouched —
    the wire protocol is engine-agnostic), **prometheus, otlp, augurs**.
+   *"wingfoil-js untouched" holds only if the ported web adapter reproduces
+   the v2 control plane the client depends on:* `Hello`/`Subscribe`/
+   `Unsubscribe`, burst payloads (`Stream<Vec<T>>` published as an array), both
+   codecs (`Bincode` + `Json` — the latency tracker requires `Json`), and —
+   the one JS-facing behaviour riding on an **engine-side** trigger rather than
+   the frozen wire format — `ControlMessage::Complete { topic }` emitted when a
+   `web_pub` source stream *ends* (historical replay / finite `RunFor`). The
+   client's `onComplete` and its "stop reconnecting after a clean finish" logic
+   both hinge on `Complete`, so the port must plumb a "publish source finished"
+   signal (adjacent to `Ctx::is_last_cycle` / lifecycle) through to the adapter,
+   not just carry the wire types over.
 8. **aeron, iceoryx2, fluvio** last — build-environment pain (CMake/clang);
    their ring-buffer polling is the natural `ALWAYS`-cap shape.
 


### PR DESCRIPTION
## Summary

This PR clarifies the control plane contract that the ported web adapter must maintain to keep the JavaScript client unchanged. The documentation specifies the exact behaviors and signals required from the engine side.

## Changes

- **Expanded port-plan.md section 7 (web adapter)** with detailed requirements for the v2 web adapter port:
  - Lists the required control messages: `Hello`, `Subscribe`, `Unsubscribe`
  - Specifies burst payload format: `Stream<Vec<T>>` published as arrays
  - Documents both required codecs: `Bincode` and `Json` (latter needed by latency tracker)
  - Clarifies the critical engine-side behavior: `ControlMessage::Complete { topic }` must be emitted when a `web_pub` source stream ends (e.g., historical replay or finite `RunFor`)
  - Notes that client's `onComplete` callback and reconnection logic depend on `Complete` signals
  - Emphasizes that the port must plumb a "publish source finished" signal through the adapter lifecycle (adjacent to `Ctx::is_last_cycle`), not just mechanically carry wire types over

## Implementation Notes

The key insight is that `ControlMessage::Complete` is an **engine-side trigger** rather than part of the frozen wire format. The adapter must detect when a `web_pub` source finishes and emit the corresponding control message to the client, ensuring the JavaScript side can properly clean up and stop reconnection attempts after a clean finish.

https://claude.ai/code/session_012aeB8jKXQaKqRWNRZB1UTr