### PR TITLE
wingfoil-next: port the zmq adapter (Phase 4)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,6 +60,11 @@ jobs:
     uses: ./.github/workflows/zmq-etcd-integration.yml
     secrets: inherit
 
+  zmq-next-integration:
+    name: ZMQ (next) Integration Tests
+    uses: ./.github/workflows/zmq-next-integration.yml
+    secrets: inherit
+
   iceoryx2-integration:
     name: iceoryx2 Integration Tests
     uses: ./.github/workflows/iceoryx2-integration.yml

--- a/.github/workflows/zmq-next-integration.yml
+++ b/.github/workflows/zmq-next-integration.yml
@@ -1,0 +1,62 @@
+name: test.integration.zmq-next
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'next/crates/wingfoil-next/src/adapters/zmq**'
+      - 'next/crates/wingfoil-next/tests/zmq_integration.rs'
+      - 'next/crates/wingfoil-next/tests/zmq_etcd_integration.rs'
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  zmq-next-integration:
+    name: ZMQ (next) Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: integration
+
+      - name: Install system dependencies
+        # `libzmq` is linked by the `zmq` crate; `protoc` is needed by a
+        # transitive build dependency.
+        run: sudo apt-get update && sudo apt-get install -y libzmq3-dev pkg-config protobuf-compiler
+
+      - name: Pre-pull etcd image
+        # testcontainers pulls the image lazily on first use, which is
+        # vulnerable to transient registry flakes. Pull once up front with
+        # retries so every discovery test reuses the cached image.
+        run: |
+          for i in 1 2 3; do
+            docker pull gcr.io/etcd-development/etcd:v3.5.0 && exit 0
+            echo "pull attempt $i failed, retrying..."
+            sleep 5
+          done
+          echo "failed to pull etcd image after 3 attempts" && exit 1
+
+      - name: Run ZMQ (next) core pub/sub integration tests
+        run: |
+          cargo test --features zmq-integration-test -p wingfoil-next \
+            --test zmq_integration -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO
+
+      - name: Run ZMQ (next) etcd discovery integration tests
+        run: |
+          cargo test --features zmq-etcd-integration-test -p wingfoil-next \
+            --test zmq_etcd_integration -- --test-threads=1 --nocapture
+        env:
+          RUST_LOG: INFO

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7693,6 +7693,7 @@ dependencies = [
  "trybuild",
  "wingfoil",
  "wingfoil-next-macros",
+ "zmq",
 ]
 
 [[package]]

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -98,6 +98,16 @@ reqwest = { version = "0.12", features = [
     "blocking",
 ], optional = true }
 
+# `zmq` feature: real-time pub/sub over ØMQ sockets (`zmq_sub` source +
+# `ZeroMqPub` sink), with optional etcd-based service discovery. Synchronous and
+# poll-based, so — like the classic `wingfoil` zmq adapter — it uses a background
+# thread over the `channel` layer and deliberately does NOT pull in `async`.
+# Messages are `bincode`-framed (reuses the optional `bincode`/`serde` entries
+# above). Version mirrors the classic `wingfoil` crate's zmq adapter so the two
+# trees don't drift; the `zmq` crate links the system `libzmq` (Debian/Ubuntu:
+# `libzmq3-dev`).
+zmq = { version = "0.10.0", optional = true }
+
 [dev-dependencies]
 # Compile-fail tests pinning the `graph!` macro's key error paths.
 trybuild = "1"
@@ -123,6 +133,15 @@ prometheus = ["dep:arc-swap"]
 # Adds the end-to-end scrape test (a live Prometheus scraping the exporter);
 # `reqwest` (blocking) queries Prometheus. Mirrors classic wingfoil.
 prometheus-integration-test = ["prometheus", "dep:reqwest"]
+# ZMQ pub/sub adapter. `bincode`/`serde` frame the wire envelope; the `zmq` crate
+# links the system `libzmq`. No `async` — the subscriber uses a background thread
+# over the `channel` layer (matching classic).
+zmq = ["dep:zmq", "dep:bincode", "dep:serde"]
+# Core pub/sub parity tests (real sockets, no external service / container).
+zmq-integration-test = ["zmq"]
+# etcd service-discovery parity tests (needs Docker via testcontainers). Enables
+# the `etcd`-gated `EtcdRegistry` discovery backend alongside `zmq`.
+zmq-etcd-integration-test = ["zmq", "etcd", "dep:testcontainers"]
 # Runtime graph dynamism: append nodes and splice edges into a live graph
 # mid-run (`Runner::run_dynamic` + `Extension`). Mirrors classic wingfoil's
 # `dynamic-graph` feature; off the default hot path until wired in. The layered
@@ -176,6 +195,10 @@ required-features = ["redis"]
 [[example]]
 name = "prometheus_adapter"
 required-features = ["prometheus"]
+
+[[example]]
+name = "zmq_adapter"
+required-features = ["zmq"]
 
 # Ports of the classic `wingfoil/examples/` onto the next engine's fluent API.
 # Each lives in its own directory with a README, mirroring the classic layout.

--- a/next/crates/wingfoil-next/examples/zmq_adapter.rs
+++ b/next/crates/wingfoil-next/examples/zmq_adapter.rs
@@ -1,0 +1,64 @@
+//! zmq pub/sub adapter example — publish a counter, subscribe, print it.
+//!
+//! A self-contained port of the classic `wingfoil/examples/zmq` (direct mode)
+//! onto the next engine. Two roles run as separate graphs:
+//!
+//! - **publisher** — on a background thread, binds a `PUB` socket and publishes
+//!   a UTF-8 counter every 100 ms.
+//! - **subscriber** — in `main`, connects a `SUB` socket to that address and
+//!   prints each received value (plus connection-status transitions).
+//!
+//! The publisher buffers early messages until the subscriber's subscription
+//! propagates, so no counter values are dropped at startup (ZeroMQ's
+//! slow-joiner problem). ZMQ is peer-to-peer — no broker process is required.
+//! Service discovery via `EtcdRegistry` (`("name", registry)`) is exercised by
+//! the `zmq-etcd-integration-test` suite.
+//!
+//! # Run
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example zmq_adapter --features zmq
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{RunFor, RunMode};
+use wingfoil_next::adapters::zmq::{ZeroMqPub, ZmqStatus, zmq_sub};
+use wingfoil_next::prelude::*;
+
+const ADDRESS: &str = "tcp://127.0.0.1:5556";
+const PORT: u16 = 5556;
+
+fn main() -> anyhow::Result<()> {
+    // Publisher: bind a PUB socket and publish a counter for two seconds.
+    let publisher = std::thread::spawn(move || -> anyhow::Result<()> {
+        let g = GraphBuilder::new();
+        let _pub = g
+            .ticker(Duration::from_millis(100))
+            .count()
+            .map(|n: &u64| format!("{n}").into_bytes())
+            .zmq_pub(PORT, ());
+        g.build()
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+        Ok(())
+    });
+
+    // Subscriber: connect and print received counters + status transitions.
+    let g = GraphBuilder::new();
+    let (data, status) = zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, ADDRESS)?;
+    let _print = data.collapse().for_each(|msg: &Vec<u8>| {
+        println!("received: {}", String::from_utf8_lossy(msg));
+        Ok(())
+    });
+    let _status = status.for_each(|s: &ZmqStatus| {
+        println!("status: {s:?}");
+        Ok(())
+    });
+    g.build().run(
+        RunMode::RealTime,
+        RunFor::Duration(Duration::from_millis(1500)),
+    )?;
+
+    publisher.join().expect("publisher thread panicked")?;
+    Ok(())
+}

--- a/next/crates/wingfoil-next/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next/src/adapters/mod.rs
@@ -35,6 +35,10 @@
 //!   `RedisStreamSinkOps::redis_stream_write` sink), behind the `redis` feature
 //!   (built on the async `produce_async` / `consume_async` ergonomics). The
 //!   sources are realtime-only.
+//! - [`zmq`] — real-time ØMQ pub/sub (`zmq_sub` source with a connection-status
+//!   stream + `ZeroMqPub::zmq_pub` sink), with optional etcd service discovery,
+//!   behind the `zmq` feature. Synchronous/poll-based, so it uses a background
+//!   thread over the `channel` layer (not `async`); the source is realtime-only.
 
 #[cfg(feature = "augurs")]
 pub mod augurs;
@@ -50,3 +54,5 @@ pub mod lines;
 pub mod prometheus;
 #[cfg(feature = "redis")]
 pub mod redis;
+#[cfg(feature = "zmq")]
+pub mod zmq;

--- a/next/crates/wingfoil-next/src/adapters/zmq.rs
+++ b/next/crates/wingfoil-next/src/adapters/zmq.rs
@@ -1,0 +1,659 @@
+//! zmq adapter — real-time pub/sub messaging over ØMQ (ZeroMQ) sockets, with
+//! optional service discovery. It ports the classic `wingfoil::adapters::zmq`
+//! module onto the Op model.
+//!
+//! # Layering
+//!
+//! Following the [`lines`](crate::adapters::lines) / [`stats`](crate::stats)
+//! pattern, the adapter is *not* in the [`prelude`](crate::prelude) and is gated
+//! behind the `zmq` feature. Bring in what you need explicitly:
+//!
+//! - **Source** — the free function [`zmq_sub`] on a [`GraphBuilder`]: connects a
+//!   `SUB` socket to a publisher and emits a `(data, status)` pair — a
+//!   `Stream<Burst<T>>` of received messages plus a `Stream<ZmqStatus>` of
+//!   connection-status transitions.
+//! - **Sink** — the [`ZeroMqPub`] extension trait on any `Stream<T>`, enabled
+//!   with `use wingfoil_next::adapters::zmq::ZeroMqPub;`: binds a `PUB` socket
+//!   and publishes each value.
+//!
+//! # Source semantics (background thread over the channel)
+//!
+//! ZeroMQ sockets are synchronous and poll-based, so the subscriber dedicates a
+//! background OS thread that polls the socket and feeds a
+//! [`channel`](crate::fluent::SourceOps::channel) — the sync-streaming-client
+//! shape from the adapter skill, rather than `produce_async`. Deliberately, the
+//! `zmq` feature does **not** pull in `async`/tokio (matching the classic
+//! adapter's design decision).
+//!
+//! Values arriving between graph cycles group into one [`Burst`]. A ZMQ *monitor*
+//! socket is opened alongside the data socket so `Connected` / `Disconnected`
+//! transitions surface on the status stream without external state; the subscriber
+//! multiplexes data and status over the one channel (an internal `ZmqEvent`
+//! envelope), then splits them back into the two streams.
+//!
+//! The subscriber is a live, never-closing source: it **rejects
+//! [`RunMode::HistoricalFrom`] at wiring time** and returns an error. It cannot
+//! replay historically — next's channel receiver block-collects the whole stream
+//! up front in a historical run, so an unbounded live producer would deadlock the
+//! graph at `start`. Run [`zmq_sub`] under [`RunMode::RealTime`].
+//!
+//! # Sink
+//!
+//! [`ZeroMqPub::zmq_pub`] binds a `PUB` socket (on `127.0.0.1` by default, or a
+//! routable address via [`zmq_pub_on`](ZeroMqPub::zmq_pub_on)) and publishes the
+//! stream's current value each cycle. Because a fresh `SUB` peer misses messages
+//! sent before its subscription filter propagates (ZeroMQ's *slow-joiner*
+//! problem), the publisher watches its own monitor socket for the first accepted
+//! connection and **buffers** outgoing messages until the subscriber is ready
+//! (up to [`BUFFER_TIMEOUT`], plus a short subscription-propagation delay). The
+//! publisher is realtime-only: a [`RunMode::HistoricalFrom`] run **aborts** with a
+//! "real-time" error on the first cycle (publishing fast-forwarded historical
+//! data to a live socket is meaningless — matching classic, which errors rather
+//! than the skill's no-op default for exporters).
+//!
+//! # Service discovery (pluggable backend)
+//!
+//! Both endpoints accept a bare address *or* a `(name, registry)` pair for
+//! discovery-based lookup, via `impl Into<_>` config wrappers ([`ZmqSubConfig`] /
+//! [`ZmqPubRegistration`]) with `From` impls — one signature, several call
+//! shapes. The registry is a pluggable backend behind the [`ZmqRegistry`] trait;
+//! with the `etcd` feature also enabled, [`EtcdRegistry`] becomes a discovery
+//! backend that stores the publisher address in etcd under a lease.
+//!
+//! ```ignore
+//! stream.zmq_pub(5556, ());                                   // no registration
+//! stream.zmq_pub(5556, ("quotes", EtcdRegistry::new(conn)));  // register in etcd
+//!
+//! zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, "tcp://host:5556")?;               // direct
+//! zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, ("quotes", EtcdRegistry::new(conn)))?; // discovery
+//! ```
+//!
+//! # Deviations from classic
+//!
+//! Every classic *capability* (sub with a status stream, pub with slow-joiner
+//! buffering, the `ZmqRegistry`/`EtcdRegistry` discovery backend, `zmq_pub_on`
+//! for routable binds) is preserved. The surface differs in three deliberate
+//! ways:
+//!
+//! 1. **[`zmq_sub`] takes a [`GraphBuilder`] and a [`RunMode`].** It wires a
+//!    `channel` source on the builder (like every next source) and needs the run
+//!    mode to reject `HistoricalFrom` at wiring time — next's channel is bimodal
+//!    and would deadlock rather than erroring at run start the way classic's
+//!    realtime-only `ReceiverStream` does.
+//! 2. **[`ZeroMqPub::zmq_pub`] returns `Stream<()>`** (a sink to add to the
+//!    graph) instead of classic's `Rc<dyn Node>`. Binding, registration and the
+//!    run-mode check happen lazily on the first cycle (like classic's `start`),
+//!    so a historical run still errors with "real-time" *before* touching the
+//!    registry.
+//! 3. **The wire envelope is next-local.** Messages are `bincode`-framed with an
+//!    internal envelope, so a next publisher interoperates with a next
+//!    subscriber but is **not** wire-compatible with a classic/Python
+//!    `wingfoil` peer — cross-language interop lands with the Python bindings
+//!    (port-plan Phase 6).
+//!
+//! Two smaller surface reductions: the internal `ZmqEvent<T>` data/status
+//! multiplexing envelope is **private** here (classic exposed it as `pub`, but it
+//! is purely an internal transport detail); and `ZmqStatus` derives `Eq` in
+//! addition to classic's `PartialEq` (harmless).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use wingfoil::RunMode;
+
+use crate::Burst;
+use crate::channel::ChannelSender;
+use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
+use crate::op::{Activation, Ctx, Tick};
+
+mod registry;
+
+use registry::ZmqSubResolution;
+pub use registry::{ZmqHandle, ZmqPubRegistration, ZmqRegistry, ZmqSubConfig};
+
+#[cfg(feature = "etcd")]
+pub use registry::EtcdRegistry;
+
+/// Distinct monitor `inproc://` addresses across every socket in the process.
+static MONITOR_ID: AtomicUsize = AtomicUsize::new(0);
+
+// ZeroMQ socket monitor event flags (from `zmq.h`).
+const ZMQ_EVENT_CONNECTED: u16 = 0x0001;
+const ZMQ_EVENT_ACCEPTED: u16 = 0x0008;
+const ZMQ_EVENT_DISCONNECTED: u16 = 0x0200;
+
+/// Maximum time the publisher buffers messages while waiting for a subscriber to
+/// connect. Messages buffered longer than this are discarded — a subscriber
+/// connecting after this window should not receive stale data.
+pub const BUFFER_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Connection status reported by the subscriber's socket monitor.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ZmqStatus {
+    /// The `SUB` socket has connected to a publisher.
+    Connected,
+    /// The `SUB` socket is not connected (initial state, or after a disconnect /
+    /// publisher `EndOfStream`).
+    #[default]
+    Disconnected,
+}
+
+/// Internal per-message envelope multiplexed over the one channel: either a
+/// decoded data value or a connection-status transition. The subscriber splits
+/// these back into the `(data, status)` streams so a `Connected` transition
+/// stays correctly ordered relative to the values around it.
+#[derive(Debug, Clone)]
+enum ZmqEvent<T> {
+    Data(T),
+    Status(ZmqStatus),
+}
+
+impl<T: Default> Default for ZmqEvent<T> {
+    fn default() -> Self {
+        ZmqEvent::Data(T::default())
+    }
+}
+
+/// The `bincode`-framed wire envelope. Realtime-only, so a publisher only ever
+/// sends [`WireMessage::Value`] and [`WireMessage::EndOfStream`]. Mirrors the
+/// variants of classic wingfoil's `channel::Message` (including its `Error`
+/// case) but is **not** byte-compatible with it (see the module-level
+/// deviations).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum WireMessage<T> {
+    /// A published value.
+    Value(T),
+    /// The publisher is shutting down cleanly.
+    EndOfStream,
+    /// An error, carried in the envelope for symmetry with classic. Not sent by
+    /// this publisher; the subscriber synthesizes it locally on a decode failure
+    /// (see [`run_subscriber`]) to route the error through the same match arm.
+    Error(String),
+}
+
+/// Serialize the payload-free `EndOfStream` frame. The variant carries no `T`,
+/// so any element type produces identical bytes — used at publisher teardown
+/// without naming the stream's element type.
+fn end_of_stream_bytes() -> Result<Vec<u8>> {
+    bincode::serialize(&WireMessage::<()>::EndOfStream).context("zmq_pub: serializing EndOfStream")
+}
+
+// ---------------------------------------------------------------------------
+// Source
+// ---------------------------------------------------------------------------
+
+/// Sets the shared stop flag when the graph is torn down, so the background
+/// subscriber thread exits promptly on its next poll timeout instead of leaking.
+struct ThreadStopGuard(Arc<AtomicBool>);
+
+impl Drop for ThreadStopGuard {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Connect a `SUB` socket to a ZMQ publisher and stream incoming messages.
+///
+/// Accepts either a direct address (`"tcp://host:5556"`) or a `(name, registry)`
+/// tuple for discovery-based lookup. With a registry tuple the address is
+/// resolved **at call time** (not at graph start), so the publisher must have
+/// registered before [`zmq_sub`] is called; otherwise the lookup errors here.
+///
+/// Returns a `(data, status)` pair:
+/// - `data` ticks with each burst of received messages, decoded as `T`.
+/// - `status` ticks on each connection-status transition
+///   ([`ZmqStatus::Connected`] / [`ZmqStatus::Disconnected`]).
+///
+/// # Errors
+///
+/// Returns an error at **wiring time** if:
+/// - `run_mode` is [`RunMode::HistoricalFrom`] — the subscriber is a live,
+///   never-closing source with no historical timeline to replay, and next's
+///   channel receiver would block-collect it up front and deadlock at `start`.
+///   Run under [`RunMode::RealTime`].
+/// - a `(name, registry)` config is passed and the registry lookup fails (e.g.
+///   the backend is unreachable, or no publisher registered under `name`).
+///
+/// A socket connect failure surfaces **during the run** via the channel's error
+/// path (the socket lives on the background thread), aborting the run with
+/// context — matching classic, whose subscriber also connects on its thread.
+pub fn zmq_sub<T>(
+    g: &GraphBuilder,
+    run_mode: RunMode,
+    config: impl Into<ZmqSubConfig>,
+) -> Result<(Stream<Burst<T>>, Stream<ZmqStatus>)>
+where
+    T: Clone + Default + Send + DeserializeOwned + 'static,
+{
+    if let RunMode::HistoricalFrom(_) = run_mode {
+        anyhow::bail!(
+            "zmq_sub: RunMode::HistoricalFrom is unsupported — the subscriber is a \
+             live, unbounded, never-closing source with no historical timeline to \
+             replay; run zmq_sub under RunMode::RealTime"
+        );
+    }
+
+    let address = match config.into().0 {
+        ZmqSubResolution::Direct(addr) => addr,
+        ZmqSubResolution::Discover(name, registry) => registry
+            .lookup(&name)
+            .with_context(|| format!("zmq_sub: resolving {name:?} via registry"))?,
+    };
+
+    let (events, sender) = g.channel::<ZmqEvent<T>>();
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = stop.clone();
+    std::thread::Builder::new()
+        .name("zmq-sub".into())
+        .spawn(move || {
+            if let Err(e) = run_subscriber::<T>(&address, &sender, &thread_stop) {
+                sender.send_error(e);
+            }
+        })
+        .context("zmq_sub: spawning subscriber thread")?;
+
+    // Route the raw event burst through a passthrough op that owns the stop
+    // guard, so the background thread is signalled to stop when the graph is
+    // dropped at teardown.
+    let events = events.wire(move |b, h| {
+        b.register_op1(
+            h,
+            "zmq_sub",
+            Activation::NONE,
+            ThreadStopGuard(stop),
+            || (),
+            move |_g: &mut ThreadStopGuard,
+                  _s: &mut (),
+                  burst: &Burst<ZmqEvent<T>>,
+                  _ctx: &mut Ctx<'_>| { Ok(Tick::Value(burst.clone())) },
+        )
+    });
+
+    let data = events.map_filter(|burst: &Burst<ZmqEvent<T>>| {
+        let data: Burst<T> = burst
+            .iter()
+            .filter_map(|e| match e {
+                ZmqEvent::Data(v) => Some(v.clone()),
+                ZmqEvent::Status(_) => None,
+            })
+            .collect();
+        let ticked = !data.is_empty();
+        (data, ticked)
+    });
+
+    let status = events.map_filter(|burst: &Burst<ZmqEvent<T>>| {
+        match burst
+            .iter()
+            .filter_map(|e| match e {
+                ZmqEvent::Status(s) => Some(s.clone()),
+                ZmqEvent::Data(_) => None,
+            })
+            .last()
+        {
+            Some(s) => (s, true),
+            None => (ZmqStatus::default(), false),
+        }
+    });
+
+    Ok((data, status))
+}
+
+/// The background thread body: poll the data + monitor sockets and feed the
+/// channel. Returns `Ok(())` on a clean stop (stop flag, receiver gone, or
+/// publisher `EndOfStream`); an `Err` is forwarded to the graph as a channel
+/// error by the caller.
+fn run_subscriber<T>(
+    address: &str,
+    sender: &ChannelSender<ZmqEvent<T>>,
+    stop: &AtomicBool,
+) -> Result<()>
+where
+    T: Clone + Default + Send + DeserializeOwned + 'static,
+{
+    let context = zmq::Context::new();
+    let socket = context
+        .socket(zmq::SUB)
+        .context("zmq_sub: creating SUB socket")?;
+    socket
+        .connect(address)
+        .with_context(|| format!("zmq_sub: connecting to {address}"))?;
+    socket
+        .set_subscribe(b"")
+        .context("zmq_sub: setting subscription filter")?;
+
+    let monitor_id = MONITOR_ID.fetch_add(1, Ordering::Relaxed);
+    let monitor_addr = format!("inproc://zmq-sub-monitor-{monitor_id}");
+    socket
+        .monitor(
+            &monitor_addr,
+            (ZMQ_EVENT_CONNECTED | ZMQ_EVENT_DISCONNECTED) as i32,
+        )
+        .context("zmq_sub: registering socket monitor")?;
+    let monitor = context
+        .socket(zmq::PAIR)
+        .context("zmq_sub: creating monitor socket")?;
+    monitor
+        .connect(&monitor_addr)
+        .context("zmq_sub: connecting monitor socket")?;
+
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        let mut items = [
+            socket.as_poll_item(zmq::POLLIN),
+            monitor.as_poll_item(zmq::POLLIN),
+        ];
+        zmq::poll(&mut items, 200).context("zmq_sub: polling sockets")?;
+
+        if items[1].is_readable() {
+            let event_frame = monitor
+                .recv_msg(0)
+                .context("zmq_sub: reading monitor event")?;
+            // Drain the trailing address frame.
+            while monitor.get_rcvmore().unwrap_or(false) {
+                let _ = monitor.recv_msg(0);
+            }
+            if event_frame.len() >= 2 {
+                let event_id = u16::from_le_bytes([event_frame[0], event_frame[1]]);
+                let status = match event_id {
+                    ZMQ_EVENT_CONNECTED => Some(ZmqStatus::Connected),
+                    ZMQ_EVENT_DISCONNECTED => Some(ZmqStatus::Disconnected),
+                    _ => None,
+                };
+                if let Some(status) = status
+                    && !sender.send(ZmqEvent::Status(status))
+                {
+                    // Receiver gone — a normal teardown race.
+                    return Ok(());
+                }
+            }
+        }
+
+        if items[0].is_readable() {
+            let bytes = socket.recv_bytes(0).context("zmq_sub: receiving message")?;
+            let msg: WireMessage<T> = bincode::deserialize(&bytes)
+                .unwrap_or_else(|err| WireMessage::Error(format!("{err}")));
+            match msg {
+                WireMessage::Value(v) => {
+                    if !sender.send(ZmqEvent::Data(v)) {
+                        return Ok(());
+                    }
+                }
+                WireMessage::EndOfStream => {
+                    // Publisher is gone: report a final disconnect, then close.
+                    let _ = sender.send(ZmqEvent::Status(ZmqStatus::Disconnected));
+                    sender.close();
+                    return Ok(());
+                }
+                WireMessage::Error(err) => {
+                    sender.send_error(anyhow::anyhow!(err).context("zmq_sub: decoding message"));
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sink
+// ---------------------------------------------------------------------------
+
+/// Graph-thread-local publisher state. Bound and registered lazily on the first
+/// cycle (like classic's `start`); its [`Drop`] sends `EndOfStream` and revokes
+/// the registry handle at graph teardown (like classic's `stop`).
+struct ZmqPubState {
+    port: u16,
+    bind_address: String,
+    registration: ZmqPubRegistration,
+    socket: Option<zmq::Socket>,
+    monitor: Option<zmq::Socket>,
+    registry_handle: Option<Box<dyn ZmqHandle>>,
+    subscriber_connected: bool,
+    accepted_at: Option<Instant>,
+    buffer: Vec<Vec<u8>>,
+    buffer_start: Option<Instant>,
+    started: bool,
+}
+
+impl ZmqPubState {
+    fn new(port: u16, bind_address: String, registration: ZmqPubRegistration) -> Self {
+        Self {
+            port,
+            bind_address,
+            registration,
+            socket: None,
+            monitor: None,
+            registry_handle: None,
+            subscriber_connected: false,
+            accepted_at: None,
+            buffer: Vec::new(),
+            buffer_start: None,
+            started: false,
+        }
+    }
+
+    /// Bind the `PUB` socket, open its monitor, and register with a discovery
+    /// backend. Runs once, on the first cycle.
+    fn start(&mut self) -> Result<()> {
+        let context = zmq::Context::new();
+        let socket = context
+            .socket(zmq::SocketType::PUB)
+            .context("zmq_pub: creating PUB socket")?;
+
+        let monitor_id = MONITOR_ID.fetch_add(1, Ordering::Relaxed);
+        let monitor_addr = format!("inproc://zmq-pub-monitor-{monitor_id}");
+        socket
+            .monitor(&monitor_addr, ZMQ_EVENT_ACCEPTED as i32)
+            .context("zmq_pub: registering socket monitor")?;
+        let monitor = context
+            .socket(zmq::PAIR)
+            .context("zmq_pub: creating monitor socket")?;
+        monitor
+            .connect(&monitor_addr)
+            .context("zmq_pub: connecting monitor socket")?;
+
+        let address = format!("tcp://{}:{}", self.bind_address, self.port);
+        socket
+            .bind(&address)
+            .with_context(|| format!("zmq_pub: binding {address}"))?;
+
+        if let Some((name, registry)) = &self.registration.0 {
+            self.registry_handle = Some(
+                registry
+                    .register(name, &address)
+                    .with_context(|| format!("zmq_pub: registering {name:?}"))?,
+            );
+        }
+        self.socket = Some(socket);
+        self.monitor = Some(monitor);
+        self.started = true;
+        Ok(())
+    }
+
+    /// Drain any pending monitor events, noting when a subscriber's TCP
+    /// connection is accepted.
+    fn check_monitor(&mut self) {
+        let Some(monitor) = self.monitor.as_ref() else {
+            return;
+        };
+        loop {
+            let mut items = [monitor.as_poll_item(zmq::POLLIN)];
+            if zmq::poll(&mut items, 0).is_err() || !items[0].is_readable() {
+                break;
+            }
+            let Ok(event_frame) = monitor.recv_msg(0) else {
+                break;
+            };
+            while monitor.get_rcvmore().unwrap_or(false) {
+                let _ = monitor.recv_msg(0);
+            }
+            if event_frame.len() >= 2 {
+                let event_id = u16::from_le_bytes([event_frame[0], event_frame[1]]);
+                if event_id == ZMQ_EVENT_ACCEPTED {
+                    self.accepted_at = Some(Instant::now());
+                }
+            }
+        }
+    }
+
+    /// Publish (or buffer) one already-serialized message.
+    fn publish(&mut self, data: Vec<u8>) -> Result<()> {
+        self.check_monitor();
+        if !self.subscriber_connected
+            && let Some(accepted_at) = self.accepted_at
+        {
+            // After the TCP accept, the subscriber still needs a moment for its
+            // subscription filter to propagate through ZMQ internals. 50 ms is
+            // generous for slow CI while keeping buffered-message latency to
+            // roughly one graph cycle.
+            if accepted_at.elapsed() >= Duration::from_millis(50) {
+                self.subscriber_connected = true;
+            }
+        }
+
+        let sock = self
+            .socket
+            .as_ref()
+            .expect("invariant: socket bound on the first cycle");
+
+        if self.subscriber_connected {
+            for buffered in self.buffer.drain(..) {
+                sock.send(buffered, 0).context("zmq_pub: flushing buffer")?;
+            }
+            self.buffer_start = None;
+            sock.send(data, 0).context("zmq_pub: sending message")?;
+        } else {
+            // No subscriber yet — buffer the message. Only discard stale buffered
+            // data while no subscriber has begun connecting; once a TCP accept is
+            // observed we are committed to flushing to that subscriber within the
+            // propagation window, so clearing here would drop the very messages the
+            // buffer exists to preserve.
+            let now = Instant::now();
+            let start = *self.buffer_start.get_or_insert(now);
+            if self.accepted_at.is_none() && now.duration_since(start) > BUFFER_TIMEOUT {
+                self.buffer.clear();
+                self.buffer_start = Some(now);
+            }
+            self.buffer.push(data);
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ZmqPubState {
+    fn drop(&mut self) {
+        if let Some(mut handle) = self.registry_handle.take() {
+            handle.revoke();
+        }
+        // Best-effort EndOfStream so a live subscriber sees a clean disconnect.
+        if let Some(sock) = self.socket.as_ref()
+            && let Ok(bytes) = end_of_stream_bytes()
+        {
+            let _ = sock.send(bytes, 0);
+        }
+    }
+}
+
+/// Fluent API for publishing a stream over a ZMQ `PUB` socket — an extension
+/// trait on any `Stream<T>` whose values are [`Serialize`].
+///
+/// `use`ing it enables `stream.zmq_pub(port, registration)` chaining. Pass `()`
+/// for no registration, or `("name", registry)` to register the bound address
+/// with a discovery backend.
+pub trait ZeroMqPub<T> {
+    /// Bind on `127.0.0.1:port` and publish each value. Returns the sink
+    /// `Stream<()>` (add it to the graph). Optionally register the address with a
+    /// discovery backend.
+    ///
+    /// **Multi-host note:** `127.0.0.1` is loopback and unreachable from other
+    /// machines. When registering in a multi-host deployment, use
+    /// [`zmq_pub_on`](Self::zmq_pub_on) with a routable bind address so the stored
+    /// address is reachable by remote subscribers.
+    ///
+    /// The publisher is realtime-only: a [`RunMode::HistoricalFrom`] run aborts
+    /// with a "real-time" error on the first cycle.
+    fn zmq_pub(&self, port: u16, registration: impl Into<ZmqPubRegistration>) -> Stream<()>;
+
+    /// Bind on `address:port` (rather than `127.0.0.1`) and publish each value.
+    /// Use this in multi-host deployments where `127.0.0.1` is not reachable.
+    fn zmq_pub_on(
+        &self,
+        address: &str,
+        port: u16,
+        registration: impl Into<ZmqPubRegistration>,
+    ) -> Stream<()>;
+}
+
+impl<T> ZeroMqPub<T> for Stream<T>
+where
+    T: Serialize + Clone + Default + Send + 'static,
+{
+    fn zmq_pub(&self, port: u16, registration: impl Into<ZmqPubRegistration>) -> Stream<()> {
+        self.zmq_pub_on("127.0.0.1", port, registration)
+    }
+
+    fn zmq_pub_on(
+        &self,
+        address: &str,
+        port: u16,
+        registration: impl Into<ZmqPubRegistration>,
+    ) -> Stream<()> {
+        let state = ZmqPubState::new(port, address.to_string(), registration.into());
+        self.wire(move |b, h| {
+            b.register_op1(
+                h,
+                "zmq_pub",
+                Activation::NONE,
+                state,
+                || (),
+                move |state: &mut ZmqPubState, _s: &mut (), value: &T, ctx: &mut Ctx<'_>| {
+                    if !state.started {
+                        if let RunMode::HistoricalFrom(_) = ctx.run_mode() {
+                            // Reject historical before binding or touching the
+                            // registry, so the error names the run mode — not a
+                            // registry connection failure (classic ordering).
+                            anyhow::bail!("ZMQ nodes only support real-time mode");
+                        }
+                        state.start()?;
+                    }
+                    let data = bincode::serialize(&WireMessage::Value(value.clone()))
+                        .context("zmq_pub: serializing message")?;
+                    state.publish(data)?;
+                    Ok(Tick::Value(()))
+                },
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sub_config_from_address() {
+        let direct = ZmqSubConfig::from("tcp://host:5556");
+        assert!(matches!(direct.0, ZmqSubResolution::Direct(ref a) if a == "tcp://host:5556"));
+
+        let owned = ZmqSubConfig::from(String::from("tcp://host:5557"));
+        assert!(matches!(owned.0, ZmqSubResolution::Direct(ref a) if a == "tcp://host:5557"));
+    }
+
+    #[test]
+    fn pub_registration_from_unit_is_none() {
+        let reg = ZmqPubRegistration::from(());
+        assert!(reg.0.is_none());
+    }
+
+    #[test]
+    fn end_of_stream_frame_round_trips() {
+        let bytes = end_of_stream_bytes().unwrap();
+        let decoded: WireMessage<u64> = bincode::deserialize(&bytes).unwrap();
+        assert!(matches!(decoded, WireMessage::EndOfStream));
+    }
+}

--- a/next/crates/wingfoil-next/src/adapters/zmq/registry.rs
+++ b/next/crates/wingfoil-next/src/adapters/zmq/registry.rs
@@ -1,0 +1,297 @@
+//! Registry traits and config wrappers for ZMQ service discovery.
+//!
+//! A backend-agnostic [`ZmqRegistry`] trait decouples ZMQ from any specific
+//! name-resolution mechanism. The [`ZmqPubRegistration`] / [`ZmqSubConfig`]
+//! wrappers use `From` impls so a single `zmq_pub` / `zmq_sub` signature serves a
+//! bare address *and* a `(name, registry)` discovery pair.
+//!
+//! - [`EtcdRegistry`] — stores the publisher address in etcd under a lease
+//!   (requires the `etcd` feature).
+
+use anyhow::Result;
+
+// ============ Traits ============
+
+/// Backend-agnostic service registry for ZMQ service discovery.
+///
+/// Implemented (when the `etcd` feature is enabled) by [`EtcdRegistry`].
+pub trait ZmqRegistry: Send + 'static {
+    /// Register `address` under `name`. Returns a handle whose
+    /// [`ZmqHandle::revoke`] cleans up the registration (removes the key, revokes
+    /// a lease).
+    fn register(&self, name: &str, address: &str) -> Result<Box<dyn ZmqHandle>>;
+    /// Resolve `name` to a ZMQ address string (e.g. `"tcp://host:5556"`).
+    fn lookup(&self, name: &str) -> Result<String>;
+}
+
+/// Handle returned by [`ZmqRegistry::register`]. Call [`revoke`](Self::revoke) to
+/// clean up the registration on clean shutdown.
+pub trait ZmqHandle: Send {
+    /// Revoke the registration. Called at graph teardown; errors are logged, not
+    /// propagated.
+    fn revoke(&mut self);
+}
+
+// ============ Config wrappers ============
+
+/// Passed to [`ZeroMqPub::zmq_pub`](super::ZeroMqPub::zmq_pub) /
+/// [`zmq_pub_on`](super::ZeroMqPub::zmq_pub_on).
+///
+/// Constructed via `From` impls — pass `()` for no registration, or
+/// `("name", registry)` to register with a backend.
+pub struct ZmqPubRegistration(pub(super) Option<(String, Box<dyn ZmqRegistry>)>);
+
+impl From<()> for ZmqPubRegistration {
+    fn from(_: ()) -> Self {
+        ZmqPubRegistration(None)
+    }
+}
+
+impl<R: ZmqRegistry + 'static> From<(&str, R)> for ZmqPubRegistration {
+    fn from((name, registry): (&str, R)) -> Self {
+        ZmqPubRegistration(Some((name.to_string(), Box::new(registry))))
+    }
+}
+
+/// Passed to [`zmq_sub`](super::zmq_sub).
+///
+/// Constructed via `From` impls — pass a `&str`/`String` for a direct address, or
+/// `("name", registry)` for discovery-based lookup.
+pub struct ZmqSubConfig(pub(super) ZmqSubResolution);
+
+pub(super) enum ZmqSubResolution {
+    Direct(String),
+    Discover(String, Box<dyn ZmqRegistry>),
+}
+
+impl From<&str> for ZmqSubConfig {
+    fn from(addr: &str) -> Self {
+        ZmqSubConfig(ZmqSubResolution::Direct(addr.to_string()))
+    }
+}
+
+impl From<String> for ZmqSubConfig {
+    fn from(addr: String) -> Self {
+        ZmqSubConfig(ZmqSubResolution::Direct(addr))
+    }
+}
+
+impl From<&String> for ZmqSubConfig {
+    fn from(addr: &String) -> Self {
+        ZmqSubConfig(ZmqSubResolution::Direct(addr.clone()))
+    }
+}
+
+impl<R: ZmqRegistry + 'static> From<(&str, R)> for ZmqSubConfig {
+    fn from((name, registry): (&str, R)) -> Self {
+        ZmqSubConfig(ZmqSubResolution::Discover(
+            name.to_string(),
+            Box::new(registry),
+        ))
+    }
+}
+
+// ============ EtcdRegistry (etcd feature) ============
+
+#[cfg(feature = "etcd")]
+pub use etcd_impl::EtcdRegistry;
+
+#[cfg(feature = "etcd")]
+mod etcd_impl {
+    use super::{ZmqHandle, ZmqRegistry};
+    use crate::adapters::etcd::EtcdConnection;
+    use anyhow::Result;
+    use etcd_client::{Client, PutOptions};
+    use std::sync::Arc;
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    const LEASE_TTL_SECS: i64 = 30;
+    const KEEPALIVE_INTERVAL_SECS: u64 = 10;
+
+    /// Service registry backed by etcd.
+    ///
+    /// Publishers write their address to an etcd key under a lease. The lease
+    /// expires ~30 s after a crash (no keepalive renewal); clean shutdown revokes
+    /// the lease immediately. Subscribers do a one-shot GET at construction time.
+    ///
+    /// ```ignore
+    /// use wingfoil_next::adapters::zmq::EtcdRegistry;
+    ///
+    /// // Single endpoint (URL string)
+    /// stream.zmq_pub(5556, ("quotes", EtcdRegistry::new("http://etcd:2379")));
+    ///
+    /// // etcd cluster
+    /// stream.zmq_pub(5556, ("quotes", EtcdRegistry::with_endpoints([
+    ///     "http://etcd-0.etcd:2379",
+    ///     "http://etcd-1.etcd:2379",
+    /// ])));
+    /// ```
+    pub struct EtcdRegistry {
+        conn: EtcdConnection,
+    }
+
+    impl EtcdRegistry {
+        /// Create an `EtcdRegistry` from a single endpoint URL or an
+        /// [`EtcdConnection`].
+        pub fn new(conn: impl Into<EtcdConnection>) -> Self {
+            Self { conn: conn.into() }
+        }
+
+        /// Create an `EtcdRegistry` connected to multiple etcd endpoints
+        /// (cluster).
+        pub fn with_endpoints(endpoints: impl IntoIterator<Item = impl Into<String>>) -> Self {
+            Self {
+                conn: EtcdConnection::with_endpoints(endpoints),
+            }
+        }
+    }
+
+    struct EtcdHandle {
+        lease_id: i64,
+        conn: EtcdConnection,
+        shutdown: Arc<Notify>,
+        keepalive_thread: Option<JoinHandle<()>>,
+    }
+
+    impl ZmqHandle for EtcdHandle {
+        fn revoke(&mut self) {
+            self.shutdown.notify_one();
+            if let Some(t) = self.keepalive_thread.take() {
+                let _ = t.join();
+            }
+            revoke_lease(self.lease_id, &self.conn);
+        }
+    }
+
+    impl ZmqRegistry for EtcdRegistry {
+        fn register(&self, name: &str, address: &str) -> Result<Box<dyn ZmqHandle>> {
+            let handle = etcd_register(name, address, &self.conn)?;
+            Ok(Box::new(handle))
+        }
+
+        fn lookup(&self, name: &str) -> Result<String> {
+            etcd_lookup(name, &self.conn)
+        }
+    }
+
+    fn etcd_register(name: &str, address: &str, conn: &EtcdConnection) -> Result<EtcdHandle> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let lease_id = rt.block_on(async {
+            let mut client = Client::connect(&conn.endpoints, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?;
+            let lease_resp = client
+                .lease_grant(LEASE_TTL_SECS, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd lease_grant failed: {e}"))?;
+            let id = lease_resp.id();
+            let opts = PutOptions::new().with_lease(id);
+            client
+                .put(name, address, Some(opts))
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd put failed: {e}"))?;
+            Ok::<i64, anyhow::Error>(id)
+        })?;
+
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_clone = shutdown.clone();
+        let endpoints = conn.endpoints.clone();
+
+        let keepalive_thread = std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("etcd keepalive runtime");
+            rt.block_on(async {
+                let mut client = match Client::connect(&endpoints, None).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        log::error!("etcd keepalive connect failed: {e}");
+                        return;
+                    }
+                };
+                let (mut keeper, mut ka_stream) = match client.lease_keep_alive(lease_id).await {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        log::error!("etcd lease_keep_alive failed: {e}");
+                        return;
+                    }
+                };
+                loop {
+                    tokio::select! {
+                        _ = shutdown_clone.notified() => break,
+                        _ = tokio::time::sleep(Duration::from_secs(KEEPALIVE_INTERVAL_SECS)) => {}
+                    }
+                    if keeper.keep_alive().await.is_err() {
+                        break;
+                    }
+                    match ka_stream.message().await {
+                        Ok(Some(_)) => {}
+                        _ => break,
+                    }
+                }
+            });
+        });
+
+        Ok(EtcdHandle {
+            lease_id,
+            conn: conn.clone(),
+            shutdown,
+            keepalive_thread: Some(keepalive_thread),
+        })
+    }
+
+    fn etcd_lookup(name: &str, conn: &EtcdConnection) -> Result<String> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        rt.block_on(async {
+            let mut client = Client::connect(&conn.endpoints, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd connect failed: {e}"))?;
+            let resp = client
+                .get(name, None)
+                .await
+                .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
+            match resp.kvs().first() {
+                Some(kv) => {
+                    let addr = kv
+                        .value_str()
+                        .map_err(|e| anyhow::anyhow!("etcd value is not valid UTF-8: {e}"))?
+                        .to_string();
+                    Ok(addr)
+                }
+                None => Err(anyhow::anyhow!("no publisher named {name:?} found in etcd")),
+            }
+        })
+    }
+
+    fn revoke_lease(lease_id: i64, conn: &EtcdConnection) {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                log::error!("etcd revoke runtime failed: {e}");
+                return;
+            }
+        };
+        rt.block_on(async {
+            let mut client = match Client::connect(&conn.endpoints, None).await {
+                Ok(c) => c,
+                Err(e) => {
+                    log::error!("etcd revoke connect failed: {e}");
+                    return;
+                }
+            };
+            if let Err(e) = client.lease_revoke(lease_id).await {
+                log::error!("etcd lease_revoke failed: {e}");
+            }
+        });
+    }
+}

--- a/next/crates/wingfoil-next/tests/zmq_adapter.rs
+++ b/next/crates/wingfoil-next/tests/zmq_adapter.rs
@@ -1,0 +1,60 @@
+//! zmq adapter tests that need no live socket peer or external service.
+//!
+//! The real-socket parity tests live in `tests/zmq_integration.rs` behind the
+//! `zmq-integration-test` feature; the etcd service-discovery parity tests in
+//! `tests/zmq_etcd_integration.rs` behind `zmq-etcd-integration-test`. Run these
+//! with:
+//! ```sh
+//! cargo test -p wingfoil-next --features zmq
+//! ```
+#![cfg(feature = "zmq")]
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::zmq::{ZeroMqPub, zmq_sub};
+use wingfoil_next::prelude::*;
+
+/// `zmq_sub` rejects a `HistoricalFrom` run at wiring time — the live,
+/// never-closing subscriber has no historical timeline to replay, and next's
+/// channel receiver would block-collect it up front and deadlock at `start`.
+/// The error must name the adapter rather than hang.
+#[test]
+fn sub_rejects_historical_mode() {
+    let g = GraphBuilder::new();
+    let err = match zmq_sub::<u64>(
+        &g,
+        RunMode::HistoricalFrom(NanoTime::ZERO),
+        "tcp://127.0.0.1:5701",
+    ) {
+        Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:#}");
+    assert!(msg.contains("zmq_sub"), "names the adapter: {msg}");
+    assert!(
+        msg.contains("HistoricalFrom") || msg.contains("historical"),
+        "explains historical replay is unsupported: {msg}"
+    );
+}
+
+/// The publisher checks the run mode lazily on its first cycle (like classic's
+/// `start`), so a `HistoricalFrom` run aborts with a "real-time" error — parity
+/// of classic `zmq_pub_historical_mode_fails`.
+#[test]
+fn pub_rejects_historical_mode() {
+    let g = GraphBuilder::new();
+    let _sink = g
+        .ticker(Duration::from_millis(10))
+        .count()
+        .map(|n: &u64| format!("{n}").into_bytes())
+        .zmq_pub(5702, ());
+    let result = g
+        .build()
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1));
+    let err = result.expect_err("expected historical mode to fail for zmq pub");
+    assert!(
+        format!("{err:#}").contains("real-time"),
+        "expected the error to mention real-time, got: {err:#}"
+    );
+}

--- a/next/crates/wingfoil-next/tests/zmq_etcd_integration.rs
+++ b/next/crates/wingfoil-next/tests/zmq_etcd_integration.rs
@@ -1,0 +1,221 @@
+//! etcd service-discovery parity tests for the zmq adapter — a port of the
+//! `etcd_tests` module from the classic
+//! `wingfoil/src/adapters/zmq/integration_tests.rs`.
+//!
+//! These exercise the pluggable [`EtcdRegistry`] discovery backend: a publisher
+//! registers its bound address in etcd under a lease, and a subscriber resolves
+//! it by name. Requires Docker (an etcd container via testcontainers) and
+//! `libzmq`. Run with:
+//! ```sh
+//! cargo test -p wingfoil-next --features zmq-etcd-integration-test \
+//!   -- --test-threads=1 --nocapture
+//! ```
+#![cfg(feature = "zmq-etcd-integration-test")]
+
+use std::time::Duration;
+
+use etcd_client::Client;
+use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::SyncRunner};
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::etcd::EtcdConnection;
+use wingfoil_next::adapters::zmq::{EtcdRegistry, ZeroMqPub, zmq_sub};
+use wingfoil_next::prelude::*;
+
+/// Start an etcd container and return `(container_handle, connection)`. The
+/// container stops when the handle is dropped.
+fn start_etcd() -> anyhow::Result<(impl Drop, EtcdConnection)> {
+    let container = GenericImage::new("gcr.io/etcd-development/etcd", "v3.5.0")
+        .with_wait_for(WaitFor::message_on_stderr(
+            "now serving peer/client/metrics",
+        ))
+        .with_env_var("ETCD_LISTEN_CLIENT_URLS", "http://0.0.0.0:2379")
+        .with_env_var("ETCD_ADVERTISE_CLIENT_URLS", "http://0.0.0.0:2379")
+        .start()?;
+    let port = container.get_host_port_ipv4(2379)?;
+    let conn = EtcdConnection::new(format!("http://127.0.0.1:{port}"));
+    Ok((container, conn))
+}
+
+/// Poll etcd until `key` is present or `timeout` elapses, returning its value.
+fn wait_for_key(conn: &EtcdConnection, key: &str, timeout: Duration) -> anyhow::Result<String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let val = rt.block_on(async {
+            let mut client = Client::connect(&conn.endpoints, None).await?;
+            let resp = client.get(key, None).await?;
+            anyhow::Ok(
+                resp.kvs()
+                    .first()
+                    .and_then(|kv| kv.value_str().ok())
+                    .map(|s| s.to_string()),
+            )
+        })?;
+        if let Some(v) = val {
+            return Ok(v);
+        }
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!("key {key:?} not found in etcd within {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn read_key(conn: &EtcdConnection, key: &str) -> anyhow::Result<Option<String>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let mut client = Client::connect(&conn.endpoints, None).await?;
+        let resp = client.get(key, None).await?;
+        Ok(resp
+            .kvs()
+            .first()
+            .and_then(|kv| kv.value_str().ok())
+            .map(|s| s.to_string()))
+    })
+}
+
+#[test]
+fn sub_etcd_no_etcd_returns_error() {
+    // No container — a lookup against an unreachable etcd must error at wiring.
+    let conn = EtcdConnection::new("http://127.0.0.1:59999");
+    let g = GraphBuilder::new();
+    let result = zmq_sub::<u64>(&g, RunMode::RealTime, ("anything", EtcdRegistry::new(conn)));
+    assert!(result.is_err(), "expected error when etcd is unreachable");
+}
+
+#[test]
+fn sub_etcd_name_not_found() {
+    let (_container, conn) = start_etcd().unwrap();
+    let g = GraphBuilder::new();
+    let result = zmq_sub::<u64>(
+        &g,
+        RunMode::RealTime,
+        ("nonexistent-key", EtcdRegistry::new(conn)),
+    );
+    assert!(result.is_err(), "expected error for absent key");
+    let msg = format!("{:#}", result.err().unwrap());
+    assert!(
+        msg.contains("no publisher named"),
+        "unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn pub_etcd_registers_address() {
+    let (_container, conn) = start_etcd().unwrap();
+    let port = 5721u16;
+
+    let conn_pub = conn.clone();
+    let handle = std::thread::spawn(move || -> anyhow::Result<()> {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .ticker(Duration::from_millis(50))
+            .count()
+            .zmq_pub(port, ("etcd-quotes", EtcdRegistry::new(conn_pub)));
+        g.build()
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+        Ok(())
+    });
+
+    let val = wait_for_key(&conn, "etcd-quotes", Duration::from_secs(5)).unwrap();
+    assert!(
+        val.contains(&port.to_string()),
+        "address should contain the port: {val}"
+    );
+    handle.join().expect("publisher panicked").unwrap();
+}
+
+#[test]
+fn sub_etcd_end_to_end() {
+    let (_container, conn) = start_etcd().unwrap();
+    let port = 5722u16;
+
+    let conn_pub = conn.clone();
+    std::thread::spawn(move || -> anyhow::Result<()> {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .ticker(Duration::from_millis(50))
+            .count()
+            .map(|n: &u64| format!("{n}").into_bytes())
+            .zmq_pub(port, ("etcd-data", EtcdRegistry::new(conn_pub)));
+        g.build()
+            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(3)))?;
+        Ok(())
+    });
+
+    wait_for_key(&conn, "etcd-data", Duration::from_secs(5)).unwrap();
+
+    let g = GraphBuilder::new();
+    let (data, _status) = zmq_sub::<Vec<u8>>(
+        &g,
+        RunMode::RealTime,
+        ("etcd-data", EtcdRegistry::new(conn)),
+    )
+    .unwrap();
+    let received = data.collapse_accumulate();
+    let mut runner = g.build();
+    runner
+        .run(
+            RunMode::RealTime,
+            RunFor::Duration(Duration::from_millis(1500)),
+        )
+        .unwrap();
+    assert!(
+        !runner.value(&received).is_empty(),
+        "no data received via etcd discovery"
+    );
+}
+
+#[test]
+fn pub_etcd_lease_revoked_on_stop() {
+    let (_container, conn) = start_etcd().unwrap();
+    let port = 5723u16;
+
+    let conn_pub = conn.clone();
+    let handle = std::thread::spawn(move || -> anyhow::Result<()> {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .ticker(Duration::from_millis(50))
+            .count()
+            .zmq_pub(port, ("etcd-lease-key", EtcdRegistry::new(conn_pub)));
+        g.build().run(
+            RunMode::RealTime,
+            RunFor::Duration(Duration::from_millis(300)),
+        )?;
+        Ok(())
+    });
+    handle.join().expect("publisher panicked").unwrap();
+
+    // Give etcd a moment to process the revoke.
+    std::thread::sleep(Duration::from_millis(200));
+    let val = read_key(&conn, "etcd-lease-key").unwrap();
+    assert!(
+        val.is_none(),
+        "key should be gone after publisher stop, got: {val:?}"
+    );
+}
+
+#[test]
+fn pub_etcd_historical_mode_fails() {
+    // The run-mode check runs before the registry is touched, so a historical
+    // run errors with "real-time" — not an etcd connection error — even against
+    // an unreachable etcd. Parity of classic `zmq_pub_etcd_historical_mode_fails`.
+    let conn = EtcdConnection::new("http://127.0.0.1:59999");
+    let g = GraphBuilder::new();
+    let _sink = g
+        .ticker(Duration::from_millis(10))
+        .count()
+        .zmq_pub(5724, ("test-hist", EtcdRegistry::new(conn)));
+    let result = g
+        .build()
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1));
+    let err = result.expect_err("expected historical mode to fail");
+    assert!(
+        format!("{err:#}").contains("real-time"),
+        "expected the error to mention real-time, got: {err:#}"
+    );
+}

--- a/next/crates/wingfoil-next/tests/zmq_integration.rs
+++ b/next/crates/wingfoil-next/tests/zmq_integration.rs
@@ -1,0 +1,199 @@
+//! Real-socket parity tests for the zmq adapter — a port of the core pub/sub
+//! tests from the classic `wingfoil/src/adapters/zmq/integration_tests.rs`.
+//!
+//! These need `libzmq` and real TCP sockets, but no external service or
+//! container. Because they run against a live wall clock, they assert received
+//! *values* (consecutive counters, connection status) rather than exact tick
+//! times — the zmq source is realtime-only, so there is no historical timeline
+//! to replay deterministically. Run with:
+//! ```sh
+//! cargo test -p wingfoil-next --features zmq-integration-test \
+//!   -- --test-threads=1 --nocapture
+//! ```
+//!
+//! Parity coverage note: classic's `zmq_same_thread` (publisher + subscriber
+//! nodes in one graph on one thread) is not ported separately — next's
+//! subscriber runs its own background thread over the `channel`, and
+//! `round_trip_consecutive_counters` exercises the same pub→sub path across
+//! threads. Classic's two first-message variants collapse into one here:
+//! `first_message_not_dropped` uses a *no-delay* publisher (the harder
+//! slow-joiner case, classic's `..._no_delay`), which subsumes the delayed one.
+#![cfg(feature = "zmq-integration-test")]
+
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use wingfoil::{RunFor, RunMode};
+use wingfoil_next::adapters::zmq::{ZeroMqPub, ZmqStatus, zmq_sub};
+use wingfoil_next::prelude::*;
+
+/// Spawn a publisher graph on its own thread: a `count()` published as UTF-8
+/// bytes every `period`, for `run_for`.
+fn spawn_publisher(
+    port: u16,
+    period: Duration,
+    run_for: Duration,
+) -> JoinHandle<anyhow::Result<()>> {
+    std::thread::spawn(move || -> anyhow::Result<()> {
+        let g = GraphBuilder::new();
+        let _sink = g
+            .ticker(period)
+            .count()
+            .map(|n: &u64| format!("{n}").into_bytes())
+            .zmq_pub(port, ());
+        g.build()
+            .run(RunMode::RealTime, RunFor::Duration(run_for))?;
+        Ok(())
+    })
+}
+
+/// Subscribe to `address` for `run_for` and return every received counter value.
+fn receive_counters(address: &str, run_for: Duration) -> anyhow::Result<Vec<u64>> {
+    let g = GraphBuilder::new();
+    let (data, _status) = zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, address)?;
+    let received = data.collapse_accumulate();
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Duration(run_for))?;
+    let values: Vec<Vec<u8>> = runner.value(&received);
+    Ok(values
+        .into_iter()
+        .map(|b| String::from_utf8(b).expect("utf8").parse().expect("u64"))
+        .collect())
+}
+
+#[test]
+fn round_trip_consecutive_counters() {
+    let port = 5711;
+    let address = format!("tcp://127.0.0.1:{port}");
+    let publisher = spawn_publisher(port, Duration::from_millis(50), Duration::from_secs(2));
+
+    let values = receive_counters(&address, Duration::from_millis(1500)).unwrap();
+    assert!(values.len() >= 5, "expected >= 5 counters, got {values:?}");
+    for w in values.windows(2) {
+        assert_eq!(w[1], w[0] + 1, "expected consecutive counters: {values:?}");
+    }
+    publisher
+        .join()
+        .expect("publisher thread panicked")
+        .unwrap();
+}
+
+#[test]
+fn first_message_not_dropped() {
+    // The publisher buffers early messages until the subscriber's subscription
+    // filter propagates, so counter value 1 is never lost to the ZMQ
+    // slow-joiner problem — parity of classic `zmq_first_message_not_dropped`.
+    let port = 5712;
+    let address = format!("tcp://127.0.0.1:{port}");
+    let publisher = spawn_publisher(port, Duration::from_millis(50), Duration::from_secs(2));
+
+    let values = receive_counters(&address, Duration::from_millis(1500)).unwrap();
+    assert!(!values.is_empty(), "no values received");
+    assert_eq!(values[0], 1, "first message dropped: got {values:?}");
+    publisher
+        .join()
+        .expect("publisher thread panicked")
+        .unwrap();
+}
+
+#[test]
+fn reports_connected_status() {
+    // The subscriber's socket monitor surfaces a `Connected` transition on the
+    // status stream — parity of classic `zmq_reports_connected_status`.
+    let port = 5713;
+    let address = format!("tcp://127.0.0.1:{port}");
+    let publisher = spawn_publisher(port, Duration::from_millis(50), Duration::from_secs(2));
+
+    let g = GraphBuilder::new();
+    let (data, status) = zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, &address).unwrap();
+    let received = data.collapse_accumulate();
+    let statuses = status.accumulate();
+    let mut runner = g.build();
+    runner
+        .run(
+            RunMode::RealTime,
+            RunFor::Duration(Duration::from_millis(1500)),
+        )
+        .unwrap();
+
+    assert!(
+        !runner.value(&received).is_empty(),
+        "no data received alongside status"
+    );
+    let statuses: Vec<ZmqStatus> = runner.value(&statuses);
+    assert!(
+        statuses.contains(&ZmqStatus::Connected),
+        "expected a Connected status, got: {statuses:?}"
+    );
+    publisher
+        .join()
+        .expect("publisher thread panicked")
+        .unwrap();
+}
+
+#[test]
+fn deserialization_error_propagates() {
+    // A publisher sending frames the subscriber cannot decode must abort the
+    // subscriber's run with an error — parity of classic
+    // `zmq_deserialization_error_propagates`.
+    let port = 5714;
+    let address = format!("tcp://127.0.0.1:{port}");
+
+    let publisher = std::thread::spawn(move || {
+        let ctx = zmq::Context::new();
+        let sock = ctx.socket(zmq::PUB).unwrap();
+        sock.bind(&format!("tcp://127.0.0.1:{port}")).unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+        for _ in 0..40 {
+            sock.send("not valid bincode".as_bytes(), 0).unwrap();
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    });
+
+    let g = GraphBuilder::new();
+    let (data, _status) = zmq_sub::<u64>(&g, RunMode::RealTime, &address).unwrap();
+    let _acc = data.collapse_accumulate();
+    let result = g
+        .build()
+        .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(3)));
+    assert!(
+        result.is_err(),
+        "expected the deserialization error to propagate"
+    );
+    let _ = publisher.join();
+}
+
+#[test]
+fn sub_stops_cleanly_without_publisher_endofstream() {
+    // A publisher that binds then drops the socket without sending EndOfStream
+    // (a crash) must not hang the subscriber; the runner's duration bounds the
+    // run and the background thread stops via its stop flag — parity of classic
+    // `zmq_sub_stops_cleanly_without_publisher_endofstream`.
+    let port = 5715;
+    let address = format!("tcp://127.0.0.1:{port}");
+
+    std::thread::spawn(move || {
+        let ctx = zmq::Context::new();
+        let sock = ctx.socket(zmq::PUB).unwrap();
+        sock.bind(&format!("tcp://127.0.0.1:{port}")).unwrap();
+        std::thread::sleep(Duration::from_millis(500));
+        // sock drops here — no EndOfStream.
+    });
+
+    let g = GraphBuilder::new();
+    let (data, _status) = zmq_sub::<u64>(&g, RunMode::RealTime, &address).unwrap();
+    let _acc = data.collapse_accumulate();
+
+    let start = std::time::Instant::now();
+    g.build()
+        .run(
+            RunMode::RealTime,
+            RunFor::Duration(Duration::from_millis(300)),
+        )
+        .unwrap();
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "subscriber took too long to stop: {elapsed:?}"
+    );
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -572,6 +572,35 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    wall-clock streams — Pub/Sub has no backlog, the stream tail blocks forever —
    with no historical timeline to replay).
 5. **zmq, kafka, kdb** — streaming; `poll`/`external` + lifecycle.
+   ✅ **zmq** *(done)*: real-time ØMQ pub/sub — a `zmq_sub` source (a background
+   OS thread polling the `SUB` socket + monitor, feeding the `channel` layer,
+   returning a `(data, status)` pair) and a `ZeroMqPub::zmq_pub` /
+   `zmq_pub_on` sink (a `register_op1` op that binds the `PUB` socket lazily on
+   the first cycle, buffers around the ZMQ slow-joiner, and sends `EndOfStream`
+   + revokes the registry via a `Drop` on its state), behind the `zmq` feature.
+   The pluggable **discovery backend** is preserved as the skill's
+   trait-behind-a-feature: a `ZmqRegistry` trait with `ZmqPubRegistration` /
+   `ZmqSubConfig` `Into`-wrappers (`()` / bare-address vs `(name, registry)`),
+   and an `EtcdRegistry` implementation gated on the `etcd` feature. Parity port
+   of the classic tests: no-service wiring tests in `tests/zmq_adapter.rs`
+   (`zmq`), real-socket pub/sub tests in `tests/zmq_integration.rs`
+   (`zmq-integration-test`), and etcd-discovery tests in
+   `tests/zmq_etcd_integration.rs` (`zmq-etcd-integration-test`, testcontainers);
+   classic direct-mode example ported to `examples/zmq_adapter.rs`. Like classic,
+   the `zmq` feature deliberately does **not** depend on `async`. **Deviations**
+   (capabilities all preserved): (a) `zmq_sub` takes a `&GraphBuilder` and a
+   `RunMode` and **rejects `RunMode::HistoricalFrom` at wiring time** — next's
+   channel is bimodal and would block-collect the never-closing subscriber and
+   deadlock at `start`, so it errors rather than rejecting at run start the way
+   classic's realtime-only `ReceiverStream` does; (b) `zmq_pub` returns a sink
+   `Stream<()>` (not `Rc<dyn Node>`), binding/registering/run-mode-checking
+   lazily on the first cycle so a historical run still errors with "real-time"
+   before touching the registry; (c) the `bincode` wire envelope is next-local,
+   so a next publisher interoperates with a next subscriber but is **not**
+   wire-compatible with a classic/Python peer — cross-language interop lands with
+   the Python bindings (Phase 6), which is also why the classic `zmq-cross-lang`
+   tests are not ported. Realtime-only, so the parity tests assert received
+   values (consecutive counters, connection status) rather than exact tick times.
 6. **fix** — codec-heavy; fallibility with context.
 7. **web** (+ wingfoil-wire-types, wingfoil-wasm, wingfoil-js untouched —
    the wire protocol is engine-agnostic), **prometheus, otlp, augurs**.


### PR DESCRIPTION
Ports the classic `wingfoil::adapters::zmq` real-time ØMQ pub/sub adapter onto the next Op model (port-plan Phase 4, item 5), following the `new-adapter-next` skill.

## What landed

- **`zmq_sub` source** — synchronous/poll-based ZMQ, so a background OS thread polls the `SUB` socket and its monitor and feeds the `channel` layer, returning a `(data, status)` pair (`Stream<Burst<T>>` of messages + `Stream<ZmqStatus>` of connection transitions). The `zmq` feature deliberately does **not** depend on `async` (matching classic). Being a live, never-closing source, it **rejects `RunMode::HistoricalFrom` at wiring time** and returns `Result` — next's channel receiver block-collects the whole stream up front in a historical run, so an unbounded live producer would deadlock at `start`.
- **`ZeroMqPub::zmq_pub` / `zmq_pub_on` sink** — a `register_op1` op that binds the `PUB` socket lazily on the first cycle (so a historical run aborts with a "real-time" error *before* touching the registry), buffers messages around the ZMQ slow-joiner problem, and sends `EndOfStream` + revokes the registry via a `Drop` on its state.
- **Pluggable discovery backend** — preserved as the skill's trait-behind-a-feature: a `ZmqRegistry` trait with `ZmqPubRegistration` / `ZmqSubConfig` `Into`-wrappers (`()` / bare address vs `(name, registry)`), and an `EtcdRegistry` implementation gated on the `etcd` feature (lease + background keepalive + revoke-on-teardown), reusing next's `EtcdConnection`.

## Feature flags

`zmq = ["dep:zmq", "dep:bincode", "dep:serde"]` (`zmq` crate pinned to classic's `0.10.0`), `zmq-integration-test`, and `zmq-etcd-integration-test = ["zmq", "etcd", "dep:testcontainers"]`.

## Tests & example

- `tests/zmq_adapter.rs` (`zmq`) — no-service wiring: historical-mode rejection for sub (wiring) and pub (first cycle).
- `tests/zmq_integration.rs` (`zmq-integration-test`) — real-socket parity: round-trip consecutive counters, first-message-not-dropped (slow-joiner buffering), connected-status, deserialization-error propagation, clean stop without publisher EndOfStream.
- `tests/zmq_etcd_integration.rs` (`zmq-etcd-integration-test`, testcontainers) — etcd discovery: unreachable/absent-key errors, register-address, end-to-end, lease-revoked-on-stop, historical-mode-fails.
- `examples/zmq_adapter.rs` — classic direct-mode example ported as a self-contained pub/sub demo.
- CI: `zmq-next-integration.yml` installs libzmq/protoc, pre-pulls the etcd image, runs both core and etcd suites; registered in the `integration-tests.yml` hub.

## Deviations from classic (capabilities all preserved; documented in module docs + port-plan)

1. `zmq_sub` takes a `&GraphBuilder` and a `RunMode`, rejecting `HistoricalFrom` at wiring (classic's realtime-only `ReceiverStream` rejects at run start; next's channel is bimodal and would deadlock instead).
2. `zmq_pub` returns a sink `Stream<()>` rather than `Rc<dyn Node>`, binding/registering/run-mode-checking lazily on the first cycle.
3. The `bincode` wire envelope is next-local — a next publisher interoperates with a next subscriber but is not wire-compatible with a classic/Python peer, so the classic cross-language tests are deferred with the Python bindings (Phase 6). Two smaller reductions: the internal `ZmqEvent<T>` envelope is private, and `ZmqStatus` adds `Eq`.

No Python bindings step — `wingfoil-python` binds the legacy crate only; next bindings arrive in the facade/cutover phase.

## Checks

`cargo fmt --all --check`, `cargo lint`, and `cargo lint-all` (full all-features workspace) all pass clean. `cargo test -p wingfoil-next --features zmq-integration-test` passes all real-socket tests. The etcd-discovery suite compiles and its non-Docker tests pass; the container-backed cases need Docker (run in CI).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_