### PR TITLE
wingfoil-next: port the time-weighted median (Phase 4.1)

### DIFF
--- a/next/crates/wingfoil-next/src/ops.rs
+++ b/next/crates/wingfoil-next/src/ops.rs
@@ -2176,6 +2176,195 @@ impl Op for TimeWindowedStdTimeWeighted {
     }
 }
 
+// ── time-weighted median (Weighting::Time) ───────────────────────────────────
+//
+// The time-*weighted* twin of the count-weighted median ops (cumulative,
+// count-windowed, and time-windowed). Unlike the moment ops above it is **not**
+// an incremental West's-algorithm accumulator: the median has no cheap
+// incremental form, so — like the classic `WindowStream::weighted_median` — it
+// retains the `(value, time)` samples in the window and recomputes over them
+// each tick. Ported verbatim from `wingfoil/src/adapters/statistics.rs`
+// (`WindowStream` + `for_each_weight` + `weighted_median`, `Weighting::Time`).
+// Semantics reproduced:
+//
+//   * each retained sample is weighted by the interval it was in effect — the
+//     gap to its successor in the buffer, and the most recent sample by the gap
+//     to `now` (which is zero, since it was just pushed at `now`, so the newest
+//     sample carries no weight until the next tick advances the clock);
+//   * zero-weight samples (a Δt of 0, e.g. the newest sample or simultaneous
+//     ticks) are dropped; if *every* retained sample has zero weight the latest
+//     value is returned;
+//   * the samples are sorted by value and the result is the value at which
+//     cumulative weight first crosses half the total; a crossing landing exactly
+//     on a boundary averages the two straddling values (so unit-length intervals
+//     reproduce the even-count average, matching the count-weighted median);
+//   * the leading edge uses only retained samples, so a value in effect *before*
+//     the window opened is not carried in (the count/time eviction happens first).
+
+/// Recompute-per-tick buffer for the time-weighted median: the `(value, time)`
+/// samples currently in the window. Each tick pushes the new sample, evicts per
+/// the window rule, then recomputes the weighted median over what remains — the
+/// same `VecDeque<(f64, NanoTime)>` and algorithm as the classic `WindowStream`
+/// under `Weighting::Time`; only the eviction rule differs between the three
+/// windows.
+#[derive(Default)]
+pub struct TimeWeightedMedianState {
+    buffer: VecDeque<(f64, NanoTime)>,
+}
+
+impl TimeWeightedMedianState {
+    /// Time-weighted median of the retained samples: weight each by the gap to
+    /// its successor (the newest by the gap to `now`, i.e. zero), drop zero
+    /// weights, then return the value at which cumulative weight crosses half the
+    /// total (averaging the two straddling values on an exact boundary). Ported
+    /// verbatim from the classic `WindowStream::weighted_median`.
+    fn weighted_median(&self, now: NanoTime) -> f64 {
+        let n = self.buffer.len();
+        let mut pairs: Vec<(f64, f64)> = Vec::with_capacity(n);
+        for i in 0..n {
+            let (v, t) = self.buffer[i];
+            let next_t = if i + 1 < n { self.buffer[i + 1].1 } else { now };
+            let w = f64::from(next_t - t);
+            // Drop zero-weight samples (a time-weighted newest sample with Δt 0).
+            if w > 0.0 {
+                pairs.push((v, w));
+            }
+        }
+        if pairs.is_empty() {
+            // Every retained sample had zero weight; fall back to the latest.
+            return self.buffer.back().expect("invariant: buffer non-empty").0;
+        }
+        pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+        let half = pairs.iter().map(|&(_, w)| w).sum::<f64>() / 2.0;
+        let mut cumulative = 0.0;
+        for (i, &(v, w)) in pairs.iter().enumerate() {
+            cumulative += w;
+            if cumulative > half {
+                return v;
+            }
+            if cumulative == half {
+                // Crossing lands exactly on a boundary: average with the next
+                // value if there is one (the even-count unit-weight median).
+                return match pairs.get(i + 1) {
+                    Some(&(next, _)) => (v + next) / 2.0,
+                    None => v,
+                };
+            }
+        }
+        // Only reachable through floating-point rounding; the last value wins.
+        pairs.last().expect("invariant: pairs non-empty").0
+    }
+
+    /// Push a sample under an **unbounded** (cumulative) window — every sample is
+    /// retained, so memory grows with the stream — and return the median.
+    fn push_cumulative(&mut self, now: NanoTime, sample: f64) -> f64 {
+        self.buffer.push_back((sample, now));
+        self.weighted_median(now)
+    }
+
+    /// Push a sample under a **count** window (clamped to at least one), evicting
+    /// the oldest once more than `window` samples are retained, and return the
+    /// median.
+    fn push_count(&mut self, now: NanoTime, sample: f64, window: usize) -> f64 {
+        let window = window.max(1);
+        self.buffer.push_back((sample, now));
+        while self.buffer.len() > window {
+            self.buffer.pop_front();
+        }
+        self.weighted_median(now)
+    }
+
+    /// Push a sample under a **time** window, evicting every front sample aged
+    /// strictly past `window` nanoseconds (the just-pushed sample has age 0, so
+    /// the buffer never empties), and return the median.
+    fn push_time(&mut self, now: NanoTime, sample: f64, window: u64) -> f64 {
+        self.buffer.push_back((sample, now));
+        while self
+            .buffer
+            .front()
+            .is_some_and(|&(_, t)| aged_out(now, t, window))
+        {
+            self.buffer.pop_front();
+        }
+        self.weighted_median(now)
+    }
+}
+
+/// Cumulative time-weighted median over every sample seen so far — each sample
+/// weighted by how long it was in effect (Δt from the graph clock). Recomputed
+/// per tick (O(n log n)); retains all samples, so its memory grows with the
+/// stream. Mirrors the classic `median(Window::Unbounded, Weighting::Time)`.
+pub struct CumulativeMedianTimeWeighted;
+
+#[op(build = cumulative_median_time_weighted)]
+impl Op for CumulativeMedianTimeWeighted {
+    type Cfg = ();
+    type State = TimeWeightedMedianState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut TimeWeightedMedianState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        Ok(Tick::Value(state.push_cumulative(ctx.time(), *input.0)))
+    }
+}
+
+/// Time-weighted median over the most recent `window` samples (a count window),
+/// each weighted by how long it was in effect. Recomputed per tick (O(w log w)).
+/// Mirrors the classic `median(Window::Count(_), Weighting::Time)`.
+pub struct RollingMedianTimeWeighted;
+
+#[op(build = rolling_median_time_weighted)]
+impl Op for RollingMedianTimeWeighted {
+    type Cfg = usize;
+    type State = TimeWeightedMedianState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut TimeWeightedMedianState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        Ok(Tick::Value(state.push_count(ctx.time(), *input.0, *cfg)))
+    }
+}
+
+/// Time-weighted median over a bounded time window — the samples seen in the last
+/// `window` of graph time, each weighted by how long it was in effect. Recomputed
+/// per tick (O(w log w) over the `w` retained samples). Mirrors the classic
+/// `median(Window::Time(_), Weighting::Time)`.
+pub struct TimeWindowedMedianTimeWeighted;
+
+#[op(build = time_windowed_median_time_weighted)]
+impl Op for TimeWindowedMedianTimeWeighted {
+    type Cfg = NanoTime;
+    type State = TimeWeightedMedianState;
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut NanoTime,
+        state: &mut TimeWeightedMedianState,
+        input: (&f64,),
+        ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<f64>> {
+        Ok(Tick::Value(state.push_time(
+            ctx.time(),
+            *input.0,
+            u64::from(*cfg),
+        )))
+    }
+}
+
 /// Emits its source value when the condition stream's current value is true.
 pub struct Filter<T>(PhantomData<T>);
 

--- a/next/crates/wingfoil-next/src/stats.rs
+++ b/next/crates/wingfoil-next/src/stats.rs
@@ -162,6 +162,29 @@ pub trait StatisticsOps {
     /// root of
     /// [`time_windowed_var_time_weighted`](Self::time_windowed_var_time_weighted).
     fn time_windowed_std_time_weighted(&self, window: Duration) -> Stream<f64>;
+
+    // ── time-weighted median (Weighting::Time) ───────────────────────────────
+    //
+    // The time-weighted twin of the median ops above: each retained sample is
+    // weighted by how long it was in effect (the Δt until its successor, read
+    // from engine time) and the median is the value at which cumulative weight
+    // crosses half the total. The newest sample carries zero weight until the
+    // next tick advances the clock, so it does not shift the median on arrival.
+    // Recompute-per-tick (the median has no cheap incremental form), ported from
+    // the classic `WindowStream::weighted_median` under `Weighting::Time`.
+
+    /// Cumulative time-weighted median over every sample seen so far (an
+    /// unbounded window) — each sample weighted by how long it was in effect.
+    /// Retains all samples, so its memory grows with the stream.
+    fn cumulative_median_time_weighted(&self) -> Stream<f64>;
+
+    /// Time-weighted median over the most recent `window` samples (a count
+    /// window), each weighted by how long it was in effect.
+    fn rolling_median_time_weighted(&self, window: usize) -> Stream<f64>;
+
+    /// Time-weighted median over a bounded time window — the samples seen in the
+    /// last `window` of graph time, each weighted by how long it was in effect.
+    fn time_windowed_median_time_weighted(&self, window: Duration) -> Stream<f64>;
 }
 
 impl StatisticsOps for Stream<f64> {
@@ -309,5 +332,18 @@ impl StatisticsOps for Stream<f64> {
     fn time_windowed_std_time_weighted(&self, window: Duration) -> Stream<f64> {
         let window = NanoTime::from(window);
         self.wire(move |b, h| b.time_windowed_std_time_weighted(h, window))
+    }
+
+    fn cumulative_median_time_weighted(&self) -> Stream<f64> {
+        self.wire(|b, h| b.cumulative_median_time_weighted(h))
+    }
+
+    fn rolling_median_time_weighted(&self, window: usize) -> Stream<f64> {
+        self.wire(move |b, h| b.rolling_median_time_weighted(h, window))
+    }
+
+    fn time_windowed_median_time_weighted(&self, window: Duration) -> Stream<f64> {
+        let window = NanoTime::from(window);
+        self.wire(move |b, h| b.time_windowed_median_time_weighted(h, window))
     }
 }

--- a/next/crates/wingfoil-next/tests/statistics_time_weighted_median.rs
+++ b/next/crates/wingfoil-next/tests/statistics_time_weighted_median.rs
@@ -1,0 +1,300 @@
+//! Parity tests for the **time-weighted median** statistics
+//! (`{cumulative,rolling,time_windowed}_median_time_weighted`), ported from the
+//! classic `adapters::statistics` `median(_, Weighting::Time)` path — the
+//! recompute-per-tick `WindowStream::weighted_median`
+//! (`wingfoil/src/adapters/statistics.rs`).
+//!
+//! Unlike the time-weighted *moments* (a West's-algorithm incremental
+//! accumulator), the median has no cheap incremental form, so each tick recomputes
+//! over the retained `(value, time)` window. Time-weighting semantics reproduced
+//! (classic `Weighting::Time`):
+//!
+//! * each retained sample is weighted by the interval it was in effect — the gap
+//!   to its successor in the buffer, and the most recent sample by the gap to
+//!   `now` (which is zero, since it was just pushed at `now`), so the newest
+//!   sample carries no weight until the next tick advances the clock;
+//! * zero-weight samples are dropped; if every retained sample has zero weight
+//!   the latest value is returned;
+//! * the samples are sorted by value and the result is the value at which
+//!   cumulative weight first crosses half the total; an exact-boundary crossing
+//!   averages the two straddling values (so unit-length intervals reproduce the
+//!   even-count average, matching the count-weighted median);
+//! * the leading edge uses only retained samples (count/time eviction first), so
+//!   a value in effect before the window opened is not carried in.
+//!
+//! Ticks are 100ns apart. The classic parity references are the unit tests
+//! `rolling_median_time_weighted` (final 3.0, and the count median 3.5),
+//! `rolling_median_over_time_window`, and `cumulative_median_over_all_samples`
+//! in `wingfoil/src/adapters/statistics.rs`.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::fluent::Stream;
+use wingfoil_next::prelude::*;
+use wingfoil_next::stats::StatisticsOps;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// A 250ns window over 100ns-spaced ticks retains the three most recent samples.
+const WIN: Duration = Duration::from_nanos(250);
+
+/// 1, 2, 3, 4, 5 as `f64`, one tick every 100ns (ticks at 0,100,200,300,400ns).
+fn counter_f64(g: &GraphBuilder) -> Stream<f64> {
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(|i| *i as f64)
+}
+
+/// Assert two `f64` series equal element-wise within a tolerance.
+fn assert_series_approx(got: &[f64], expected: &[f64]) {
+    assert_eq!(got.len(), expected.len(), "length: {got:?} vs {expected:?}");
+    for (i, (g, e)) in got.iter().zip(expected).enumerate() {
+        assert!(
+            (g - e).abs() < 1e-9,
+            "at {i}: got {g}, expected {e} (series {got:?} vs {expected:?})"
+        );
+    }
+}
+
+/// Direct (from-scratch) time-weighted median over `(value, time_ns)` samples
+/// sorted by time, observed at `now_ns`: weight each by the gap to its successor
+/// (the newest by the gap to `now`), drop zero weights, then take the value at
+/// which cumulative weight crosses half the total (averaging the two straddling
+/// values on an exact boundary). An independent transcription of the classic
+/// `WindowStream::weighted_median`, used as an oracle for the recompute path.
+fn brute_time_weighted_median(samples: &[(f64, u64)], now_ns: u64) -> f64 {
+    let n = samples.len();
+    let mut pairs: Vec<(f64, f64)> = Vec::with_capacity(n);
+    for i in 0..n {
+        let (v, t) = samples[i];
+        let next_t = if i + 1 < n { samples[i + 1].1 } else { now_ns };
+        let w = (next_t - t) as f64;
+        if w > 0.0 {
+            pairs.push((v, w));
+        }
+    }
+    if pairs.is_empty() {
+        return samples.last().expect("non-empty samples").0;
+    }
+    pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    let half = pairs.iter().map(|&(_, w)| w).sum::<f64>() / 2.0;
+    let mut cumulative = 0.0;
+    for (i, &(v, w)) in pairs.iter().enumerate() {
+        cumulative += w;
+        if cumulative > half {
+            return v;
+        }
+        if cumulative == half {
+            return match pairs.get(i + 1) {
+                Some(&(next, _)) => (v + next) / 2.0,
+                None => v,
+            };
+        }
+    }
+    pairs.last().expect("non-empty pairs").0
+}
+
+// ── cumulative time-weighted median (unbounded window) ────────────────────────
+
+/// Cumulative time-weighted median over 1..5 at 100ns ticks. Each earlier sample
+/// is credited one 100ns interval; the newest carries zero weight. Walking the
+/// weighted crossing gives 1, 1, 1.5, 2, 2.5 — the newest value never shifts the
+/// median on arrival (it has no weight yet). Mirrors the classic
+/// `median(Window::Unbounded, Weighting::Time)`.
+#[test]
+fn cumulative_median_time_weighted_series() {
+    let g = GraphBuilder::new();
+    let med = counter_f64(&g)
+        .cumulative_median_time_weighted()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&med), &[1.0, 1.0, 1.5, 2.0, 2.5]);
+}
+
+// ── count-windowed time-weighted median ───────────────────────────────────────
+
+/// Mirrors classic `rolling_median_time_weighted` (final 3.0), pinned as a full
+/// series. Count window 4 over 1..5: the windows are {1},{1,2},{1,2,3},{1,2,3,4},
+/// {2,3,4,5}; each retained sample except the newest is credited one 100ns
+/// interval, so the newest is dropped. At the last tick the weights are
+/// {2:100,3:100,4:100} (5 is "now", Δt 0) — cumulative crosses half (150) at 3,
+/// so the weighted median is 3.0. The full series is 1, 1, 1.5, 2, 3.
+#[test]
+fn rolling_median_time_weighted_series() {
+    let g = GraphBuilder::new();
+    let med = counter_f64(&g).rolling_median_time_weighted(4).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&med), &[1.0, 1.0, 1.5, 2.0, 3.0]);
+}
+
+/// The time weighting must actually change the result versus the count-weighted
+/// median: over the same {2,3,4,5} count window the count median is (3+4)/2 =
+/// 3.5, whereas the time-weighted median is 3.0 (the newest sample 5 carries no
+/// weight). Mirrors the two assertions in classic `rolling_median_time_weighted`.
+#[test]
+fn rolling_median_time_vs_count_weighting_differ() {
+    let g = GraphBuilder::new();
+    let time = counter_f64(&g).rolling_median_time_weighted(4);
+    let count = counter_f64(&g).rolling_median(4);
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert!(
+        (r.value(&time) - 3.0).abs() < 1e-9,
+        "time-weighted {}",
+        r.value(&time)
+    );
+    assert!(
+        (r.value(&count) - 3.5).abs() < 1e-9,
+        "count-weighted {}",
+        r.value(&count)
+    );
+}
+
+/// The recompute path must match a direct from-scratch weighted median over the
+/// retained count window across a non-trivial sequence — i.e. eviction and
+/// weighting have not drifted. Slide a window of 5 and compare the final value.
+#[test]
+fn rolling_median_time_weighted_matches_brute() {
+    const N: u32 = 120;
+    const W: usize = 5;
+    let seq = |n: u64| ((n * 7) % 11) as f64 - 5.0;
+
+    let g = GraphBuilder::new();
+    let med = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .rolling_median_time_weighted(W);
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(N)).unwrap();
+
+    // count() emits 1..=N at times 0,100,..,(N-1)*100; the count window retains
+    // the last W samples; the observation time is the final tick, (N-1)*100.
+    let now = (N as u64 - 1) * 100;
+    let retained: Vec<(f64, u64)> = ((N as u64 - W as u64 + 1)..=N as u64)
+        .map(|n| (seq(n), (n - 1) * 100))
+        .collect();
+    let expected = brute_time_weighted_median(&retained, now);
+    assert!(
+        (r.value(&med) - expected).abs() < 1e-9,
+        "got {}, expected {expected}",
+        r.value(&med)
+    );
+}
+
+// ── time-windowed time-weighted median ────────────────────────────────────────
+
+/// Time-weighted median over a 250ns window on 100ns ticks holds the last three
+/// samples; each is credited its 100ns interval except the newest (Δt 0). From
+/// the third tick the window has two equal-weight committed values straddling the
+/// crossing, so the median averages them: 1, 1, 1.5, 2.5, 3.5 — at the last tick
+/// the window is {3@200,4@300,5@400}, weights {3:100,4:100} → (3+4)/2 = 3.5.
+/// Mirrors the classic `median(Window::Time(_), Weighting::Time)`.
+#[test]
+fn time_windowed_median_time_weighted_series() {
+    let g = GraphBuilder::new();
+    let med = counter_f64(&g)
+        .time_windowed_median_time_weighted(WIN)
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&med), &[1.0, 1.0, 1.5, 2.5, 3.5]);
+}
+
+/// The recompute path must match a direct from-scratch weighted median over the
+/// samples still inside a bounded time window across a non-trivial sequence.
+#[test]
+fn time_windowed_median_time_weighted_matches_brute() {
+    const N: u32 = 90;
+    // 350ns window over 100ns ticks retains ages 0,100,200,300 → four samples.
+    const WIN_NS: u64 = 350;
+    let win = Duration::from_nanos(WIN_NS);
+    let seq = |n: u64| ((n * 5) % 13) as f64 - 6.0;
+
+    let g = GraphBuilder::new();
+    let med = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n| seq(*n))
+        .time_windowed_median_time_weighted(win);
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(N)).unwrap();
+
+    // count() emits 1..=N at times 0,100,..,(N-1)*100; final now = (N-1)*100.
+    // Retained = samples within WIN_NS of now (age <= WIN_NS).
+    let now = (N as u64 - 1) * 100;
+    let retained: Vec<(f64, u64)> = (1..=N as u64)
+        .map(|n| (n, (n - 1) * 100))
+        .filter(|&(_, t)| now - t <= WIN_NS)
+        .map(|(n, t)| (seq(n), t))
+        .collect();
+    let expected = brute_time_weighted_median(&retained, now);
+    assert!(
+        (r.value(&med) - expected).abs() < 1e-9,
+        "got {}, expected {expected}",
+        r.value(&med)
+    );
+}
+
+// ── cross-window and tick-time parity ─────────────────────────────────────────
+
+/// A count window wide enough never to evict must equal the cumulative
+/// (unbounded) time-weighted median tick-for-tick — the two share the same
+/// recompute buffer, differing only in eviction, which a large window disables.
+#[test]
+fn wide_count_window_time_weighted_median_matches_cumulative() {
+    let g = GraphBuilder::new();
+    let rolling = counter_f64(&g)
+        .rolling_median_time_weighted(1_000)
+        .accumulate();
+    let cumulative = counter_f64(&g)
+        .cumulative_median_time_weighted()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_series_approx(&r.value(&rolling), &r.value(&cumulative));
+}
+
+/// A constant stream's time-weighted median is that constant (all retained
+/// samples share the value), and never `NaN`.
+#[test]
+fn cumulative_median_time_weighted_of_constant_is_constant() {
+    let g = GraphBuilder::new();
+    let med = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(|_| 7.0)
+        .cumulative_median_time_weighted()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    for v in r.value(&med) {
+        assert!(!v.is_nan(), "median must not be NaN");
+        assert!(
+            (v - 7.0).abs() < 1e-10,
+            "constant stream median should be 7.0, got {v}"
+        );
+    }
+}
+
+/// A time-weighted median op ticks once per upstream tick (the weighting and
+/// eviction are internal), so the emitted times are exactly the ticker's:
+/// 0,100,200,300,400ns. Pin both the tick times and the paired median values.
+#[test]
+fn time_weighted_median_tick_times_match_upstream() {
+    let g = GraphBuilder::new();
+    let acc = counter_f64(&g)
+        .cumulative_median_time_weighted()
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    let series = r.value(&acc);
+    let times: Vec<u64> = series.iter().map(|(t, _)| u64::from(*t)).collect();
+    let values: Vec<f64> = series.iter().map(|(_, v)| *v).collect();
+    assert_eq!(vec![0, 100, 200, 300, 400], times);
+    assert_series_approx(&values, &[1.0, 1.0, 1.5, 2.0, 2.5]);
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -458,7 +458,7 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
 
 1. **statistics** — pure computation, the largest single chunk, huge test
    suite, zero IO. Best stress test of engine-owned state; do it first.
-   🟡 *started*: the statistics families are largely ported with parity
+   ✅ *done*: the statistics families are ported with parity
    tests — exponential (`Ewma`, PerTick + clock-driven HalfLife,
    `tests/statistics.rs`); count-windowed rolling
    (`RollingSum`/`Mean`/`Min`/`Max`/`Var`/`Std`/`Median` — monotonic-deque and
@@ -472,12 +472,13 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    (`Weighting::Time`, mean/var/std over all three windows —
    `{Cumulative,Rolling,TimeWindowed}{Mean,Var,Std}TimeWeighted`, West's
    incremental weighted moments with an exact `remove` inverse for the sliding
-   windows, `tests/statistics_time_weighted.rs`) is now ported too. Remaining:
-   the time-*weighted* **median** (`median(_, Weighting::Time)` → the classic
-   `WindowStream::weighted_median`) — the count-weighted medians are ported but
-   the time-weighted median is not yet; it is a distinct path (recompute-per-tick
-   weighted median, not a moment) and the last classic statistics capability
-   outstanding.
+   windows, `tests/statistics_time_weighted.rs`) is ported. The final classic
+   statistics capability — the time-*weighted* **median**
+   (`median(_, Weighting::Time)` → the classic `WindowStream::weighted_median`;
+   `{Cumulative,Rolling,TimeWindowed}MedianTimeWeighted`, a recompute-per-tick
+   weighted median over the retained `(value, time)` window rather than a moment
+   accumulator, `tests/statistics_time_weighted_median.rs`) is now ported too, so
+   the statistics adapter is complete.
 2. **cache**, **common** (WindowFilter) — small, pure.
    ✅ *done*: **common** ports the always-compiled `TimeWindow`/`WindowFilter`
    out-of-window row filter (`adapters::common`, `tests/common_adapter.rs`);


### PR DESCRIPTION
## Summary

Ports the final outstanding classic statistics capability — the **time-weighted median** (`median(_, Weighting::Time)`) — into `wingfoil-next`, across all three windows (cumulative / rolling count / time-windowed). With this, the statistics adapter is complete (Phase 4 item 1 in `next/docs/port-plan.md`).

## Algorithm

Unlike the time-weighted *moments* (an incremental West's-algorithm accumulator), the median has no cheap incremental form, so — exactly like the classic `WindowStream::weighted_median` — it **recomputes over the retained `(value, time)` window each tick**:

1. weight every retained sample by the interval it was in effect — the gap to its successor in the buffer, and the most recent sample by the gap to `now` (which is zero, since it was just pushed at `now`, so the newest sample carries no weight until the next tick advances the clock);
2. drop zero-weight samples; if every retained sample has zero weight, return the latest value;
3. sort by value and return the value at which cumulative weight first crosses half the total — an exact-boundary crossing averages the two straddling values, so unit-length intervals reproduce the even-count average (matching the count-weighted median);
4. the leading edge uses only retained samples (count/time eviction happens first), so a value in effect before the window opened is not carried in.

Only the eviction rule differs between the three windows (retain-all / count window / strictly-aged time window), so all three share one `TimeWeightedMedianState` recompute buffer.

## Parity oracle

The classic `median(_, Weighting::Time)` path in `wingfoil/src/adapters/statistics.rs` (`WindowStream` + `for_each_weight` + `weighted_median`). The `weighted_median` algorithm is ported verbatim; the next twin produces identical values and tick times.

## Changes

- **`ops.rs`**: `TimeWeightedMedianState` plus three ops — `CumulativeMedianTimeWeighted`, `RollingMedianTimeWeighted`, `TimeWindowedMedianTimeWeighted`.
- **`stats.rs`**: `StatisticsOps::{cumulative,rolling,time_windowed}_median_time_weighted`, wired the same way as the existing count-weighted medians and time-weighted moments.
- **`tests/statistics_time_weighted_median.rs`**: parity tests pinning both values and tick times under `RunMode::HistoricalFrom(NanoTime::ZERO)` —
  - full pinned series for each window (cumulative `[1,1,1.5,2,2.5]`, rolling(4) `[1,1,1.5,2,3]`, time-windowed(250ns) `[1,1,1.5,2.5,3.5]`);
  - `rolling_median_time_vs_count_weighting_differ` reproduces the classic `rolling_median_time_weighted` assertions (time-weighted 3.0 vs count 3.5);
  - an independent brute-force weighted-median oracle checked over non-trivial sequences for both the count and time windows;
  - wide-count-window == cumulative, constant-stream median, and tick-time parity.
- **`port-plan.md`**: mark the statistics adapter complete.

## Checks

`cargo fmt --all`, `cargo lint`, and `cargo lint-all` all pass. `cargo test -p wingfoil-next --all-features` passes for every test binary (the new median suite: 9/9); the only failures are the Docker-gated integration tests (`etcd_integration`, etc.) which cannot start containers in this environment (`/var/run/docker.sock` missing) — unrelated to this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_