### PR TITLE
wingfoil-next: close dynamic-graph parity gaps (StreamStore + demux_it)

### DIFF
--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -3054,10 +3054,76 @@ impl Extension<'_> {
 
 /// One live per-key stream a [`dynamic_group`](Builder::dynamic_group) tracks:
 /// its output value slot and its node index (to read its per-cycle tick flag).
+///
+/// Public only so it can name the value type in a [`StreamStore`] bound on
+/// [`dynamic_group_with_store`](Builder::dynamic_group_with_store); its fields
+/// are engine internals and stay private (a store only ever moves whole
+/// `LiveStream`s around, never inspects them).
 #[cfg(feature = "dynamic-graph")]
-struct LiveStream<T> {
+pub struct LiveStream<T> {
     slot: SlotRef<T>,
     idx: usize,
+}
+
+/// Backing-store abstraction for [`dynamic_group_with_store`](Builder::dynamic_group_with_store)
+/// — the next twin of classic `StreamStore` (`nodes/dynamic_group.rs`). A
+/// `dynamic_group` keeps its live per-key members in one of these; the trait
+/// abstracts over the container so the key can be `Ord` ([`BTreeMap`]) *or*
+/// merely `Hash + Eq` ([`HashMap`]). Blanket impls cover both; implement it for
+/// any other keyed collection.
+///
+/// `BTreeMap` stays the default (via [`dynamic_group`](Builder::dynamic_group)):
+/// its deterministic iteration order is the safer backtest default, and the
+/// per-cycle cost is iterating *live* members regardless of the container.
+#[cfg(feature = "dynamic-graph")]
+pub trait StreamStore<K, V> {
+    /// Insert (or replace) the member stored under `key`.
+    fn store_insert(&mut self, key: K, value: V);
+    /// Remove and return the member stored under `key`, if any.
+    fn store_remove(&mut self, key: &K) -> Option<V>;
+    /// Iterate `(key, member)` pairs in the store's native order.
+    fn store_entries<'a>(&'a self) -> impl Iterator<Item = (&'a K, &'a V)>
+    where
+        K: 'a,
+        V: 'a;
+}
+
+#[cfg(feature = "dynamic-graph")]
+impl<K: Ord, V> StreamStore<K, V> for std::collections::BTreeMap<K, V> {
+    fn store_insert(&mut self, key: K, value: V) {
+        self.insert(key, value);
+    }
+
+    fn store_remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+
+    fn store_entries<'a>(&'a self) -> impl Iterator<Item = (&'a K, &'a V)>
+    where
+        K: 'a,
+        V: 'a,
+    {
+        self.iter()
+    }
+}
+
+#[cfg(feature = "dynamic-graph")]
+impl<K: std::hash::Hash + Eq, V> StreamStore<K, V> for std::collections::HashMap<K, V> {
+    fn store_insert(&mut self, key: K, value: V) {
+        self.insert(key, value);
+    }
+
+    fn store_remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+
+    fn store_entries<'a>(&'a self) -> impl Iterator<Item = (&'a K, &'a V)>
+    where
+        K: 'a,
+        V: 'a,
+    {
+        self.iter()
+    }
 }
 
 #[cfg(feature = "dynamic-graph")]
@@ -3078,9 +3144,11 @@ impl Builder {
     ///   current values — the fresh-read guarantee dynamic groups depend on.
     ///
     /// Runs under [`Runner::run_dynamic`] (its boundary is where the staged
-    /// insert/remove mutations apply). The store is a `BTreeMap`, so `K: Ord`;
-    /// the pluggable-`StreamStore` backends of classic are a deliberate
-    /// ergonomic omission, not a semantic one.
+    /// insert/remove mutations apply). The live members are held in a
+    /// `BTreeMap` (so `K: Ord`); use
+    /// [`dynamic_group_with_store`](Self::dynamic_group_with_store) to back them
+    /// with a `HashMap` (or any [`StreamStore`]) for a `Hash + Eq` key that is
+    /// not `Ord`.
     #[allow(clippy::too_many_arguments)]
     pub fn dynamic_group<K, T, V, Factory, OnTick, OnRemove>(
         &mut self,
@@ -3099,6 +3167,49 @@ impl Builder {
         OnTick: Fn(&mut V, &K, &T) + 'static,
         OnRemove: Fn(&mut V, &K) + 'static,
     {
+        self.dynamic_group_with_store(
+            add,
+            del,
+            factory,
+            std::collections::BTreeMap::new(),
+            init,
+            on_tick,
+            on_remove,
+        )
+    }
+
+    /// Like [`dynamic_group`](Self::dynamic_group) but with the live members
+    /// held in a caller-supplied [`StreamStore`] — the next twin of classic
+    /// `dynamic_group_stream_with_store`. Pass a `HashMap::new()` to key the
+    /// group by a `Hash + Eq` type that is not `Ord`:
+    ///
+    /// ```ignore
+    /// b.dynamic_group_with_store(
+    ///     add, del, factory,
+    ///     std::collections::HashMap::new(), // Hash + Eq key, no Ord needed
+    ///     init, on_tick, on_remove,
+    /// );
+    /// ```
+    #[allow(clippy::too_many_arguments)]
+    pub fn dynamic_group_with_store<K, T, V, S, Factory, OnTick, OnRemove>(
+        &mut self,
+        add: Handle<K>,
+        del: Handle<K>,
+        factory: Factory,
+        store: S,
+        init: V,
+        on_tick: OnTick,
+        on_remove: OnRemove,
+    ) -> Handle<V>
+    where
+        K: Clone + Default + 'static,
+        T: Clone + Default + 'static,
+        V: Clone + Default + 'static,
+        S: StreamStore<K, LiveStream<T>> + 'static,
+        Factory: Fn(&mut Extension<'_>, K) -> Handle<T> + 'static,
+        OnTick: Fn(&mut V, &K, &T) + 'static,
+        OnRemove: Fn(&mut V, &K) + 'static,
+    {
         let idx = self.nodes.len();
         let add_slot = self.slot(add);
         let del_slot = self.slot(del);
@@ -3107,8 +3218,7 @@ impl Builder {
         let pending = self.pending.clone();
         let (add_idx, del_idx) = (add.idx, del.idx);
 
-        let store: Rc<RefCell<std::collections::BTreeMap<K, LiveStream<T>>>> =
-            Rc::new(RefCell::new(std::collections::BTreeMap::new()));
+        let store: Rc<RefCell<S>> = Rc::new(RefCell::new(store));
         let factory = Rc::new(factory);
         let mut value = init;
 
@@ -3134,7 +3244,7 @@ impl Builder {
                         let slot = ext.runner.rt_slot(h);
                         let caller = ext.runner.rt_make_handle::<V>(idx);
                         ext.add_upstream(caller, h, true, true);
-                        store_ins.borrow_mut().insert(
+                        store_ins.borrow_mut().store_insert(
                             key,
                             LiveStream {
                                 slot,
@@ -3150,7 +3260,7 @@ impl Builder {
             if del_t {
                 let key: K = del_slot.borrow().clone();
                 on_remove(&mut value, &key);
-                let removed = store.borrow_mut().remove(&key);
+                let removed = store.borrow_mut().store_remove(&key);
                 if let Some(live) = removed {
                     pending.borrow_mut().push(Box::new(
                         move |runner: &mut Runner, kernel: &mut Kernel| {
@@ -3166,7 +3276,7 @@ impl Builder {
             {
                 let t = ticked.borrow();
                 let members = store.borrow();
-                for (key, live) in members.iter() {
+                for (key, live) in members.store_entries() {
                     if t[live.idx] {
                         let v = live.slot.borrow().clone();
                         on_tick(&mut value, key, &v);
@@ -3197,10 +3307,12 @@ impl Builder {
     /// re-emits the source's current value; the others stay quiet. No nodes are
     /// added or removed — the graph shape is fixed, only the tick is routed.
     ///
-    /// Returns `(children, overflow)`. Unlike classic's `DemuxMap`, key→slot
-    /// assignment and slot release (`DemuxEvent::Close`) are the caller's
-    /// concern here (a deliberately thinner surface over the routing primitive);
-    /// classic's auto-assigning map is a convenience that can layer on top.
+    /// Returns `(children, overflow)`. This is the raw routing primitive:
+    /// key→slot assignment and slot release are the caller's concern. For
+    /// classic's auto-assigning / `Close`-releasing key lifecycle, use
+    /// [`demux_map`](Self::demux_map) (single value) or
+    /// [`demux_it`](Self::demux_it) (a `Burst` per child), which layer a
+    /// [`DemuxMap`] on top of this primitive.
     pub fn demux<T, F>(
         &mut self,
         source: Handle<T>,
@@ -3270,5 +3382,217 @@ impl Builder {
             }
         }
         (children, overflow.expect("overflow child built"))
+    }
+
+    /// Auto-assigning demux — the next twin of classic `demux`
+    /// (`StreamOperators::demux`). Layers a [`DemuxMap`] key lifecycle over the
+    /// raw [`demux`](Self::demux) primitive: each cycle `func(value)` yields a
+    /// key and a [`DemuxEvent`]; the map hands each *new* key a free slot from a
+    /// pool of `capacity`, and [`DemuxEvent::Close`] routes to the key's current
+    /// slot and then releases it back to the pool. Keys arriving with no slot
+    /// free route to the overflow child.
+    ///
+    /// Returns `(children, overflow)` exactly like [`demux`](Self::demux); the
+    /// only added behaviour is the automatic slot bookkeeping.
+    pub fn demux_map<T, K, F>(
+        &mut self,
+        source: Handle<T>,
+        capacity: usize,
+        func: F,
+    ) -> (Vec<Handle<T>>, Handle<T>)
+    where
+        T: Clone + Default + 'static,
+        K: std::hash::Hash + Eq + 'static,
+        F: Fn(&T) -> (K, DemuxEvent) + 'static,
+    {
+        let map = DemuxMap::new(capacity);
+        // `route` returns `capacity` (== size) for overflow, which the raw
+        // `demux` primitive maps to the overflow child.
+        let route = move |v: &T| {
+            let (key, event) = func(v);
+            let slot = match event {
+                DemuxEvent::Close => map.release(&key),
+                DemuxEvent::None => map.get_or_insert(key),
+            };
+            slot.unwrap_or(capacity)
+        };
+        self.demux(source, capacity, route)
+    }
+
+    /// Iterable demux — the next twin of classic `demux_it`
+    /// (`StreamOperators::demux_it`). Where [`demux_map`](Self::demux_map) routes
+    /// one value to one child, this routes *each item* of an iterable source
+    /// value to its keyed child, and every selected child re-emits a
+    /// [`Burst`] of exactly the items routed to it this cycle. Unselected
+    /// children stay quiet. Same [`DemuxMap`] key lifecycle as
+    /// [`demux_map`](Self::demux_map).
+    ///
+    /// Built on the same same-cycle mark-dirty primitive as
+    /// [`demux`](Self::demux) (no engine changes): the parent clears one
+    /// `Burst` slot per child, accumulates each item into its slot's burst, and
+    /// marks that child dirty; each child reads its own burst slice.
+    pub fn demux_it<I, T, K, F>(
+        &mut self,
+        source: Handle<I>,
+        capacity: usize,
+        func: F,
+    ) -> (Vec<Handle<Burst<T>>>, Handle<Burst<T>>)
+    where
+        I: IntoIterator<Item = T> + Clone + Default + 'static,
+        T: Clone + Default + 'static,
+        K: std::hash::Hash + Eq + 'static,
+        F: Fn(&T) -> (K, DemuxEvent) + 'static,
+    {
+        self.has_marks = true;
+        let source_slot = self.slot(source);
+        let map = DemuxMap::new(capacity);
+
+        // Parent: publishes one `Burst` per child (capacity children + 1
+        // overflow), routes each source item into its slot's burst, and marks
+        // that child. It never ticks itself (`Ok(false)`).
+        let parent_idx = self.nodes.len();
+        let parent_out = self.new_slot(vec![Burst::<T>::new(); capacity + 1]);
+        let child_indices: Rc<RefCell<Vec<usize>>> = Rc::new(RefCell::new(Vec::new()));
+        let marks = self.marks.clone();
+        let idxs_cycle = child_indices.clone();
+        let publish = parent_out.clone();
+        let cycle: CycleFn = Box::new(move |_k| {
+            let items = source_slot.borrow().clone();
+            let mut rows = publish.borrow_mut();
+            for row in rows.iter_mut() {
+                row.clear();
+            }
+            for item in items {
+                let (key, event) = func(&item);
+                let slot = match event {
+                    DemuxEvent::Close => map.release(&key),
+                    DemuxEvent::None => map.get_or_insert(key),
+                }
+                .unwrap_or(capacity); // overflow slot == capacity (last row)
+                rows[slot].push(item);
+                let target = idxs_cycle.borrow()[slot];
+                marks.borrow_mut().push(target);
+            }
+            Ok(false)
+        });
+        self.push_node(
+            vec![source.idx],
+            Activation::NONE,
+            "demux_it",
+            cycle,
+            Box::new(|_| Ok(())),
+        );
+
+        // `capacity` children + 1 overflow; each reads its own burst slice from
+        // the parent's published vec (passive, so it drains after the mark) and
+        // fires only when the parent marked it.
+        let mut children = Vec::with_capacity(capacity);
+        let mut overflow = None;
+        for slot in 0..=capacity {
+            let child_idx = self.nodes.len();
+            let read = parent_out.clone();
+            let out = self.new_slot(Burst::<T>::new());
+            let cycle: CycleFn = Box::new(move |_k| {
+                let v = read.borrow()[slot].clone();
+                *out.borrow_mut() = v;
+                Ok(true)
+            });
+            self.push_node(
+                Vec::new(),
+                Activation::NONE,
+                "demux_it_child",
+                cycle,
+                Box::new(|_| Ok(())),
+            );
+            self.set_passive_ups(child_idx, vec![parent_idx]);
+            child_indices.borrow_mut().push(child_idx);
+            let handle = self.make_handle::<Burst<T>>(child_idx);
+            if slot < capacity {
+                children.push(handle);
+            } else {
+                overflow = Some(handle);
+            }
+        }
+        (children, overflow.expect("overflow child built"))
+    }
+}
+
+/// Signals, for a demuxed value, whether it opens/continues a key's slot or
+/// releases it. The next twin of classic `DemuxEvent` (`nodes/demux.rs`), used
+/// by [`Builder::demux_map`] and [`Builder::demux_it`].
+#[cfg(feature = "dynamic-graph")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DemuxEvent {
+    /// Route to the key's slot, assigning a free slot if the key is new.
+    None,
+    /// Route to the key's current slot, then release it back to the pool.
+    Close,
+}
+
+/// Auto-assigning key→slot map backing [`Builder::demux_map`] /
+/// [`Builder::demux_it`] — the next twin of classic `DemuxMap`
+/// (`nodes/demux.rs`). Hands each new key a free slot from a pool of `capacity`;
+/// [`DemuxEvent::Close`] frees a key's slot again. A key that arrives with no
+/// slot free is pinned to overflow until it is released.
+#[cfg(feature = "dynamic-graph")]
+struct DemuxMap<K: std::hash::Hash + Eq> {
+    inner: RefCell<DemuxMapInner<K>>,
+}
+
+#[cfg(feature = "dynamic-graph")]
+struct DemuxMapInner<K: std::hash::Hash + Eq> {
+    /// Slots `0..capacity` not currently assigned to a key. A `BTreeSet` (not
+    /// classic's `HashSet`) so a new key always claims the *lowest* free slot —
+    /// making slot assignment deterministic, the safer backtest default.
+    available: std::collections::BTreeSet<usize>,
+    /// Assigned keys → their slot (`None` means the key overflowed: no slot was
+    /// free when it first arrived).
+    in_use: std::collections::HashMap<K, Option<usize>>,
+}
+
+#[cfg(feature = "dynamic-graph")]
+impl<K: std::hash::Hash + Eq> DemuxMap<K> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            inner: RefCell::new(DemuxMapInner {
+                available: (0..capacity).collect(),
+                in_use: std::collections::HashMap::new(),
+            }),
+        }
+    }
+
+    /// Return the key's slot (`Some(ix)`), assigning a free one if the key is
+    /// new; `None` means overflow (already-overflowed key, or no slot free).
+    fn get_or_insert(&self, key: K) -> Option<usize> {
+        let mut m = self.inner.borrow_mut();
+        if let Some(entry) = m.in_use.get(&key) {
+            return *entry;
+        }
+        match m.available.iter().next().copied() {
+            Some(ix) => {
+                m.available.remove(&ix);
+                m.in_use.insert(key, Some(ix));
+                Some(ix)
+            }
+            None => {
+                m.in_use.insert(key, None);
+                None
+            }
+        }
+    }
+
+    /// Route the key's final value to its current slot, then free that slot back
+    /// to the pool. `None` means overflow. Releasing an unknown key routes to any
+    /// currently-free slot (classic parity) without mutating the pool.
+    fn release(&self, key: &K) -> Option<usize> {
+        let mut m = self.inner.borrow_mut();
+        match m.in_use.remove(key) {
+            Some(Some(ix)) => {
+                m.available.insert(ix);
+                Some(ix)
+            }
+            Some(None) => None,
+            None => m.available.iter().next().copied(),
+        }
     }
 }

--- a/next/crates/wingfoil-next/tests/dynamic_graph.rs
+++ b/next/crates/wingfoil-next/tests/dynamic_graph.rs
@@ -403,3 +403,185 @@ fn demux_routes_excess_to_overflow() {
         "overflow (slots >= size)"
     );
 }
+
+/// A key type that is `Hash + Eq` but deliberately **not** `Ord` — so it cannot
+/// back a `BTreeMap`. `dynamic_group_with_store(HashMap::new(), …)` must accept
+/// it (and would fail to compile if a `K: Ord` bound leaked through).
+#[derive(Clone, Default, PartialEq, Eq, Hash, Debug)]
+struct SymbolId(u64);
+
+/// `StreamStore` parity: the same live-price-book group as
+/// `dynamic_group_maintains_a_live_price_book`, but backed by a `HashMap` keyed
+/// by a non-`Ord` `SymbolId`. Proves the pluggable backing store lets a
+/// `Hash + Eq` key flow through where the default `BTreeMap` (`K: Ord`) could
+/// not. The final assertion compares whole `HashMap`s, so `HashMap`'s
+/// nondeterministic iteration order does not affect it.
+#[test]
+fn dynamic_group_with_store_supports_non_ord_hashmap_key() {
+    use std::collections::HashMap;
+
+    let g = GraphBuilder::new();
+    let n = g.ticker(Duration::from_nanos(1)).count(); // 1, 2, 3, …
+    // Shared feed: (SymbolId(key), price) with key alternating 1,0,1,0,… and
+    // price = 10*cycle.
+    let feed = n.map(|c: &u64| (SymbolId(c % 2), c * 10)).handle();
+    // Same schedule as the BTreeMap oracle: add key0 at cycle 1, key1 at cycle
+    // 2; delete key0 at cycle 4, with a no-op delete of a missing key at cycle 5
+    // to trigger the group early (the fix_layers exercise).
+    let add = n
+        .map_filter(|c: &u64| (SymbolId(if *c == 1 { 0 } else { 1 }), *c == 1 || *c == 2))
+        .handle();
+    let del = n
+        .map_filter(|c: &u64| (SymbolId(if *c == 4 { 0 } else { 99 }), *c == 4 || *c == 5))
+        .handle();
+
+    let book = g.with_builder(|b| {
+        b.dynamic_group_with_store(
+            add,
+            del,
+            move |ext: &mut Extension<'_>, k: SymbolId| {
+                let selected = ext.filter_value(feed, move |(i, _): &(SymbolId, u64)| *i == k);
+                ext.map(selected, |(_, px): &(SymbolId, u64)| *px)
+            },
+            // Members store: a HashMap keyed by the non-Ord SymbolId. Its value
+            // type (the engine's internal LiveStream) is inferred, so no private
+            // type is named here.
+            HashMap::new(),
+            // Output book (the aggregated value V).
+            HashMap::<SymbolId, u64>::new(),
+            |book: &mut HashMap<SymbolId, u64>, key: &SymbolId, price: &u64| {
+                book.insert(key.clone(), *price);
+            },
+            |book: &mut HashMap<SymbolId, u64>, key: &SymbolId| {
+                book.remove(key);
+            },
+        )
+    });
+
+    let mut runner = g.build();
+    runner
+        .run_dynamic(HISTORICAL, RunFor::Cycles(6), |_ext, _cycle| Ok(()))
+        .unwrap();
+
+    // key0 tracked on cycle 2 (20), removed at cycle 4; key1 tracked on cycles 3
+    // (30) and 5 (50). Final book holds only the live key 1 at 50.
+    let final_book = runner.value(book);
+    assert_eq!(
+        final_book,
+        HashMap::from([(SymbolId(1), 50u64)]),
+        "final price book (HashMap-backed, non-Ord key)"
+    );
+}
+
+/// `demux_map` (twin of classic `StreamOperators::demux`): the auto-assigning
+/// `DemuxMap` key lifecycle over the raw `demux` primitive. Each new key claims
+/// a free slot from the pool of `capacity`; `DemuxEvent::Close` routes to the
+/// key's current slot then frees it; a key with no slot free lands on overflow.
+///
+/// With `capacity = 2`, feeding `(key, payload = cycle)`:
+/// c1 (1,None)→slot0, c2 (2,None)→slot1, c3 (3,None)→overflow (pool full),
+/// c4 (1,Close)→slot0 then frees it, c5 (4,None)→slot0 (reused), c6 (2,None)→slot1.
+#[test]
+fn demux_map_auto_assigns_and_releases_slots() {
+    use wingfoil_next::interp::DemuxEvent;
+
+    let g = GraphBuilder::new();
+    let n = g.ticker(Duration::from_nanos(1)).count(); // 1..=6
+    // (key, event) schedule indexed by cycle; payload is the cycle number.
+    let src = n
+        .map(|c: &u64| {
+            let (key, close) = match *c {
+                1 => (1u64, false),
+                2 => (2, false),
+                3 => (3, false),
+                4 => (1, true), // Close releases key 1's slot
+                5 => (4, false),
+                _ => (2, false),
+            };
+            (key, *c, close)
+        })
+        .handle();
+
+    let (children, overflow) = g.with_builder(|b| {
+        b.demux_map(src, 2, |(key, _payload, close): &(u64, u64, bool)| {
+            let event = if *close {
+                DemuxEvent::Close
+            } else {
+                DemuxEvent::None
+            };
+            (*key, event)
+        })
+    });
+    // Collect the payload routed to each child.
+    let c0 = g
+        .wrap(children[0])
+        .map(|(_, p, _): &(u64, u64, bool)| *p)
+        .accumulate();
+    let c1 = g
+        .wrap(children[1])
+        .map(|(_, p, _): &(u64, u64, bool)| *p)
+        .accumulate();
+    let ov = g
+        .wrap(overflow)
+        .map(|(_, p, _): &(u64, u64, bool)| *p)
+        .accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+
+    assert_eq!(
+        runner.value(&c0),
+        vec![1u64, 4, 5],
+        "slot 0: key1, key1 close, key4"
+    );
+    assert_eq!(runner.value(&c1), vec![2u64, 6], "slot 1: key2 twice");
+    assert_eq!(runner.value(&ov), vec![3u64], "overflow: key3 (pool full)");
+}
+
+/// `demux_it` (twin of classic `StreamOperators::demux_it`): routes *each item*
+/// of an iterable source value to its keyed child, and every selected child
+/// re-emits a `Burst` of exactly the items routed to it this cycle. Same
+/// `DemuxMap` lifecycle as `demux_map`; unselected children stay quiet.
+///
+/// With `capacity = 2` and keys = the item value: cycle 1 emits `[10, 20]` (key
+/// 10 → slot0, key 20 → slot1); cycle 2 emits `[10, 20, 30]` (30 is new with the
+/// pool full → overflow).
+#[test]
+fn demux_it_routes_each_item_to_a_burst_per_child() {
+    use wingfoil_next::interp::DemuxEvent;
+
+    let g = GraphBuilder::new();
+    let n = g.ticker(Duration::from_nanos(1)).count(); // 1, 2
+    let src = n
+        .map(|c: &u64| {
+            if *c == 1 {
+                vec![10u64, 20]
+            } else {
+                vec![10u64, 20, 30]
+            }
+        })
+        .handle();
+
+    let (children, overflow) =
+        g.with_builder(|b| b.demux_it(src, 2, |v: &u64| (*v, DemuxEvent::None)));
+    let c0 = g.wrap(children[0]).accumulate();
+    let c1 = g.wrap(children[1]).accumulate();
+    let ov = g.wrap(overflow).accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(2)).unwrap();
+
+    // child0 (key 10) and child1 (key 20) fire both cycles; overflow (key 30)
+    // only cycle 2. Each burst holds exactly the items routed to that child.
+    assert_eq!(
+        runner.value(&c0),
+        vec![burst![10u64], burst![10u64]],
+        "child 0 (key 10)"
+    );
+    assert_eq!(
+        runner.value(&c1),
+        vec![burst![20u64], burst![20u64]],
+        "child 1 (key 20)"
+    );
+    assert_eq!(runner.value(&ov), vec![burst![30u64]], "overflow (key 30)");
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -564,25 +564,32 @@ tombstoned, not freed (classic parity). Parity tests in
 `tests/dynamic_graph.rs`.
 
 **Known parity gaps (for the cutover audit).** The runtime *behaviour* is a
-faithful twin (values + tick times match classic's oracles); what next omits so
-far is ergonomic surface, not mechanism:
+faithful twin (values + tick times match classic's oracles). The two
+dynamic-graph ergonomic gaps below are now **closed** (both were ergonomic
+surface over the existing mechanism — no engine/staging changes):
 
-- **`StreamStore` (pluggable `dynamic_group` backing store).** next's
-  `dynamic_group` hardcodes a `BTreeMap` (so `K: Ord`); classic is generic over
-  a `StreamStore` trait with `BTreeMap`/`HashMap` blanket impls. This is
-  deliberately deferred, not just unfinished. The only capability it actually
-  unlocks is a key type that is `Hash + Eq` but **not** `Ord` (the container
-  choice is otherwise near-irrelevant to cost — the per-cycle work is iterating
-  *live* members, O(members), regardless of backing store). And `HashMap`'s
-  nondeterministic iteration order is a mild footgun against backtest
-  determinism, so `BTreeMap`-only is arguably the *safer* default, not merely a
-  smaller one. Re-add the trait (a mechanical ~20-min change: one trait param +
-  two blanket impls, touching no engine/staging code) if the cutover requires
-  strict signature parity or a real non-`Ord` key appears — not speculatively.
-- **`DemuxMap` key lifecycle + `demux_it`.** next's `demux` exposes the raw
-  routing primitive (`route(value) -> slot` + overflow); classic's
-  auto-assigning/`Close`-releasing `DemuxMap` and the `Burst` `demux_it` variant
-  layer on top of it and can be added without engine changes.
+- **`StreamStore` (pluggable `dynamic_group` backing store). ✅ closed.**
+  `Builder::dynamic_group_with_store` takes a caller-supplied
+  [`StreamStore`]-implementing container for the group's live members; the
+  `StreamStore` trait (one value type param) has blanket impls for `BTreeMap`
+  (`K: Ord`) and `HashMap` (`K: Hash + Eq`). `dynamic_group` is unchanged — it
+  delegates with a `BTreeMap`, still the default (deterministic iteration is the
+  safer backtest default). The added capability is a `Hash + Eq` key that is not
+  `Ord`; the container is otherwise irrelevant to cost (per-cycle work iterates
+  *live* members, O(members), regardless of backing store). Parity test:
+  `dynamic_group_with_store_supports_non_ord_hashmap_key` in
+  `tests/dynamic_graph.rs`.
+- **`DemuxMap` key lifecycle + `demux_it`. ✅ closed.** `Builder::demux` stays
+  the raw routing primitive (`route(value) -> slot` + overflow). Layered on top
+  of it (no engine changes): `Builder::demux_map` (twin of classic
+  `StreamOperators::demux`) adds the auto-assigning / `Close`-releasing
+  `DemuxMap` key lifecycle over a single value, and `Builder::demux_it` (twin of
+  classic `demux_it`) routes each item of an iterable source value to its keyed
+  child, each selected child re-emitting a `Burst` of exactly its items. next's
+  `DemuxMap` assigns the *lowest* free slot (a `BTreeSet` pool rather than
+  classic's `HashSet`), so slot assignment is deterministic. Parity tests:
+  `demux_map_auto_assigns_and_releases_slots` and
+  `demux_it_routes_each_item_to_a_burst_per_child`.
 
 **Two follow-ons remain, both deliberately separated from the scheduler:**
 


### PR DESCRIPTION
Closes the two named engine parity gaps in `wingfoil-next`'s dynamic-graph support (the Phase 4.5 "Known parity gaps" in `next/docs/port-plan.md`). Both are ergonomic surface layered over the existing engine mechanism — **no engine/staging changes**.

## Gap 1 — `StreamStore` (pluggable `dynamic_group` backing store)

**Was:** next's `dynamic_group` hardcoded a `BTreeMap` for its live per-key members (so `K: Ord`). Classic is generic over a `StreamStore` trait with `BTreeMap`/`HashMap` blanket impls.

**Now closed:**
- Added a `StreamStore<K, V>` trait (one value-type param) with blanket impls for `BTreeMap` (`K: Ord`) and `HashMap` (`K: Hash + Eq`) — the next twin of classic's trait in `nodes/dynamic_group.rs`.
- Added `Builder::dynamic_group_with_store`, which takes a caller-supplied store for the group's live members. The value type (the engine-internal `LiveStream`) is inferred, so the caller only writes `HashMap::new()` — no private type named.
- `Builder::dynamic_group` is unchanged (existing call sites untouched) and delegates with a `BTreeMap`, still the default — deterministic iteration is the safer backtest default, and the container is otherwise irrelevant to cost (per-cycle work iterates *live* members, O(members)). The added capability is a `Hash + Eq` key that is not `Ord`.

## Gap 2 — `DemuxMap` key lifecycle + `demux_it`

**Was:** next's `demux` exposed only the raw routing primitive (`route(value) -> slot` + overflow). Classic layers an auto-assigning / `Close`-releasing `DemuxMap` and a `Burst` `demux_it` variant on top.

**Now closed (all on top of the existing mark-dirty primitive):**
- `Builder::demux` stays the raw routing primitive.
- Added `Builder::demux_map` — twin of classic `StreamOperators::demux`: the auto-assigning / `Close`-releasing `DemuxMap` key lifecycle over a single value.
- Added `Builder::demux_it` — twin of classic `demux_it`: routes each item of an iterable source value to its keyed child, each selected child re-emitting a `Burst` of exactly the items routed to it this cycle.
- Added the public `DemuxEvent` enum (`None`/`Close`).
- next's `DemuxMap` assigns the **lowest** free slot (a `BTreeSet` pool rather than classic's `HashSet`), so slot assignment is deterministic — a small improvement over classic that aids backtest determinism (routing correctness is identical).

## Tests (`tests/dynamic_graph.rs`, `dynamic-graph` feature)

- `dynamic_group_with_store_supports_non_ord_hashmap_key` — a `Hash + Eq` non-`Ord` key flowing through a `HashMap`-backed group (would fail to compile if a `K: Ord` bound leaked).
- `demux_map_auto_assigns_and_releases_slots` — slot assignment, `Close` release + reuse, and overflow when the pool is full.
- `demux_it_routes_each_item_to_a_burst_per_child` — per-child `Burst` accumulation and overflow.

## Docs

- Updated the deferred-gap doc comments in `interp.rs` (`dynamic_group`, `demux`).
- Updated the "Known parity gaps" section in `next/docs/port-plan.md` to mark both gaps ✅ closed.

## Checks

`cargo fmt --all`, `cargo lint`, and `cargo lint-all` all pass. `cargo test -p wingfoil-next --all-features` passes for every suite (dynamic_graph: 14/14); the only failures are the `etcd_integration` tests, which require a live etcd/Docker container and are unrelated to this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_