### PR TITLE
next: share csv/lines adapter primitives (for_each_mut, replay_results)

### DIFF
--- a/next/crates/wingfoil-next/src/adapters/csv.rs
+++ b/next/crates/wingfoil-next/src/adapters/csv.rs
@@ -18,8 +18,9 @@
 //! - **Source** — the free builder function [`csv_read`] on a
 //!   [`GraphBuilder`]: deterministic historical replay of a CSV file, emitting
 //!   `Stream<Burst<T>>`.
-//! - **Sink** — the [`CsvSinkOps`] extension trait on `Stream<Burst<T>>`,
-//!   enabled with `use wingfoil_next::adapters::csv::CsvSinkOps;`.
+//! - **Sink** — the [`CsvSinkOps`] extension trait on `Stream<Burst<T>>` (and,
+//!   for convenience, `Stream<T>` — each value auto-wrapped into a one-element
+//!   burst), enabled with `use wingfoil_next::adapters::csv::CsvSinkOps;`.
 //!
 //! # Historical replay (the burst model)
 //!
@@ -50,13 +51,12 @@
 //! names, via `serde_aux` introspection — a positional tuple record has no
 //! named fields, so no header is written, matching classic), and returns a
 //! `Stream<()>` sink built on
-//! [`with_time`](crate::fluent::StreamOps::with_time) then
-//! [`for_each`](crate::fluent::StreamOps::for_each): each cycle serializes every
-//! record in the incoming burst as one `(time, record)` row and flushes, with
-//! any I/O or serialization error propagated through the fallible cycle (`?` and
-//! `.context`).
+//! [`with_time`](crate::fluent::StreamOps::with_time) then the shared
+//! [`for_each_mut`](crate::fluent::StreamOps::for_each_mut): each cycle
+//! serializes every record in the incoming burst as one `(time, record)` row
+//! and flushes, with any I/O or serialization error propagated through the
+//! fallible cycle (`?` and `.context`).
 
-use std::cell::RefCell;
 use std::fs::File;
 use std::path::Path;
 
@@ -66,8 +66,8 @@ use serde::de::DeserializeOwned;
 use serde_aux::serde_introspection::serde_introspect;
 use wingfoil::NanoTime;
 
-use crate::Burst;
-use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
+use crate::fluent::{GraphBuilder, Stream, StreamOps};
+use crate::{Burst, burst};
 
 /// Deterministic historical replay of a CSV file: each record is emitted as a
 /// [`Burst<T>`] on the graph clock at `get_time(&record)`, with records sharing
@@ -105,51 +105,52 @@ where
     let file =
         File::open(path).with_context(|| format!("csv_read: failed to open {}", path.display()))?;
     let display = path.display().to_string();
-    let (stream, sender) = g.channel::<T>();
-    let mut reader = csv::ReaderBuilder::new()
+    let reader = csv::ReaderBuilder::new()
         .has_headers(has_headers)
         .from_reader(file);
-    for record in reader.deserialize::<T>() {
-        match record {
-            Ok(rec) => {
+    // Deserialize lazily into `Result<(record, time)>` rows and hand them to the
+    // shared `replay_results` engine: it queues each row via `send_at`, and — on
+    // a malformed row — forwards the error via `send_error` and stops, so the run
+    // aborts with the same context string the classic adapter uses (mirroring
+    // classic's abort-not-panic on a bad row). `into_deserialize` owns the reader
+    // so the iterator is `'static`.
+    let rows = reader.into_deserialize::<T>().map(move |record| {
+        record
+            .map(|rec| {
                 let time = get_time(&rec);
-                sender.send_at(rec, time);
-            }
-            // Mirror classic: a malformed row aborts the run rather than
-            // panicking. The channel error carries the same context string the
-            // classic adapter uses, so callers see the identical message.
-            Err(e) => {
-                sender.send_error(anyhow::Error::new(e).context(format!(
+                (rec, time)
+            })
+            .map_err(|e| {
+                anyhow::Error::new(e).context(format!(
                     "csv_read: failed to deserialize row from {display}"
-                )));
-                break;
-            }
-        }
-    }
-    // Queue the end-of-stream so the historical receiver stops collecting.
-    sender.close();
-    Ok(stream)
+                ))
+            })
+    });
+    Ok(g.replay_results(rows))
 }
 
 /// A CSV file sink — the outbound counterpart of [`csv_read`].
 ///
-/// An extension trait on `Stream<Burst<T>>` (so `use`ing it enables
-/// `stream.csv_write(path)` chaining), layered over the existing
+/// An extension trait on `Stream<Burst<T>>` — and, for convenience,
+/// `Stream<T>` (each value auto-wrapped into a one-element burst) — so `use`ing
+/// it enables `stream.csv_write(path)` chaining, layered over the existing
 /// [`with_time`](crate::fluent::StreamOps::with_time) +
-/// [`for_each`](crate::fluent::StreamOps::for_each) ops the same way
+/// [`for_each_mut`](crate::fluent::StreamOps::for_each_mut) ops the same way
 /// [`LinesSinkOps`](crate::adapters::lines::LinesSinkOps) layers over
-/// `for_each`. Each emitted burst writes every record as one `(time, record)`
-/// row — a leading `time` column carrying the graph time — then flushes; an I/O
-/// or serialization error aborts the run with context.
-///
-/// Single-value streams wrap into a one-element burst first, e.g.
-/// `stream.map(|v| burst![v.clone()]).csv_write(path)`.
+/// `for_each_mut`. Each emitted burst writes every record as one `(time,
+/// record)` row — a leading `time` column carrying the graph time — then
+/// flushes; an I/O or serialization error aborts the run with context.
 pub trait CsvSinkOps<T> {
     /// Write each record to `path` as a `(time, record)` CSV row, **truncating**
     /// the file first (created if absent). The header (a `time` column plus the
     /// record's serde field names) is written up front unless the record is a
-    /// positional tuple with no named fields. Returns the sink `Stream<()>`, or
-    /// an error if the file cannot be opened.
+    /// positional tuple with no named fields. Returns the sink `Stream<()>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened (or its header cannot be
+    /// written) at wiring time. A per-row I/O or serialization failure aborts
+    /// the run with context.
     fn csv_write(&self, path: impl AsRef<Path>) -> Result<Stream<()>>;
 }
 
@@ -166,13 +167,9 @@ where
         write_header::<T>(&mut writer)
             .with_context(|| format!("csv_write: writing header to {}", path.display()))?;
         let display = path.display().to_string();
-        // `for_each` takes an `Fn`; the `csv::Writer` needs `&mut`, so it lives
-        // behind a `RefCell`.
-        let writer = RefCell::new(writer);
         Ok(self
             .with_time()
-            .for_each(move |(time, burst): &(NanoTime, Burst<T>)| {
-                let mut w = writer.borrow_mut();
+            .for_each_mut(writer, move |w, (time, burst): &(NanoTime, Burst<T>)| {
                 for rec in burst.iter() {
                     w.serialize((*time, rec)).with_context(|| {
                         format!("csv_write: failed to serialize record to {display}")
@@ -182,6 +179,27 @@ where
                     .with_context(|| format!("csv_write: flushing {display}"))?;
                 Ok(())
             }))
+    }
+}
+
+/// Single-value convenience: a plain `Stream<T>` (not `Stream<Burst<T>>`)
+/// writes each value as one `(time, record)` row, wrapping it into a
+/// one-element burst first — so callers never wrap by hand (matching the
+/// `EtcdSinkOps for Stream<EtcdEntry>` convention).
+///
+/// This second impl is unambiguous with the `Stream<Burst<T>>` one only because
+/// `Burst<T>` (a `tinyvec`) is **not** `Serialize` in this build (the `serde`
+/// feature is off), so a `Stream<Burst<U>>` never matches this `Stream<T>` impl
+/// — the parsing counterpart of the constraint that blocks the same convenience
+/// on [`LinesSinkOps`](crate::adapters::lines::LinesSinkOps), where `Burst<T>`
+/// *is* `Display`.
+impl<T> CsvSinkOps<T> for Stream<T>
+where
+    T: Serialize + DeserializeOwned + Clone + Default + 'static,
+{
+    fn csv_write(&self, path: impl AsRef<Path>) -> Result<Stream<()>> {
+        self.map(|v: &T| -> Burst<T> { burst![v.clone()] })
+            .csv_write(path)
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/lines.rs
+++ b/next/crates/wingfoil-next/src/adapters/lines.rs
@@ -16,9 +16,10 @@
 //!   [`replay_lines`] / [`replay_lines_scheduled`] (deterministic historical
 //!   replay) and [`tail_lines`] (a realtime `poll`-driven tail). Each returns a
 //!   `Stream<Burst<String>>`.
-//! - **Sink** — the [`LinesSinkOps`] extension trait on
-//!   `Stream<Burst<T>>`, enabled with
-//!   `use wingfoil_next::adapters::lines::LinesSinkOps;`.
+//! - **Sink** — the [`LinesSinkOps`] extension trait on `Stream<Burst<T>>`,
+//!   enabled with `use wingfoil_next::adapters::lines::LinesSinkOps;`. (A
+//!   single-value `Stream<T>` maps first — see the trait docs for why there is
+//!   no `Stream<T>` convenience impl here.)
 //!
 //! # Historical replay (the burst model)
 //!
@@ -40,9 +41,9 @@
 //!
 //! [`LinesSinkOps::write_lines`] / [`LinesSinkOps::append_lines`] open the
 //! target file once at wiring time and return a `Stream<()>` sink built on the
-//! existing [`for_each`](crate::fluent::StreamOps::for_each) op: each cycle
-//! writes every record in the incoming burst as its own line and flushes, with
-//! any I/O error propagated through the fallible cycle (`?` + `.context`).
+//! shared [`for_each_mut`](crate::fluent::StreamOps::for_each_mut) op: each
+//! cycle writes every record in the incoming burst as its own line and flushes,
+//! with any I/O error propagated through the fallible cycle (`?` + `.context`).
 
 use std::cell::RefCell;
 use std::fmt::Display;
@@ -55,8 +56,8 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use wingfoil::NanoTime;
 
-use crate::Burst;
 use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
+use crate::{Burst, burst};
 
 /// Deterministic historical replay of a newline-delimited file, one record per
 /// successive graph instant.
@@ -65,6 +66,8 @@ use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
 /// `step = 1ns`, so record `i` is delivered at time `i` and every burst holds
 /// exactly one line. Run the graph with `RunMode::HistoricalFrom(t)` where
 /// `t <= base` (e.g. `NanoTime::ZERO`).
+///
+/// # Errors
 ///
 /// Returns an error if the file cannot be opened or a line cannot be read.
 pub fn replay_lines(g: &GraphBuilder, path: impl AsRef<Path>) -> Result<Stream<Burst<String>>> {
@@ -81,6 +84,8 @@ pub fn replay_lines(g: &GraphBuilder, path: impl AsRef<Path>) -> Result<Stream<B
 /// reproducible and needs no producer thread. `base` must be at or after the
 /// run's start time (the channel receiver rejects a pre-start timestamp).
 ///
+/// # Errors
+///
 /// Returns an error if the file cannot be opened or a line cannot be read.
 pub fn replay_lines_scheduled(
     g: &GraphBuilder,
@@ -91,7 +96,7 @@ pub fn replay_lines_scheduled(
     let path = path.as_ref();
     let file = File::open(path)
         .with_context(|| format!("lines adapter: opening source file {}", path.display()))?;
-    let (stream, sender) = g.channel::<String>();
+    let mut rows = Vec::new();
     for (i, line) in BufReader::new(file).lines().enumerate() {
         let line =
             line.with_context(|| format!("lines adapter: reading line {i} of {}", path.display()))?;
@@ -107,11 +112,12 @@ pub fn replay_lines_scheduled(
                 u32::MAX
             )
         })?;
-        sender.send_at(line, base + step * tick);
+        rows.push((line, base + step * tick));
     }
-    // Queue the end-of-stream so the historical receiver stops collecting.
-    sender.close();
-    Ok(stream)
+    // Read/overflow errors surface above at wiring time (via `?`);
+    // `replay_results` queues the collected rows onto a channel source and
+    // closes it. Every row is `Ok`, so nothing is forwarded via `send_error`.
+    Ok(g.replay_results(rows.into_iter().map(Ok)))
 }
 
 /// A best-effort **realtime** tail of a newline-delimited file: a busy-poll
@@ -125,8 +131,11 @@ pub fn replay_lines_scheduled(
 /// **reassembled**: the partial bytes are held until the terminating newline
 /// arrives, then emitted whole — never in fragments and never dropped. This is
 /// a deliberately minimal tail (it does not follow rotations) — the
-/// deterministic path is [`replay_lines`]. Returns an error if the file cannot
-/// be opened.
+/// deterministic path is [`replay_lines`].
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened.
 pub fn tail_lines(g: &GraphBuilder, path: impl AsRef<Path>) -> Result<Stream<Burst<String>>> {
     let path = path.as_ref();
     let file = File::open(path)
@@ -139,7 +148,7 @@ pub fn tail_lines(g: &GraphBuilder, path: impl AsRef<Path>) -> Result<Stream<Bur
     let state = Rc::new(RefCell::new((BufReader::new(file), String::new())));
     Ok(g.poll(move || {
         let (reader, pending) = &mut *state.borrow_mut();
-        poll_line(reader, pending).map(|line| Burst::from([line]))
+        poll_line(reader, pending).map(|line| burst![line])
     }))
 }
 
@@ -170,19 +179,33 @@ fn poll_line<R: BufRead>(reader: &mut R, pending: &mut String) -> Option<String>
 ///
 /// An extension trait on `Stream<Burst<T>>` (so `use`ing it enables
 /// `stream.write_lines(path)` chaining), layered over the existing
-/// [`for_each`](crate::fluent::StreamOps::for_each) op the same way
+/// [`for_each_mut`](crate::fluent::StreamOps::for_each_mut) op the same way
 /// [`StatisticsOps`](crate::stats::StatisticsOps) layers over `wire`. Each
 /// emitted burst writes every record as its own line, then flushes; an I/O
 /// error aborts the run with context.
+///
+/// Unlike [`CsvSinkOps`](crate::adapters::csv::CsvSinkOps) and
+/// [`EtcdSinkOps`](crate::adapters::etcd::EtcdSinkOps), this trait deliberately
+/// has **no single-value `Stream<T>` convenience impl**: `Burst<T>` is itself
+/// `Display` (a `tinyvec` renders as `[a, b]`), so a `Stream<Burst<T>>` *is* a
+/// `Stream<T: Display>` — a second impl for `Stream<T>` would be ambiguous with
+/// (or silently shadow) the burst form. A single-value stream therefore maps
+/// first: `stream.map(|v| burst![v.clone()]).write_lines(path)`.
 pub trait LinesSinkOps<T> {
     /// Write each record to `path` as a line, **truncating** the file first
-    /// (created if absent). Returns the sink `Stream<()>`, or an error if the
-    /// file cannot be opened.
+    /// (created if absent). Returns the sink `Stream<()>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened.
     fn write_lines(&self, path: impl AsRef<Path>) -> Result<Stream<()>>;
 
     /// Write each record to `path` as a line, **appending** to any existing
-    /// content (created if absent). Returns the sink `Stream<()>`, or an error
-    /// if the file cannot be opened.
+    /// content (created if absent). Returns the sink `Stream<()>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened.
     fn append_lines(&self, path: impl AsRef<Path>) -> Result<Stream<()>>;
 }
 
@@ -200,8 +223,9 @@ where
 }
 
 /// Shared implementation of the two [`LinesSinkOps`] methods: open the file
-/// once (truncate for write, append for append) and wire a `for_each` sink that
-/// writes every record in each burst as a line, flushing per cycle.
+/// once (truncate for write, append for append) and wire a
+/// [`for_each_mut`](crate::fluent::StreamOps::for_each_mut) sink that writes
+/// every record in each burst as a line, flushing per cycle.
 fn sink_lines<T>(
     stream: &Stream<Burst<T>>,
     path: impl AsRef<Path>,
@@ -219,19 +243,17 @@ where
         .open(path)
         .with_context(|| format!("lines adapter: opening sink file {}", path.display()))?;
     let display = path.display().to_string();
-    // `for_each` takes an `Fn`; the `BufWriter` needs `&mut`, so it lives behind
-    // a `RefCell`.
-    let writer = RefCell::new(BufWriter::new(file));
-    Ok(stream.for_each(move |burst: &Burst<T>| {
-        let mut w = writer.borrow_mut();
-        for record in burst.iter() {
-            writeln!(w, "{record}")
-                .with_context(|| format!("lines adapter: writing to {display}"))?;
-        }
-        w.flush()
-            .with_context(|| format!("lines adapter: flushing {display}"))?;
-        Ok(())
-    }))
+    Ok(
+        stream.for_each_mut(BufWriter::new(file), move |w, burst: &Burst<T>| {
+            for record in burst.iter() {
+                writeln!(w, "{record}")
+                    .with_context(|| format!("lines adapter: writing to {display}"))?;
+            }
+            w.flush()
+                .with_context(|| format!("lines adapter: flushing {display}"))?;
+            Ok(())
+        }),
+    )
 }
 
 #[cfg(test)]

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -152,6 +152,44 @@ impl GraphBuilder {
         let handle = self.with_builder(|b| b.combine(&handles));
         self.wrap(handle)
     }
+
+    /// Queue a finite, non-decreasing timestamped sequence onto a
+    /// [`channel`](SourceOps::channel) source and close it, returning the
+    /// historical-replay [`Burst`] source. Row `(value, time)` is delivered on
+    /// the graph clock at `time` (records sharing a timestamp ride one atomic
+    /// burst); the sender is closed once the sequence is exhausted so the
+    /// historical receiver stops collecting.
+    ///
+    /// Rows are `Result`, so a mid-sequence error is forwarded through
+    /// [`ChannelSender::send_error`](crate::channel::ChannelSender::send_error)
+    /// — aborting the run with that error's context — and iteration stops
+    /// there. This is the shared engine of the
+    /// [`replay_lines`](crate::adapters::lines::replay_lines) /
+    /// [`csv_read`](crate::adapters::csv::csv_read) sources; `csv_read` relies
+    /// on the error-then-stop shape to surface a decode failure.
+    pub fn replay_results<T, I>(&self, rows: I) -> Stream<Burst<T>>
+    where
+        T: Clone + Default + 'static,
+        I: IntoIterator<Item = Result<(T, NanoTime)>>,
+    {
+        let (stream, sender) = self.channel::<T>();
+        for row in rows {
+            match row {
+                Ok((value, time)) => {
+                    sender.send_at(value, time);
+                }
+                // Mirror the classic adapters: forward the producer error into
+                // the graph (it aborts the run with context) and stop queueing.
+                Err(error) => {
+                    sender.send_error(error);
+                    break;
+                }
+            }
+        }
+        // Queue the end-of-stream so the historical receiver stops collecting.
+        sender.close();
+        stream
+    }
 }
 
 /// Source constructors — the graph's entry points. An extension trait on
@@ -550,6 +588,19 @@ pub trait StreamOps<T>: Sized {
         T: 'static,
         F: Fn(&T) -> Result<()> + 'static;
 
+    /// Side-effecting sink over an owned, mutable resource opened at wiring
+    /// time — the `&mut` counterpart to [`for_each`](StreamOps::for_each).
+    /// `writer` is moved in and wrapped in a `RefCell`; `f` runs once per tick
+    /// with a `&mut W` to it, and a returned `Err` aborts the run with context.
+    /// Spares every file/socket sink the "`for_each` takes an `Fn` but my
+    /// writer needs `&mut`, so wrap it in a `RefCell`" boilerplate. Emits `()`
+    /// per tick.
+    fn for_each_mut<W, F>(&self, writer: W, f: F) -> Stream<()>
+    where
+        T: 'static,
+        W: 'static,
+        F: Fn(&mut W, &T) -> Result<()> + 'static;
+
     /// Run `f` once at teardown — after the run ends, even if a cycle aborted
     /// it. Observes this stream's last value; emits nothing.
     fn finally<F>(&self, f: F) -> Stream<()>
@@ -845,6 +896,21 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         F: Fn(&T) -> Result<()> + 'static,
     {
         self.wire(|b, h| b.for_each(h, f))
+    }
+
+    fn for_each_mut<W, F>(&self, writer: W, f: F) -> Stream<()>
+    where
+        T: 'static,
+        W: 'static,
+        F: Fn(&mut W, &T) -> Result<()> + 'static,
+    {
+        // The one place the RefCell dance lives: a sink hands in an owned `&mut`
+        // resource and a plain `Fn(&mut W, &T)`, and this wraps it for `for_each`.
+        let writer = RefCell::new(writer);
+        self.for_each(move |value: &T| {
+            let mut w = writer.borrow_mut();
+            f(&mut w, value)
+        })
     }
 
     fn finally<F>(&self, f: F) -> Stream<()>

--- a/next/crates/wingfoil-next/tests/csv_adapter.rs
+++ b/next/crates/wingfoil-next/tests/csv_adapter.rs
@@ -186,6 +186,25 @@ fn csv_round_trip_read_transform_write() {
     );
 }
 
+/// The single-value convenience impl (`CsvSinkOps for Stream<T>`) auto-wraps
+/// each value into a one-element burst, so a plain `Stream<Record>` writes
+/// without a manual `.map(|v| burst![v])`.
+#[test]
+fn single_value_stream_uses_the_convenience_sink() {
+    let path = write_tmp("sv_in.csv", "1001,1\n1002,2\n");
+    let out = write_tmp("sv_out.csv", "");
+
+    let g = GraphBuilder::new();
+    // `collapse` turns Stream<Burst<Record>> into a plain Stream<Record>.
+    let each: Stream<Record> = csv_read(&g, &path, get_time, false).unwrap().collapse();
+    let _sink = each.csv_write(&out).unwrap();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    assert_eq!(output_lines(&out), vec!["1001,1001,1", "1002,1002,2"]);
+}
+
 /// A named-struct record exercises the header path: the sink writes a leading
 /// `time` column plus the record's serde field names, then one row per record.
 #[test]

--- a/next/crates/wingfoil-next/tests/fluent_primitives.rs
+++ b/next/crates/wingfoil-next/tests/fluent_primitives.rs
@@ -1,0 +1,117 @@
+//! Focused tests for the shared adapter-support primitives on the fluent layer:
+//! `GraphBuilder::replay_results` (the historical replay engine behind the
+//! `lines`/`csv` sources) and `StreamOps::for_each_mut` (the `&mut`-writer sink
+//! behind their file sinks). The adapter tests cover them end-to-end through
+//! files; these exercise the primitives directly.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::Burst;
+use wingfoil_next::prelude::*;
+
+/// `replay_results` queues each `(value, time)` onto a historical source and
+/// groups same-instant rows into one atomic burst, delivering them on the graph
+/// clock at their timestamps.
+#[test]
+fn replay_results_groups_same_instant_rows_into_bursts() {
+    let g = GraphBuilder::new();
+    let rows: Vec<anyhow::Result<(u32, NanoTime)>> = vec![
+        Ok((1, NanoTime::new(10))),
+        Ok((2, NanoTime::new(10))), // same instant → same burst
+        Ok((3, NanoTime::new(20))),
+    ];
+    let src = g.replay_results(rows);
+    let stamped = src.with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    let got: Vec<(NanoTime, Vec<u32>)> = r
+        .value(&stamped)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().copied().collect()))
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            (NanoTime::new(10), vec![1, 2]),
+            (NanoTime::new(20), vec![3]),
+        ],
+    );
+}
+
+/// A mid-sequence `Err` row is forwarded via `send_error` and aborts the run
+/// with that error's context; rows after it are never queued.
+#[test]
+fn replay_results_forwards_error_and_stops() {
+    let g = GraphBuilder::new();
+    let rows: Vec<anyhow::Result<(u32, NanoTime)>> = vec![
+        Ok((1, NanoTime::new(10))),
+        Err(anyhow::anyhow!("replay boom")),
+        Ok((2, NanoTime::new(20))), // never reached
+    ];
+    let src = g.replay_results(rows);
+    let _acc = src.accumulate();
+
+    let mut r = g.build();
+    let err = r
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .expect_err("the forwarded error must abort the run");
+    assert!(
+        format!("{err:#}").contains("replay boom"),
+        "unexpected error: {err:#}"
+    );
+}
+
+/// `for_each_mut` moves an owned resource in and hands `f` a `&mut` to it each
+/// tick. A retained `Rc` clone (the writer shares one) lets the test read what
+/// was written after the run.
+#[test]
+fn for_each_mut_gives_a_mutable_writer_each_tick() {
+    #[derive(Clone, Default)]
+    struct Recorder(Rc<RefCell<Vec<u32>>>);
+
+    let recorder = Recorder::default();
+
+    let g = GraphBuilder::new();
+    let src = g.replay_results(vec![
+        Ok((10u32, NanoTime::new(1))),
+        Ok((20, NanoTime::new(2))),
+        Ok((30, NanoTime::new(3))),
+    ]);
+    let _sink = src.for_each_mut(recorder.clone(), |w: &mut Recorder, burst: &Burst<u32>| {
+        for v in burst.iter() {
+            w.0.borrow_mut().push(*v);
+        }
+        Ok(())
+    });
+
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    assert_eq!(*recorder.0.borrow(), vec![10, 20, 30]);
+}
+
+/// An `Err` from the `for_each_mut` closure aborts the run with context.
+#[test]
+fn for_each_mut_error_aborts_the_run() {
+    let g = GraphBuilder::new();
+    let src = g.replay_results(vec![Ok((1u32, NanoTime::new(1)))]);
+    let _sink = src.for_each_mut(Vec::<u32>::new(), |w: &mut Vec<u32>, burst: &Burst<u32>| {
+        w.extend(burst.iter().copied());
+        anyhow::bail!("sink boom")
+    });
+
+    let mut r = g.build();
+    let err = r
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .expect_err("a sink error must abort the run");
+    assert!(
+        format!("{err:#}").contains("sink boom"),
+        "unexpected error: {err:#}"
+    );
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -492,6 +492,21 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    here; (b) `FileCache`'s log messages drop the classic "KDB " prefix (the
    cache is not kdb-specific in next).
 3. **csv** — replay source + sink; exercises 0.3 historical bursts.
+   ✅ *done*. The `csv` and `lines` adapters share two fluent primitives so the
+   source/sink boilerplate lives in one place: `GraphBuilder::replay_results`
+   (queue a finite `Result<(value, time)>` sequence onto a `channel` source and
+   close it — the decode-error-then-stop shape `csv_read` needs) and
+   `StreamOps::for_each_mut` (the `&mut`-writer sink, wrapping the owned resource
+   in a `RefCell` once instead of in every sink). **Deviation (B3)**: next's
+   `csv_read` reads and deserializes the whole file up front (it queues every row
+   onto the channel source before the run), whereas classic's `TryIteratorStream`
+   streams rows lazily; behaviour is identical for finite files, but next holds
+   the full row set in memory and surfaces a decode error at the start of replay
+   rather than mid-stream. `csv` also gains the single-value `CsvSinkOps for
+   Stream<T>` convenience (auto-wrapping into a one-element burst, matching
+   `etcd`); `lines` deliberately keeps its sink burst-only, because `Burst<T>`
+   *is* `Display` — a `Stream<Burst<T>>` would be indistinguishable from a
+   single-value `Stream<T: Display>`, so the same convenience is ambiguous there.
 4. **redis, postgres, etcd** — request/response shaped; fallible cycle +
    lifecycle hooks.
    ✅ **etcd** *(done)*: snapshot→watch source (`etcd_sub`) on `produce_async`


### PR DESCRIPTION
Extracts the duplicated source/sink boilerplate shared by the `csv` and `lines` adapters in `wingfoil-next` into two fluent primitives, and fixes the related consistency/doc nits from the adapter-quality review. Behavior-preserving refactor; one PR onto `next`. (Does **not** touch `etcd.rs` or `async_source.rs` — a parallel PR owns those.)

## What changed

**A1 — `StreamOps::for_each_mut` sink primitive** (`fluent.rs`)
A side-effecting sink over an owned, mutable resource opened at wiring time: it wraps `writer` in a `RefCell` once and runs `f(&mut W, &T)` per tick, aborting on `Err`. `sink_lines` (lines) and `csv_write` (csv) now build on it — the `RefCell` and its explanatory comment are gone from both.

**A3 — `GraphBuilder::replay_results` source primitive** (`fluent.rs`)
Queues a finite, non-decreasing `Result<(value, time)>` sequence onto a `channel` source and closes it. Rows are `Result`, so a decode error is forwarded via `send_error` (aborting the run) and iteration stops — the shape `csv_read` needs. `replay_lines_scheduled` and `csv_read` build on it, preserving exact behavior: lines still surfaces read/overflow errors at wiring time via `?`; csv keeps the `"failed to deserialize row"` context and error-then-stop semantics; non-decreasing timestamps and `close()`-at-end are unchanged.

**C1 — Sink-convention consistency**
`csv` gains the single-value `CsvSinkOps for Stream<T>` convenience (auto-wraps into a one-element burst, matching `etcd`), and the redundant `.map(|v| burst[v])` doc instruction is dropped.

> **Deviation from the finding for `lines`:** the same single-value convenience is **not feasible** for `lines`. `Burst<T>` (a `tinyvec`) is itself `Display`, so a `Stream<Burst<T>>` *is* a `Stream<T: Display>` — a second `LinesSinkOps<T> for Stream<T>` impl is ambiguous (E0283) with the burst form, and an inherent method silently shadows it (writes `[ALPHA]` instead of `ALPHA`). `etcd`/`csv` avoid this only because their record types are non-`Display`-as-collection (`etcd`'s trait is non-generic; `Burst<T>` is not `Serialize` with tinyvec's `serde` feature off). `lines` therefore stays burst-only, documented in the trait and `port-plan.md`. Single-value callers map first: `stream.map(|v| burst[v.clone()]).write_lines(path)`.

**D — Doc nits**
Added `# Errors` sections to the fallible `lines` factories (`replay_lines`, `replay_lines_scheduled`, `tail_lines`, `write_lines`, `append_lines`) and to `csv_write`; normalized burst construction to `burst[...]` (`tail_lines` no longer uses `Burst::from`).

**port-plan.md**
Noted that csv/lines now build on the shared `for_each_mut`/`replay_results` primitives, plus the known B3 deviation (next's `csv_read` buffers the whole file up front vs classic's lazy row streaming) and the C1 lines asymmetry. Kept to a distinct spot for an easy rebase against the parallel PR.

## Tests
- All existing csv/lines parity tests stay green (behavior-preserving).
- New `tests/fluent_primitives.rs`: focused tests for `replay_results` (same-instant grouping; error-forward-and-stop) and `for_each_mut` (mutable writer per tick; error aborts the run).
- New single-value csv sink test in `tests/csv_adapter.rs`.

## Checks
- `cargo fmt --all -- --check` — clean
- `cargo lint` (default workspace) — clean
- `cargo lint-all` (all features) — clean
- `cargo test -p wingfoil-next --all-features` — all pass **except** `etcd_integration` (needs a Docker socket to spin up a live etcd container; unavailable in this environment, unrelated to this change).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_