### PR TITLE
next: make join_passive, try_join_passive, delay_with_reset, with_time dual-mode

### DIFF
--- a/next/crates/wingfoil-next/src/ops.rs
+++ b/next/crates/wingfoil-next/src/ops.rs
@@ -580,8 +580,19 @@ where
 }
 
 /// Pairs each value with the current engine time: emits `(time, value)`.
+///
+/// `no_builder`: a hand-written [`Builder::with_time`](crate::interp::Builder::with_time)
+/// seeds the output `(NanoTime, T)` slot from the input's current value, so the
+/// interpreted path needs only `T: Clone` (never `T: Default`). The `#[op]`
+/// attribute is kept for its `graph!` forwarders, which seed the value slot
+/// with `Default::default()` — so inside `graph!`/compiled the output type must
+/// be `Default` (`(NanoTime, T): Default`, i.e. `T: Default`). That pre-first-tick
+/// seed is only ever read by a passive downstream before the first tick; the op
+/// itself ticks in lockstep with its source, so the observed values agree across
+/// all three engines.
 pub struct WithTime<T>(PhantomData<T>);
 
+#[op(build = with_time, no_builder)]
 impl<T: Clone + 'static> Op for WithTime<T> {
     type Cfg = ();
     type State = ();
@@ -1998,6 +2009,61 @@ where
     }
 }
 
+/// The `graph!`/compiled forwarder witness for [`join_passive`] — [`Join`]'s
+/// semantics with the **second** edge passive (read but not activating: the
+/// `bimap(Active, Passive)` shape a feedback input takes). The interpreted path
+/// wires this shape through [`Builder::bimap`](crate::interp::Builder::bimap)
+/// (`join_passive` = `bimap(_, true, _, false)`); this separate witness exists
+/// only so `#[op(passive = [1])]` can emit the `__wf_op_join_passive_*`
+/// forwarders — a second `#[op]` cannot be attached to [`Join`], and the
+/// passive mask is the only thing that differs. `cycle` delegates to [`Join`]
+/// so the semantics are single-sourced.
+pub struct JoinPassive<A, B, C, F>(PhantomData<(A, B, C, F)>);
+
+#[op(build = join_passive, no_builder, passive = [1])]
+impl<A, B, C, F> Op for JoinPassive<A, B, C, F>
+where
+    A: 'static,
+    B: 'static,
+    C: Clone + 'static,
+    F: Fn(&A, &B) -> C + 'static,
+{
+    type Cfg = F;
+    type State = ();
+    type In<'a> = (&'a A, &'a B);
+    type Out = C;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(cfg: &mut F, state: &mut (), input: (&A, &B), ctx: &mut Ctx<'_>) -> Result<Tick<C>> {
+        <Join<A, B, C, F> as Op>::cycle(cfg, state, input, ctx)
+    }
+}
+
+/// The `graph!`/compiled forwarder witness for [`try_join_passive`] — the
+/// `try_` counterpart to [`JoinPassive`], delegating to [`TryJoin`] with the
+/// second edge passive. See [`JoinPassive`] for why a separate witness is
+/// needed.
+pub struct TryJoinPassive<A, B, C, F>(PhantomData<(A, B, C, F)>);
+
+#[op(build = try_join_passive, no_builder, passive = [1])]
+impl<A, B, C, F> Op for TryJoinPassive<A, B, C, F>
+where
+    A: 'static,
+    B: 'static,
+    C: Clone + 'static,
+    F: Fn(&A, &B) -> Result<C> + 'static,
+{
+    type Cfg = F;
+    type State = ();
+    type In<'a> = (&'a A, &'a B);
+    type Out = C;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(cfg: &mut F, state: &mut (), input: (&A, &B), ctx: &mut Ctx<'_>) -> Result<Tick<C>> {
+        <TryJoin<A, B, C, F> as Op>::cycle(cfg, state, input, ctx)
+    }
+}
+
 /// Delays its source by a fixed interval. The op that forced the retrofit's
 /// `cycle_typed` tier — here it needs nothing special: `SCHEDULES` grants it
 /// `Ctx::schedule`, its queue is ordinary `State`, and the upstream tick
@@ -2200,5 +2266,41 @@ impl<T: Clone + PartialEq + 'static> Op for DelayWithReset<T> {
             return Ok(Tick::Silent(value.clone()));
         }
         Ok(out)
+    }
+}
+
+/// The `graph!`/compiled forwarder witness for [`delay_with_reset`] — a thin
+/// adapter over [`DelayWithReset`], delegating so its scheduling/seeding
+/// semantics are single-sourced. The real op's `In = (&T, bool, bool)` (source
+/// value, source tick, reset tick — the trigger's *value* is never read) is a
+/// shape `#[op]` cannot parse from tokens (two consecutive tick flags with no
+/// second value edge). This witness restates `In` in the uniform two-edge form
+/// `(&T, bool, &U, bool)` that `#[op]` *does* parse — one `(value, tick)` pair
+/// per edge — then drops the trigger's value when delegating. Both engines run
+/// identical [`DelayWithReset::cycle`] logic.
+///
+/// `U` is the trigger stream's value type; it is generic because the reset
+/// trigger may carry any payload (only its tick matters), matching the fluent
+/// [`delay_with_reset`](crate::fluent::StreamOps::delay_with_reset)`<U>`.
+pub struct DelayWithResetFwd<T, U>(PhantomData<(T, U)>);
+
+#[op(build = delay_with_reset, no_builder)]
+impl<T: Clone + PartialEq + 'static, U: 'static> Op for DelayWithResetFwd<T, U> {
+    type Cfg = Duration;
+    type State = DelayWithResetState<T>;
+    /// Source value, source tick, trigger value (ignored), trigger tick — the
+    /// two-edge `(value, tick)`-per-edge form `#[op]` parses.
+    type In<'a> = (&'a T, bool, &'a U, bool);
+    type Out = T;
+    const ACTIVATION: Activation = Activation::SCHEDULES;
+
+    fn cycle(
+        cfg: &mut Duration,
+        state: &mut DelayWithResetState<T>,
+        input: (&T, bool, &U, bool),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<T>> {
+        let (value, upstream_ticked, _trigger_value, trigger_ticked) = input;
+        <DelayWithReset<T> as Op>::cycle(cfg, state, (value, upstream_ticked, trigger_ticked), ctx)
     }
 }

--- a/next/crates/wingfoil-next/tests/op_completeness.rs
+++ b/next/crates/wingfoil-next/tests/op_completeness.rs
@@ -47,14 +47,28 @@
 //!     ARE expressible; covered in `surface_sugar` below.)
 //!
 //! **3. Currently interpreted-only — candidate follow-up, not by design:**
-//!   * `join_passive`, `try_join_passive` — passive-edge joins; the passive
-//!     variant carries no `#[op]` forwarder yet (the active `join` / `try_join`
-//!     do — covered below).
-//!   * `delay_with_reset` — a hand-written builder method (no `#[op]`), so no
-//!     forwarder yet.
-//!   * `with_time` — a hand-written builder method (its `(NanoTime, T)` output
-//!     is seeded from the input, so it dodges `T: Default` and can't be a plain
-//!     `#[op]`); no forwarder yet.
+//!   * *(empty — all four former members are now dual-mode.)* `join_passive`,
+//!     `try_join_passive`, `delay_with_reset`, and `with_time` were once
+//!     interpreted-only for want of a `graph!` forwarder; they now carry one
+//!     (see `surface_passive_delay` below, exercised across all three engines)
+//!     and moved out of this list. The mechanism, for each:
+//!     - `join_passive` / `try_join_passive` — the passive-edge join shape. A
+//!       second `#[op]` cannot attach to `Join` / `TryJoin` (only the passive
+//!       mask differs), so a thin forwarder-witness op (`JoinPassive` /
+//!       `TryJoinPassive` in `ops.rs`, `#[op(passive = [1])]`, delegating its
+//!       `cycle` to `Join` / `TryJoin`) emits the `__wf_op_join_passive_*` /
+//!       `__wf_op_try_join_passive_*` forwarders.
+//!     - `delay_with_reset` — the real op's `In = (&T, bool, bool)` (two tick
+//!       flags, the trigger's value unread) is unparseable by `#[op]`; a
+//!       witness op (`DelayWithResetFwd`) restates it in the two-edge
+//!       `(&T, bool, &U, bool)` form `#[op]` parses and delegates to
+//!       `DelayWithReset::cycle`.
+//!     - `with_time` — `#[op(build = with_time, no_builder)]` on the op itself
+//!       (the hand-written `Builder::with_time` stays for its `T: Clone`-only
+//!       interpreted seeding). Inside `graph!`/compiled the output must be
+//!       `Default` (`(NanoTime, T): Default`), which holds for every value type
+//!       used here; the differing pre-first-tick seed is never observed because
+//!       the op ticks in lockstep with its source.
 //!
 //! This file is the single place that classification is written down; the
 //! *enforcement* is that everything in category (none) — i.e. every op meant to
@@ -175,6 +189,42 @@ wingfoil_next::graph! {
     }
 }
 
+// Formerly-interpreted-only surface, now dual-mode: `with_time`,
+// `join_passive`, `try_join_passive`, and `delay_with_reset`. Each reaches
+// `graph!`/compiled through a forwarder added alongside its op (see the module
+// doc, category 3). Exercising them here — and in the `nested` parity test
+// below — is exactly the two-sided guard: a dropped forwarder fails to resolve
+// `__wf_op_<name>_cycle` at these call sites.
+wingfoil_next::graph! {
+    fn surface_passive_delay(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let count = g.ticker(P).count();
+        // `with_time`: (NanoTime, u64) folded back to a single u64 stream. The
+        // engine clock is deterministic in historical mode, so the stamped time
+        // agrees across engines.
+        let stamped = count
+            .with_time()
+            .map(|pair: &(NanoTime, u64)| u64::from(pair.0) + pair.1);
+        // Two derived streams to join; `passive_src` is read passively.
+        let base = count.map(|i| i * 2);
+        let passive_src = count.map(|i| i * 100);
+        // `join_passive` / `try_join_passive`: `base` active, `passive_src`
+        // read passively (does not activate the node).
+        let joined = base.join_passive(&passive_src, |x: &u64, y: &u64| x + y);
+        let tried = base.try_join_passive(&passive_src, |x: &u64, y: &u64| Ok(x + y));
+        // `delay_with_reset`: delay `count`, snapping to the live value whenever
+        // the reset trigger (even counts) ticks.
+        let flag = count.map(|i| i.is_multiple_of(2));
+        let trigger = count.filter(&flag);
+        let delayed = count.delay_with_reset(Duration::from_millis(25), &trigger);
+        let out = joined
+            .merge(&tried)
+            .merge(&delayed)
+            .merge(&stamped)
+            .accumulate();
+        out
+    }
+}
+
 // --- Three-engine agreement across the surface ------------------------------
 //
 // Each block above compiled (proving fluent + forwarder both exist for every op
@@ -235,4 +285,41 @@ fn sugar_surface_three_engine_parity() {
 #[test]
 fn lifecycle_surface_three_engine_parity() {
     assert_interp_eq_compiled!(surface_lifecycle);
+}
+
+#[test]
+fn passive_delay_surface_interp_eq_compiled() {
+    assert_interp_eq_compiled!(surface_passive_delay);
+}
+
+/// Full three-engine agreement for the formerly-interpreted-only ops
+/// (`with_time`, `join_passive`, `try_join_passive`, `delay_with_reset`):
+/// `interpreted() == compiled() == nested()`. The self-contained graph is a
+/// source island, so it exposes all three expansions; `nested` mounts it as one
+/// node in an interpreted outer graph (following `nested_islands.rs`).
+#[test]
+fn passive_delay_surface_three_engine_parity() {
+    let (mut runner, out) = surface_passive_delay::interpreted();
+    runner.run(HISTORICAL, RUN).unwrap();
+    let interp = runner.value(out);
+    assert!(
+        !interp.is_empty(),
+        "surface_passive_delay produced no values"
+    );
+
+    let (compiled,) = surface_passive_delay::compiled(HISTORICAL, RUN).unwrap();
+    assert_eq!(
+        interp, compiled,
+        "interpreted vs compiled drift in surface_passive_delay"
+    );
+
+    let g = GraphBuilder::new();
+    let island = surface_passive_delay::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, RUN).unwrap();
+    assert_eq!(
+        interp,
+        r.value(&island),
+        "interpreted vs nested drift in surface_passive_delay"
+    );
 }


### PR DESCRIPTION
## Summary

Four fluent combinators worked only on the **interpreted** engine because they lacked a `graph!` forwarder — the naming-convention `__wf_op_<name>_*` functions the macro dispatches `compiled()`/`nested()` emission through (see `docs/macro-extensibility-decision.md`, and the "Completeness test" note in `docs/port-plan.md` that flagged these as candidate follow-ups). This PR adds a forwarder to each, so all four are reachable inside `graph!` / `compiled()` / `nested()`, not just interpreted. **No runtime semantics change** — every forwarder either delegates to the existing op's `cycle` or is the same op with the derive attached.

## What changed, per op

- **`with_time`** — `#[op(build = with_time, no_builder)]` on the op itself. The hand-written `Builder::with_time` stays (it seeds the `(NanoTime, T)` slot from the input's current value, so the interpreted path needs only `T: Clone`). The derive supplies the `graph!` forwarders; their `Default`-based value-slot seed makes the compiled path require `(NanoTime, T): Default` (i.e. `T: Default`). That pre-first-tick seed is never observed — the op ticks in lockstep with its source — so the three engines agree.
- **`join_passive` / `try_join_passive`** — a second `#[op]` cannot attach to `Join` / `TryJoin` (only the passive mask differs), so thin witness ops `JoinPassive` / `TryJoinPassive` carry `#[op(passive = [1])]` and delegate `cycle` to `Join` / `TryJoin`, emitting the passive-edge (`__wf_op_join_passive_*` / `__wf_op_try_join_passive_*`) forwarders. The interpreted path is unchanged (still `Builder::bimap(_, true, _, false)`).
- **`delay_with_reset`** — the real op's `In = (&T, bool, bool)` (two tick flags, the trigger's value unread) is a shape `#[op]` cannot parse from tokens. Witness op `DelayWithResetFwd` restates it in the two-edge `(&T, bool, &U, bool)` form the derive parses (one `(value, tick)` pair per edge) and delegates to `DelayWithReset::cycle`, dropping the trigger's value.

All four were made dual-mode; none stayed interpreted-only.

## Tests

`tests/op_completeness.rs`: the four move out of the interpreted-only allowlist (category 3, now empty, with the mechanism documented inline) into a new `surface_passive_delay` `graph!` block. Two new tests assert `interpreted() == compiled()` and full three-engine `interpreted() == compiled() == nested()` parity (the block is a self-contained source island, so it exposes all three expansions).

## Validation

- `cargo fmt --all` — clean
- `cargo lint` (default features) — passes
- `cargo lint-all` (`--all-features` clippy, with `protoc` present) — passes, so all feature-gated code compiles under the new ops
- `cargo test -p wingfoil-next` (default features) — 36/36 test binaries pass, including the two new parity tests

Note: `cargo test -p wingfoil-next --all-features` could not complete in this sandbox — the all-features build tree (etcd/testcontainers/bollard, augurs, kafka, zmq, fix, aeron, …) exhausted the available disk while linking test binaries ("No space left on device"). The changes are not feature-gated (core `ops.rs` + the completeness test), so default-feature tests fully exercise them, and `cargo lint-all` confirms the all-features code compiles cleanly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCSuEZ1SGPcVqKUT8RXyKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCSuEZ1SGPcVqKUT8RXyKU)_