### PR TITLE
wingfoil-next: port the redis adapter (Phase 4)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,6 +30,11 @@ jobs:
     uses: ./.github/workflows/redis-integration.yml
     secrets: inherit
 
+  redis-next-integration:
+    name: redis (next) Integration Tests
+    uses: ./.github/workflows/redis-next-integration.yml
+    secrets: inherit
+
   postgres-integration:
     name: postgres Integration Tests
     uses: ./.github/workflows/postgres-integration.yml

--- a/.github/workflows/redis-next-integration.yml
+++ b/.github/workflows/redis-next-integration.yml
@@ -1,0 +1,52 @@
+name: test.integration.redis-next
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'next/crates/wingfoil-next/src/adapters/redis**'
+      - 'next/crates/wingfoil-next/tests/redis_integration.rs'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  redis-next-integration:
+    name: redis (next) Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
+
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Pre-pull redis image
+        # testcontainers pulls the image lazily on first use, which is
+        # vulnerable to transient registry flakes. Pull once up front with
+        # retries so every test reuses the cached image.
+        run: |
+          for i in 1 2 3; do
+            docker pull redis:7-alpine && exit 0
+            echo "pull attempt $i failed, retrying..."
+            sleep 5
+          done
+          echo "failed to pull redis image after 3 attempts" && exit 1
+
+      - name: Run redis (next) integration tests
+        run: |
+          cargo test --features redis-integration-test -p wingfoil-next \
+            -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7682,6 +7682,7 @@ dependencies = [
  "etcd-client",
  "futures",
  "log",
+ "redis",
  "reqwest",
  "serde",
  "serde-aux",

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -74,6 +74,18 @@ testcontainers = { version = "0.27", features = [
     "blocking",
 ], optional = true }
 
+# `redis` feature: Pub/Sub (`SUBSCRIBE`/`PUBLISH`) and Streams
+# (`XRANGE`/`XREAD`/`XADD`) transports. Built on the `async` `produce_async`
+# source and `consume_async` sink ergonomics (`redis` is a tokio client).
+# Version + features mirror the classic `wingfoil` crate's redis adapter so the
+# two trees don't drift. Reuses the optional `async-stream` and `testcontainers`
+# entries above (testcontainers is only used by the gated integration tests).
+redis = { version = "0.27", features = [
+    "tokio-comp",
+    "aio",
+    "streams",
+], optional = true }
+
 # `prometheus` feature: a realtime, pull-based metrics sink serving a hand-rolled
 # `GET /metrics` endpoint (no Prometheus client crate — just `std::net` + a
 # lock-free `arc-swap` slot per metric). `reqwest` (used only by the end-to-end
@@ -102,6 +114,10 @@ cache = ["dep:sha2", "dep:bincode", "dep:serde", "async", "tokio/fs"]
 augurs = ["dep:augurs"]
 etcd = ["dep:etcd-client", "dep:async-stream", "async"]
 etcd-integration-test = ["etcd", "dep:testcontainers"]
+# Redis Pub/Sub + Streams adapter. Built on `async` (produce_async source +
+# consume_async sink) and `async-stream` (the snapshot→tail stream! macro).
+redis = ["dep:redis", "dep:async-stream", "async"]
+redis-integration-test = ["redis", "dep:testcontainers"]
 # Realtime pull-based Prometheus metrics sink (hand-rolled HTTP + `arc-swap`).
 prometheus = ["dep:arc-swap"]
 # Adds the end-to-end scrape test (a live Prometheus scraping the exporter);
@@ -152,6 +168,10 @@ required-features = ["augurs"]
 [[example]]
 name = "etcd_adapter"
 required-features = ["etcd"]
+
+[[example]]
+name = "redis_adapter"
+required-features = ["redis"]
 
 [[example]]
 name = "prometheus_adapter"

--- a/next/crates/wingfoil-next/examples/redis_adapter.rs
+++ b/next/crates/wingfoil-next/examples/redis_adapter.rs
@@ -1,0 +1,125 @@
+//! redis Pub/Sub adapter example — publish, subscribe, transform, republish.
+//!
+//! A port of the classic `wingfoil/examples/redis` example onto the next engine.
+//! Redis Pub/Sub is fire-and-forget: a subscriber only sees messages published
+//! after its `SUBSCRIBE` completes. This example therefore wires three roles as
+//! separate graphs (each on its own thread with its own tokio runtime) and starts
+//! the subscribers before the publisher sends anything:
+//!
+//! - **processor** — subscribes to `source`, uppercases each payload, republishes
+//!   to `dest`.
+//! - **verifier**  — subscribes to `dest` and prints what it receives.
+//! - **publisher** — publishes two messages to `source`.
+//!
+//! Unlike classic, the runtime is the caller's: each thread builds a tokio
+//! runtime and hands its `handle()` to `redis_sub` / `redis_pub` (see the module
+//! docs). Because the sinks drive writes with `Handle::block_on`, each graph is
+//! built, run, and dropped from its (non-async) thread.
+//!
+//! # Prerequisites
+//!
+//! A running Redis:
+//! ```sh
+//! docker run --rm -p 6379:6379 redis:7-alpine
+//! ```
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example redis_adapter --features redis
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::redis::{RedisConnection, RedisEntry, RedisSinkOps, redis_sub};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+const URL: &str = "redis://127.0.0.1:6379";
+const SOURCE: &str = "example-source";
+const DEST: &str = "example-dest";
+
+/// A realtime run description lasting `secs` seconds.
+fn realtime(secs: u64) -> RunParams {
+    RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Duration(Duration::from_secs(secs)),
+        start_time: NanoTime::ZERO,
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let conn = RedisConnection::new(URL);
+
+    // processor: source -> uppercase -> dest
+    let processor_conn = conn.clone();
+    let processor = std::thread::spawn(move || -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let g = GraphBuilder::new();
+        let _sink = redis_sub(&g, rt.handle(), realtime(2), processor_conn.clone(), SOURCE)?
+            .map(|burst: &Burst<_>| {
+                burst
+                    .iter()
+                    .map(|event: &wingfoil_next::adapters::redis::RedisEvent| {
+                        let upper = event
+                            .payload_str()
+                            .unwrap_or("")
+                            .to_uppercase()
+                            .into_bytes();
+                        RedisEntry {
+                            channel: DEST.to_string(),
+                            payload: upper,
+                        }
+                    })
+                    .collect::<Burst<RedisEntry>>()
+            })
+            .redis_pub(rt.handle(), processor_conn, None)?;
+        g.build()
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+        Ok(())
+    });
+
+    // verifier: print everything that lands on dest
+    let verifier_conn = conn.clone();
+    let verifier = std::thread::spawn(move || -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let g = GraphBuilder::new();
+        let _print = redis_sub(&g, rt.handle(), realtime(2), verifier_conn, DEST)?
+            .collapse()
+            .for_each(|event: &wingfoil_next::adapters::redis::RedisEvent| {
+                println!(
+                    "  {} -> {}",
+                    event.channel,
+                    event.payload_str().unwrap_or("?")
+                );
+                Ok(())
+            });
+        g.build()
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+        Ok(())
+    });
+
+    // Give both subscribers time to register before publishing.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let rt = tokio::runtime::Runtime::new()?;
+    let g = GraphBuilder::new();
+    let _pub = g
+        .constant(burst![
+            RedisEntry {
+                channel: SOURCE.into(),
+                payload: b"hello".to_vec(),
+            },
+            RedisEntry {
+                channel: SOURCE.into(),
+                payload: b"world".to_vec(),
+            },
+        ])
+        .redis_pub(rt.handle(), conn, None)?;
+    g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    processor.join().expect("processor thread panicked")?;
+    verifier.join().expect("verifier thread panicked")?;
+    Ok(())
+}

--- a/next/crates/wingfoil-next/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next/src/adapters/mod.rs
@@ -30,6 +30,11 @@
 //!   `GET /metrics` endpoint in Prometheus text format (register streams as
 //!   gauges via `PrometheusSinkOps::prometheus_gauge`), behind the `prometheus`
 //!   feature. A sink only; a no-op under historical replay.
+//! - [`redis`] — Redis Pub/Sub (`redis_sub` source + `RedisSinkOps::redis_pub`
+//!   sink) and Streams (`redis_stream_read` source +
+//!   `RedisStreamSinkOps::redis_stream_write` sink), behind the `redis` feature
+//!   (built on the async `produce_async` / `consume_async` ergonomics). The
+//!   sources are realtime-only.
 
 #[cfg(feature = "augurs")]
 pub mod augurs;
@@ -43,3 +48,5 @@ pub mod etcd;
 pub mod lines;
 #[cfg(feature = "prometheus")]
 pub mod prometheus;
+#[cfg(feature = "redis")]
+pub mod redis;

--- a/next/crates/wingfoil-next/src/adapters/redis.rs
+++ b/next/crates/wingfoil-next/src/adapters/redis.rs
@@ -1,0 +1,612 @@
+//! redis adapter — Pub/Sub (`SUBSCRIBE`/`PUBLISH`) and Streams
+//! (`XRANGE`/`XREAD`/`XADD`) transports for Redis. It ports the classic
+//! `wingfoil::adapters::redis` module onto the Op model.
+//!
+//! Two transports, each with a source and a sink:
+//!
+//! - **Pub/Sub** (fire-and-forget channels): [`redis_sub`] subscribes to a
+//!   channel and emits each message; [`RedisSinkOps::redis_pub`] publishes.
+//! - **Streams** (a persistent, replayable log): [`redis_stream_read`] replays a
+//!   snapshot of existing entries then tails live appends;
+//!   [`RedisStreamSinkOps::redis_stream_write`] appends via `XADD`.
+//!
+//! `HSET`/key-value operations are intentionally out of scope, matching classic.
+//!
+//! # Layering
+//!
+//! Following the [`lines`](crate::adapters::lines) / [`stats`](crate::stats)
+//! pattern, the adapter is *not* in the [`prelude`](crate::prelude). Bring in
+//! what you need explicitly:
+//!
+//! - **Sources** — the free builder functions [`redis_sub`] and
+//!   [`redis_stream_read`] on a [`GraphBuilder`], emitting
+//!   `Stream<Burst<RedisEvent>>` / `Stream<Burst<RedisStreamEvent>>`.
+//! - **Sinks** — the [`RedisSinkOps`] and [`RedisStreamSinkOps`] extension
+//!   traits on `Stream<Burst<T>>` (and, for convenience, `Stream<T>`), enabled
+//!   with `use wingfoil_next::adapters::redis::{RedisSinkOps, RedisStreamSinkOps};`.
+//!
+//! # Deviations from classic
+//!
+//! Every classic *capability* (Pub/Sub sub+pub, Streams snapshot→tail read +
+//! append, all four value types) is preserved. The surface differs in three
+//! deliberate ways, mirroring the [`etcd`](crate::adapters::etcd) port:
+//!
+//! 1. **The tokio runtime is the caller's.** Classic hides a global runtime
+//!    inside `produce_async`/`consume_async`. Next's
+//!    [`produce_async`](crate::async_source::produce_async) and
+//!    [`consume_async`](crate::async_source::consume_async) take the runtime
+//!    [`Handle`](tokio::runtime::Handle) explicitly (and the sources a
+//!    [`RunParams`]), so the caller owns a `tokio::runtime::Runtime` and hands
+//!    in its `handle()`.
+//! 2. **The sinks connect eagerly, at wiring time.** `redis_pub` /
+//!    `redis_stream_write` return `Result` and a connection failure surfaces
+//!    *before* the run, whereas classic connected lazily inside the async
+//!    consumer (skill step 8 prefers wiring-time I/O errors).
+//! 3. **The sinks are traits only.** Classic exposed free `redis_pub` /
+//!    `redis_stream_write` functions *and* operator traits; next folds each into
+//!    a single sink trait ([`RedisSinkOps`] / [`RedisStreamSinkOps`]), per the
+//!    sink-as-trait convention shared with [`lines`](crate::adapters::lines) /
+//!    [`csv`](crate::adapters::csv) / [`etcd`](crate::adapters::etcd).
+//!
+//! Two behavioural notes carried from the burst model:
+//!
+//! - **Snapshot bursts.** [`redis_stream_read`]'s snapshot phase stamps every
+//!   existing entry with one shared `NanoTime::now()`, so the whole snapshot
+//!   rides a single atomic [`Burst`] (never latest-wins, never split across
+//!   cycles) — matching the [`etcd`](crate::adapters::etcd) port. Classic
+//!   stamped each snapshot entry with its own `NanoTime::now()`.
+//! - **Realtime only.** Both sources are live, unbounded, wall-clock-stamped
+//!   streams with no historical timeline to replay (Pub/Sub has no backlog; the
+//!   stream tail blocks forever). A `HistoricalFrom` run is **rejected at wiring
+//!   time** — the historical channel path would block-collect the whole stream
+//!   up front and deadlock at `start` (the same reasoning as `etcd_sub`).
+//!
+//! ## Runtime requirement (a `block_on` footgun)
+//!
+//! The sinks drive their writes off the graph thread with
+//! [`consume_async`](crate::async_source::consume_async), which uses
+//! [`Handle::block_on`](tokio::runtime::Handle::block_on) on the graph thread
+//! for back-pressure and the teardown flush. So **the graph must be built, run,
+//! and dropped from a non-async thread** (`main`, a `#[test]` fn). Driving it
+//! from inside an async context makes those `block_on` calls panic.
+//!
+//! # Pub/Sub: fire-and-forget (no snapshot)
+//!
+//! Redis Pub/Sub has **no backlog, replay, or offsets**. A subscriber only
+//! receives messages published *after* its `SUBSCRIBE` completes, so there is no
+//! snapshot phase. A publisher racing a subscriber must order subscribe before
+//! publish (retry until captured, or wait for a ready flag).
+//!
+//! # Streams: snapshot → tail handoff (race prevention)
+//!
+//! [`redis_stream_read`] reads the snapshot with `XRANGE key - +`, captures its
+//! last entry ID, then tails with `XREAD BLOCK 0 STREAMS key <last_id>` — which
+//! only returns entries with an ID strictly greater than `last_id`. Because the
+//! tail reads from the exact snapshot boundary, any entry appended between the
+//! `XRANGE` and the first `XREAD` is returned by `XREAD` (never missed) and no
+//! snapshot entry is re-delivered. This mirrors `etcd_sub`'s watch-before-GET
+//! guarantee, with stream IDs instead of etcd revisions.
+//!
+//! # Setup
+//!
+//! ```sh
+//! docker run --rm -p 6379:6379 redis:7-alpine
+//! ```
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use redis::AsyncCommands;
+use redis::streams::{StreamId, StreamRangeReply, StreamReadOptions, StreamReadReply};
+use tokio::runtime::Handle;
+use wingfoil::{NanoTime, RunMode};
+
+use crate::async_source::{RunParams, consume_async, produce_async};
+use crate::fluent::{GraphBuilder, Stream, StreamOps};
+use crate::{Burst, burst};
+
+/// Connection configuration for Redis.
+#[derive(Debug, Clone)]
+pub struct RedisConnection {
+    /// Redis connection URL, e.g. `"redis://127.0.0.1:6379"`.
+    ///
+    /// Supports the standard `redis://`/`rediss://` URL scheme, including an
+    /// optional password and database index: `"redis://:pass@host:6379/0"`.
+    pub url: String,
+}
+
+impl RedisConnection {
+    /// Create a connection config from a Redis URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+impl From<&str> for RedisConnection {
+    fn from(url: &str) -> Self {
+        Self::new(url)
+    }
+}
+
+impl From<String> for RedisConnection {
+    fn from(url: String) -> Self {
+        Self::new(url)
+    }
+}
+
+impl From<&String> for RedisConnection {
+    fn from(url: &String) -> Self {
+        Self::new(url.clone())
+    }
+}
+
+/// A message to publish to a Redis channel.
+#[derive(Debug, Clone, Default)]
+pub struct RedisEntry {
+    /// The target channel.
+    pub channel: String,
+    /// The message payload.
+    pub payload: Vec<u8>,
+}
+
+impl RedisEntry {
+    /// Interpret the payload as a UTF-8 string.
+    pub fn payload_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.payload)
+    }
+}
+
+/// A message received from a subscribed Redis channel.
+#[derive(Debug, Clone, Default)]
+pub struct RedisEvent {
+    /// The channel the message was published to.
+    pub channel: String,
+    /// The message payload.
+    pub payload: Vec<u8>,
+}
+
+impl RedisEvent {
+    /// Interpret the payload as a UTF-8 string.
+    pub fn payload_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.payload)
+    }
+}
+
+/// A record to append to a Redis stream via `XADD`.
+///
+/// A Redis stream entry is an ordered map of field → value pairs. The entry ID
+/// is assigned by Redis (`XADD key *`), so it is not part of the record.
+#[derive(Debug, Clone, Default)]
+pub struct RedisStreamRecord {
+    /// The target stream key.
+    pub key: String,
+    /// The entry's field → value pairs, in insertion order.
+    pub fields: Vec<(String, Vec<u8>)>,
+}
+
+impl RedisStreamRecord {
+    /// Build a single-field record (`field` → `value`) for stream `key`.
+    pub fn single(
+        key: impl Into<String>,
+        field: impl Into<String>,
+        value: impl Into<Vec<u8>>,
+    ) -> Self {
+        Self {
+            key: key.into(),
+            fields: vec![(field.into(), value.into())],
+        }
+    }
+}
+
+/// An entry read from a Redis stream via `XRANGE` (snapshot) or `XREAD` (tail).
+#[derive(Debug, Clone, Default)]
+pub struct RedisStreamEvent {
+    /// The source stream key.
+    pub key: String,
+    /// The Redis-assigned entry ID, e.g. `"1526919030474-0"`.
+    pub id: String,
+    /// The entry's field → value pairs.
+    pub fields: Vec<(String, Vec<u8>)>,
+}
+
+impl RedisStreamEvent {
+    /// Look up a field's value by name.
+    pub fn field(&self, name: &str) -> Option<&[u8]> {
+        self.fields
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_slice())
+    }
+}
+
+/// Convert a redis `StreamId` (id + field map) into a [`RedisStreamEvent`].
+fn to_event(key: &str, id: &StreamId) -> RedisStreamEvent {
+    let fields = id
+        .map
+        .iter()
+        .filter_map(|(name, value)| {
+            redis::from_redis_value::<Vec<u8>>(value)
+                .ok()
+                .map(|bytes| (name.clone(), bytes))
+        })
+        .collect();
+    RedisStreamEvent {
+        key: key.to_string(),
+        id: id.id.clone(),
+        fields,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sources
+// ---------------------------------------------------------------------------
+
+/// Subscribe to a Redis `channel` and stream every message published to it as a
+/// [`RedisEvent`], as a `Burst<RedisEvent>` source.
+///
+/// Connects and issues `SUBSCRIBE` once at startup, then emits each incoming
+/// message stamped with `NanoTime::now()`. Redis Pub/Sub has no backlog: only
+/// messages published *after* the subscription is registered are delivered. Any
+/// connection or subscribe error aborts the run with context. Use `.collapse()`
+/// for single-event processing.
+///
+/// `handle` is the caller's tokio runtime handle and `params` describes the run
+/// the graph will be driven with (see [`produce_async`] and the module docs).
+///
+/// # Errors
+///
+/// Returns an error at **wiring time** if `params.run_mode` is
+/// [`RunMode::HistoricalFrom`]: Pub/Sub is a live, unbounded, wall-clock-stamped
+/// stream with no historical timeline to replay, and the historical channel path
+/// would block-collect it up front and deadlock at `start`. Run under
+/// [`RunMode::RealTime`].
+pub fn redis_sub(
+    g: &GraphBuilder,
+    handle: &Handle,
+    params: RunParams,
+    conn: impl Into<RedisConnection>,
+    channel: impl Into<String>,
+) -> Result<Stream<Burst<RedisEvent>>> {
+    if let RunMode::HistoricalFrom(_) = params.run_mode {
+        anyhow::bail!(
+            "redis_sub: RunMode::HistoricalFrom is unsupported — Redis Pub/Sub is a \
+             live, unbounded, wall-clock-stamped stream with no historical timeline \
+             to replay; run redis_sub under RunMode::RealTime"
+        );
+    }
+    let conn = conn.into();
+    let channel = channel.into();
+    Ok(produce_async(
+        g,
+        handle,
+        params,
+        move |_p: RunParams| async move {
+            let client = redis::Client::open(conn.url.as_str())
+                .with_context(|| format!("redis_sub: opening client for {:?}", conn.url))?;
+            let mut pubsub = client
+                .get_async_pubsub()
+                .await
+                .with_context(|| format!("redis_sub: connecting to {:?}", conn.url))?;
+            pubsub
+                .subscribe(channel.as_str())
+                .await
+                .with_context(|| format!("redis_sub: subscribing to {channel:?}"))?;
+
+            Ok(async_stream::stream! {
+                let mut messages = pubsub.on_message();
+                while let Some(msg) = messages.next().await {
+                    let event = RedisEvent {
+                        channel: msg.get_channel_name().to_string(),
+                        payload: msg.get_payload_bytes().to_vec(),
+                    };
+                    yield Ok((NanoTime::now(), event));
+                }
+                // `on_message` ends only when the connection drops.
+                yield Err(anyhow::anyhow!(
+                    "redis_sub: subscription stream closed unexpectedly"
+                ));
+            })
+        },
+    ))
+}
+
+/// Read a Redis stream `key`: emit a snapshot of all existing entries, then tail
+/// live appends as [`RedisStreamEvent`]s, as a `Burst<RedisStreamEvent>` source.
+///
+/// The snapshot is read with `XRANGE key - +` (its entries share one timestamp,
+/// so they ride one atomic burst) and its last entry ID is captured; the tail
+/// then issues `XREAD BLOCK 0 STREAMS key <last_id>`, which only returns entries
+/// with an ID strictly greater than `last_id`. Because the tail reads from the
+/// exact snapshot boundary, no entry is missed or duplicated in the handoff. Use
+/// `.collapse()` for single-event processing.
+///
+/// `handle` is the caller's tokio runtime handle and `params` describes the run
+/// the graph will be driven with (see [`produce_async`] and the module docs).
+///
+/// # Errors
+///
+/// Returns an error at **wiring time** if `params.run_mode` is
+/// [`RunMode::HistoricalFrom`]: the stream tail (`XREAD BLOCK 0`) is a live,
+/// unbounded, wall-clock-stamped stream with no historical timeline to replay,
+/// and the historical channel path would block-collect it up front and deadlock
+/// at `start`. Run under [`RunMode::RealTime`].
+pub fn redis_stream_read(
+    g: &GraphBuilder,
+    handle: &Handle,
+    params: RunParams,
+    conn: impl Into<RedisConnection>,
+    key: impl Into<String>,
+) -> Result<Stream<Burst<RedisStreamEvent>>> {
+    if let RunMode::HistoricalFrom(_) = params.run_mode {
+        anyhow::bail!(
+            "redis_stream_read: RunMode::HistoricalFrom is unsupported — the stream \
+             tail (XREAD BLOCK 0) is a live, unbounded, wall-clock-stamped stream \
+             with no historical timeline to replay; run redis_stream_read under \
+             RunMode::RealTime"
+        );
+    }
+    let conn = conn.into();
+    let key = key.into();
+    Ok(produce_async(
+        g,
+        handle,
+        params,
+        move |_p: RunParams| async move {
+            let client = redis::Client::open(conn.url.as_str())
+                .with_context(|| format!("redis_stream_read: opening client for {:?}", conn.url))?;
+            let mut connection = client
+                .get_multiplexed_async_connection()
+                .await
+                .with_context(|| format!("redis_stream_read: connecting to {:?}", conn.url))?;
+
+            // 1. Snapshot all existing entries and capture the last ID.
+            let snapshot: StreamRangeReply = connection
+                .xrange(&key, "-", "+")
+                .await
+                .with_context(|| format!("redis_stream_read: XRANGE on {key:?} failed"))?;
+            // "0" means "from the beginning" — used when the stream is empty so the
+            // tail picks up the very first appended entry.
+            let mut last_id = snapshot
+                .ids
+                .last()
+                .map(|id| id.id.clone())
+                .unwrap_or_else(|| "0".to_string());
+            let snapshot_events: Vec<RedisStreamEvent> =
+                snapshot.ids.iter().map(|id| to_event(&key, id)).collect();
+
+            Ok(async_stream::stream! {
+                // Phase 1: emit the snapshot as one atomic burst — every entry
+                // shares ONE timestamp so a bounded run cannot observe only the
+                // first (the etcd snapshot-burst reasoning).
+                let snapshot_time = NanoTime::now();
+                for event in snapshot_events {
+                    yield Ok((snapshot_time, event));
+                }
+
+                // Phase 2: tail live appends from the snapshot boundary.
+                let opts = StreamReadOptions::default().block(0);
+                loop {
+                    let reply: redis::RedisResult<StreamReadReply> =
+                        connection.xread_options(&[&key], &[&last_id], &opts).await;
+                    match reply {
+                        Ok(reply) => {
+                            for stream_key in &reply.keys {
+                                for id in &stream_key.ids {
+                                    last_id = id.id.clone();
+                                    yield Ok((NanoTime::now(), to_event(&stream_key.key, id)));
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            yield Err(anyhow::Error::new(e)
+                                .context(format!("redis_stream_read: XREAD on {key:?} failed")));
+                            break;
+                        }
+                    }
+                }
+            })
+        },
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Sinks
+// ---------------------------------------------------------------------------
+
+/// Extension trait providing a fluent API for publishing streams to Redis
+/// Pub/Sub via `PUBLISH`.
+///
+/// Implemented for both `Stream<Burst<RedisEntry>>` (multi-item) and
+/// `Stream<RedisEntry>` (single-item, auto-wrapped into one-element bursts), so
+/// burst wrapping is never required in user code.
+pub trait RedisSinkOps {
+    /// Publish this stream to Redis via `PUBLISH`, issuing one `PUBLISH` per
+    /// [`RedisEntry`] to the channel it names. Returns the sink `Stream<()>`.
+    ///
+    /// - `handle`: the caller's tokio runtime handle (see the module docs).
+    /// - `buffer_size`: back-pressure bound handed to
+    ///   [`consume_async`](crate::async_source::consume_async) — `Some(n)` blocks
+    ///   the graph once ~`n` entries are unwritten; `None` is unbounded.
+    ///
+    /// Publishing runs off the graph thread; writes land in order and are flushed
+    /// at teardown. `PUBLISH` returns the number of clients that received the
+    /// message (which may be zero); this count is not surfaced.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error at wiring time if the Redis connection fails. A per-entry
+    /// publish failure aborts the run with context on a subsequent cycle.
+    fn redis_pub(
+        &self,
+        handle: &Handle,
+        conn: impl Into<RedisConnection>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>>;
+}
+
+impl RedisSinkOps for Stream<Burst<RedisEntry>> {
+    fn redis_pub(
+        &self,
+        handle: &Handle,
+        conn: impl Into<RedisConnection>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>> {
+        let conn = conn.into();
+        let client = redis::Client::open(conn.url.as_str())
+            .with_context(|| format!("redis_pub: opening client for {:?}", conn.url))?;
+        // Connect at wiring time so a connection error surfaces before the run.
+        let connection = handle
+            .block_on(client.get_multiplexed_async_connection())
+            .with_context(|| format!("redis_pub: connecting to {:?}", conn.url))?;
+
+        let sink = consume_async(handle, buffer_size, move |entry: RedisEntry| {
+            let mut connection = connection.clone();
+            async move {
+                redis::cmd("PUBLISH")
+                    .arg(entry.channel.as_str())
+                    .arg(entry.payload.as_slice())
+                    .query_async::<i64>(&mut connection)
+                    .await
+                    .with_context(|| format!("redis_pub: PUBLISH to {:?} failed", entry.channel))?;
+                Ok(())
+            }
+        });
+        Ok(self.for_each(sink))
+    }
+}
+
+impl RedisSinkOps for Stream<RedisEntry> {
+    fn redis_pub(
+        &self,
+        handle: &Handle,
+        conn: impl Into<RedisConnection>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>> {
+        self.map(|entry: &RedisEntry| burst![entry.clone()])
+            .redis_pub(handle, conn, buffer_size)
+    }
+}
+
+/// Extension trait providing a fluent API for appending streams to Redis streams
+/// via `XADD`.
+///
+/// Implemented for both `Stream<Burst<RedisStreamRecord>>` (multi-item) and
+/// `Stream<RedisStreamRecord>` (single-item, auto-wrapped into one-element
+/// bursts), so burst wrapping is never required in user code.
+pub trait RedisStreamSinkOps {
+    /// Append this stream to Redis streams via `XADD`, issuing one `XADD <key> *`
+    /// per [`RedisStreamRecord`] (Redis assigns the entry ID). Returns the sink
+    /// `Stream<()>`.
+    ///
+    /// - `handle`: the caller's tokio runtime handle (see the module docs).
+    /// - `buffer_size`: back-pressure bound handed to
+    ///   [`consume_async`](crate::async_source::consume_async).
+    ///
+    /// Appending runs off the graph thread; writes land in order and are flushed
+    /// at teardown.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error at wiring time if the Redis connection fails. A per-record
+    /// append failure aborts the run with context on a subsequent cycle.
+    fn redis_stream_write(
+        &self,
+        handle: &Handle,
+        conn: impl Into<RedisConnection>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>>;
+}
+
+impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
+    fn redis_stream_write(
+        &self,
+        handle: &Handle,
+        conn: impl Into<RedisConnection>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>> {
+        let conn = conn.into();
+        let client = redis::Client::open(conn.url.as_str())
+            .with_context(|| format!("redis_stream_write: opening client for {:?}", conn.url))?;
+        // Connect at wiring time so a connection error surfaces before the run.
+        let connection = handle
+            .block_on(client.get_multiplexed_async_connection())
+            .with_context(|| format!("redis_stream_write: connecting to {:?}", conn.url))?;
+
+        let sink = consume_async(handle, buffer_size, move |record: RedisStreamRecord| {
+            let mut connection = connection.clone();
+            async move {
+                let mut cmd = redis::cmd("XADD");
+                cmd.arg(record.key.as_str()).arg("*");
+                for (field, value) in &record.fields {
+                    cmd.arg(field.as_str()).arg(value.as_slice());
+                }
+                cmd.query_async::<String>(&mut connection)
+                    .await
+                    .with_context(|| {
+                        format!("redis_stream_write: XADD to {:?} failed", record.key)
+                    })?;
+                Ok(())
+            }
+        });
+        Ok(self.for_each(sink))
+    }
+}
+
+impl RedisStreamSinkOps for Stream<RedisStreamRecord> {
+    fn redis_stream_write(
+        &self,
+        handle: &Handle,
+        conn: impl Into<RedisConnection>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>> {
+        self.map(|record: &RedisStreamRecord| burst![record.clone()])
+            .redis_stream_write(handle, conn, buffer_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RedisConnection, RedisEntry, RedisStreamEvent, RedisStreamRecord};
+
+    #[test]
+    fn entry_payload_str_reads_utf8() {
+        let entry = RedisEntry {
+            channel: "ch".to_string(),
+            payload: b"bar".to_vec(),
+        };
+        assert_eq!(entry.payload_str().unwrap(), "bar");
+    }
+
+    #[test]
+    fn stream_record_single_builds_one_field() {
+        let record = RedisStreamRecord::single("k", "f", b"v".to_vec());
+        assert_eq!(record.key, "k");
+        assert_eq!(record.fields, vec![("f".to_string(), b"v".to_vec())]);
+    }
+
+    #[test]
+    fn stream_event_field_lookup() {
+        let event = RedisStreamEvent {
+            key: "k".to_string(),
+            id: "1-0".to_string(),
+            fields: vec![
+                ("a".to_string(), b"1".to_vec()),
+                ("b".to_string(), b"2".to_vec()),
+            ],
+        };
+        assert_eq!(event.field("a"), Some(b"1".as_ref()));
+        assert_eq!(event.field("b"), Some(b"2".as_ref()));
+        assert_eq!(event.field("missing"), None);
+    }
+
+    #[test]
+    fn connection_from_str_and_string() {
+        assert_eq!(
+            RedisConnection::from("redis://h:6379").url,
+            "redis://h:6379"
+        );
+        assert_eq!(
+            RedisConnection::from("redis://h:6379".to_string()).url,
+            "redis://h:6379"
+        );
+    }
+}

--- a/next/crates/wingfoil-next/tests/redis_adapter.rs
+++ b/next/crates/wingfoil-next/tests/redis_adapter.rs
@@ -1,0 +1,151 @@
+//! redis adapter tests that need no running service.
+//!
+//! The container-backed parity tests live in `tests/redis_integration.rs` behind
+//! the `redis-integration-test` feature. Run these with:
+//! ```sh
+//! cargo test -p wingfoil-next --features redis
+//! ```
+#![cfg(feature = "redis")]
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::redis::{
+    RedisConnection, RedisEntry, RedisSinkOps, RedisStreamRecord, RedisStreamSinkOps,
+    redis_stream_read, redis_sub,
+};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+/// A realtime run description (start time is ignored in realtime).
+fn realtime(cycles: u32) -> RunParams {
+    RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Cycles(cycles),
+        start_time: NanoTime::ZERO,
+    }
+}
+
+/// A historical run description (its start time is validated against the run).
+fn historical() -> RunParams {
+    RunParams {
+        run_mode: RunMode::HistoricalFrom(NanoTime::ZERO),
+        run_for: RunFor::Cycles(1),
+        start_time: NanoTime::ZERO,
+    }
+}
+
+/// An unreachable endpoint must abort the Pub/Sub source's run rather than hang
+/// or panic — the parity of classic `test_connection_refused`.
+#[test]
+fn sub_connection_refused_aborts_the_run() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let conn = RedisConnection::new("redis://127.0.0.1:59999");
+    let _events = redis_sub(&g, rt.handle(), realtime(1), conn, "ch")
+        .expect("realtime redis_sub wires without error")
+        .collapse_accumulate();
+
+    let mut runner = g.build();
+    let result = runner.run(RunMode::RealTime, RunFor::Cycles(1));
+    assert!(
+        result.is_err(),
+        "an unreachable Redis endpoint must abort the run"
+    );
+}
+
+/// The same for the stream source.
+#[test]
+fn stream_read_connection_refused_aborts_the_run() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let conn = RedisConnection::new("redis://127.0.0.1:59999");
+    let _events = redis_stream_read(&g, rt.handle(), realtime(1), conn, "key")
+        .expect("realtime redis_stream_read wires without error")
+        .collapse_accumulate();
+
+    let mut runner = g.build();
+    let result = runner.run(RunMode::RealTime, RunFor::Cycles(1));
+    assert!(
+        result.is_err(),
+        "an unreachable Redis endpoint must abort the run"
+    );
+}
+
+/// `redis_sub` rejects a `HistoricalFrom` run at wiring time — the live,
+/// unbounded, wall-clock Pub/Sub stream has no historical timeline to replay.
+#[test]
+fn sub_rejects_historical_mode() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let conn = RedisConnection::new("redis://127.0.0.1:6379");
+    let err = match redis_sub(&g, rt.handle(), historical(), conn, "ch") {
+        Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("redis_sub"), "names the adapter: {msg}");
+    assert!(
+        msg.contains("HistoricalFrom") || msg.contains("historical"),
+        "explains historical replay is unsupported: {msg}"
+    );
+}
+
+/// `redis_stream_read` likewise rejects a `HistoricalFrom` run at wiring time.
+#[test]
+fn stream_read_rejects_historical_mode() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let conn = RedisConnection::new("redis://127.0.0.1:6379");
+    let err = match redis_stream_read(&g, rt.handle(), historical(), conn, "key") {
+        Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("redis_stream_read"),
+        "names the adapter: {msg}"
+    );
+    assert!(
+        msg.contains("HistoricalFrom") || msg.contains("historical"),
+        "explains historical replay is unsupported: {msg}"
+    );
+}
+
+/// The Pub/Sub sink must surface a connection failure — at wiring (eager connect)
+/// or, if the client connects lazily, during the run.
+#[test]
+fn pub_connection_refused_surfaces_an_error() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let source = g.constant(burst![RedisEntry {
+        channel: "ch".to_string(),
+        payload: b"v".to_vec(),
+    }]);
+    let conn = RedisConnection::new("redis://127.0.0.1:59999");
+
+    let outcome = match source.redis_pub(rt.handle(), conn, None) {
+        Err(_) => return, // errored at wiring (eager connect) — acceptable
+        Ok(_sink) => g.build().run(RunMode::RealTime, RunFor::Cycles(1)),
+    };
+    assert!(
+        outcome.is_err(),
+        "an unreachable Redis endpoint must surface an error at wiring or during the run"
+    );
+}
+
+/// The stream sink must surface a connection failure the same way.
+#[test]
+fn stream_write_connection_refused_surfaces_an_error() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let source = g.constant(burst![RedisStreamRecord::single("key", "f", b"v".to_vec())]);
+    let conn = RedisConnection::new("redis://127.0.0.1:59999");
+
+    let outcome = match source.redis_stream_write(rt.handle(), conn, None) {
+        Err(_) => return, // errored at wiring (eager connect) — acceptable
+        Ok(_sink) => g.build().run(RunMode::RealTime, RunFor::Cycles(1)),
+    };
+    assert!(
+        outcome.is_err(),
+        "an unreachable Redis endpoint must surface an error at wiring or during the run"
+    );
+}

--- a/next/crates/wingfoil-next/tests/redis_integration.rs
+++ b/next/crates/wingfoil-next/tests/redis_integration.rs
@@ -1,0 +1,297 @@
+//! Integration tests for the redis adapter — parity port of the classic
+//! `wingfoil/src/adapters/redis/integration_tests.rs`.
+//!
+//! Requires Docker. Run with:
+//! ```sh
+//! cargo test -p wingfoil-next --features redis-integration-test \
+//!   -- --test-threads=1 --nocapture
+//! ```
+#![cfg(feature = "redis-integration-test")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use futures::StreamExt;
+use testcontainers::{GenericImage, core::WaitFor, runners::SyncRunner};
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::redis::{
+    RedisConnection, RedisEntry, RedisEvent, RedisSinkOps, RedisStreamEvent, RedisStreamRecord,
+    RedisStreamSinkOps, redis_stream_read, redis_sub,
+};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+const REDIS_PORT: u16 = 6379;
+const REDIS_IMAGE: &str = "redis";
+const REDIS_TAG: &str = "7-alpine";
+
+/// A realtime run description (start time is ignored in realtime).
+fn realtime(cycles: u32) -> RunParams {
+    RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Cycles(cycles),
+        start_time: NanoTime::ZERO,
+    }
+}
+
+/// Start a Redis container and return the connection URL.
+/// The returned container must be kept alive for the duration of the test.
+fn start_redis() -> anyhow::Result<(impl Drop, String)> {
+    let container = GenericImage::new(REDIS_IMAGE, REDIS_TAG)
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()?;
+    let port = container.get_host_port_ipv4(REDIS_PORT)?;
+    let url = format!("redis://127.0.0.1:{port}");
+    Ok((container, url))
+}
+
+/// Spawn a background thread that repeatedly publishes `payload` to `channel`
+/// until the returned flag is set. Redis Pub/Sub drops messages with no live
+/// subscriber, so the publisher keeps retrying until the graph has captured one.
+fn spawn_publisher(
+    url: &str,
+    channel: &str,
+    payload: &[u8],
+) -> (Arc<AtomicBool>, std::thread::JoinHandle<()>) {
+    let done = Arc::new(AtomicBool::new(false));
+    let done_thread = done.clone();
+    let url = url.to_string();
+    let channel = channel.to_string();
+    let payload = payload.to_vec();
+    let handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let client = redis::Client::open(url.as_str()).unwrap();
+            let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+            while !done_thread.load(Ordering::Relaxed) {
+                let _: i64 = redis::cmd("PUBLISH")
+                    .arg(channel.as_str())
+                    .arg(payload.as_slice())
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap_or(0);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        });
+    });
+    (done, handle)
+}
+
+/// Subscribe to `channel` on a dedicated thread, set `ready` once the
+/// subscription is registered server-side, then collect up to `n` payloads.
+fn spawn_subscriber(
+    url: &str,
+    channel: &str,
+    n: usize,
+    ready: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<anyhow::Result<Vec<Vec<u8>>>> {
+    let url = url.to_string();
+    let channel = channel.to_string();
+    std::thread::spawn(move || -> anyhow::Result<Vec<Vec<u8>>> {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async {
+            let client = redis::Client::open(url.as_str())?;
+            let mut pubsub = client.get_async_pubsub().await?;
+            pubsub.subscribe(channel.as_str()).await?;
+            // Subscription is now active server-side.
+            ready.store(true, Ordering::Relaxed);
+            let mut messages = pubsub.on_message();
+            let mut out = Vec::new();
+            while out.len() < n {
+                match tokio::time::timeout(Duration::from_secs(10), messages.next()).await {
+                    Ok(Some(msg)) => out.push(msg.get_payload_bytes().to_vec()),
+                    _ => break,
+                }
+            }
+            Ok(out)
+        })
+    })
+}
+
+/// Append a single-field entry directly to a stream via the client.
+fn xadd(url: &str, key: &str, field: &str, value: &[u8]) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let client = redis::Client::open(url)?;
+        let mut conn = client.get_multiplexed_async_connection().await?;
+        redis::cmd("XADD")
+            .arg(key)
+            .arg("*")
+            .arg(field)
+            .arg(value)
+            .query_async::<String>(&mut conn)
+            .await?;
+        Ok(())
+    })
+}
+
+// ---- Pub/Sub tests ----
+
+#[test]
+fn test_sub_live_message() -> anyhow::Result<()> {
+    // A message published while the graph is subscribed arrives as a RedisEvent.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, url) = start_redis()?;
+
+    let (done, publisher) = spawn_publisher(&url, "live", b"hello");
+
+    let g = GraphBuilder::new();
+    let events = redis_sub(
+        &g,
+        rt.handle(),
+        realtime(1),
+        RedisConnection::new(&url),
+        "live",
+    )?
+    .collapse_accumulate();
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    done.store(true, Ordering::Relaxed);
+    publisher.join().unwrap();
+
+    let events: Vec<RedisEvent> = runner.value(&events);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].channel, "live");
+    assert_eq!(events[0].payload, b"hello");
+    Ok(())
+}
+
+#[test]
+fn test_pub_round_trip() -> anyhow::Result<()> {
+    // redis_pub publishes a message; a direct subscriber receives it.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, url) = start_redis()?;
+
+    let ready = Arc::new(AtomicBool::new(false));
+    let subscriber = spawn_subscriber(&url, "rt", 1, ready.clone());
+
+    // Wait until the subscriber's SUBSCRIBE is registered server-side so the
+    // fire-and-forget PUBLISH is guaranteed to reach it.
+    while !ready.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![RedisEntry {
+                channel: "rt".to_string(),
+                payload: b"value1".to_vec(),
+            }])
+            .redis_pub(rt.handle(), RedisConnection::new(&url), None)?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    let payloads = subscriber.join().unwrap()?;
+    assert_eq!(payloads, vec![b"value1".to_vec()]);
+    Ok(())
+}
+
+#[test]
+fn test_pub_multiple_entries_in_burst() -> anyhow::Result<()> {
+    // Multiple entries in a single burst are all published.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, url) = start_redis()?;
+
+    let ready = Arc::new(AtomicBool::new(false));
+    let subscriber = spawn_subscriber(&url, "multi", 3, ready.clone());
+
+    while !ready.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![
+                RedisEntry {
+                    channel: "multi".to_string(),
+                    payload: b"a".to_vec(),
+                },
+                RedisEntry {
+                    channel: "multi".to_string(),
+                    payload: b"b".to_vec(),
+                },
+                RedisEntry {
+                    channel: "multi".to_string(),
+                    payload: b"c".to_vec(),
+                },
+            ])
+            .redis_pub(rt.handle(), RedisConnection::new(&url), None)?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    let mut payloads = subscriber.join().unwrap()?;
+    payloads.sort();
+    assert_eq!(payloads, vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()]);
+    Ok(())
+}
+
+// ---- Streams ----
+
+#[test]
+fn test_stream_write_and_read_snapshot() -> anyhow::Result<()> {
+    // redis_stream_write appends entries; redis_stream_read replays them as a
+    // single snapshot burst.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, url) = start_redis()?;
+    let conn = RedisConnection::new(&url);
+
+    {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![
+                RedisStreamRecord::single("events", "kind", b"login".to_vec()),
+                RedisStreamRecord::single("events", "kind", b"logout".to_vec()),
+            ])
+            .redis_stream_write(rt.handle(), conn.clone(), None)?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    let g = GraphBuilder::new();
+    // `.accumulate()` keeps whole bursts (the snapshot rides one burst), then we
+    // flatten — `.collapse_accumulate()` would drop all but the last entry.
+    let bursts = redis_stream_read(&g, rt.handle(), realtime(1), conn, "events")?.accumulate();
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+
+    let events: Vec<RedisStreamEvent> = runner.value(&bursts).into_iter().flatten().collect();
+    assert_eq!(events.len(), 2);
+    let kinds: Vec<Vec<u8>> = events
+        .iter()
+        .map(|e| e.field("kind").unwrap_or_default().to_vec())
+        .collect();
+    assert_eq!(kinds, vec![b"login".to_vec(), b"logout".to_vec()]);
+    // Redis assigns monotonically increasing IDs.
+    assert!(events[0].id < events[1].id);
+    Ok(())
+}
+
+#[test]
+fn test_stream_read_live_tail() -> anyhow::Result<()> {
+    // An entry appended after the (empty) snapshot arrives via the XREAD tail.
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, url) = start_redis()?;
+    let conn = RedisConnection::new(&url);
+
+    let url_writer = url.clone();
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(300));
+        xadd(&url_writer, "tail", "msg", b"live").unwrap();
+    });
+
+    let g = GraphBuilder::new();
+    let events =
+        redis_stream_read(&g, rt.handle(), realtime(1), conn, "tail")?.collapse_accumulate();
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+    writer.join().unwrap();
+
+    let events: Vec<RedisStreamEvent> = runner.value(&events);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].key, "tail");
+    assert_eq!(events[0].field("msg"), Some(b"live".as_ref()));
+    Ok(())
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -551,6 +551,26 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
      conditional-write test aborts a single-cycle (`RunFor::Cycles(1)`) run on
      the very write that fails. Until `consume_async` can preserve that
      final-write abort, `etcd_pub` keeps its per-write `Handle::block_on` path.
+   ✅ **redis** *(done)*: Pub/Sub (`redis_sub` source + `RedisSinkOps::redis_pub`
+   sink) and Streams (`redis_stream_read` snapshot→tail source +
+   `RedisStreamSinkOps::redis_stream_write` sink), behind the `redis` feature.
+   Both sources ride `produce_async`; both sinks ride the shared **`consume_async`**
+   primitive (redis has no per-write conditional to abort synchronously, unlike
+   `etcd_pub`, so the off-thread sink fits — writes land in order and flush at
+   teardown). Parity port of the classic adapter's tests as
+   `tests/redis_integration.rs` (testcontainers, gated on `redis-integration-test`)
+   plus no-service tests in `tests/redis_adapter.rs`; classic example ported to
+   `examples/redis_adapter.rs`. **Deviations** (capabilities all preserved), the
+   same three as etcd: (a) the tokio runtime is the caller's (`&Handle` + a
+   `RunParams` for the sources); (b) the sinks connect eagerly at wiring and
+   return `Result`, so a connection error surfaces before the run; (c) the sinks
+   are the `RedisSinkOps` / `RedisStreamSinkOps` traits only (classic's free
+   functions + operator traits folded into one trait each). Two burst-model
+   notes: `redis_stream_read`'s snapshot rides one atomic burst (one shared
+   timestamp, as etcd) rather than classic's per-entry `NanoTime::now()`; and both
+   sources **reject `RunMode::HistoricalFrom` at wiring time** (live, unbounded,
+   wall-clock streams — Pub/Sub has no backlog, the stream tail blocks forever —
+   with no historical timeline to replay).
 5. **zmq, kafka, kdb** — streaming; `poll`/`external` + lifecycle.
 6. **fix** — codec-heavy; fallibility with context.
 7. **web** (+ wingfoil-wire-types, wingfoil-wasm, wingfoil-js untouched —


### PR DESCRIPTION
Ports the classic `wingfoil::adapters::redis` module onto the next Op model, behind the `redis` feature (port-plan Phase 4, item 4). Follows the `new-adapter-next` skill end to end.

## What's included

Two transports, each a source + sink, mirroring classic:

- **Pub/Sub** — `redis_sub` source (`SUBSCRIBE`, built on `produce_async`) + `RedisSinkOps::redis_pub` sink (`PUBLISH`, built on `consume_async`).
- **Streams** — `redis_stream_read` snapshot→tail source (`XRANGE` then `XREAD BLOCK`, built on `produce_async`) + `RedisStreamSinkOps::redis_stream_write` sink (`XADD`, built on `consume_async`).

All four classic value types are carried over: `RedisEntry`, `RedisEvent`, `RedisStreamRecord` (`::single`), `RedisStreamEvent` (`.field`), plus `RedisConnection` with `From<&str>`/`From<String>`. `HSET`/key-value ops stay out of scope, as in classic.

## Shared primitives used

- Sources ride `produce_async` (async client → timestamped burst stream).
- **Both sinks ride the shared `consume_async` primitive** — the off-thread async sink. Redis has no synchronous per-write conditional to abort (unlike `etcd_pub`'s `force:false`), so `consume_async` fits cleanly: writes land in order and are flushed at teardown.

## Tests & example

- `tests/redis_adapter.rs` — no-service tests (source/sink connection-refused, both sources rejecting `HistoricalFrom` at wiring), all passing.
- `tests/redis_integration.rs` — container-backed parity tests (testcontainers `redis:7-alpine`, gated on `redis-integration-test`): live message, pub round-trip, multi-entry burst, stream write+read snapshot, stream live tail.
- Inline unit tests for the pure types.
- `examples/redis_adapter.rs` — the classic pub→transform→republish round-trip ported.
- CI: `redis-next-integration.yml` wired into the `integration-tests.yml` hub.

## Deviations from classic (all capabilities preserved)

Same three as the etcd port: (a) the tokio runtime is the caller's (`&Handle` + a `RunParams` for the sources); (b) the sinks connect eagerly at wiring and return `Result`, so a connection error surfaces before the run; (c) the sinks are the `RedisSinkOps` / `RedisStreamSinkOps` traits only (classic's free functions + operator traits folded into one trait each). Two burst-model notes: `redis_stream_read`'s snapshot rides one atomic burst (one shared timestamp, as etcd); and both sources reject `RunMode::HistoricalFrom` at wiring time (live, unbounded, wall-clock streams with no historical timeline to replay).

No Python bindings — next binds only via the facade/cutover phase (port-plan Phase 6), per the skill.

## Checks

- `cargo fmt --all`, `cargo lint` (default) — pass.
- `cargo clippy -p wingfoil-next --all-features --all-targets -- -D warnings` — clean (covers all redis code). Note: the workspace-wide `cargo lint-all` could not complete in the sandbox because the **aeron** adapter's C library fails to build (CMake `Inappropriate ioctl for device`) — a pre-existing system-dependency issue unrelated to this change; `wingfoil-next` has no aeron feature, so the scoped all-features clippy is the equivalent gate for this diff.
- `cargo test -p wingfoil-next --features redis` — all green.
- Docker-gated `redis-integration-test` tests compile (`--no-run` OK) but were **not run in-sandbox** (no Docker available); they run in CI via the new workflow.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_