### PR TITLE
wingfoil-next: port the prometheus adapter (Phase 4.7)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,6 +40,11 @@ jobs:
     uses: ./.github/workflows/prometheus-integration.yml
     secrets: inherit
 
+  prometheus-next-integration:
+    name: Prometheus (next) Integration Tests
+    uses: ./.github/workflows/prometheus-next-integration.yml
+    secrets: inherit
+
   otlp-integration:
     name: OTLP Integration Tests
     uses: ./.github/workflows/otlp-integration.yml

--- a/.github/workflows/prometheus-next-integration.yml
+++ b/.github/workflows/prometheus-next-integration.yml
@@ -1,0 +1,68 @@
+name: test.integration.prometheus-next
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    paths:
+      - 'next/crates/wingfoil-next/src/adapters/prometheus**'
+      - 'next/crates/wingfoil-next/tests/prometheus_integration.rs'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  prometheus-next-integration:
+    name: Prometheus (next) Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
+
+      - name: Start Grafana + Prometheus stack
+        # Reuses the classic prometheus adapter's Docker stack — the exporter's
+        # `/metrics` text format is identical, and the stack scrapes
+        # WINGFOIL_METRICS_PORT (9091) on the host.
+        run: docker compose up -d
+        working-directory: wingfoil/src/adapters/prometheus/docker
+
+      - name: Wait for Prometheus to be healthy
+        run: |
+          for i in $(seq 1 12); do
+            if curl -sf http://localhost:9090/-/healthy > /dev/null; then
+              echo "Prometheus is up"
+              break
+            fi
+            echo "Waiting for Prometheus... ($i/12)"
+            sleep 5
+          done
+          curl -sf http://localhost:9090/-/healthy || (echo "Prometheus never became healthy" && exit 1)
+
+      - name: Run Prometheus (next) integration tests
+        run: |
+          cargo test --features prometheus-integration-test -p wingfoil-next \
+            -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO
+          PROMETHEUS_TEST_URL: http://localhost:9090
+          WINGFOIL_METRICS_PORT: "9091"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose logs
+        working-directory: wingfoil/src/adapters/prometheus/docker
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down
+        working-directory: wingfoil/src/adapters/prometheus/docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7673,6 +7673,7 @@ name = "wingfoil-next"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-stream",
  "augurs",
  "bincode",
@@ -7681,6 +7682,7 @@ dependencies = [
  "etcd-client",
  "futures",
  "log",
+ "reqwest",
  "serde",
  "serde-aux",
  "sha2 0.10.9",

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -74,6 +74,18 @@ testcontainers = { version = "0.27", features = [
     "blocking",
 ], optional = true }
 
+# `prometheus` feature: a realtime, pull-based metrics sink serving a hand-rolled
+# `GET /metrics` endpoint (no Prometheus client crate — just `std::net` + a
+# lock-free `arc-swap` slot per metric). `reqwest` (used only by the end-to-end
+# scrape integration test) is an optional [dependencies] entry because feature
+# flags cannot gate dev-dependencies. Versions mirror the classic `wingfoil`
+# crate's prometheus adapter so the two trees don't drift.
+arc-swap = { version = "1.7", optional = true }
+reqwest = { version = "0.12", features = [
+    "json",
+    "blocking",
+], optional = true }
+
 [dev-dependencies]
 # Compile-fail tests pinning the `graph!` macro's key error paths.
 trybuild = "1"
@@ -90,6 +102,11 @@ cache = ["dep:sha2", "dep:bincode", "dep:serde", "async", "tokio/fs"]
 augurs = ["dep:augurs"]
 etcd = ["dep:etcd-client", "dep:async-stream", "async"]
 etcd-integration-test = ["etcd", "dep:testcontainers"]
+# Realtime pull-based Prometheus metrics sink (hand-rolled HTTP + `arc-swap`).
+prometheus = ["dep:arc-swap"]
+# Adds the end-to-end scrape test (a live Prometheus scraping the exporter);
+# `reqwest` (blocking) queries Prometheus. Mirrors classic wingfoil.
+prometheus-integration-test = ["prometheus", "dep:reqwest"]
 # Runtime graph dynamism: append nodes and splice edges into a live graph
 # mid-run (`Runner::run_dynamic` + `Extension`). Mirrors classic wingfoil's
 # `dynamic-graph` feature; off the default hot path until wired in. The layered
@@ -135,6 +152,10 @@ required-features = ["augurs"]
 [[example]]
 name = "etcd_adapter"
 required-features = ["etcd"]
+
+[[example]]
+name = "prometheus_adapter"
+required-features = ["prometheus"]
 
 # Ports of the classic `wingfoil/examples/` onto the next engine's fluent API.
 # Each lives in its own directory with a README, mirroring the classic layout.

--- a/next/crates/wingfoil-next/examples/prometheus_adapter.rs
+++ b/next/crates/wingfoil-next/examples/prometheus_adapter.rs
@@ -1,0 +1,46 @@
+//! prometheus adapter example — serve `GET /metrics` so Grafana can scrape a
+//! wingfoil stream value.
+//!
+//! A port of the classic `wingfoil/examples/telemetry/prometheus` example onto
+//! the next engine. The exporter serves the Prometheus text format on port 9091;
+//! point Grafana's Prometheus data source at it (or scrape it directly).
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example prometheus_adapter --features prometheus
+//! ```
+//!
+//! Then scrape it:
+//!
+//! ```sh
+//! curl http://localhost:9091/metrics
+//! # TYPE wingfoil_ticks_total gauge
+//! wingfoil_ticks_total 5
+//! ```
+//!
+//! Press Ctrl+C to stop.
+
+use std::time::Duration;
+
+use wingfoil::{RunFor, RunMode};
+use wingfoil_next::adapters::prometheus::{PrometheusExporter, PrometheusSinkOps};
+use wingfoil_next::prelude::*;
+
+fn main() -> anyhow::Result<()> {
+    // Bind the exporter synchronously so a bind error surfaces before the run.
+    let exporter = PrometheusExporter::new("0.0.0.0:9091");
+    let port = exporter.serve()?;
+    println!("Prometheus metrics available at http://localhost:{port}/metrics");
+
+    let g = GraphBuilder::new();
+    // The gauge sink is wired into `g` at this call; the returned handle is the
+    // graph's only root. Run it forever (Ctrl+C stops).
+    let _metric = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .prometheus_gauge(&exporter, "wingfoil_ticks_total");
+
+    g.build().run(RunMode::RealTime, RunFor::Forever)?;
+    Ok(())
+}

--- a/next/crates/wingfoil-next/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next/src/adapters/mod.rs
@@ -26,6 +26,10 @@
 //! - [`common`] — helpers shared across adapters (the out-of-window row
 //!   [`WindowFilter`](common::WindowFilter) for caller-parameterised historical
 //!   replays). Always compiled, dependency-light.
+//! - [`prometheus`] — a realtime, pull-based metrics sink serving a
+//!   `GET /metrics` endpoint in Prometheus text format (register streams as
+//!   gauges via `PrometheusSinkOps::prometheus_gauge`), behind the `prometheus`
+//!   feature. A sink only; a no-op under historical replay.
 
 #[cfg(feature = "augurs")]
 pub mod augurs;
@@ -37,3 +41,5 @@ pub mod csv;
 #[cfg(feature = "etcd")]
 pub mod etcd;
 pub mod lines;
+#[cfg(feature = "prometheus")]
+pub mod prometheus;

--- a/next/crates/wingfoil-next/src/adapters/prometheus.rs
+++ b/next/crates/wingfoil-next/src/adapters/prometheus.rs
@@ -1,0 +1,285 @@
+//! prometheus adapter — a realtime, pull-based metrics **sink**: it serves a
+//! hand-rolled `GET /metrics` endpoint in Prometheus text format so Grafana (or
+//! any Prometheus-compatible system) can scrape stream values. It ports the
+//! classic `wingfoil::adapters::prometheus` module onto the Op model.
+//!
+//! # Layering
+//!
+//! Following the [`lines`](crate::adapters::lines) / [`stats`](crate::stats)
+//! pattern, the adapter is *not* in the [`prelude`](crate::prelude) and is gated
+//! behind the `prometheus` feature (it pulls in `arc-swap` only — the HTTP
+//! server is `std::net`, no Prometheus client crate). Bring in what you need
+//! explicitly:
+//!
+//! - **Exporter** — [`PrometheusExporter`]: owns the metric registry and spawns
+//!   the HTTP server thread ([`serve`](PrometheusExporter::serve)).
+//! - **Sink** — the [`PrometheusSinkOps`] extension trait on any `Stream<T>`
+//!   whose values are [`Display`], enabled with
+//!   `use wingfoil_next::adapters::prometheus::PrometheusSinkOps;`. Register a
+//!   stream as a gauge with [`prometheus_gauge`](PrometheusSinkOps::prometheus_gauge)
+//!   and add the returned sink `Stream<()>` to the graph.
+//!
+//! # Sink (the metric slot model)
+//!
+//! Each registered stream gets its own lock-free
+//! `Arc<ArcSwapOption<String>>` slot. On every realtime cycle the sink
+//! stringifies the stream's current value and publishes it into the slot with a
+//! single atomic pointer swap — never a lock on the graph thread. The HTTP
+//! scrape thread snapshots the registry (locked only at registration and once
+//! per scrape, off the graph thread), then loads each slot to render the
+//! response. A slot that has never been written (`None`) is omitted from the
+//! response.
+//!
+//! # Historical / backtesting mode
+//!
+//! The exporter is a **realtime** concept. Under
+//! [`RunMode::HistoricalFrom`](wingfoil::RunMode::HistoricalFrom) the sink is a
+//! no-op — no slot is written — so a backtest never publishes fast-forwarded
+//! values to a live endpoint. The HTTP server (if [`serve`](PrometheusExporter::serve)
+//! was called) still answers, but with an empty body. This mirrors classic,
+//! whose metric node detected the run mode in `setup` and short-circuited
+//! `cycle`; next reads it from [`Ctx::run_mode`](crate::op::Ctx::run_mode) in
+//! the cycle itself.
+//!
+//! # Deviations from classic
+//!
+//! Every classic *capability* (the `GET /metrics` text endpoint, per-metric
+//! slots omitted until first written, the historical no-op, the 404 for other
+//! paths, synchronous bind so errors surface before the run) is preserved. The
+//! surface differs in two deliberate ways:
+//!
+//! 1. **The sink is an extension trait, not an exporter method.** Classic called
+//!    `exporter.register(name, stream)`; next uses the sink-as-trait convention
+//!    shared with [`lines`](crate::adapters::lines) / [`etcd`](crate::adapters::etcd):
+//!    `stream.prometheus_gauge(&exporter, name)`. The exporter still owns the
+//!    registry; the trait method registers a slot in it and wires the sink.
+//! 2. **`serve` returns [`anyhow::Result`].** Classic returned
+//!    `Result<u16, std::io::Error>`; next attaches `.context` at the bind, per
+//!    the fallible-with-context convention. The bind is still synchronous, so a
+//!    bind error surfaces at `serve()` time, before the run.
+//!
+//! # Setup (integration test)
+//!
+//! The end-to-end Prometheus scrape test reuses the classic Docker stack:
+//!
+//! ```sh
+//! docker compose -f wingfoil/src/adapters/prometheus/docker/docker-compose.yml up -d
+//! ```
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use arc_swap::ArcSwapOption;
+use wingfoil::RunMode;
+
+use crate::fluent::Stream;
+use crate::op::{Activation, Ctx, Tick};
+
+const READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Latest stringified value for a single metric. `ArcSwapOption` lets the sink
+/// cycle publish a new value with a lock-free atomic pointer swap, and the HTTP
+/// scrape thread read it without coordinating with the graph thread. `None`
+/// means "never ticked" — such slots are omitted from the scrape response so
+/// historical-mode graphs produce an empty body.
+type MetricSlot = Arc<ArcSwapOption<String>>;
+
+/// Registry of all metrics the HTTP thread should render. Only locked when a
+/// new metric is registered (wiring time) and once per HTTP scrape (off the
+/// graph thread) — never from a sink cycle.
+type Registry = Arc<Mutex<Vec<(String, MetricSlot)>>>;
+
+/// Serves a Prometheus-compatible `GET /metrics` endpoint.
+///
+/// Register streams as gauges with
+/// [`PrometheusSinkOps::prometheus_gauge`], call
+/// [`serve`](PrometheusExporter::serve) to start the HTTP thread, then run the
+/// returned sink streams as part of your graph.
+pub struct PrometheusExporter {
+    addr: String,
+    registry: Registry,
+}
+
+impl PrometheusExporter {
+    /// Create an exporter bound (on [`serve`](Self::serve)) to `addr`, e.g.
+    /// `"0.0.0.0:9091"` or `"127.0.0.1:0"` for an OS-assigned port.
+    pub fn new(addr: impl Into<String>) -> Self {
+        Self {
+            addr: addr.into(),
+            registry: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Spawn the HTTP server thread. Binds the listener synchronously so bind
+    /// errors are returned immediately, before the graph starts.
+    ///
+    /// Returns the port that was actually bound — useful when `addr` specifies
+    /// port `0` for OS-assigned port selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the listener cannot bind `addr` (e.g. the port is
+    /// already in use).
+    pub fn serve(&self) -> Result<u16> {
+        let listener = TcpListener::bind(&self.addr)
+            .with_context(|| format!("prometheus: binding metrics server to {}", self.addr))?;
+        let port = listener
+            .local_addr()
+            .context("prometheus: reading bound local address")?
+            .port();
+        let registry = self.registry.clone();
+        std::thread::Builder::new()
+            .name("prometheus-exporter".into())
+            .spawn(move || run_server(listener, registry))
+            .context("prometheus: spawning metrics server thread")?;
+        Ok(port)
+    }
+
+    /// Register a metric name and return its (initially empty) slot, pushing the
+    /// `(name, slot)` pair into the shared registry. Locks the registry once, at
+    /// wiring time — never on the graph thread.
+    fn register_metric(&self, name: String) -> MetricSlot {
+        let slot: MetricSlot = Arc::new(ArcSwapOption::empty());
+        self.registry
+            .lock()
+            .expect("prometheus registry mutex poisoned")
+            .push((name, slot.clone()));
+        slot
+    }
+}
+
+fn run_server(listener: TcpListener, registry: Registry) {
+    for stream in listener.incoming() {
+        match stream {
+            Ok(conn) => handle_connection(conn, &registry),
+            Err(_) => break,
+        }
+    }
+}
+
+fn handle_connection(mut conn: TcpStream, registry: &Registry) {
+    if let Err(e) = conn.set_read_timeout(Some(READ_TIMEOUT)) {
+        log::warn!("prometheus: failed to set read timeout: {e}");
+    }
+    let mut reader = BufReader::new(&conn);
+
+    let mut request_line = String::new();
+    if let Err(e) = reader.read_line(&mut request_line) {
+        if !matches!(
+            e.kind(),
+            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+        ) {
+            log::warn!("prometheus: failed to read request: {e}");
+        }
+        return;
+    }
+    // Drain HTTP headers.
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) if line == "\r\n" || line == "\n" => break,
+            _ => {}
+        }
+    }
+
+    if !request_line.starts_with("GET /metrics HTTP") {
+        if let Err(e) = conn.write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n") {
+            log::warn!("prometheus: failed to write 404 response: {e}");
+        }
+        return;
+    }
+
+    let body = build_metrics_body(registry);
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body,
+    );
+    if let Err(e) = conn.write_all(response.as_bytes()) {
+        log::warn!("prometheus: failed to write metrics response: {e}");
+    }
+}
+
+fn build_metrics_body(registry: &Registry) -> String {
+    // Snapshot the registry under the lock, then release it before loading any
+    // slots so a slow serialize can never block a concurrent registration.
+    let snapshot: Vec<(String, MetricSlot)> = match registry.lock() {
+        Ok(g) => g.clone(),
+        Err(_) => {
+            log::warn!("prometheus: registry lock poisoned, serving empty body");
+            return String::new();
+        }
+    };
+    let mut pairs: Vec<(String, Arc<String>)> = snapshot
+        .into_iter()
+        .filter_map(|(name, slot)| slot.load_full().map(|v| (name, v)))
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = String::new();
+    for (name, value) in pairs {
+        out.push_str(&format!("# TYPE {name} gauge\n{name} {value}\n"));
+    }
+    out
+}
+
+/// A pull-based Prometheus metrics sink — an extension trait on any
+/// `Stream<T>` whose values are [`Display`].
+///
+/// `use`ing it enables `stream.prometheus_gauge(&exporter, name)` chaining,
+/// layered over the [`register_op1`](crate::interp::Builder::register_op1)
+/// primitive the same way [`LinesSinkOps`](crate::adapters::lines::LinesSinkOps)
+/// layers over `for_each`.
+pub trait PrometheusSinkOps<T> {
+    /// Register this stream as a Prometheus **gauge** named `name` on `exporter`
+    /// and return the sink `Stream<()>` that publishes the stream's stringified
+    /// value on every realtime cycle. The sink is a no-op under
+    /// [`RunMode::HistoricalFrom`](wingfoil::RunMode::HistoricalFrom).
+    ///
+    /// `name` should follow Prometheus naming conventions, e.g.
+    /// `wingfoil_counter_total`.
+    ///
+    /// The returned `Stream<()>` **must** be added to the graph (or built and
+    /// run) for the metric to update.
+    #[must_use = "prometheus_gauge returns a sink Stream that must be added to the graph"]
+    fn prometheus_gauge(
+        &self,
+        exporter: &PrometheusExporter,
+        name: impl Into<String>,
+    ) -> Stream<()>;
+}
+
+impl<T> PrometheusSinkOps<T> for Stream<T>
+where
+    T: std::fmt::Display + 'static,
+{
+    fn prometheus_gauge(
+        &self,
+        exporter: &PrometheusExporter,
+        name: impl Into<String>,
+    ) -> Stream<()> {
+        let slot = exporter.register_metric(name.into());
+        self.wire(|b, h| {
+            b.register_op1(
+                h,
+                "prometheus_gauge",
+                Activation::NONE,
+                slot,
+                || (),
+                move |slot: &mut MetricSlot, _state: &mut (), value: &T, ctx: &mut Ctx<'_>| {
+                    // The exporter is a realtime endpoint; a backtest must not
+                    // publish its fast-forwarded values. Leaving the slot as
+                    // `None` keeps historical runs' scrape bodies empty.
+                    if matches!(ctx.run_mode(), RunMode::HistoricalFrom(_)) {
+                        return Ok(Tick::Value(()));
+                    }
+                    slot.store(Some(Arc::new(value.to_string())));
+                    Ok(Tick::Value(()))
+                },
+            )
+        })
+    }
+}

--- a/next/crates/wingfoil-next/src/op.rs
+++ b/next/crates/wingfoil-next/src/op.rs
@@ -8,7 +8,7 @@
 
 use anyhow::Result;
 use wingfoil::codegen::Kernel;
-use wingfoil::{NanoTime, TimeQueue};
+use wingfoil::{NanoTime, RunMode, TimeQueue};
 
 /// Static declaration of how the engine must activate an op — beyond a plain
 /// upstream data-tick.
@@ -121,6 +121,7 @@ pub struct Ctx<'a> {
     time: NanoTime,
     start_time: NanoTime,
     is_last_cycle: bool,
+    run_mode: RunMode,
     sink: Sink<'a>,
 }
 
@@ -142,6 +143,7 @@ impl<'a> Ctx<'a> {
             time: kernel.time(),
             start_time: kernel.start_time(),
             is_last_cycle: kernel.is_last_cycle(),
+            run_mode: kernel.run_mode(),
             sink: Sink::Kernel { kernel, node },
         }
     }
@@ -151,7 +153,10 @@ impl<'a> Ctx<'a> {
     /// `is_last_cycle` is not propagated into islands (the composite runs its
     /// own inner schedule), so a boundary-flush op inside an island flushes
     /// only on window boundaries, not at the outer run's end — a documented
-    /// island limitation.
+    /// island limitation. For the same reason `run_mode` inside an island is
+    /// reported as [`RunMode::RealTime`]: no macro-expressible op is run-mode
+    /// gated (a run-mode-gated IO sink cannot live inside a straight-line
+    /// island), so islands never observe the distinction.
     #[doc(hidden)]
     pub fn nested(
         time: NanoTime,
@@ -163,6 +168,7 @@ impl<'a> Ctx<'a> {
             time,
             start_time,
             is_last_cycle: false,
+            run_mode: RunMode::RealTime,
             sink: Sink::Queue { queue, node },
         }
     }
@@ -181,6 +187,15 @@ impl<'a> Ctx<'a> {
     /// pending contents when true.
     pub fn is_last_cycle(&self) -> bool {
         self.is_last_cycle
+    }
+
+    /// The [`RunMode`] the graph is being driven with. Lets a realtime-only IO
+    /// op (e.g. the prometheus metrics sink) no-op under
+    /// [`RunMode::HistoricalFrom`] rather than publish backtest values to a
+    /// live endpoint. Reported as [`RunMode::RealTime`] inside an island (see
+    /// [`nested`](Ctx::nested)).
+    pub fn run_mode(&self) -> RunMode {
+        self.run_mode
     }
 
     /// Schedule this node to be activated at `at`. Only meaningful for ops

--- a/next/crates/wingfoil-next/tests/prometheus_adapter.rs
+++ b/next/crates/wingfoil-next/tests/prometheus_adapter.rs
@@ -1,0 +1,146 @@
+//! prometheus adapter tests that need no running service — the parity port of
+//! the classic `wingfoil::adapters::prometheus::exporter` unit tests (plus the
+//! self-contained `multiple_metrics` integration test).
+//!
+//! The end-to-end scrape test (a live Prometheus scraping the exporter) lives in
+//! `tests/prometheus_integration.rs` behind the `prometheus-integration-test`
+//! feature. Run these with:
+//! ```sh
+//! cargo test -p wingfoil-next --features prometheus
+//! ```
+#![cfg(feature = "prometheus")]
+
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::prometheus::{PrometheusExporter, PrometheusSinkOps};
+use wingfoil_next::prelude::*;
+
+/// Scrape `GET /metrics` over a raw TCP connection, returning the response body
+/// (headers stripped). Retries briefly in case the server thread has not bound
+/// yet. Port `0` binds are OS-assigned, so parallel tests never collide.
+fn get_metrics(port: u16) -> String {
+    for _ in 0..20 {
+        if let Ok(mut conn) = std::net::TcpStream::connect(format!("127.0.0.1:{port}")) {
+            conn.write_all(b"GET /metrics HTTP/1.0\r\n\r\n").unwrap();
+            let mut response = String::new();
+            conn.read_to_string(&mut response).unwrap();
+            if let Some(pos) = response.find("\r\n\r\n") {
+                return response[pos + 4..].to_string();
+            }
+            return response;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("could not connect to metrics server on port {port}");
+}
+
+/// Parity of classic `connection_refused_when_port_occupied`: binding a port
+/// another listener already holds must fail at `serve()`, before any run.
+#[test]
+fn connection_refused_when_port_occupied() {
+    let occupied =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("failed to bind test listener");
+    let port = occupied.local_addr().unwrap().port();
+    let exporter = PrometheusExporter::new(format!("127.0.0.1:{port}"));
+    let result = exporter.serve();
+    assert!(result.is_err(), "expected bind error when port is occupied");
+}
+
+/// Parity of classic `serves_registered_metric`: a realtime run publishes the
+/// stringified stream value into the scrape body, with the `# TYPE … gauge`
+/// header.
+#[test]
+fn serves_registered_metric() {
+    let exporter = PrometheusExporter::new("127.0.0.1:0");
+    let port = exporter.serve().unwrap();
+
+    let g = GraphBuilder::new();
+    let _metric = g
+        .ticker(Duration::from_millis(10))
+        .count()
+        .prometheus_gauge(&exporter, "test_counter");
+
+    g.build().run(RunMode::RealTime, RunFor::Cycles(5)).unwrap();
+
+    let body = get_metrics(port);
+    assert!(
+        body.contains("test_counter 5"),
+        "expected 'test_counter 5' in:\n{body}"
+    );
+    assert!(
+        body.contains("# TYPE test_counter gauge"),
+        "expected TYPE line in:\n{body}"
+    );
+}
+
+/// Parity of classic `historical_mode_produces_no_metrics`: under
+/// `RunMode::HistoricalFrom` the sink is a no-op, so the scrape body is empty
+/// (the slot is never written, so it is omitted).
+#[test]
+fn historical_mode_produces_no_metrics() {
+    let exporter = PrometheusExporter::new("127.0.0.1:0");
+    let port = exporter.serve().unwrap();
+
+    let g = GraphBuilder::new();
+    let _metric = g
+        .ticker(Duration::from_millis(10))
+        .count()
+        .prometheus_gauge(&exporter, "hist_counter");
+
+    g.build()
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5))
+        .unwrap();
+
+    let body = get_metrics(port);
+    assert!(
+        body.is_empty(),
+        "expected no metrics in historical mode, got:\n{body}"
+    );
+}
+
+/// Parity of classic `returns_404_for_unknown_path`: any path other than
+/// `GET /metrics` gets a 404.
+#[test]
+fn returns_404_for_unknown_path() {
+    let exporter = PrometheusExporter::new("127.0.0.1:0");
+    let port = exporter.serve().unwrap();
+    std::thread::sleep(Duration::from_millis(50));
+
+    let mut conn = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    conn.write_all(b"GET /other HTTP/1.0\r\n\r\n").unwrap();
+    let mut response = String::new();
+    conn.read_to_string(&mut response).unwrap();
+    assert!(
+        response.starts_with("HTTP/1.1 404"),
+        "expected 404, got: {response}"
+    );
+}
+
+/// Parity of the classic self-contained `multiple_metrics_all_appear_in_scrape`
+/// integration test: two metrics sharing one graph both appear in the scrape.
+#[test]
+fn multiple_metrics_all_appear_in_scrape() {
+    let exporter = PrometheusExporter::new("127.0.0.1:0");
+    let port = exporter.serve().unwrap();
+
+    let g = GraphBuilder::new();
+    let counter = g.ticker(Duration::from_millis(10)).count();
+    let doubled = counter.map(|n: &u64| n * 2);
+
+    let _a = counter.prometheus_gauge(&exporter, "multi_counter_a");
+    let _b = doubled.prometheus_gauge(&exporter, "multi_counter_b");
+
+    g.build().run(RunMode::RealTime, RunFor::Cycles(3)).unwrap();
+
+    let body = get_metrics(port);
+    assert!(
+        body.contains("multi_counter_a"),
+        "missing multi_counter_a in:\n{body}"
+    );
+    assert!(
+        body.contains("multi_counter_b"),
+        "missing multi_counter_b in:\n{body}"
+    );
+}

--- a/next/crates/wingfoil-next/tests/prometheus_integration.rs
+++ b/next/crates/wingfoil-next/tests/prometheus_integration.rs
@@ -1,0 +1,87 @@
+//! prometheus adapter end-to-end integration test — a live Prometheus scraping
+//! the exporter. The parity port of the classic
+//! `prometheus::integration_tests::prometheus_exporter_scrapeable_by_prometheus`.
+//!
+//! Reuses the classic Docker stack (which scrapes `WINGFOIL_METRICS_PORT`, default
+//! `9091`, on the host):
+//! ```sh
+//! docker compose -f wingfoil/src/adapters/prometheus/docker/docker-compose.yml up -d
+//! cargo test -p wingfoil-next --features prometheus-integration-test -- --test-threads=1 --nocapture
+//! ```
+//! The test skips itself (prints and returns) if Prometheus is unreachable.
+#![cfg(feature = "prometheus-integration-test")]
+
+use std::time::Duration;
+
+use wingfoil::{RunFor, RunMode};
+use wingfoil_next::adapters::prometheus::{PrometheusExporter, PrometheusSinkOps};
+use wingfoil_next::prelude::*;
+
+fn prometheus_url() -> String {
+    std::env::var("PROMETHEUS_TEST_URL").unwrap_or_else(|_| "http://localhost:9090".into())
+}
+
+fn metrics_port() -> u16 {
+    std::env::var("WINGFOIL_METRICS_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(9091)
+}
+
+fn prometheus_available() -> bool {
+    reqwest::blocking::get(format!("{}/api/v1/query?query=up", prometheus_url()))
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn prometheus_exporter_scrapeable_by_prometheus() {
+    if !prometheus_available() {
+        eprintln!("skipping: Prometheus not available at {}", prometheus_url());
+        return;
+    }
+    let port = metrics_port();
+    let exporter = PrometheusExporter::new(format!("0.0.0.0:{port}"));
+    exporter.serve().unwrap();
+
+    let g = GraphBuilder::new();
+    let _metric = g
+        .ticker(Duration::from_millis(100))
+        .count()
+        .prometheus_gauge(&exporter, "wingfoil_integration_counter");
+
+    // Run long enough for Prometheus to complete at least one scrape (interval = 5s).
+    g.build()
+        .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(7)))
+        .unwrap();
+
+    // Poll Prometheus until the metric appears (scrape may lag by up to one
+    // interval). Parse the vector query response by text — an empty match is
+    // `"result":[]`, a hit names the metric — so the test needs only `reqwest`,
+    // no JSON crate.
+    let prom = prometheus_url();
+    let mut found = false;
+    for attempt in 1..=12 {
+        let resp = reqwest::blocking::get(format!(
+            "{prom}/api/v1/query?query=wingfoil_integration_counter"
+        ))
+        .expect("Prometheus query failed");
+        assert!(
+            resp.status().is_success(),
+            "Prometheus query returned {}",
+            resp.status()
+        );
+        let body = resp.text().expect("Prometheus response was not text");
+        if body.contains("wingfoil_integration_counter") && !body.contains("\"result\":[]") {
+            println!("Prometheus scrape hit (attempt {attempt}): {body}");
+            found = true;
+            break;
+        }
+        println!("attempt {attempt}: metric not yet in Prometheus, retrying...");
+        std::thread::sleep(Duration::from_secs(5));
+    }
+    assert!(
+        found,
+        "wingfoil_integration_counter never appeared in Prometheus after polling"
+    );
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -523,6 +523,24 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    both hinge on `Complete`, so the port must plumb a "publish source finished"
    signal (adjacent to `Ctx::is_last_cycle` / lifecycle) through to the adapter,
    not just carry the wire types over.
+   ✅ **prometheus** *(done)*: a realtime, pull-based metrics **sink** —
+   `PrometheusExporter` (owns the registry, spawns the hand-rolled `GET /metrics`
+   HTTP server, synchronous bind) plus the `PrometheusSinkOps::prometheus_gauge`
+   extension trait that registers a lock-free `arc-swap` slot per metric and
+   wires the publish sink (over `register_op1`), behind the `prometheus` feature.
+   No-op under historical replay (reads the new
+   [`Ctx::run_mode`](../crates/wingfoil-next/src/op.rs) accessor). Self-contained
+   parity tests in `tests/prometheus_adapter.rs` (the classic exporter unit tests
+   + the `multiple_metrics` self-contained integration test, raw-TCP scrape); the
+   end-to-end Prometheus-scrape test is `tests/prometheus_integration.rs` behind
+   `prometheus-integration-test` (reuses the classic Docker stack;
+   `prometheus-next-integration.yml`). **Deviations** (all capabilities
+   preserved): (a) the sink is the `PrometheusSinkOps` extension trait
+   (`stream.prometheus_gauge(&exporter, name)`), not an `exporter.register(...)`
+   method, per the sink-as-trait convention; (b) `serve` returns
+   `anyhow::Result<u16>` with `.context`, not `Result<u16, io::Error>`. The one
+   engine addition is `Ctx::run_mode()` (a realtime-only IO sink needs to see the
+   run mode; reported as `RealTime` inside an island, like `is_last_cycle`).
 8. **aeron, iceoryx2, fluvio** last — build-environment pain (CMake/clang);
    their ring-buffer polling is the natural `ALWAYS`-cap shape.
 


### PR DESCRIPTION
Ports the classic `wingfoil::adapters::prometheus` module onto the next Op-pattern engine (port-plan Phase 4, item 7). A realtime, pull-based metrics **sink**: it serves a hand-rolled `GET /metrics` endpoint in Prometheus text format so Grafana (or any Prometheus-compatible system) can scrape stream values.

## Capabilities preserved (parity oracle: `wingfoil/src/adapters/prometheus/`)

- **`PrometheusExporter`** — owns the metric registry and spawns the HTTP server thread; `serve()` binds the listener **synchronously** so a bind error surfaces before the run, and returns the actually-bound port (supports `:0` OS-assigned ports).
- **`GET /metrics` text format** — `# TYPE <name> gauge` + `<name> <value>` per metric, sorted by name; any other path gets a 404. HTTP server ported verbatim (`std::net`, no Prometheus client crate).
- **Per-metric lock-free slots** — each registered stream gets an `Arc<ArcSwapOption<String>>`. The graph thread publishes the stringified value with a single atomic pointer swap per cycle — **no lock on the cycle path**. The registry `Mutex` is locked only at registration (wiring) and once per scrape (off the graph thread). A never-written slot (`None`) is omitted from the response.
- **Historical no-op** — under `RunMode::HistoricalFrom` the sink writes nothing, so a backtest never publishes fast-forwarded values to a live endpoint (the scrape body stays empty). Classic detected this in `setup`; next reads it from a new `Ctx::run_mode()` accessor.

## Feature gate

- `prometheus = ["dep:arc-swap"]` (mirrors classic — `arc-swap` only, HTTP server is hand-rolled).
- `prometheus-integration-test = ["prometheus", "dep:reqwest"]` for the end-to-end scrape test.

## Layering / conventions

- Sink is the `PrometheusSinkOps` extension trait on `Stream<T>` (out of the prelude): `stream.prometheus_gauge(&exporter, name)`, wired over the public `register_op1` primitive.
- Adapter registered in `adapters/mod.rs` (gate + doc bullet); example registered with `required-features`.

## Deviations from classic (all capabilities preserved)

1. **Sink is an extension trait, not an exporter method.** Classic called `exporter.register(name, stream)`; next uses the sink-as-trait convention shared with `lines`/`etcd`: `stream.prometheus_gauge(&exporter, name)`. The exporter still owns the registry.
2. **`serve` returns `anyhow::Result<u16>`** (with `.context`) instead of `Result<u16, std::io::Error>`, per the fallible-with-context convention. Still a synchronous bind, so errors surface at wiring.
3. **One small engine addition: `Ctx::run_mode()`.** A realtime-only IO sink needs to see the run mode to no-op in historical replay; `for_each` closures have no `Ctx`, so the sink uses `register_op1`. Populated from the kernel in `Ctx::new` (zero call-site changes); reported as `RealTime` inside an island — consistent with the existing `is_last_cycle` treatment and documented on `Ctx::nested` (no macro-expressible op is run-mode gated).

## Tests

- `tests/prometheus_adapter.rs` (gated `#[cfg(feature = "prometheus")]`) — ports the classic exporter unit tests **and** the self-contained `multiple_metrics` integration test as parity tests (raw-TCP scrape, no deps): bind-error-when-occupied, realtime metric served with TYPE line, historical produces empty body, 404 for unknown path, multiple metrics. **5 passed.**
- `tests/prometheus_integration.rs` (gated `#[cfg(feature = "prometheus-integration-test")]`) — ports the end-to-end Prometheus-scrape test with skip-if-unavailable (reuses the classic Docker stack; queries Prometheus over `reqwest`, no JSON crate needed).

## CI note (flagged per request)

Added `.github/workflows/prometheus-next-integration.yml` and registered it in `integration-tests.yml`, mirroring how the existing `etcd-next-integration.yml` next adapter is wired (`workflow_call`/`workflow_dispatch`/path-scoped `push`). It reuses the **classic** prometheus adapter's Docker stack (identical exporter output format; the stack scrapes `WINGFOIL_METRICS_PORT`).

## Checks

`cargo fmt --all --check`, `cargo lint`, `cargo lint-all` all green. Full test suite green (`--all-features` minus `etcd-integration-test`, which needs Docker unavailable in the sandbox; the prometheus integration test skips cleanly when Prometheus is absent).

No wingfoil-python step: bindings target the legacy crate and arrive with the facade/cutover phase (per the `/new-adapter-next` skill).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_