### PR TITLE
wingfoil-next: add consume_async sink primitive; fix two etcd issues

### DIFF
--- a/next/crates/wingfoil-next/examples/etcd_adapter.rs
+++ b/next/crates/wingfoil-next/examples/etcd_adapter.rs
@@ -62,7 +62,7 @@ fn main() -> anyhow::Result<()> {
         run_for: RunFor::Cycles(3),
         start_time: NanoTime::ZERO,
     };
-    let _round_trip = etcd_sub(&g, handle, params, conn.clone(), SOURCE_PREFIX)
+    let _round_trip = etcd_sub(&g, handle, params, conn.clone(), SOURCE_PREFIX)?
         .map(|burst: &Burst<_>| {
             burst
                 .iter()

--- a/next/crates/wingfoil-next/src/adapters/etcd.rs
+++ b/next/crates/wingfoil-next/src/adapters/etcd.rs
@@ -23,13 +23,13 @@
 //! surface differs in three deliberate ways:
 //!
 //! 1. **The tokio runtime is the caller's.** Classic `etcd_sub`/`etcd_pub` hide
-//!    a global runtime inside `produce_async`/`consume_async`. Next has no
-//!    `consume_async`, and its
-//!    [`produce_async`](crate::async_source::produce_async) takes the runtime
-//!    [`Handle`](tokio::runtime::Handle) and [`RunParams`] explicitly (the
-//!    producer task is spawned at wiring time, before the run). Both functions
-//!    here follow that convention: the caller owns a `tokio::runtime::Runtime`
-//!    and hands in its `handle()`.
+//!    a global runtime inside `produce_async`/`consume_async`. Next's
+//!    [`produce_async`](crate::async_source::produce_async) (and its sink
+//!    counterpart [`consume_async`](crate::async_source::consume_async)) take
+//!    the runtime [`Handle`](tokio::runtime::Handle) and [`RunParams`]
+//!    explicitly (the producer task is spawned at wiring time, before the run).
+//!    Both functions here follow that convention: the caller owns a
+//!    `tokio::runtime::Runtime` and hands in its `handle()`.
 //! 2. **The sink connects eagerly, at wiring time.** `etcd_pub` returns
 //!    `Result` and a connection (or `lease_grant`) failure surfaces *before* the
 //!    run, whereas classic connected lazily inside the async consumer so the
@@ -53,6 +53,19 @@
 //! The producer and keepalive tasks, by contrast, run on the runtime's own
 //! workers via [`Handle::spawn`] and have no such constraint.
 //!
+//! ## Why `etcd_pub` still blocks the graph thread (deferred follow-up)
+//!
+//! The general async-sink primitive [`consume_async`](crate::async_source::consume_async)
+//! now exists to move a networked sink's writes off the graph thread. `etcd_pub`
+//! does **not** yet use it: `consume_async` writes off-thread and surfaces a write
+//! error only on a *later* cycle (or swallows it in the teardown flush), whereas
+//! `etcd_pub`'s `force: false` conditional-write test aborts a **single-cycle**
+//! (`RunFor::Cycles(1)`) run on the very write that fails — a guarantee off-thread
+//! writes cannot preserve. Migrating `etcd_pub` to `consume_async` is a tracked
+//! follow-up (see `docs/port-plan.md`); until then the sink keeps its
+//! `Handle::block_on` per-write path so that per-write failures still abort the
+//! run deterministically.
+//!
 //! # Subscribing to a key prefix (the snapshot→watch handoff)
 //!
 //! [`etcd_sub`] first emits a snapshot of all keys matching the prefix as
@@ -60,9 +73,12 @@
 //! deletes). The watch is opened **before** the GET so no write is missed in
 //! the handoff window; any event already covered by the snapshot
 //! (`mod_revision <= snapshot_rev`) is filtered out as a duplicate. Snapshot and
-//! live events are stamped with `NanoTime::now()`, so — like classic — the
-//! source is designed for `RunMode::RealTime`; a `HistoricalFrom` run replays
-//! them at wall-clock instants rather than a historical timeline.
+//! live events are stamped with `NanoTime::now()`: the source is a **live,
+//! unbounded, wall-clock stream** with no historical timeline to replay, so it
+//! runs under [`RunMode::RealTime`] only. A `HistoricalFrom` run is **rejected
+//! at wiring time** — [`etcd_sub`] returns an error rather than deadlocking (the
+//! channel receiver's historical path block-collects the whole stream up front,
+//! and this watch never closes).
 //!
 //! # Sink
 //!
@@ -97,7 +113,7 @@ use anyhow::{Context, Result};
 use etcd_client::{Client, Compare, CompareOp, GetOptions, PutOptions, Txn, TxnOp, WatchOptions};
 use futures::StreamExt;
 use tokio::runtime::Handle;
-use wingfoil::NanoTime;
+use wingfoil::{NanoTime, RunMode};
 
 use crate::Burst;
 use crate::async_source::{RunParams, produce_async};
@@ -197,117 +213,136 @@ pub struct EtcdEvent {
 /// `handle` is the caller's tokio runtime handle and `params` describes the run
 /// the graph will be driven with (see [`produce_async`] and the module docs).
 /// Use `.collapse()` for single-event processing.
-#[must_use]
+///
+/// # Errors
+///
+/// Returns an error at **wiring time** if `params.run_mode` is
+/// [`RunMode::HistoricalFrom`]: the etcd watch is a live, unbounded,
+/// wall-clock-stamped stream with no historical timeline to replay, and the
+/// historical channel path would block-collect it up front and deadlock at
+/// `start`. Run `etcd_sub` under [`RunMode::RealTime`].
 pub fn etcd_sub(
     g: &GraphBuilder,
     handle: &Handle,
     params: RunParams,
     conn: impl Into<EtcdConnection>,
     prefix: impl Into<String>,
-) -> Stream<Burst<EtcdEvent>> {
+) -> Result<Stream<Burst<EtcdEvent>>> {
+    if let RunMode::HistoricalFrom(_) = params.run_mode {
+        anyhow::bail!(
+            "etcd_sub: RunMode::HistoricalFrom is unsupported — the etcd watch is a \
+             live, unbounded, wall-clock-stamped stream with no historical timeline \
+             to replay; run etcd_sub under RunMode::RealTime"
+        );
+    }
     let conn = conn.into();
     let prefix = prefix.into();
-    produce_async(g, handle, params, move |_p: RunParams| async move {
-        let mut client = Client::connect(&conn.endpoints, None)
-            .await
-            .with_context(|| format!("etcd_sub: connecting to etcd at {:?}", conn.endpoints))?;
+    Ok(produce_async(
+        g,
+        handle,
+        params,
+        move |_p: RunParams| async move {
+            let mut client = Client::connect(&conn.endpoints, None)
+                .await
+                .with_context(|| format!("etcd_sub: connecting to etcd at {:?}", conn.endpoints))?;
 
-        // 1. Open the watch BEFORE the GET to prevent the snapshot/watch race.
-        let watch_opts = WatchOptions::new().with_prefix();
-        let mut watch_stream = client
-            .watch(prefix.as_bytes(), Some(watch_opts))
-            .await
-            .map_err(|e| anyhow::anyhow!("etcd watch failed: {e}"))?;
+            // 1. Open the watch BEFORE the GET to prevent the snapshot/watch race.
+            let watch_opts = WatchOptions::new().with_prefix();
+            let mut watch_stream = client
+                .watch(prefix.as_bytes(), Some(watch_opts))
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd watch failed: {e}"))?;
 
-        // 2. Read the snapshot and capture its revision.
-        let get_opts = GetOptions::new().with_prefix();
-        let get_resp = client
-            .get(prefix.as_bytes(), Some(get_opts))
-            .await
-            .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
-        let snapshot_rev = get_resp.header().map(|h| h.revision()).unwrap_or(0);
+            // 2. Read the snapshot and capture its revision.
+            let get_opts = GetOptions::new().with_prefix();
+            let get_resp = client
+                .get(prefix.as_bytes(), Some(get_opts))
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
+            let snapshot_rev = get_resp.header().map(|h| h.revision()).unwrap_or(0);
 
-        // 3. Collect snapshot KVs into owned data to move into the stream.
-        let snapshot: Vec<EtcdEvent> = get_resp
-            .kvs()
-            .iter()
-            .map(|kv| EtcdEvent {
-                kind: EtcdEventKind::Put,
-                entry: EtcdEntry {
-                    key: String::from_utf8_lossy(kv.key()).into_owned(),
-                    value: kv.value().to_vec(),
-                },
-                revision: snapshot_rev,
-            })
-            .collect();
+            // 3. Collect snapshot KVs into owned data to move into the stream.
+            let snapshot: Vec<EtcdEvent> = get_resp
+                .kvs()
+                .iter()
+                .map(|kv| EtcdEvent {
+                    kind: EtcdEventKind::Put,
+                    entry: EtcdEntry {
+                        key: String::from_utf8_lossy(kv.key()).into_owned(),
+                        value: kv.value().to_vec(),
+                    },
+                    revision: snapshot_rev,
+                })
+                .collect();
 
-        // 4. Return the combined snapshot + live stream. `watch_stream` is moved
-        //    in and kept alive for the stream's lifetime so the watch stays open.
-        Ok(async_stream::stream! {
-            // Phase 1: emit the snapshot as a single atomic burst. Every
-            // snapshot KV shares ONE timestamp so they are grouped into one
-            // burst (never latest-wins, never split across cycles) — matching
-            // classic's single `HistoricalValue` snapshot burst. Stamping each
-            // event with its own `NanoTime::now()` would scatter them across
-            // distinct instants, so a bounded run (e.g. `RunFor::Cycles(1)`)
-            // could observe only the first key — an intermittent "missing key"
-            // under load.
-            let snapshot_time = NanoTime::now();
-            for event in snapshot {
-                yield Ok((snapshot_time, event));
-            }
+            // 4. Return the combined snapshot + live stream. `watch_stream` is moved
+            //    in and kept alive for the stream's lifetime so the watch stays open.
+            Ok(async_stream::stream! {
+                // Phase 1: emit the snapshot as a single atomic burst. Every
+                // snapshot KV shares ONE timestamp so they are grouped into one
+                // burst (never latest-wins, never split across cycles) — matching
+                // classic's single `HistoricalValue` snapshot burst. Stamping each
+                // event with its own `NanoTime::now()` would scatter them across
+                // distinct instants, so a bounded run (e.g. `RunFor::Cycles(1)`)
+                // could observe only the first key — an intermittent "missing key"
+                // under load.
+                let snapshot_time = NanoTime::now();
+                for event in snapshot {
+                    yield Ok((snapshot_time, event));
+                }
 
-            // Phase 2: drain the watch stream, deduplicating against the snapshot.
-            loop {
-                match watch_stream.next().await {
-                    Some(Ok(resp)) => {
-                        // Skip the initial "watch created" confirmation (no events).
-                        if resp.created() {
-                            continue;
-                        }
-                        if resp.canceled() {
-                            yield Err(anyhow::anyhow!(
-                                "etcd watch cancelled: {}",
-                                resp.cancel_reason()
-                            ));
-                            break;
-                        }
-                        for event in resp.events() {
-                            let kv = match event.kv() {
-                                Some(kv) => kv,
-                                None => continue,
-                            };
-                            let mod_rev = kv.mod_revision();
-                            // Skip events already covered by the snapshot.
-                            if mod_rev <= snapshot_rev {
+                // Phase 2: drain the watch stream, deduplicating against the snapshot.
+                loop {
+                    match watch_stream.next().await {
+                        Some(Ok(resp)) => {
+                            // Skip the initial "watch created" confirmation (no events).
+                            if resp.created() {
                                 continue;
                             }
-                            let kind = match event.event_type() {
-                                etcd_client::EventType::Put => EtcdEventKind::Put,
-                                etcd_client::EventType::Delete => EtcdEventKind::Delete,
-                            };
-                            yield Ok((NanoTime::now(), EtcdEvent {
-                                kind,
-                                entry: EtcdEntry {
-                                    key: String::from_utf8_lossy(kv.key()).into_owned(),
-                                    value: kv.value().to_vec(),
-                                },
-                                revision: mod_rev,
-                            }));
+                            if resp.canceled() {
+                                yield Err(anyhow::anyhow!(
+                                    "etcd watch cancelled: {}",
+                                    resp.cancel_reason()
+                                ));
+                                break;
+                            }
+                            for event in resp.events() {
+                                let kv = match event.kv() {
+                                    Some(kv) => kv,
+                                    None => continue,
+                                };
+                                let mod_rev = kv.mod_revision();
+                                // Skip events already covered by the snapshot.
+                                if mod_rev <= snapshot_rev {
+                                    continue;
+                                }
+                                let kind = match event.event_type() {
+                                    etcd_client::EventType::Put => EtcdEventKind::Put,
+                                    etcd_client::EventType::Delete => EtcdEventKind::Delete,
+                                };
+                                yield Ok((NanoTime::now(), EtcdEvent {
+                                    kind,
+                                    entry: EtcdEntry {
+                                        key: String::from_utf8_lossy(kv.key()).into_owned(),
+                                        value: kv.value().to_vec(),
+                                    },
+                                    revision: mod_rev,
+                                }));
+                            }
+                        }
+                        Some(Err(e)) => {
+                            yield Err(anyhow::anyhow!("etcd watch error: {e}"));
+                            break;
+                        }
+                        None => {
+                            yield Err(anyhow::anyhow!("etcd watch stream closed unexpectedly"));
+                            break;
                         }
                     }
-                    Some(Err(e)) => {
-                        yield Err(anyhow::anyhow!("etcd watch error: {e}"));
-                        break;
-                    }
-                    None => {
-                        yield Err(anyhow::anyhow!("etcd watch stream closed unexpectedly"));
-                        break;
-                    }
                 }
-            }
-        })
-    })
+            })
+        },
+    ))
 }
 
 /// Holds a granted lease alive and revokes it on drop.

--- a/next/crates/wingfoil-next/src/async_source.rs
+++ b/next/crates/wingfoil-next/src/async_source.rs
@@ -10,6 +10,12 @@
 //! aborts the run. The graph source emits [`Burst<T>`](crate::Burst),
 //! never latest-wins.
 //!
+//! Its sink counterpart is [`consume_async`]: an async consumer that drains each
+//! [`Burst<T>`](crate::Burst) to a background task over a bounded channel
+//! (back-pressure + preserved write order), so networked sinks run off the
+//! single-threaded engine via [`for_each`](crate::fluent::StreamOps::for_each)
+//! instead of blocking a `cycle` on I/O.
+//!
 //! Gated behind the `async` feature (it pulls in `tokio` + `futures`); the
 //! core engine stays executor-free.
 //!
@@ -52,8 +58,10 @@
 //! ```
 
 use std::future::Future;
+use std::sync::mpsc;
 
 use futures::{SinkExt, StreamExt};
+use tokio::runtime::Handle;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
 use crate::Burst;
@@ -229,4 +237,206 @@ where
         }
     });
     validated
+}
+
+// ---------------------------------------------------------------------------
+// consume_async — the sink counterpart of produce_async
+// ---------------------------------------------------------------------------
+
+/// Drive a graph **sink** from an async consumer, so networked writes run off
+/// the single-threaded engine instead of blocking a `cycle` on I/O. The mirror
+/// image of [`produce_async`]: where the source hands values *from* a background
+/// task *into* the graph, this hands each burst's values *out of* the graph to a
+/// background task.
+///
+/// Returns a closure to plug into [`for_each`](crate::fluent::StreamOps::for_each):
+///
+/// ```ignore
+/// let rt = tokio::runtime::Runtime::new()?;
+/// let g = GraphBuilder::new();
+/// let sink = some_burst_stream.for_each(consume_async(rt.handle(), Some(64), |v| async move {
+///     write_somewhere(v).await // returns anyhow::Result<()>
+/// }));
+/// ```
+///
+/// # Guarantees
+///
+/// * **Order is preserved.** Every value is drained by a **single** consumer
+///   task that awaits each `run(value)` to completion before taking the next, so
+///   writes land in the exact order the graph produced them (values within a
+///   burst, and across bursts).
+/// * **Back-pressure.** `buffer_size` bounds how far the graph may run ahead of a
+///   slower sink: `Some(n)` uses a bounded channel of ~`n` and the sink closure
+///   *blocks the graph thread* on a full channel (on `handle`, exactly as
+///   [`produce_async_bounded`]'s producer blocks on a full permit channel) until
+///   the consumer drains one — so at most ~`n` values sit unwritten, memory does
+///   not grow without bound, and nothing is dropped. `None` is unbounded (a fast
+///   graph feeding a slow sink accumulates an arbitrarily large backlog). Unlike
+///   a source, back-pressure applies in **both** run modes here — the sink never
+///   collects up front, so bounding it can never deadlock.
+/// * **Errors propagate into the graph.** A write error is reported over an error
+///   channel (not a lock — the graph execution path stays lock-free) and the
+///   consumer task stops. The sink closure polls that channel on entry to each
+///   cycle and, once an error is present, [aborts the run](anyhow::bail) with
+///   context — mirroring how [`produce_async`] surfaces a producer error on the
+///   next cycle rather than mid-await. A closed data channel (the consumer having
+///   stopped after an error) is likewise turned into an aborting error on the
+///   next send.
+///
+/// # Teardown
+///
+/// The returned closure owns the sender and the consumer task's join handle; when
+/// the graph is dropped it drops the sender (so the consumer's `recv` ends) and
+/// **blocks until the consumer has drained every queued write**, so an offloaded
+/// sink is fully flushed at teardown rather than losing in-flight writes.
+///
+/// # Limitation — a final-cycle write error is not surfaced
+///
+/// Because writes run off-thread and the error is observed on a *later* cycle,
+/// an error from the writes of the **last** cycle of a bounded run has no
+/// subsequent cycle to surface it, and the teardown flush cannot turn an
+/// already-`Ok` run into an `Err` (Drop returns no `Result`). Sinks that must
+/// abort the run deterministically on the final write (e.g. etcd's `force:false`
+/// conditional under `RunFor::Cycles(1)`) therefore cannot yet migrate to this
+/// primitive — see `docs/port-plan.md`.
+///
+/// # Runtime requirement (the same `block_on` footgun as the etcd sink)
+///
+/// The sink closure and the teardown flush drive the runtime with
+/// [`Handle::block_on`] on the graph thread, so **the graph must be built, run,
+/// and dropped from a non-async thread** (`main`, a `#[test]` fn). Driving it
+/// from inside an async context makes those `block_on` calls panic.
+///
+/// Gated behind the `async` feature, like [`produce_async`].
+pub fn consume_async<T, F, Fut>(
+    handle: &Handle,
+    buffer_size: Option<usize>,
+    run: F,
+) -> impl Fn(&Burst<T>) -> anyhow::Result<()> + use<T, F, Fut>
+where
+    T: Clone + Default + Send + 'static,
+    F: FnMut(T) -> Fut + Send + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    // Error channel: the consumer task reports the first write error here; the
+    // sink closure polls it (non-blocking) each cycle and aborts the run. A
+    // channel — not a lock — keeps the graph execution path lock-free.
+    let (err_tx, err_rx) = mpsc::channel::<String>();
+
+    // Bounded (back-pressure) or unbounded data channel, per `buffer_size`.
+    let (tx, mut rx) = sink_channel::<T>(buffer_size);
+
+    let mut run = run;
+    let task = handle.spawn(async move {
+        // Single consumer: await each write to completion before the next, so
+        // writes land in the order the graph produced them.
+        while let Some(item) = rx.recv().await {
+            if let Err(e) = run(item).await {
+                // Report the error, then return — dropping the receiver closes
+                // the data channel so the sink's next send fails fast too.
+                let _ = err_tx.send(format!("{e:#}"));
+                return;
+            }
+        }
+    });
+
+    let state = SinkState {
+        handle: handle.clone(),
+        tx: Some(tx),
+        task: Some(task),
+    };
+    let send_handle = handle.clone();
+    move |burst: &Burst<T>| -> anyhow::Result<()> {
+        // Surface a prior async write error before doing more work.
+        if let Ok(msg) = err_rx.try_recv() {
+            anyhow::bail!("consume_async: background sink write failed: {msg}");
+        }
+        let tx = state
+            .tx
+            .as_ref()
+            .expect("invariant: sink sender present during the run");
+        for item in burst.iter() {
+            if tx.send_blocking(&send_handle, item.clone()).is_err() {
+                // A closed data channel means the consumer task stopped, which
+                // only happens after a write error; surface it with context.
+                return match err_rx.try_recv() {
+                    Ok(msg) => Err(anyhow::anyhow!(
+                        "consume_async: background sink write failed: {msg}"
+                    )),
+                    Err(_) => Err(anyhow::anyhow!(
+                        "consume_async: background sink task ended unexpectedly"
+                    )),
+                };
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Sender half of the sink's data channel — bounded (back-pressured) or
+/// unbounded, chosen by `buffer_size`.
+enum SinkTx<T> {
+    Bounded(tokio::sync::mpsc::Sender<T>),
+    Unbounded(tokio::sync::mpsc::UnboundedSender<T>),
+}
+
+impl<T: Send + 'static> SinkTx<T> {
+    /// Hand a value to the consumer task. Bounded: block the caller (on
+    /// `handle`) until the channel has capacity (back-pressure). Unbounded:
+    /// never blocks. `Err(())` means the channel is closed (consumer stopped).
+    fn send_blocking(&self, handle: &Handle, item: T) -> Result<(), ()> {
+        match self {
+            SinkTx::Bounded(s) => handle.block_on(s.send(item)).map_err(|_| ()),
+            SinkTx::Unbounded(s) => s.send(item).map_err(|_| ()),
+        }
+    }
+}
+
+/// Receiver half of the sink's data channel.
+enum SinkRx<T> {
+    Bounded(tokio::sync::mpsc::Receiver<T>),
+    Unbounded(tokio::sync::mpsc::UnboundedReceiver<T>),
+}
+
+impl<T> SinkRx<T> {
+    async fn recv(&mut self) -> Option<T> {
+        match self {
+            SinkRx::Bounded(r) => r.recv().await,
+            SinkRx::Unbounded(r) => r.recv().await,
+        }
+    }
+}
+
+fn sink_channel<T>(buffer_size: Option<usize>) -> (SinkTx<T>, SinkRx<T>) {
+    match buffer_size {
+        // `Some(0)` would be a zero-capacity channel (a panic); treat it as 1.
+        Some(n) => {
+            let (tx, rx) = tokio::sync::mpsc::channel::<T>(n.max(1));
+            (SinkTx::Bounded(tx), SinkRx::Bounded(rx))
+        }
+        None => {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<T>();
+            (SinkTx::Unbounded(tx), SinkRx::Unbounded(rx))
+        }
+    }
+}
+
+/// Owns the sink's sender and consumer-task handle so teardown can flush.
+struct SinkState<T> {
+    handle: Handle,
+    tx: Option<SinkTx<T>>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl<T> Drop for SinkState<T> {
+    fn drop(&mut self) {
+        // Flush at teardown: drop the sender so the consumer task's `recv()`
+        // returns `None` and it finishes draining every queued write, then wait
+        // for the task to complete. Runs on the (non-async) graph thread, like
+        // produce_async's teardown, so `block_on` is safe here.
+        self.tx.take();
+        if let Some(task) = self.task.take() {
+            let _ = self.handle.block_on(task);
+        }
+    }
 }

--- a/next/crates/wingfoil-next/tests/consume_async.rs
+++ b/next/crates/wingfoil-next/tests/consume_async.rs
@@ -1,0 +1,143 @@
+//! Phase 3/4: the `consume_async` ergonomic — the sink counterpart of
+//! `produce_async`. Each burst is drained to a background tokio task over a
+//! bounded channel (back-pressure), a single consumer preserves write order,
+//! and a write error propagates back into the graph and aborts the run. Gated
+//! by the `async` feature.
+#![cfg(feature = "async")]
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::async_source::consume_async;
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// A finite sink drains every value in the exact order the graph produced it —
+/// the single-consumer ordering guarantee — and the teardown flush ensures all
+/// queued writes have landed before the run returns.
+#[test]
+fn consume_async_preserves_order() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let collected = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    {
+        let sink_values = collected.clone();
+        let g = GraphBuilder::new();
+        // Unbounded buffer: every item is enqueued in one cycle, then drained in
+        // order by the single consumer task.
+        let consume = consume_async(rt.handle(), None, move |v: u64| {
+            let sink_values = sink_values.clone();
+            async move {
+                sink_values
+                    .lock()
+                    .expect("sink values mutex poisoned")
+                    .push(v);
+                Ok(())
+            }
+        });
+        let _sink = g.constant(burst![1u64, 2, 3, 4, 5]).for_each(consume);
+        let mut r = g.build();
+        r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
+        // `r` drops here → the sink flushes (drains every queued write) before
+        // the scope ends.
+    }
+
+    assert_eq!(
+        vec![1, 2, 3, 4, 5],
+        *collected.lock().expect("sink values mutex poisoned"),
+        "single consumer preserves write order; teardown flushes all writes",
+    );
+}
+
+/// A small `buffer_size` bounds how far the graph runs ahead of a slow sink: the
+/// sink closure blocks the graph thread on a full channel and resumes as the
+/// consumer drains, so every value still arrives, in order, under back-pressure
+/// (nothing dropped, no deadlock).
+#[test]
+fn consume_async_applies_backpressure() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let collected = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    {
+        let sink_values = collected.clone();
+        let g = GraphBuilder::new();
+        // Twenty values through a bounded channel of 2, with a slow sink so the
+        // channel keeps filling and the graph thread blocks on `send` until the
+        // consumer drains — exercising the back-pressure path.
+        let consume = consume_async(rt.handle(), Some(2), move |v: u64| {
+            let sink_values = sink_values.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                sink_values
+                    .lock()
+                    .expect("sink values mutex poisoned")
+                    .push(v);
+                Ok(())
+            }
+        });
+        let values: Vec<u64> = (1..=20).collect();
+        let mut burst = wingfoil::Burst::new();
+        for v in values {
+            burst.push(v);
+        }
+        let _sink = g.constant(burst).for_each(consume);
+        let mut r = g.build();
+        r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
+    }
+
+    assert_eq!(
+        (1..=20).collect::<Vec<u64>>(),
+        *collected.lock().expect("sink values mutex poisoned"),
+        "all values, in order, under back-pressure",
+    );
+}
+
+/// A background write error propagates into the graph and aborts the run with
+/// context. Values arrive across successive cycles (a historical channel
+/// source); the erroring write closes the sink so a later cycle's send surfaces
+/// the failure deterministically.
+#[test]
+fn consume_async_error_aborts_the_run() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let collected = Arc::new(Mutex::new(Vec::<u64>::new()));
+
+    let sink_values = collected.clone();
+    let g = GraphBuilder::new();
+    let (stream, sender) = g.channel::<u64>();
+    // One value per cycle at distinct historical instants.
+    sender.send_at(1, NanoTime::new(100));
+    sender.send_at(2, NanoTime::new(200));
+    sender.send_at(3, NanoTime::new(300));
+    sender.send_at(4, NanoTime::new(400));
+    sender.send_at(5, NanoTime::new(500));
+    sender.close();
+
+    // buffer_size = 1 so a send blocks until the consumer takes the prior value;
+    // once the consumer errors on `2` and stops, a later send hits the closed
+    // channel and the run aborts — no reliance on async timing.
+    let consume = consume_async(rt.handle(), Some(1), move |v: u64| {
+        let sink_values = sink_values.clone();
+        async move {
+            if v == 2 {
+                anyhow::bail!("sink write blew up on {v}");
+            }
+            sink_values
+                .lock()
+                .expect("sink values mutex poisoned")
+                .push(v);
+            Ok(())
+        }
+    });
+    let _sink = stream.for_each(consume);
+
+    let mut r = g.build();
+    let err = r
+        .run(HISTORICAL, RunFor::Forever)
+        .expect_err("a background write error must abort the run");
+    assert!(
+        format!("{err:#}").contains("sink write blew up"),
+        "the run aborts with the write error as context: {err:#}",
+    );
+}

--- a/next/crates/wingfoil-next/tests/etcd_adapter.rs
+++ b/next/crates/wingfoil-next/tests/etcd_adapter.rs
@@ -24,13 +24,41 @@ fn sub_connection_refused_aborts_the_run() {
         start_time: NanoTime::ZERO,
     };
     let conn = EtcdConnection::new("http://127.0.0.1:59999");
-    let _events = etcd_sub(&g, rt.handle(), params, conn, "/x/").collapse_accumulate();
+    let _events = etcd_sub(&g, rt.handle(), params, conn, "/x/")
+        .expect("realtime etcd_sub wires without error")
+        .collapse_accumulate();
 
     let mut runner = g.build();
     let result = runner.run(RunMode::RealTime, RunFor::Cycles(1));
     assert!(
         result.is_err(),
         "an unreachable etcd endpoint must abort the run"
+    );
+}
+
+/// `etcd_sub` rejects a `HistoricalFrom` run at wiring time — the live,
+/// unbounded, wall-clock watch has no historical timeline to replay, and the
+/// historical channel path would deadlock at `start`. The error must name the
+/// adapter rather than hang.
+#[test]
+fn sub_rejects_historical_mode() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let params = RunParams {
+        run_mode: RunMode::HistoricalFrom(NanoTime::ZERO),
+        run_for: RunFor::Cycles(1),
+        start_time: NanoTime::ZERO,
+    };
+    let conn = EtcdConnection::new("http://127.0.0.1:2379");
+    let err = match etcd_sub(&g, rt.handle(), params, conn, "/x/") {
+        Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("etcd_sub"), "names the adapter: {msg}");
+    assert!(
+        msg.contains("HistoricalFrom") || msg.contains("historical"),
+        "explains historical replay is unsupported: {msg}"
     );
 }
 

--- a/next/crates/wingfoil-next/tests/etcd_integration.rs
+++ b/next/crates/wingfoil-next/tests/etcd_integration.rs
@@ -102,7 +102,7 @@ fn test_sub_empty_snapshot_then_live_write() -> anyhow::Result<()> {
         realtime(1),
         EtcdConnection::new(&endpoint),
         "/empty/",
-    )
+    )?
     .collapse_accumulate();
 
     let endpoint_clone = endpoint.clone();
@@ -136,7 +136,7 @@ fn test_sub_snapshot_with_existing_keys() -> anyhow::Result<()> {
         realtime(1),
         EtcdConnection::new(&endpoint),
         "/snap/",
-    )
+    )?
     .collapse_accumulate();
 
     let mut runner = g.build();
@@ -172,7 +172,7 @@ fn test_sub_live_updates() -> anyhow::Result<()> {
         realtime(1),
         EtcdConnection::new(&endpoint),
         "/live/",
-    )
+    )?
     .collapse_accumulate();
 
     let mut runner = g.build();
@@ -208,7 +208,7 @@ fn test_sub_delete_events() -> anyhow::Result<()> {
         realtime(2),
         EtcdConnection::new(&endpoint),
         "/del/",
-    )
+    )?
     .collapse_accumulate();
 
     let mut runner = g.build();
@@ -244,7 +244,7 @@ fn test_sub_no_race_between_snapshot_and_watch() -> anyhow::Result<()> {
         realtime(1),
         EtcdConnection::new(&endpoint),
         "/race/",
-    )
+    )?
     .collapse_accumulate();
 
     let mut runner = g.build();

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -441,6 +441,19 @@ values and tick times.
   classic. `tests/produce_async.rs` (deterministic historical replay,
   same-time-one-burst, mid-stream error abort) + `produce_async_feed`
   example.
+- ✅ `consume_async` ergonomic — the **sink** counterpart of `produce_async`,
+  completing the source/sink async symmetry (the classic `consume_async`),
+  gated behind `async`: `async_source::consume_async(handle, buffer_size, |v|
+  async {...})` returns a closure to plug into `for_each`. A single background
+  consumer task drains each burst so **write order is preserved**; a bounded
+  channel (`buffer_size`) applies back-pressure (the sink closure blocks the
+  graph thread on a full channel, both run modes); a write error propagates
+  into the graph over an error channel and aborts the run on the next cycle;
+  teardown flushes all queued writes. `tests/consume_async.rs` (order,
+  bounded back-pressure, error-abort). Known limitation: a write error from the
+  **last** cycle of a bounded run has no later cycle to surface it (the teardown
+  flush cannot turn an `Ok` run into `Err`), so a sink that must abort
+  deterministically on its final write cannot migrate to it yet (see etcd).
 - ✅ Classic `threading`/`async` examples re-implemented on next. `threading`
   (`examples/threading/`) offloads a producer sub-graph to a worker thread that
   feeds the main graph over the channel layer — next's take on classic
@@ -509,6 +522,20 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    is the `EtcdSinkOps` trait only (classic's free `etcd_pub` fn folded into the
    trait, per next's sink-as-trait convention). The sink drives writes with
    `Handle::block_on`, so the graph must be driven from a non-async thread.
+   - **Historical mode unsupported:** `etcd_sub` is a live, unbounded,
+     wall-clock-stamped watch with no historical timeline to replay, and the
+     historical channel path would block-collect it up front and deadlock at
+     `start`. `etcd_sub` now returns `Result` and **rejects
+     `RunMode::HistoricalFrom` at wiring time** with a clear error; run it under
+     `RunMode::RealTime`.
+   - **Follow-up — migrate `etcd_pub` to `consume_async`:** the async-sink
+     primitive `consume_async` (Phase 3, landed) exists to move `etcd_pub`'s
+     writes off the graph thread, but the migration is **deferred**:
+     `consume_async` surfaces a write error only on a later cycle (or swallows
+     it in the teardown flush), whereas `etcd_pub`'s `force: false`
+     conditional-write test aborts a single-cycle (`RunFor::Cycles(1)`) run on
+     the very write that fails. Until `consume_async` can preserve that
+     final-write abort, `etcd_pub` keeps its per-write `Handle::block_on` path.
 5. **zmq, kafka, kdb** — streaming; `poll`/`external` + lifecycle.
 6. **fix** — codec-heavy; fallibility with context.
 7. **web** (+ wingfoil-wire-types, wingfoil-wasm, wingfoil-js untouched —


### PR DESCRIPTION
From an adapter-quality review: add the missing async **sink** primitive, and fix two etcd issues. Targets `next`.

## 1. `consume_async` sink primitive (finding A2)

Next had `produce_async` (source side) but no sink counterpart, so networked sinks blocked the single-threaded engine. Adds `consume_async` to `async_source.rs` (gated on `async`, like `produce_async`):

- Hands each burst's values to a **background tokio task** over a **bounded** channel (`buffer_size`), so writes run off the graph thread.
- A **single consumer task** drains the channel and awaits each `run(value)` to completion before the next, so **write order is preserved** (within and across bursts).
- **Back-pressure** like `produce_async_bounded`: the sink closure blocks the graph thread on a full channel (both run modes — a sink never collects up front, so bounding can't deadlock). `None` = unbounded.
- **Errors propagate into the graph** over an error channel (not a lock — the execution path stays lock-free) and abort the run on the next cycle, mirroring how `produce_async` surfaces producer errors.
- **Teardown flushes** all queued writes before the run returns.

Exposed as a **free function** returning `impl Fn(&Burst<T>) -> Result<()>` for use via `for_each` (no `fluent.rs`/`StreamOps` edits). New `tests/consume_async.rs`: deterministic order, bounded back-pressure (all-in-order under a slow sink + small buffer), and error propagation.

**Known limitation** (documented): a write error from the **last** cycle of a bounded run has no later cycle to surface it, and the teardown flush cannot turn an `Ok` run into `Err`.

## 2. `etcd_pub` — deferred, not relanded (finding B2, escape hatch taken)

`etcd_pub` still does `handle.block_on(...)` per write. Migrating it onto `consume_async` was **deferred**: its `force:false` conditional-write test aborts a **single-cycle** (`RunFor::Cycles(1)`) run on the very write that fails — a guarantee off-thread writes cannot preserve (the error is observed asynchronously, after the cycle completed, and `for_each` has no teardown hook to surface it). Relanding would break `test_pub_force_false_fails_if_exists`, so per the escape hatch the sink keeps its per-write `block_on` path. Documented in the module docs + tracked as a follow-up in `port-plan.md`. All existing etcd tests preserved.

## 3. `etcd_sub` historical hang (finding B1)

`etcd_sub` is a live, unbounded, wall-clock-stamped watch that never closes; the historical channel receiver block-collects the whole stream up front → deadlock at `start`. Fix: `etcd_sub` now returns `Result` and **rejects `RunMode::HistoricalFrom` at wiring time** with a clear error naming the adapter. Corrects the misleading module doc that claimed historical "replays". New `sub_rejects_historical_mode` test; the realtime call sites (example + integration tests) updated to unwrap/`?`.

## 4. port-plan.md

`consume_async` recorded as landed (source/sink async symmetry, Phase 3/4); etcd historical mode noted as unsupported (rejected at wiring) with the `etcd_pub`→`consume_async` migration tracked as follow-up.

## Checks

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p wingfoil-next --features async,etcd --all-targets -- -D warnings`: clean
- `cargo test -p wingfoil-next --features async,etcd` (consume_async, produce_async, etcd_adapter no-service, lib, doctests): green
- etcd integration tests need Docker — not run in-sandbox
- Full `cargo lint-all` / `--all-features` could not run in-sandbox: the shared disk was full (unrelated adapters pull `aws-lc-sys` + `protoc` needing several GB). All changed code is behind `async`/`etcd`, both covered clean by the scoped clippy/tests above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_