### PR TITLE
Port kafka adapter to wingfoil-next

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,6 +25,11 @@ jobs:
     uses: ./.github/workflows/etcd-next-integration.yml
     secrets: inherit
 
+  kafka-next-integration:
+    name: kafka (next) Integration Tests
+    uses: ./.github/workflows/kafka-next-integration.yml
+    secrets: inherit
+
   redis-integration:
     name: redis Integration Tests
     uses: ./.github/workflows/redis-integration.yml

--- a/.github/workflows/kafka-next-integration.yml
+++ b/.github/workflows/kafka-next-integration.yml
@@ -1,0 +1,52 @@
+name: test.integration.kafka-next
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'next/crates/wingfoil-next/src/adapters/kafka**'
+      - 'next/crates/wingfoil-next/tests/kafka_integration.rs'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  kafka-next-integration:
+    name: kafka (next) Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
+
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Pre-pull Redpanda image
+        # testcontainers pulls the image lazily on first use, which is
+        # vulnerable to transient registry flakes. Pull once up front with
+        # retries so every test reuses the cached image.
+        run: |
+          for i in 1 2 3; do
+            docker pull docker.redpanda.com/redpandadata/redpanda:v24.1.1 && exit 0
+            echo "pull attempt $i failed, retrying..."
+            sleep 5
+          done
+          echo "failed to pull Redpanda image after 3 attempts" && exit 1
+
+      - name: Run kafka (next) integration tests
+        run: |
+          cargo test --features kafka-integration-test -p wingfoil-next \
+            -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7683,6 +7683,7 @@ dependencies = [
  "etcd-client",
  "futures",
  "log",
+ "rdkafka",
  "redis",
  "reqwest",
  "serde",

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -85,6 +85,15 @@ redis = { version = "0.27", features = [
     "aio",
     "streams",
 ], optional = true }
+# `kafka` feature: a streaming topic-consume source and a topic-produce sink for
+# Apache Kafka, built on the async `produce_async` / `consume_async` ergonomics
+# (`rdkafka` is a tokio client). Version mirrors the classic `wingfoil` crate's
+# kafka adapter so the two trees don't drift. As classic does, the bundled
+# `librdkafka` uses rdkafka's default build path (`./configure` + `make`); the
+# `cmake-build` feature is deliberately not enabled (its curl.h dependency breaks
+# CI). `testcontainers` (used only by the integration tests) is already an
+# optional [dependencies] entry above, shared with the etcd adapter.
+rdkafka = { version = "0.37", optional = true }
 
 # `postgres` feature: time-partitioned historical reads, a `LISTEN`/`NOTIFY`
 # live-tail source, and a streaming insert sink, on the async `tokio-postgres`
@@ -127,7 +136,10 @@ criterion = "0.8.1"
 
 [features]
 default = []
-async = ["dep:tokio", "dep:futures"]
+# `tokio/sync` backs `consume_async`'s bounded/unbounded sink channels; it is
+# part of the async module, so the feature enables it directly rather than
+# relying on a companion adapter (etcd-client) to pull it in transitively.
+async = ["dep:tokio", "dep:futures", "tokio/sync"]
 csv = ["dep:csv", "dep:serde", "dep:serde-aux"]
 # File-backed result cache. Reuses `async` for the tokio runtime and adds
 # tokio's `fs` for the async file IO. Mirrors classic wingfoil's `kdb` deps
@@ -145,6 +157,11 @@ redis-integration-test = ["redis", "dep:testcontainers"]
 # timestamp column conversions.
 postgres = ["dep:tokio-postgres", "dep:chrono", "dep:async-stream", "async"]
 postgres-integration-test = ["postgres", "dep:testcontainers"]
+# Streaming Kafka consume source + produce sink. Built on the async
+# `produce_async` / `consume_async` ergonomics; needs `async-stream` for the
+# consumer's `recv()` loop. Mirrors classic wingfoil's `kafka` deps.
+kafka = ["dep:rdkafka", "dep:async-stream", "async"]
+kafka-integration-test = ["kafka", "dep:testcontainers"]
 # Realtime pull-based Prometheus metrics sink (hand-rolled HTTP + `arc-swap`).
 prometheus = ["dep:arc-swap"]
 # Adds the end-to-end scrape test (a live Prometheus scraping the exporter);
@@ -213,6 +230,10 @@ required-features = ["redis"]
 name = "postgres_adapter"
 path = "examples/postgres_adapter/main.rs"
 required-features = ["postgres"]
+
+[[example]]
+name = "kafka_adapter"
+required-features = ["kafka"]
 
 [[example]]
 name = "prometheus_adapter"

--- a/next/crates/wingfoil-next/examples/kafka_adapter.rs
+++ b/next/crates/wingfoil-next/examples/kafka_adapter.rs
@@ -1,0 +1,89 @@
+//! kafka adapter example — produce messages, consume and transform, write back.
+//!
+//! A port of the classic `wingfoil/examples/kafka` example onto the next engine.
+//! Two independent graph roots share one [`GraphBuilder`]:
+//!
+//! - `seed`       — writes source messages once via `constant` + `kafka_pub`.
+//! - `round_trip` — consumes the source topic, uppercases each value, and writes
+//!   the result to a destination topic.
+//!
+//! Unlike classic, the runtime is the caller's: we build a tokio runtime and
+//! hand its `handle()` to `kafka_sub` / `kafka_pub` (see the module docs).
+//!
+//! # Prerequisites
+//!
+//! A running Kafka-compatible broker (Redpanda recommended):
+//! ```sh
+//! docker run --rm -p 9092:9092 \
+//!   docker.redpanda.com/redpandadata/redpanda:v24.1.1 \
+//!   redpanda start --overprovisioned --smp 1 --memory 512M \
+//!   --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr localhost:9092
+//! ```
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example kafka_adapter --features kafka
+//! ```
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::kafka::{KafkaEvent, KafkaRecord, KafkaSinkOps, kafka_sub};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+const BROKERS: &str = "localhost:9092";
+const SOURCE_TOPIC: &str = "example-source";
+const DEST_TOPIC: &str = "example-dest";
+
+fn main() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    let handle = rt.handle();
+
+    let g = GraphBuilder::new();
+
+    // Seed the source topic with two messages, once.
+    let _seed = g
+        .constant(burst![
+            KafkaRecord {
+                topic: SOURCE_TOPIC.into(),
+                key: Some(b"greeting".to_vec()),
+                value: b"hello".to_vec(),
+            },
+            KafkaRecord {
+                topic: SOURCE_TOPIC.into(),
+                key: Some(b"subject".to_vec()),
+                value: b"world".to_vec(),
+            },
+        ])
+        .kafka_pub(handle, BROKERS)?;
+
+    // Consume the source topic, uppercase each value, write to the dest topic.
+    let params = RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Cycles(3),
+        start_time: NanoTime::ZERO,
+    };
+    let _round_trip = kafka_sub(&g, handle, params, BROKERS, SOURCE_TOPIC, "example-group")?
+        .map(|burst: &Burst<KafkaEvent>| {
+            burst
+                .iter()
+                .map(|event| {
+                    let upper = event.value_str().unwrap_or("").to_uppercase().into_bytes();
+                    println!(
+                        "  {} → {}",
+                        event.key_str().and_then(|r| r.ok()).unwrap_or("?"),
+                        String::from_utf8_lossy(&upper)
+                    );
+                    KafkaRecord {
+                        topic: DEST_TOPIC.into(),
+                        key: event.key.clone(),
+                        value: upper,
+                    }
+                })
+                .collect::<Burst<KafkaRecord>>()
+        })
+        .kafka_pub(handle, BROKERS)?;
+
+    g.build().run(RunMode::RealTime, RunFor::Cycles(3))?;
+    Ok(())
+}

--- a/next/crates/wingfoil-next/src/adapters/kafka.rs
+++ b/next/crates/wingfoil-next/src/adapters/kafka.rs
@@ -1,0 +1,410 @@
+//! kafka adapter — a streaming topic-consume **source** (`kafka_sub`) and a
+//! topic-produce **sink** (`KafkaSinkOps::kafka_pub`) for Apache Kafka. It ports
+//! the classic `wingfoil::adapters::kafka` module onto the Op model.
+//!
+//! # Layering
+//!
+//! Following the [`lines`](crate::adapters::lines) / [`stats`](crate::stats)
+//! pattern, the adapter is *not* in the [`prelude`](crate::prelude). Bring in
+//! what you need explicitly:
+//!
+//! - **Source** — the free builder function [`kafka_sub`] on a
+//!   [`GraphBuilder`]: consumes a topic in a consumer group and emits each
+//!   message as a [`KafkaEvent`], as a `Stream<Burst<KafkaEvent>>`.
+//! - **Sink** — the [`KafkaSinkOps`] extension trait on `Stream<Burst<KafkaRecord>>`
+//!   (and, for convenience, `Stream<KafkaRecord>`), enabled with
+//!   `use wingfoil_next::adapters::kafka::KafkaSinkOps;`.
+//!
+//! # Deviations from classic
+//!
+//! Every classic *capability* (consumer-group offset tracking, the earliest
+//! auto-offset-reset, per-record topic/key/partition, at-most-once delivery via
+//! background auto-commit, multi-topic writes from one sink) is preserved. The
+//! surface differs in these deliberate ways:
+//!
+//! 1. **The tokio runtime is the caller's.** Classic `kafka_sub`/`kafka_pub`
+//!    hide a global runtime inside `produce_async`/`consume_async`. Next's
+//!    [`produce_async`](crate::async_source::produce_async) and its sink
+//!    counterpart [`consume_async`](crate::async_source::consume_async) take the
+//!    runtime [`Handle`](tokio::runtime::Handle) explicitly (and `kafka_sub` a
+//!    [`RunParams`], since the producer task spawns at wiring time). Both
+//!    functions here follow that convention: the caller owns a
+//!    `tokio::runtime::Runtime` and hands in its `handle()`.
+//! 2. **`kafka_sub` is realtime-only, rejected at wiring time under historical
+//!    replay.** The consumer is a live, unbounded, wall-clock-stamped stream
+//!    with no historical timeline to replay: its `recv()` loop never ends, so
+//!    the historical channel path (which block-collects the whole stream up
+//!    front) would deadlock at `start`. Classic technically permitted a
+//!    `HistoricalFrom` run (with wall-clock `NanoTime::now()` timestamps); next
+//!    [rejects it at wiring time](kafka_sub#errors) with a clear error rather
+//!    than deadlocking. Run `kafka_sub` under [`RunMode::RealTime`].
+//! 3. **The sink is a trait only, connecting at wiring time.** Classic exposed
+//!    both a free `kafka_pub` function and a `KafkaPubOperators` trait; next
+//!    folds the single public entry point into the [`KafkaSinkOps`] trait
+//!    (renamed for the sink-as-trait convention shared with
+//!    [`lines`](crate::adapters::lines) / [`csv`](crate::adapters::csv) /
+//!    [`etcd`](crate::adapters::etcd)). The [`FutureProducer`] is created at
+//!    wiring time and the factory returns [`Result`]; librdkafka connects
+//!    lazily, so a bad broker surfaces on the first produced record during the
+//!    run rather than at wiring.
+//! 4. **Records are produced sequentially, not concurrently per burst.** Classic
+//!    handed every record in a burst to the producer up front and drained their
+//!    delivery futures together (`FuturesUnordered`), so per-burst latency was
+//!    one broker roundtrip. Next's [`consume_async`] drains each burst's records
+//!    through a **single** consumer task that awaits each `send` to delivery
+//!    confirmation before the next, so writes land in the exact order the graph
+//!    produced them at the cost of N sequential roundtrips per burst. The
+//!    explicit `producer.flush()` at upstream end is therefore unnecessary and
+//!    dropped: every send is awaited to its delivery ack (nothing is left
+//!    queued), and `consume_async` drains all queued writes at teardown.
+//!
+//! # Consumer group and offsets
+//!
+//! [`kafka_sub`] creates a `StreamConsumer` in the given `group_id` and
+//! subscribes to the topic. The `group_id` determines offset tracking: the same
+//! group across multiple runs continues from the last committed offset; a unique
+//! group reads from the beginning (`auto.offset.reset = earliest`). Delivery is
+//! **at-most-once** — `enable.auto.commit = true` commits offsets periodically
+//! in the background, so a message fetched but not fully processed before an
+//! error is not re-delivered. For at-least-once, disable auto-commit and manage
+//! offsets via the rdkafka API.
+//!
+//! # Sink
+//!
+//! [`KafkaSinkOps::kafka_pub`] produces one Kafka message per [`KafkaRecord`] in
+//! each burst. Each record names its own target topic, so a single sink can
+//! write to many topics. A delivery failure aborts the run with context (on the
+//! next cycle, per [`consume_async`]'s off-thread error propagation).
+//!
+//! # Setup
+//!
+//! Using Redpanda (Kafka-compatible, faster startup):
+//!
+//! ```sh
+//! docker run --rm -p 9092:9092 \
+//!   docker.redpanda.com/redpandadata/redpanda:v24.1.1 \
+//!   redpanda start --overprovisioned --smp 1 --memory 512M \
+//!   --kafka-addr 0.0.0.0:9092 --advertise-kafka-addr localhost:9092
+//! ```
+
+use anyhow::{Context, Result};
+use rdkafka::Message;
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::error::KafkaError;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::types::RDKafkaErrorCode;
+use std::time::Duration;
+use tokio::runtime::Handle;
+use wingfoil::{NanoTime, RunMode};
+
+use crate::Burst;
+use crate::async_source::{RunParams, consume_async, produce_async};
+use crate::burst;
+use crate::fluent::{GraphBuilder, Stream, StreamOps};
+
+/// Delivery-confirmation timeout for a single produced record.
+const SEND_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Connection configuration for Kafka.
+#[derive(Debug, Clone)]
+pub struct KafkaConnection {
+    /// Kafka bootstrap servers, e.g. `"localhost:9092"`.
+    ///
+    /// Multiple brokers can be comma-separated: `"host1:9092,host2:9092"`.
+    pub brokers: String,
+}
+
+impl KafkaConnection {
+    /// Create a connection config with a broker string.
+    ///
+    /// Multiple brokers can be separated by commas: `"host1:9092,host2:9092"`.
+    pub fn new(brokers: impl Into<String>) -> Self {
+        Self {
+            brokers: brokers.into(),
+        }
+    }
+}
+
+impl From<&str> for KafkaConnection {
+    fn from(brokers: &str) -> Self {
+        Self::new(brokers)
+    }
+}
+
+impl From<String> for KafkaConnection {
+    fn from(brokers: String) -> Self {
+        Self::new(brokers)
+    }
+}
+
+impl From<&String> for KafkaConnection {
+    fn from(brokers: &String) -> Self {
+        Self::new(brokers.clone())
+    }
+}
+
+/// A record to be produced to Kafka.
+#[derive(Debug, Clone, Default)]
+pub struct KafkaRecord {
+    /// The target topic.
+    pub topic: String,
+    /// Optional message key (used for partitioning).
+    pub key: Option<Vec<u8>>,
+    /// The message payload.
+    pub value: Vec<u8>,
+}
+
+impl KafkaRecord {
+    /// Interpret the value as a UTF-8 string.
+    pub fn value_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.value)
+    }
+}
+
+/// An event consumed from a Kafka topic.
+#[derive(Debug, Clone, Default)]
+pub struct KafkaEvent {
+    /// The source topic.
+    pub topic: String,
+    /// The partition from which this message was consumed.
+    pub partition: i32,
+    /// The offset of this message within the partition.
+    pub offset: i64,
+    /// The message key, if present.
+    pub key: Option<Vec<u8>>,
+    /// The message payload.
+    pub value: Vec<u8>,
+}
+
+impl KafkaEvent {
+    /// Interpret the value as a UTF-8 string.
+    pub fn value_str(&self) -> std::result::Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.value)
+    }
+
+    /// Interpret the key as a UTF-8 string, if present.
+    pub fn key_str(&self) -> Option<std::result::Result<&str, std::str::Utf8Error>> {
+        self.key.as_deref().map(std::str::from_utf8)
+    }
+}
+
+/// Consume messages from a Kafka `topic` in the `group_id` consumer group as a
+/// `Burst<KafkaEvent>` source.
+///
+/// Creates a `StreamConsumer` in the given group, subscribes to the topic, and
+/// emits each message as a [`KafkaEvent`] carrying the topic, partition, offset,
+/// key, and value. Messages arriving between graph cycles group into one
+/// [`Burst`]. Use `.collapse_accumulate()` (or `.collapse()`) for single-event
+/// processing.
+///
+/// `handle` is the caller's tokio runtime handle and `params` describes the run
+/// the graph will be driven with (see [`produce_async`] and the module docs).
+///
+/// # Consumer group and delivery
+///
+/// The same `group_id` across runs continues from the last committed offset; a
+/// unique group reads from the beginning (`auto.offset.reset = earliest`).
+/// Delivery is at-most-once (`enable.auto.commit = true`); see the module docs.
+///
+/// # Errors
+///
+/// Returns an error at **wiring time** if `params.run_mode` is
+/// [`RunMode::HistoricalFrom`]: the Kafka consumer is a live, unbounded,
+/// wall-clock-stamped stream with no historical timeline to replay, and the
+/// historical channel path would block-collect its never-ending `recv()` loop up
+/// front and deadlock at `start`. Run `kafka_sub` under [`RunMode::RealTime`].
+pub fn kafka_sub(
+    g: &GraphBuilder,
+    handle: &Handle,
+    params: RunParams,
+    conn: impl Into<KafkaConnection>,
+    topic: impl Into<String>,
+    group_id: impl Into<String>,
+) -> Result<Stream<Burst<KafkaEvent>>> {
+    if let RunMode::HistoricalFrom(_) = params.run_mode {
+        anyhow::bail!(
+            "kafka_sub: RunMode::HistoricalFrom is unsupported — the Kafka consumer \
+             is a live, unbounded, wall-clock-stamped stream with no historical \
+             timeline to replay; run kafka_sub under RunMode::RealTime"
+        );
+    }
+    let conn = conn.into();
+    let topic = topic.into();
+    let group_id = group_id.into();
+    Ok(produce_async(
+        g,
+        handle,
+        params,
+        move |_p: RunParams| async move {
+            let consumer: StreamConsumer = ClientConfig::new()
+                .set("bootstrap.servers", &conn.brokers)
+                .set("group.id", &group_id)
+                .set("auto.offset.reset", "earliest")
+                .set("enable.auto.commit", "true")
+                .set("session.timeout.ms", "6000")
+                .create()
+                .context("kafka_sub: creating consumer")?;
+
+            consumer
+                .subscribe(&[&topic])
+                .with_context(|| format!("kafka_sub: subscribing to {topic}"))?;
+
+            Ok(async_stream::stream! {
+                loop {
+                    match consumer.recv().await {
+                        Ok(msg) => {
+                            let event = KafkaEvent {
+                                topic: msg.topic().to_string(),
+                                partition: msg.partition(),
+                                offset: msg.offset(),
+                                key: msg.key().map(|k| k.to_vec()),
+                                value: msg.payload().unwrap_or_default().to_vec(),
+                            };
+                            yield Ok((NanoTime::now(), event));
+                        }
+                        Err(e) if is_transient_subscribe_error(&e) => continue,
+                        Err(e) => {
+                            yield Err(anyhow::anyhow!("kafka_sub: consume error: {e}"));
+                            break;
+                        }
+                    }
+                }
+            })
+        },
+    ))
+}
+
+/// `UnknownTopicOrPartition` is reported while the broker is still catching up on
+/// topic metadata (or the topic is pending auto-create). librdkafka keeps
+/// retrying the subscription in the background, so we swallow it and wait for the
+/// next event rather than terminating the stream.
+fn is_transient_subscribe_error(err: &KafkaError) -> bool {
+    matches!(
+        err,
+        KafkaError::MessageConsumption(RDKafkaErrorCode::UnknownTopicOrPartition)
+    )
+}
+
+/// Extension trait providing a fluent API for producing streams to Kafka.
+///
+/// Implemented for both `Stream<Burst<KafkaRecord>>` (multi-item) and
+/// `Stream<KafkaRecord>` (single-item, auto-wrapped into one-element bursts), so
+/// burst wrapping is never required in user code.
+pub trait KafkaSinkOps {
+    /// Produce this stream's [`KafkaRecord`]s to Kafka. Each record names its own
+    /// target topic, so one sink can write to many topics. Returns the sink
+    /// `Stream<()>`.
+    ///
+    /// - `handle`: the caller's tokio runtime handle (see the module docs).
+    ///
+    /// Records are drained off the graph thread and produced in order, each
+    /// awaited to its delivery confirmation. A delivery failure aborts the run
+    /// with context (surfaced on the next cycle, per [`consume_async`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error at wiring time if the [`FutureProducer`] cannot be
+    /// created (a client-config error). librdkafka connects lazily, so an
+    /// unreachable broker surfaces as a produce failure during the run, not at
+    /// wiring.
+    fn kafka_pub(&self, handle: &Handle, conn: impl Into<KafkaConnection>) -> Result<Stream<()>>;
+}
+
+impl KafkaSinkOps for Stream<Burst<KafkaRecord>> {
+    fn kafka_pub(&self, handle: &Handle, conn: impl Into<KafkaConnection>) -> Result<Stream<()>> {
+        let conn = conn.into();
+        // Create the producer at wiring time so a config error surfaces before
+        // the run (librdkafka connects lazily; a bad broker surfaces on the
+        // first produced record).
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", &conn.brokers)
+            .set("message.timeout.ms", "5000")
+            .create()
+            .context("kafka_pub: creating producer")?;
+
+        // `consume_async` drains each burst's records through a single consumer
+        // task (order preserved) off the graph thread; a write error propagates
+        // back into the graph on the next cycle. The producer is cloned per send
+        // (it is an `Arc` internally, cheap to clone and `Send`).
+        let sink = consume_async(handle, None, move |record: KafkaRecord| {
+            let producer = producer.clone();
+            async move {
+                let mut fut_record = FutureRecord::to(&record.topic).payload(&record.value);
+                if let Some(ref key) = record.key {
+                    fut_record = fut_record.key(key.as_slice());
+                }
+                producer
+                    .send(fut_record, SEND_TIMEOUT)
+                    .await
+                    .map_err(|(e, _)| {
+                        anyhow::anyhow!("kafka_pub: producing to {} failed: {e}", record.topic)
+                    })?;
+                Ok(())
+            }
+        });
+        Ok(self.for_each(sink))
+    }
+}
+
+impl KafkaSinkOps for Stream<KafkaRecord> {
+    fn kafka_pub(&self, handle: &Handle, conn: impl Into<KafkaConnection>) -> Result<Stream<()>> {
+        self.map(|record: &KafkaRecord| burst![record.clone()])
+            .kafka_pub(handle, conn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_value_str_reads_utf8() {
+        let record = KafkaRecord {
+            topic: "t".to_string(),
+            key: Some(b"k".to_vec()),
+            value: b"hello".to_vec(),
+        };
+        assert_eq!(record.value_str().unwrap(), "hello");
+    }
+
+    #[test]
+    fn event_no_key_is_none() {
+        let event = KafkaEvent {
+            topic: "t".to_string(),
+            partition: 0,
+            offset: 0,
+            key: None,
+            value: b"val".to_vec(),
+        };
+        assert!(event.key_str().is_none());
+    }
+
+    #[test]
+    fn event_key_and_value_str() {
+        let event = KafkaEvent {
+            topic: "t".to_string(),
+            partition: 1,
+            offset: 7,
+            key: Some(b"field-key".to_vec()),
+            value: b"field-value".to_vec(),
+        };
+        assert_eq!(event.value_str().unwrap(), "field-value");
+        assert_eq!(event.key_str().unwrap().unwrap(), "field-key");
+    }
+
+    #[test]
+    fn connection_from_str() {
+        let conn = KafkaConnection::from("localhost:9092");
+        assert_eq!(conn.brokers, "localhost:9092");
+    }
+
+    #[test]
+    fn transient_subscribe_error_detected() {
+        let transient = KafkaError::MessageConsumption(RDKafkaErrorCode::UnknownTopicOrPartition);
+        assert!(is_transient_subscribe_error(&transient));
+
+        let fatal = KafkaError::MessageConsumption(RDKafkaErrorCode::BrokerNotAvailable);
+        assert!(!is_transient_subscribe_error(&fatal));
+    }
+}

--- a/next/crates/wingfoil-next/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next/src/adapters/mod.rs
@@ -20,6 +20,10 @@
 //!   a key-value PUT sink (`EtcdSinkOps::etcd_pub`) for the etcd key-value
 //!   store, behind the `etcd` feature (built on the async `produce_async`
 //!   ergonomic).
+//! - [`kafka`] — a streaming topic-consume source (`kafka_sub`) and a
+//!   topic-produce sink (`KafkaSinkOps::kafka_pub`) for Apache Kafka, behind the
+//!   `kafka` feature (built on the async `produce_async` / `consume_async`
+//!   ergonomics).
 //! - [`cache`] — a file-backed, query-keyed, LRU-evicting result cache for
 //!   time-sliced historical readers, behind the `cache` feature. A pure utility
 //!   (async `get`/`put`), not a source/sink op.
@@ -55,6 +59,8 @@ pub mod common;
 pub mod csv;
 #[cfg(feature = "etcd")]
 pub mod etcd;
+#[cfg(feature = "kafka")]
+pub mod kafka;
 pub mod lines;
 #[cfg(feature = "postgres")]
 pub mod postgres;

--- a/next/crates/wingfoil-next/tests/kafka_adapter.rs
+++ b/next/crates/wingfoil-next/tests/kafka_adapter.rs
@@ -1,0 +1,97 @@
+//! kafka adapter tests that need no running service.
+//!
+//! The container-backed parity tests live in `tests/kafka_integration.rs` behind
+//! the `kafka-integration-test` feature. Run these with:
+//! ```sh
+//! cargo test -p wingfoil-next --features kafka
+//! ```
+#![cfg(feature = "kafka")]
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::kafka::{KafkaConnection, KafkaRecord, KafkaSinkOps, kafka_sub};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+/// `kafka_sub` rejects a `HistoricalFrom` run at wiring time — the live,
+/// unbounded, wall-clock consumer has no historical timeline to replay, and the
+/// historical channel path would block-collect its never-ending `recv()` loop up
+/// front and deadlock at `start`. The error must name the adapter rather than
+/// hang.
+#[test]
+fn sub_rejects_historical_mode() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let params = RunParams {
+        run_mode: RunMode::HistoricalFrom(NanoTime::ZERO),
+        run_for: RunFor::Cycles(1),
+        start_time: NanoTime::ZERO,
+    };
+    let err = match kafka_sub(
+        &g,
+        rt.handle(),
+        params,
+        KafkaConnection::new("127.0.0.1:9092"),
+        "topic",
+        "group",
+    ) {
+        Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("kafka_sub"), "names the adapter: {msg}");
+    assert!(
+        msg.contains("HistoricalFrom") || msg.contains("historical"),
+        "explains historical replay is unsupported: {msg}"
+    );
+}
+
+/// An unreachable broker must not hang or panic the consumer's run — with no
+/// broker up, librdkafka retries in the background, so a bounded-duration run
+/// simply terminates (with events or an error) rather than deadlocking. This is
+/// the parity of classic `test_connection_refused`.
+#[test]
+fn sub_connection_refused_terminates() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let params = RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Duration(Duration::from_secs(3)),
+        start_time: NanoTime::ZERO,
+    };
+    let _events = kafka_sub(
+        &g,
+        rt.handle(),
+        params,
+        KafkaConnection::new("127.0.0.1:59999"),
+        "nonexistent",
+        "test-group",
+    )
+    .expect("realtime kafka_sub wires without error")
+    .collapse_accumulate();
+
+    // rdkafka retries a bad broker rather than erroring immediately; we only
+    // verify the run terminates within the duration without panicking.
+    let mut runner = g.build();
+    let _ = runner.run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(3)));
+}
+
+/// The sink wires without error against a plausible broker string (librdkafka
+/// connects lazily, so producer creation succeeds even when the broker is down)
+/// — the parity of classic's producer-create path. The record's target topic is
+/// carried on each [`KafkaRecord`], so the sink can be built from a plain
+/// `Stream<KafkaRecord>` too.
+#[test]
+fn pub_wires_from_single_record_stream() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new();
+    let _sink = g
+        .constant(KafkaRecord {
+            topic: "t".to_string(),
+            key: Some(b"k".to_vec()),
+            value: b"v".to_vec(),
+        })
+        .kafka_pub(rt.handle(), "127.0.0.1:9092")
+        .expect("kafka_pub wires from a single-record stream");
+}

--- a/next/crates/wingfoil-next/tests/kafka_integration.rs
+++ b/next/crates/wingfoil-next/tests/kafka_integration.rs
@@ -1,0 +1,348 @@
+//! Integration tests for the kafka adapter — parity port of the classic
+//! `wingfoil/src/adapters/kafka/integration_tests.rs`.
+//!
+//! Requires Docker. Run with:
+//! ```sh
+//! cargo test -p wingfoil-next --features kafka-integration-test \
+//!   -- --test-threads=1 --nocapture
+//! ```
+#![cfg(feature = "kafka-integration-test")]
+
+use std::time::Duration;
+
+use rdkafka::Message;
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::SyncRunner};
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::kafka::{
+    KafkaConnection, KafkaEvent, KafkaRecord, KafkaSinkOps, kafka_sub,
+};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::*;
+
+const REDPANDA_IMAGE: &str = "docker.redpanda.com/redpandadata/redpanda";
+const REDPANDA_TAG: &str = "v24.1.1";
+
+/// Pick an OS-assigned free TCP port.
+///
+/// The port is released when the returned listener drops, so there is a small
+/// TOCTOU window before the container binds it. Good enough for tests.
+fn free_port() -> anyhow::Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+/// Start a Redpanda container and return the host endpoint.
+///
+/// Uses a fresh OS-assigned port for each container. Redpanda's
+/// `--advertise-kafka-addr` must match the address clients connect to, so the
+/// container binds the same port internally, mapped 1:1 to the host. This avoids
+/// collisions with any broker a developer might already be running on 9092.
+/// Parallel tests on the same machine are serialized by `--test-threads=1`.
+///
+/// The returned container must be kept alive for the duration of the test.
+fn start_redpanda() -> anyhow::Result<(impl Drop, String)> {
+    let port = free_port()?;
+    let container = GenericImage::new(REDPANDA_IMAGE, REDPANDA_TAG)
+        .with_wait_for(WaitFor::message_on_stderr("Started Kafka API server"))
+        .with_mapped_port(port, port.into())
+        .with_cmd(vec![
+            "redpanda".to_string(),
+            "start".to_string(),
+            "--overprovisioned".to_string(),
+            "--smp".to_string(),
+            "1".to_string(),
+            "--memory".to_string(),
+            "512M".to_string(),
+            "--reserve-memory".to_string(),
+            "0M".to_string(),
+            "--node-id".to_string(),
+            "0".to_string(),
+            "--check=false".to_string(),
+            "--kafka-addr".to_string(),
+            format!("0.0.0.0:{port}"),
+            "--advertise-kafka-addr".to_string(),
+            format!("127.0.0.1:{port}"),
+        ])
+        .start()?;
+    let endpoint = format!("127.0.0.1:{port}");
+    Ok((container, endpoint))
+}
+
+/// Create a topic via the admin API.
+fn create_topic(brokers: &str, topic: &str, partitions: i32) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let admin: AdminClient<rdkafka::client::DefaultClientContext> = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .create()
+            .map_err(|e| anyhow::anyhow!("admin create failed: {e}"))?;
+        let new_topic = NewTopic::new(topic, partitions, TopicReplication::Fixed(1));
+        admin
+            .create_topics(&[new_topic], &AdminOptions::new())
+            .await
+            .map_err(|e| anyhow::anyhow!("create topic failed: {e}"))?;
+        // Give the broker a moment to propagate metadata.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Ok(())
+    })
+}
+
+/// Produce messages directly via the client.
+fn produce_messages(brokers: &str, topic: &str, messages: &[(&str, &str)]) -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let producer: FutureProducer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("message.timeout.ms", "5000")
+            .create()
+            .map_err(|e| anyhow::anyhow!("producer create failed: {e}"))?;
+        for (key, value) in messages {
+            producer
+                .send(
+                    FutureRecord::to(topic).key(*key).payload(*value),
+                    Duration::from_secs(5),
+                )
+                .await
+                .map_err(|(e, _)| anyhow::anyhow!("produce failed: {e}"))?;
+        }
+        Ok(())
+    })
+}
+
+/// Consume messages directly via the client, returning up to `max` messages.
+fn consume_messages(
+    brokers: &str,
+    topic: &str,
+    group_id: &str,
+    max: usize,
+) -> anyhow::Result<Vec<(Option<Vec<u8>>, Vec<u8>)>> {
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("group.id", group_id)
+            .set("auto.offset.reset", "earliest")
+            .set("session.timeout.ms", "6000")
+            .create()
+            .map_err(|e| anyhow::anyhow!("consumer create failed: {e}"))?;
+        consumer
+            .subscribe(&[topic])
+            .map_err(|e| anyhow::anyhow!("subscribe failed: {e}"))?;
+
+        let mut results = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if results.len() >= max || tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            match tokio::time::timeout(Duration::from_secs(2), consumer.recv()).await {
+                Ok(Ok(msg)) => {
+                    results.push((
+                        msg.key().map(|k| k.to_vec()),
+                        msg.payload().unwrap_or_default().to_vec(),
+                    ));
+                }
+                Ok(Err(e)) => return Err(anyhow::anyhow!("consume error: {e}")),
+                Err(_) => break, // timeout
+            }
+        }
+        Ok(results)
+    })
+}
+
+/// Consume a topic with `kafka_sub` for `duration`, returning every event seen.
+///
+/// Collects bursts losslessly via `collapse_accumulate` (never dropping events
+/// that arrive within one graph cycle — exactly what happens the first time
+/// after a consumer-group rebalance), then reads the accumulated `Vec` off the
+/// runner. Uses `RunFor::Duration` so rebalance + delivery have time to complete.
+fn consume_with_sub(
+    brokers: &str,
+    topic: &str,
+    group: &str,
+    secs: u64,
+) -> anyhow::Result<Vec<KafkaEvent>> {
+    let rt = tokio::runtime::Runtime::new()?;
+    let g = GraphBuilder::new();
+    let params = RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Duration(Duration::from_secs(secs)),
+        start_time: NanoTime::ZERO,
+    };
+    let events = kafka_sub(
+        &g,
+        rt.handle(),
+        params,
+        KafkaConnection::new(brokers),
+        topic,
+        group,
+    )?
+    .collapse_accumulate();
+    let mut runner = g.build();
+    runner.run(
+        RunMode::RealTime,
+        RunFor::Duration(Duration::from_secs(secs)),
+    )?;
+    Ok(runner.value(&events))
+}
+
+// ---- Source tests ----
+
+#[test]
+fn test_sub_receives_pre_seeded_messages() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-sub-seeded";
+    create_topic(&brokers, topic, 1)?;
+    produce_messages(&brokers, topic, &[("k1", "v1"), ("k2", "v2")])?;
+
+    let events = consume_with_sub(&brokers, topic, "sub-seeded-group", 20)?;
+    assert!(
+        events.len() >= 2,
+        "expected at least 2 events, got {}",
+        events.len()
+    );
+    let values: Vec<Vec<u8>> = events.iter().map(|e| e.value.clone()).collect();
+    assert!(values.contains(&b"v1".to_vec()));
+    assert!(values.contains(&b"v2".to_vec()));
+    Ok(())
+}
+
+#[test]
+fn test_sub_live_messages() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-sub-live";
+    create_topic(&brokers, topic, 1)?;
+
+    let brokers_clone = brokers.clone();
+    let topic_owned = topic.to_string();
+    let handle = std::thread::spawn(move || {
+        // Give the consumer a few seconds to subscribe and rebalance before
+        // producing, so we exercise the live-stream path.
+        std::thread::sleep(Duration::from_secs(3));
+        produce_messages(&brokers_clone, &topic_owned, &[("live-key", "live-value")]).unwrap();
+    });
+
+    let events = consume_with_sub(&brokers, topic, "sub-live-group", 20)?;
+    handle.join().unwrap();
+
+    assert!(!events.is_empty(), "expected at least 1 live event, got 0");
+    assert_eq!(events[0].value, b"live-value");
+    Ok(())
+}
+
+#[test]
+fn test_sub_event_fields() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-sub-fields";
+    create_topic(&brokers, topic, 1)?;
+    produce_messages(&brokers, topic, &[("field-key", "field-value")])?;
+
+    let events = consume_with_sub(&brokers, topic, "fields-group", 20)?;
+    assert!(!events.is_empty(), "expected at least 1 event, got 0");
+    let event = &events[0];
+    assert_eq!(event.topic, topic);
+    assert_eq!(event.partition, 0);
+    assert!(event.offset >= 0);
+    assert_eq!(event.key.as_deref(), Some(b"field-key".as_ref()));
+    assert_eq!(event.value, b"field-value");
+    assert_eq!(event.value_str().unwrap(), "field-value");
+    assert_eq!(event.key_str().unwrap().unwrap(), "field-key");
+    Ok(())
+}
+
+// ---- Sink tests ----
+
+#[test]
+fn test_pub_round_trip() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-pub-rt";
+    create_topic(&brokers, topic, 1)?;
+
+    {
+        let rt = tokio::runtime::Runtime::new()?;
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![KafkaRecord {
+                topic: topic.to_string(),
+                key: Some(b"rt-key".to_vec()),
+                value: b"rt-value".to_vec(),
+            }])
+            .kafka_pub(rt.handle(), KafkaConnection::new(&brokers))?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    // Verify via direct consumer read.
+    let messages = consume_messages(&brokers, topic, "rt-verify-group", 1)?;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].0.as_deref(), Some(b"rt-key".as_ref()));
+    assert_eq!(messages[0].1, b"rt-value");
+    Ok(())
+}
+
+#[test]
+fn test_pub_multiple_records_in_burst() -> anyhow::Result<()> {
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-pub-multi";
+    create_topic(&brokers, topic, 1)?;
+
+    {
+        let rt = tokio::runtime::Runtime::new()?;
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![
+                KafkaRecord {
+                    topic: topic.to_string(),
+                    key: Some(b"k1".to_vec()),
+                    value: b"v1".to_vec(),
+                },
+                KafkaRecord {
+                    topic: topic.to_string(),
+                    key: Some(b"k2".to_vec()),
+                    value: b"v2".to_vec(),
+                },
+            ])
+            .kafka_pub(rt.handle(), KafkaConnection::new(&brokers))?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    let messages = consume_messages(&brokers, topic, "multi-verify-group", 2)?;
+    assert_eq!(messages.len(), 2);
+    let values: Vec<Vec<u8>> = messages.iter().map(|(_, v)| v.clone()).collect();
+    assert!(values.contains(&b"v1".to_vec()));
+    assert!(values.contains(&b"v2".to_vec()));
+    Ok(())
+}
+
+#[test]
+fn test_pub_round_trip_via_sub() -> anyhow::Result<()> {
+    // Produce with kafka_pub, then read back the same records with kafka_sub —
+    // both adapter directions in one flow.
+    let (_container, brokers) = start_redpanda()?;
+    let topic = "test-pub-sub-rt";
+    create_topic(&brokers, topic, 1)?;
+
+    {
+        let rt = tokio::runtime::Runtime::new()?;
+        let g = GraphBuilder::new();
+        let _sink = g
+            .constant(burst![KafkaRecord {
+                topic: topic.to_string(),
+                key: Some(b"key".to_vec()),
+                value: b"payload".to_vec(),
+            }])
+            .kafka_pub(rt.handle(), KafkaConnection::new(&brokers))?;
+        g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    }
+
+    let events = consume_with_sub(&brokers, topic, "pub-sub-rt-group", 20)?;
+    assert!(
+        !events.is_empty(),
+        "kafka_sub should read the produced record"
+    );
+    assert!(events.iter().any(|e| e.value == b"payload"));
+    Ok(())
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -632,6 +632,37 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    - **kdb** reuses the `postgres`-ported time slicer in `adapters::common` —
      add `feature = "kdb"` to the `#[cfg]` gate on `compute_time_slices` /
      `compute_validated_time_slices` and their tests.
+   ✅ **kafka** *(done)*: a streaming topic-consume source (`kafka_sub`) on
+   `produce_async` and a topic-produce sink (`KafkaSinkOps::kafka_pub`) on
+   `consume_async`, behind the `kafka` feature (`rdkafka` 0.37, mirroring
+   classic). Parity port of the classic adapter's tests as
+   `tests/kafka_integration.rs` (testcontainers/Redpanda, gated on
+   `kafka-integration-test`; `kafka-next-integration.yml`) plus no-service tests
+   in `tests/kafka_adapter.rs`, and the round-trip example (`kafka_adapter`).
+   **Deviations** (capabilities all preserved): (a) the tokio runtime is the
+   caller's — `kafka_sub`/`kafka_pub` take a `&tokio::runtime::Handle` (and
+   `kafka_sub` a `RunParams`), matching next's `produce_async` convention rather
+   than classic's hidden global runtime; (b) the sink is the `KafkaSinkOps` trait
+   only (classic's free `kafka_pub` fn folded into the trait, per next's
+   sink-as-trait convention), creating the `FutureProducer` at wiring and
+   returning `Result`; (c) records in a burst are produced **sequentially**
+   (single ordered `consume_async` consumer, each `send` awaited to delivery
+   confirmation) rather than concurrently via `FuturesUnordered` — order is
+   preserved at the cost of N roundtrips per burst, and the explicit
+   `producer.flush()` at upstream end is dropped as unnecessary (every send is
+   already awaited to its ack; `consume_async` drains queued writes at teardown).
+   - **Historical mode unsupported:** like `etcd_sub`, `kafka_sub` is a live,
+     unbounded, wall-clock-stamped consumer with no historical timeline to
+     replay, and the historical channel path would block-collect its never-ending
+     `recv()` loop up front and deadlock at `start`. `kafka_sub` returns `Result`
+     and **rejects `RunMode::HistoricalFrom` at wiring time** with a clear error;
+     run it under `RunMode::RealTime`. (Classic technically permitted a
+     historical run with wall-clock timestamps.)
+   - **`async` feature fix:** enabling `async` now also enables `tokio/sync`
+     (which `consume_async`'s sink channels need). Previously the `async` feature
+     compiled only because a companion adapter (`etcd-client`) pulled `tokio/sync`
+     in transitively; `kafka` is the first async adapter that does not, so the
+     feature is now self-contained.
 6. **fix** — codec-heavy; fallibility with context.
 7. **web** (+ wingfoil-wire-types, wingfoil-wasm, wingfoil-js untouched —
    the wire protocol is engine-agnostic), **prometheus, otlp, augurs**.


### PR DESCRIPTION
Ports the classic `wingfoil::adapters::kafka` module onto the wingfoil-next Op model (port-plan Phase 4, item 5). Follows the `new-adapter-next` skill. **Base: `next`.**

## What's added

- **`kafka_sub`** — topic-consume **source** built on `produce_async` (the async ergonomic, matching classic's `read.rs`). Creates a `StreamConsumer` in a consumer group, subscribes, and emits each message as a `KafkaEvent` (topic/partition/offset/key/value) in bursts. Swallows the transient `UnknownTopicOrPartition` while the broker catches up on metadata, exactly as classic does.
- **`KafkaSinkOps::kafka_pub`** — topic-produce **sink** built on `consume_async`. Produces each `KafkaRecord` (with its own target topic, so one sink can write many topics) in order, each `send` awaited to delivery confirmation. Implemented for both `Stream<Burst<KafkaRecord>>` and `Stream<KafkaRecord>`.
- Behind the `kafka` feature (`rdkafka` 0.37, mirroring classic; default `./configure`+`make` build path, no `cmake-build`). `kafka-integration-test` adds testcontainers.
- Round-trip example `kafka_adapter` (port of classic `examples/kafka`).
- Tests: no-service `tests/kafka_adapter.rs` + Docker/Redpanda `tests/kafka_integration.rs` (gated), wired into the hub via `.github/workflows/kafka-next-integration.yml`.
- `mod.rs` gate + doc bullet; `docs/port-plan.md` Phase 4 marked ✅.

## Primitives used

`produce_async` for the source and `consume_async` for the sink (the async source/sink pair over the `channel` layer), plus `for_each` to wire the sink — the exact shapes the skill's step-7/step-8 prescribe for an async client library. This mirrors the `etcd` adapter.

## Incidental fix

The `async` feature now enables `tokio/sync` directly. `consume_async`'s bounded/unbounded sink channels use `tokio::sync::mpsc`, but the `async` feature didn't enable `tokio/sync` — it only compiled because a companion async adapter (`etcd-client`) pulled it in transitively. `kafka` is the first async adapter that doesn't, so the feature is now self-contained.

## Deviations from classic (all capabilities preserved)

1. **Caller-owned tokio runtime** — `kafka_sub`/`kafka_pub` take a `&tokio::runtime::Handle` (and `kafka_sub` a `RunParams`), per next's `produce_async` convention, rather than classic's hidden global runtime.
2. **Sink is a trait only, eager producer** — the free `kafka_pub` fn folds into `KafkaSinkOps`; the `FutureProducer` is created at wiring time and the factory returns `Result` (librdkafka connects lazily, so a bad broker surfaces on the first produced record).
3. **Sequential per-burst produce** — records in a burst are produced through a single ordered `consume_async` consumer (each `send` awaited to its ack) rather than concurrently via `FuturesUnordered`. Write order is preserved at the cost of N roundtrips per burst; the explicit `producer.flush()` at upstream end is dropped as unnecessary (every send is already awaited; `consume_async` drains queued writes at teardown).
4. **Historical mode rejected at wiring time** — like `etcd_sub`, the live, never-closing consumer would deadlock next's historical channel path (which block-collects up front). Classic technically permitted a historical run with wall-clock timestamps.

## Checks

- `cargo fmt --all` ✓
- `cargo lint` (default features) ✓
- `cargo lint-all` (all features — compiles the `kafka`/`kafka-integration-test` code) ✓
- `cargo test -p wingfoil-next --all-features` — every non-Docker binary green (lib incl. 5 kafka unit tests, `kafka_adapter` 3, `consume_async`/`produce_async`, `trybuild`, etc.). The Docker-backed `kafka_integration` (6) and pre-existing `etcd_integration` (12) suites can't run in the sandbox (no Docker) and are expected to run in CI via the integration-tests hub.

No system dependencies needed — librdkafka built with the toolchain already present. No Python bindings (per the skill, next bindings arrive with the facade/cutover phase).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_