### PR TITLE
wingfoil-next: extend compat facade with more classic StreamOperators surface

### DIFF
--- a/next/crates/wingfoil-next/src/compat.rs
+++ b/next/crates/wingfoil-next/src/compat.rs
@@ -23,6 +23,7 @@
 //! the full ~40-method surface is mechanical from here.
 
 use std::cell::RefCell;
+use std::fmt::Debug;
 use std::ops::{Not, Sub};
 use std::rc::Rc;
 use std::time::Duration;
@@ -93,6 +94,70 @@ impl<T: 'static> Signal<T> {
         F: Fn(&T) -> B + 'static,
     {
         self.wrap(self.stream.map(f))
+    }
+
+    /// Apply a fallible closure to each value; a returned `Err` aborts the
+    /// run with context.
+    pub fn try_map<B, F>(&self, f: F) -> Signal<B>
+    where
+        B: Clone + Default + 'static,
+        F: Fn(&T) -> Result<B> + 'static,
+    {
+        self.wrap(self.stream.try_map(f))
+    }
+
+    /// Map and filter in one pass: `f` returns `(value, emit?)` — emit the
+    /// value only when the flag is true.
+    pub fn map_filter<B, F>(&self, f: F) -> Signal<B>
+    where
+        B: Clone + Default + 'static,
+        F: Fn(&T) -> (B, bool) + 'static,
+    {
+        self.wrap(self.stream.map_filter(f))
+    }
+
+    /// Map and filter with an `Option` (the classic `filter_map`): tick the
+    /// returned `Some`, drop `None`. Delegates to the fluent
+    /// [`map_filter`](StreamOps::map_filter).
+    pub fn filter_map<B, F>(&self, f: F) -> Signal<B>
+    where
+        B: Clone + Default + 'static,
+        F: Fn(&T) -> Option<B> + 'static,
+    {
+        self.wrap(self.stream.map_filter(move |v| match f(v) {
+            Some(out) => (out, true),
+            None => (B::default(), false),
+        }))
+    }
+
+    /// Emit the result of `f()` on each tick, ignoring the value (the classic
+    /// `produce`). Sugar over [`map`](StreamOps::map).
+    pub fn produce<B, F>(&self, f: F) -> Signal<B>
+    where
+        B: Clone + Default + 'static,
+        F: Fn() -> B + 'static,
+    {
+        self.wrap(self.stream.map(move |_| f()))
+    }
+
+    /// Run a side-effecting fallible closure on each tick — the graph's
+    /// outbound edge (the classic `for_each` / `try_for_each`). A returned
+    /// `Err` aborts the run with context; emits `()` per tick.
+    pub fn for_each<F>(&self, f: F) -> Signal<()>
+    where
+        F: Fn(&T) -> Result<()> + 'static,
+    {
+        self.wrap(self.stream.for_each(f))
+    }
+
+    /// Collapse a burst/iterator value into a single tick of its **last** item
+    /// (the classic `collapse`); stays quiet when the iterator is empty.
+    pub fn collapse<OUT>(&self) -> Signal<OUT>
+    where
+        T: Clone + IntoIterator<Item = OUT>,
+        OUT: Clone + Default + 'static,
+    {
+        self.wrap(self.stream.collapse())
     }
 
     /// Fold values into an accumulator, emitting it after each fold.
@@ -204,6 +269,53 @@ impl<T: Clone + Default + 'static> Signal<T> {
     pub fn buffer(&self, capacity: usize) -> Signal<Vec<T>> {
         self.wrap(self.stream.buffer(capacity))
     }
+
+    /// Drop values contingent on a predicate (the classic `filter_value`):
+    /// keep a value only when `predicate` returns true. Delegates to the
+    /// fluent [`map_filter`](StreamOps::map_filter).
+    pub fn filter_value<F>(&self, predicate: F) -> Signal<T>
+    where
+        F: Fn(&T) -> bool + 'static,
+    {
+        self.wrap(self.stream.map_filter(move |v| (v.clone(), predicate(v))))
+    }
+
+    /// Fold values into an accumulator seeded from `T::default()`, applying
+    /// `f(acc, value)` (the classic `reduce`). Delegates to the fluent
+    /// [`fold`](StreamOps::fold).
+    pub fn reduce<F>(&self, f: F) -> Signal<T>
+    where
+        F: Fn(&T, &T) -> T + 'static,
+    {
+        self.wrap(self.stream.fold(T::default(), move |acc, val| {
+            *acc = f(acc, val);
+        }))
+    }
+
+    /// Observe each value with a side-effecting closure, passing it through
+    /// unchanged (a debug tap — the classic `inspect`).
+    pub fn inspect<F>(&self, f: F) -> Signal<T>
+    where
+        F: Fn(&T) + 'static,
+    {
+        self.wrap(self.stream.inspect(f))
+    }
+
+    /// Pass each value through unchanged, printing a performance summary at
+    /// the end of the run (the classic `timed`).
+    pub fn timed(&self) -> Signal<T> {
+        self.wrap(self.stream.timed())
+    }
+
+    /// Run `f` once at teardown — after the run ends, even if a cycle aborted
+    /// it (the classic `finally`). Observes this signal's last value; emits
+    /// nothing.
+    pub fn finally<F>(&self, f: F) -> Signal<()>
+    where
+        F: Fn(&T) -> Result<()> + 'static,
+    {
+        self.wrap(self.stream.finally(f))
+    }
 }
 
 impl<T: Clone + Default + PartialEq + 'static> Signal<T> {
@@ -215,6 +327,47 @@ impl<T: Clone + Default + PartialEq + 'static> Signal<T> {
     /// Suppress consecutive duplicate values (emit on change only).
     pub fn distinct(&self) -> Signal<T> {
         self.wrap(self.stream.distinct())
+    }
+
+    /// [`delay`](Signal::delay) with a reset trigger (the classic
+    /// `delay_with_reset`): when `trigger` ticks, the output snaps to the
+    /// current value and any pending (delayed) values are dropped. `trigger`
+    /// is read for its tick only, so its value type is irrelevant.
+    pub fn delay_with_reset<U: 'static>(&self, delay: Duration, trigger: &Signal<U>) -> Signal<T> {
+        self.wrap(self.stream.delay_with_reset(delay, &trigger.stream))
+    }
+}
+
+impl<T: Clone + Default + Debug + 'static> Signal<T> {
+    /// Pass each value through unchanged while buffering it, then print the
+    /// whole buffer at teardown (the classic `print`).
+    pub fn print(&self) -> Signal<T> {
+        self.wrap(self.stream.print())
+    }
+}
+
+impl<A, B> Signal<(A, B)>
+where
+    A: Clone + Default + 'static,
+    B: Clone + Default + 'static,
+{
+    /// Decompose a signal of pairs into its two component signals (the classic
+    /// `split`). Both branches tick whenever the source does.
+    pub fn split(&self) -> (Signal<A>, Signal<B>) {
+        let (a, b) = self.stream.split();
+        (self.wrap(a), self.wrap(b))
+    }
+}
+
+impl<T: Clone + Default + 'static> Signal<Option<T>> {
+    /// Drop `None` values, yielding a `Signal<T>` of just the `Some` payloads
+    /// (the classic `filter_none`). Delegates to the fluent
+    /// [`map_filter`](StreamOps::map_filter).
+    pub fn filter_none(&self) -> Signal<T> {
+        self.wrap(self.stream.map_filter(|opt: &Option<T>| match opt.clone() {
+            Some(v) => (v, true),
+            None => (T::default(), false),
+        }))
     }
 }
 

--- a/next/crates/wingfoil-next/tests/compat.rs
+++ b/next/crates/wingfoil-next/tests/compat.rs
@@ -4,6 +4,8 @@
 //! the new `Op`/`Builder` engine. This is the compatibility surface that
 //! lets existing code (and the Python bindings) migrate unchanged.
 
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::time::Duration;
 
 use wingfoil::{NanoTime, RunFor, RunMode};
@@ -233,4 +235,205 @@ fn classic_buffer_flushes_by_capacity() {
         .accumulate();
     buffered.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
     assert_eq!(vec![vec![1, 2], vec![3, 4], vec![5]], buffered.peek_value());
+}
+
+// --- Newly surfaced operator methods, all in the classic idiom -------------
+
+/// `try_map` applies a fallible closure; the `Ok` path passes values through.
+#[test]
+fn classic_try_map_transforms_values() {
+    let doubled = ticker(Duration::from_nanos(100))
+        .count()
+        .try_map(|i: &u64| Ok(*i * 2))
+        .accumulate();
+    doubled.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![2, 4, 6], doubled.peek_value());
+}
+
+/// `map_filter` maps and drops in one pass, preserving values **and** the tick
+/// times of the values it keeps.
+#[test]
+fn classic_map_filter_keeps_even_counts_with_times() {
+    // counts 1,2,3,4 at t=0,100,200,300; keep even counts → (2@100, 4@300)
+    let evens = ticker(Duration::from_nanos(100))
+        .count()
+        .map_filter(|i: &u64| (*i, i.is_multiple_of(2)))
+        .with_time()
+        .accumulate();
+    evens.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::from(100u64), 2u64),
+            (NanoTime::from(300u64), 4u64),
+        ],
+        evens.peek_value()
+    );
+}
+
+/// `filter_map` keeps `Some`, drops `None`.
+#[test]
+fn classic_filter_map_keeps_some() {
+    // counts 1..=6; keep squares of odd inputs → 1, 9, 25
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .filter_map(|i: &u64| (i % 2 == 1).then_some(i * i))
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(vec![1, 9, 25], out.peek_value());
+}
+
+/// `filter_value` drops values failing a predicate.
+#[test]
+fn classic_filter_value_drops_on_predicate() {
+    // counts 1..=5; keep > 3 → 4, 5
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .filter_value(|i: &u64| *i > 3)
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![4, 5], out.peek_value());
+}
+
+/// `reduce` folds from `T::default()`, applying `f(acc, value)` — a running sum.
+#[test]
+fn classic_reduce_running_sum() {
+    // counts 1,2,3,4; running sum 1,3,6,10
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .reduce(|acc: &u64, v: &u64| acc + v)
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(vec![1, 3, 6, 10], out.peek_value());
+}
+
+/// `produce` emits a fresh value on each tick, ignoring the source value.
+#[test]
+fn classic_produce_emits_on_each_tick() {
+    let out = ticker(Duration::from_nanos(100))
+        .produce(|| 42u64)
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![42, 42, 42], out.peek_value());
+}
+
+/// `inspect` runs a side effect while passing values through unchanged.
+#[test]
+fn classic_inspect_taps_and_passes_through() {
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let s = seen.clone();
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .inspect(move |v: &u64| s.borrow_mut().push(*v))
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1, 2, 3], out.peek_value());
+    assert_eq!(vec![1, 2, 3], *seen.borrow());
+}
+
+/// `for_each` runs a side-effecting sink on each tick.
+#[test]
+fn classic_for_each_sinks_each_value() {
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let s = seen.clone();
+    let sink = ticker(Duration::from_nanos(100))
+        .count()
+        .for_each(move |v: &u64| {
+            s.borrow_mut().push(*v);
+            Ok(())
+        });
+    sink.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1, 2, 3], *seen.borrow());
+}
+
+/// `finally` runs once at teardown, observing the last value.
+#[test]
+fn classic_finally_runs_at_teardown() {
+    let last = Rc::new(RefCell::new(0u64));
+    let f = last.clone();
+    let sink = ticker(Duration::from_nanos(100))
+        .count()
+        .finally(move |v: &u64| {
+            *f.borrow_mut() = *v;
+            Ok(())
+        });
+    sink.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(3, *last.borrow());
+}
+
+/// `collapse` reduces an iterable value to its last item, quiet when empty.
+#[test]
+fn classic_collapse_takes_last_item() {
+    // counts 1,2,3 → vecs [1,10],[2,20],[3,30] → collapse → 10,20,30
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .map(|i: &u64| vec![*i, *i * 10])
+        .collapse::<u64>()
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![10, 20, 30], out.peek_value());
+}
+
+/// `timed` passes values through unchanged (it only prints a summary).
+#[test]
+fn classic_timed_passes_through() {
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .timed()
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1, 2, 3], out.peek_value());
+}
+
+/// `print` passes values through unchanged (it only prints at teardown).
+#[test]
+fn classic_print_passes_through() {
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .print()
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1, 2, 3], out.peek_value());
+}
+
+/// `delay_with_reset` with a never-firing trigger behaves like plain `delay`.
+#[test]
+fn classic_delay_with_reset_never_resets() {
+    let c = constant(7u64);
+    // A trigger derived from the same graph that never ticks.
+    let never = c.filter_value(|_| false);
+    let delayed = c
+        .delay_with_reset(Duration::from_nanos(50), &never)
+        .accumulate();
+    // constant ticks once at t=0; delayed re-emits it at t=50.
+    delayed.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![7], delayed.peek_value());
+}
+
+/// `split` decomposes a signal of pairs into two component signals.
+#[test]
+fn classic_split_decomposes_pairs() {
+    let pairs = ticker(Duration::from_nanos(100))
+        .count()
+        .map(|i: &u64| (*i, *i * 10));
+    let (a, b) = pairs.split();
+    let aa = a.accumulate();
+    let bb = b.accumulate();
+    // Running `aa` builds the shared graph (which includes `bb`); both read
+    // off the same retained runner.
+    aa.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1, 2, 3], aa.peek_value());
+    assert_eq!(vec![10, 20, 30], bb.peek_value());
+}
+
+/// `filter_none` drops `None`, yielding just the `Some` payloads.
+#[test]
+fn classic_filter_none_drops_none() {
+    // counts 1..=6; Some for odd inputs only → 1, 3, 5
+    let out = ticker(Duration::from_nanos(100))
+        .count()
+        .map(|i: &u64| (i % 2 == 1).then_some(*i))
+        .filter_none()
+        .accumulate();
+    out.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(vec![1, 3, 5], out.peek_value());
 }


### PR DESCRIPTION
## What

Phase 6 facade follow-up: surface more of the classic
`StreamOperators`/`NodeOperators` method surface on `compat::Signal`
(`next/crates/wingfoil-next/src/compat.rs`), so classic-idiom code runs on the
next engine. Each new method **delegates to a fluent combinator that already
exists in next** — no new engine capability, only classic-shaped names over
existing `Stream`/`GraphBuilder` combinators.

## Methods added

| compat method | delegates to (next fluent) |
|---|---|
| `try_map` | `StreamOps::try_map` |
| `map_filter` | `StreamOps::map_filter` |
| `filter_map` (Option) | `map_filter` |
| `filter_value` (predicate) | `map_filter` |
| `reduce` | `fold` (seeded from `T::default()`) |
| `produce` | `map` (ignoring the input value) |
| `inspect` | `StreamOps::inspect` |
| `for_each` (fallible sink) | `StreamOps::for_each` |
| `finally` | `StreamOps::finally` |
| `collapse` | `StreamOps::collapse` |
| `timed` | `StreamOps::timed` |
| `print` | `StreamOps::print` |
| `delay_with_reset` | `StreamOps::delay_with_reset` |
| `split` (on `Signal<(A,B)>`) | `Stream::split` |
| `filter_none` (on `Signal<Option<T>>`) | `map_filter` |

The pre-existing surface (`map`, `fold`, `filter`, `sample`, `merge`, `limit`,
`throttle`, `window`, `buffer`, `delay`, `distinct`, `difference`, `not`,
`accumulate`, `with_time`, `ticked_at`, `ticked_at_elapsed`, `count`, `run`,
`peek_value`) is unchanged.

## Methods skipped (and why)

Skipped classic methods whose underlying next combinator does not exist, or
that don't fit the free-function facade shape:

- **`collect`** — returns `Vec<ValueAt<T>>`; `ValueAt` is a classic queue type
  with no next fluent combinator.
- **`logged`** — no next combinator (classic uses the `log` crate directly).
- **`demux` / `demux_it` / `demux_it_with_map`** — `Builder::demux` exists
  behind the `dynamic-graph` feature but is not exposed as a fluent `StreamOps`
  combinator, and classic's auto-assigning `DemuxMap`/`demux_it` layer is a
  documented Phase 4.5 parity gap.
- **`consume_async` / `mapper`** — async sinks/sub-graphs (async feature),
  outside the scope of this mechanical operator port.
- **`into_graph`** — the facade has no classic `Graph` type; `run` covers
  execution.
- **`feedback`** (Stream- and Node-level) — the next `feedback` combinator
  *does* exist, but surfacing it needs a shared-graph feedback-**source**
  constructor. The free-function facade gives each source its own
  `GraphBuilder`, so there is no way to create the paired `(source, sink)`
  within an existing `Signal`'s graph yet. This is a facade-shape gap, not a
  missing combinator; left for a follow-up that adds a graph-aware feedback
  constructor to compat.

## Tests

Added a parity test per new method in
`next/crates/wingfoil-next/tests/compat.rs`, all in the classic idiom, running
`RunMode::HistoricalFrom(NanoTime::ZERO)` and asserting values;
`map_filter`'s test also asserts exact tick times via `with_time()`.

## Checks

- `cargo fmt --all -- --check` — clean
- `cargo lint` (default features) — pass
- `cargo lint-all` (all features) — pass (needed `protoc` + CMake ≥3.30 for the
  aeron adapter, per root CLAUDE.md; installed locally)
- `cargo test -p wingfoil-next --all-features` — `tests/compat.rs` 33 passed;
  every other binary green. The only failures are the 12
  `tests/etcd_integration.rs` tests, which require a live etcd via
  testcontainers/Docker (unavailable in this environment) — they fail at
  container startup in ~0.3s and are unrelated to this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCSuEZ1SGPcVqKUT8RXyKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCSuEZ1SGPcVqKUT8RXyKU)_