### PR TITLE
next(otlp): roll opentelemetry forward to 0.32; drop advisory allowlist

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -89,12 +89,3 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
-          # GHSA-w9wp-h8wv-79jx: opentelemetry_sdk 0.28 unbounded allocation in
-          # W3C Baggage propagation (fixed in 0.29). The classic `wingfoil` crate
-          # already ships opentelemetry_sdk 0.28 (wingfoil/Cargo.toml), so this is
-          # not a newly introduced risk — dependency-review only flags it because
-          # wingfoil-next adds the same pinned dep. The next otlp sink is
-          # metrics-only and never uses Baggage propagation (the vulnerable path).
-          # Pinned to 0.28 to stay in lockstep with the classic tree; revisit when
-          # the classic otlp adapter bumps to >= 0.29.
-          allow-ghsas: GHSA-w9wp-h8wv-79jx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,6 +4233,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4241,9 +4255,22 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry",
- "reqwest",
+ "opentelemetry 0.28.0",
+ "reqwest 0.12.28",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -4255,14 +4282,30 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry_sdk",
+ "opentelemetry 0.28.0",
+ "opentelemetry-http 0.28.0",
+ "opentelemetry-proto 0.28.0",
+ "opentelemetry_sdk 0.28.0",
  "prost 0.13.5",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http 0.32.0",
+ "opentelemetry-proto 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.3",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4271,10 +4314,21 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.28.0",
+ "opentelemetry_sdk 0.28.0",
  "prost 0.13.5",
  "tonic 0.12.3",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -4288,7 +4342,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "glob",
- "opentelemetry",
+ "opentelemetry 0.28.0",
  "percent-encoding",
  "rand 0.8.6",
  "serde_json",
@@ -4296,6 +4350,24 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -5251,6 +5323,37 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
  "tower",
  "tower-http",
  "tower-service",
@@ -7622,15 +7725,15 @@ dependencies = [
  "lobster",
  "log",
  "num-traits",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.28.0",
+ "opentelemetry-otlp 0.28.0",
+ "opentelemetry_sdk 0.28.0",
  "ordered-float 4.6.0",
  "quanta",
  "rcgen",
  "rdkafka",
  "redis",
- "reqwest",
+ "reqwest 0.12.28",
  "rusteron-client",
  "rusteron-media-driver",
  "rustls",
@@ -7683,12 +7786,12 @@ dependencies = [
  "etcd-client",
  "futures",
  "log",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.32.0",
+ "opentelemetry-otlp 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "rdkafka",
  "redis",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde-aux",
  "sha2 0.10.9",

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -132,17 +132,23 @@ zmq = { version = "0.10.0", optional = true }
 # stream values as OTLP gauge metrics over HTTP/protobuf to any OTLP-compatible
 # backend (Grafana Alloy, Datadog, Honeycomb, New Relic, …). Built on the async
 # `consume_async` ergonomic so exports run off the graph thread (the OTel SDK's
-# `rt-tokio` PeriodicReader needs a tokio runtime). Versions mirror the classic
-# `wingfoil` crate's otlp adapter so the two trees don't drift; only the metrics
-# features are enabled (the classic trace/span exporter is a deferred deviation —
-# it needs the `Traced`/`HasLatency` latency infrastructure, not yet ported to
-# next; see `src/adapters/otlp.rs`).
-opentelemetry = { version = "0.28", optional = true }
-opentelemetry_sdk = { version = "0.28", features = [
+# `rt-tokio` PeriodicReader needs a tokio runtime). Only the metrics features are
+# enabled (the classic trace/span exporter is a deferred deviation — it needs the
+# `Traced`/`HasLatency` latency infrastructure, not yet ported to next; see
+# `src/adapters/otlp.rs`).
+#
+# NOTE — deliberate divergence from classic: next pins opentelemetry* 0.32 while
+# classic still ships 0.28. This is to clear GHSA-w9wp-h8wv-79jx (opentelemetry_sdk
+# < 0.29: unbounded allocation in W3C Baggage propagation), which the dependency-
+# review gate flags on the newly added next dep. The 0.32 API is source-compatible
+# with the adapter's usage (no code change needed). Classic should be bumped to
+# match in a follow-up to restore lockstep and fix the same advisory there.
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", features = [
     "metrics",
     "rt-tokio",
 ], optional = true }
-opentelemetry-otlp = { version = "0.28", features = [
+opentelemetry-otlp = { version = "0.32", features = [
     "http-proto",
     "reqwest-blocking-client",
     "metrics",


### PR DESCRIPTION
Replaces the `dependency-review` allowlist (added when the otlp adapter landed in #536) with the real fix: roll next's opentelemetry stack forward.

## Change
- **`opentelemetry` / `opentelemetry_sdk` / `opentelemetry-otlp`: 0.28 → 0.32** in `next/crates/wingfoil-next/Cargo.toml`. This clears **GHSA-w9wp-h8wv-79jx** (`opentelemetry_sdk` < 0.29: unbounded allocation in W3C Baggage propagation).
- **Removed the `allow-ghsas: GHSA-w9wp-h8wv-79jx`** entry from `.github/workflows/security-audit.yml` — no longer needed now that the vulnerable version is gone.
- **No adapter code change**: the 0.32 API is source-compatible with `adapters/otlp.rs`'s usage (`MetricExporter::builder`, `PeriodicReader`, `SdkMeterProvider`, `f64_gauge`, `Resource`). `cargo tree` confirms next → `opentelemetry-otlp 0.32.0` → `opentelemetry_sdk 0.32.1`.

## Deliberate deviation
next now diverges from the classic `wingfoil` crate, which still ships opentelemetry 0.28 (and still carries the advisory — unflagged only because it isn't a *new* dep on classic PRs). Documented inline in Cargo.toml. **Follow-up:** bump classic to match, to restore lockstep and fix the same advisory there.

## Verification
- `cargo build -p wingfoil-next --features otlp` / `--tests` — clean
- `cargo test -p wingfoil-next --features otlp` — all green (otlp suite + full crate)
- `cargo clippy -p wingfoil-next --features otlp --all-targets` — clean
- `cargo fmt --all --check` — clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_