### PR TITLE
next: defer I/O source establishment to start() (source_at_start + zmq_sub)

### DIFF
--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -11,6 +11,9 @@ reference implementations; read them before writing code:
   realtime `poll` tail + sink), dependency-free.
 - `src/adapters/csv.rs` — the serde-typed parsing cousin (feature-gated deps,
   wiring-time `Result`, header introspection).
+- `src/adapters/zmq.rs` — a live sync-streaming subscriber over a background
+  thread, using [`source_at_start`] to **defer the socket connect + thread spawn
+  to graph `start()`** (see the source shape in step 7); plus a status stream.
 - `src/adapters/augurs.rs` — a pure-compute adapter (custom `Op`s +
   `#[op(build = ...)]` + config builder types, no I/O).
 - `src/async_source.rs` — `produce_async` for async client libraries.
@@ -123,7 +126,14 @@ run mode from the `RunParams` the factory already takes.
 
 - **Wiring-time I/O** (open file, bind socket, connect) happens in the factory
   function, which returns `anyhow::Result<Stream<...>>` — errors surface at
-  wiring, before the run (see `csv_read`, `sink_lines`).
+  wiring, before the run (see `csv_read`, `sink_lines`). **Exception — a live
+  socket/subscription source's connect + thread spawn belongs in `start()`, not
+  the factory**: wire it with [`source_at_start`] so wiring stays pure (parse /
+  registry lookup / historical rejection only) and the connect+spawn happen in
+  the `setup` closure at run start (see step 7). The factory still returns
+  `Result` for the pure validation; a *connection* error then surfaces at
+  run-start with node context (classic-consistent) rather than at wiring. `zmq_sub`
+  is the reference.
 - **Run-time errors** flow through the fallible cycle: `for_each`/`try_map`
   closures return `Result`, custom `Op` lifecycle functions return `Result`,
   producer threads use `send_error`. Attach `.context("...")`/`.with_context`
@@ -189,7 +199,7 @@ load-bearing decision:
 | Library / data shape | Source | Sink | Reference |
 |---|---|---|---|
 | File / batch replay (historical) | read fully at wiring → `send_at` per record → `close` | `for_each` + `RefCell` writer | `csv.rs`, `lines.rs` |
-| Synchronous streaming client (blocking recv) | background `std::thread` feeding a `ChannelSender` (realtime) | `for_each` pushing into an `mpsc` drained by a writer thread | pattern below |
+| Synchronous streaming client (blocking recv) | `source_at_start`: background `std::thread` feeding a `ChannelSender`, connected+spawned at graph `start()` (realtime) | `for_each` pushing into an `mpsc` drained by a writer thread | `zmq.rs`, pattern below |
 | Async client library (tokio-based) | `produce_async` / `produce_async_bounded` (`async` feature) | writer task + `for_each` (as above, tokio flavour) | `async_source.rs` |
 | Non-blocking poll, ultra-low latency | `g.poll(...)` busy-spin (realtime only) | non-blocking write in `for_each` | `tail_lines` |
 | Push-only telemetry (no source) | n/a | `for_each` pushing each burst to the exporter/collector client | otlp (classic), step 8 |
@@ -359,35 +369,73 @@ sender.close();   // the historical receiver needs the end-of-stream
 
 ### Background thread over the channel (sync streaming client — realtime)
 
+**Use [`source_at_start`], not `g.channel()` + a wiring-time spawn.** A live
+source's socket connect and background thread belong in `start()`, not the
+factory: `source_at_start` allocates the channel at wiring but runs your `setup`
+closure — which connects and spawns the feeder thread — at graph `start()`, and
+returns the running producer as a [`StopHandle`] dropped at teardown to stop it
+(the generalised `ThreadStopGuard`). That keeps wiring side-effect-free and
+unit-testable (no live socket to construct the graph), and surfaces a connection
+error at run-start with node context — classic-consistent. `zmq_sub` is the
+reference.
+
 ```rust
-pub fn $ARGUMENTS_sub<T>(g: &GraphBuilder, conn: impl Into<<Name>Config>) -> Result<Stream<Burst<T>>>
+pub fn $ARGUMENTS_sub<T>(g: &GraphBuilder, run_mode: RunMode, conn: impl Into<<Name>Config>)
+    -> Result<Stream<Burst<T>>>
 where
     T: Clone + Default + Send + 'static,
 {
-    let client = connect(conn.into())?;               // wiring-time: Err before the run
-    let (stream, sender) = g.channel::<T>();
-    std::thread::Builder::new()
-        .name("$ARGUMENTS-sub".into())
-        .spawn(move || {
-            loop {
-                match client.recv() {
-                    Ok(msg) => {
+    // Wiring is PURE: reject historical (a live source is realtime-only, see the
+    // invariant), resolve/validate config. No socket, no thread here.
+    if let RunMode::HistoricalFrom(_) = run_mode {
+        anyhow::bail!("$ARGUMENTS_sub: RunMode::HistoricalFrom is unsupported — run realtime");
+    }
+    let cfg = conn.into().resolve()?;                  // parse / registry lookup — Err before the run
+
+    // Deferred to start(): connect + spawn the feeder. `setup` is handed a fresh
+    // ChannelSender each run; whatever it returns is dropped at teardown.
+    Ok(g.source_at_start::<T, _>(move |sender| {
+        let cfg = cfg.clone();
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let thread_stop = stop.clone();
+        std::thread::Builder::new()
+            .name("$ARGUMENTS-sub".into())
+            .spawn(move || {
+                let client = match connect(&cfg) {     // connect on the thread → error at run-start
+                    Ok(c) => c,
+                    Err(e) => { sender.send_error(e.context("$ARGUMENTS: connecting")); return; }
+                };
+                loop {
+                    if thread_stop.load(std::sync::atomic::Ordering::Relaxed) { return; }
+                    match client.recv() {
                         // `send` returns false once the receiver is gone —
                         // a normal teardown race; stop producing.
-                        if !sender.send(msg) { return; }
+                        Ok(msg) => if !sender.send(msg) { return; },
+                        Err(e) if is_end_of_stream(&e) => { sender.close(); return; }
+                        Err(e) => { sender.send_error(anyhow::Error::new(e).context("...")); return; }
                     }
-                    Err(e) if is_end_of_stream(&e) => { sender.close(); return; }
-                    Err(e) => { sender.send_error(anyhow::Error::new(e).context("...")); return; }
                 }
-            }
-        })
-        .context("$ARGUMENTS: spawning subscriber thread")?;
-    Ok(stream)
+            })
+            .context("$ARGUMENTS: spawning subscriber thread")?;
+        // Its Drop flips `stop`, so the thread exits on its next loop turn.
+        Ok(StopHandle::new(ThreadStopGuard(stop)))
+    }))
 }
 ```
 
 Each `send` wakes the kernel; values arriving between cycles group into one
 `Burst`. Realtime only — do not offer this path for historical runs.
+`source_at_start` builds on `channel`, so a graph containing it is **single-run**
+for now (the receive channel + waker are consumed by the first run), same as a
+plain `channel` source. `StopHandle`/`source_at_start` are `use
+wingfoil_next::interp::{...}` / the `SourceOps` trait; define `ThreadStopGuard`
+as a tiny `Drop` that sets the stop flag (the zmq adapter's is the template).
+
+> **Not on `source_at_start` yet:** the `produce_async` and plain
+> `channel`/`external` source shapes still connect/spawn at wiring. If your
+> adapter uses those, follow their sections as written; migrating them to
+> deferred establishment is tracked in
+> `next/docs/source-lifecycle-defer-to-start.md`.
 
 ### `produce_async` (async client library — `async` feature)
 

--- a/next/crates/wingfoil-next/src/adapters/zmq.rs
+++ b/next/crates/wingfoil-next/src/adapters/zmq.rs
@@ -108,6 +108,7 @@ use wingfoil::RunMode;
 use crate::Burst;
 use crate::channel::ChannelSender;
 use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
+use crate::interp::StopHandle;
 use crate::op::{Activation, Ctx, Tick};
 
 mod registry;
@@ -244,33 +245,24 @@ where
             .with_context(|| format!("zmq_sub: resolving {name:?} via registry"))?,
     };
 
-    let (events, sender) = g.channel::<ZmqEvent<T>>();
-    let stop = Arc::new(AtomicBool::new(false));
-    let thread_stop = stop.clone();
-    std::thread::Builder::new()
-        .name("zmq-sub".into())
-        .spawn(move || {
-            if let Err(e) = run_subscriber::<T>(&address, &sender, &thread_stop) {
-                sender.send_error(e);
-            }
-        })
-        .context("zmq_sub: spawning subscriber thread")?;
-
-    // Route the raw event burst through a passthrough op that owns the stop
-    // guard, so the background thread is signalled to stop when the graph is
-    // dropped at teardown.
-    let events = events.wire(move |b, h| {
-        b.register_op1(
-            h,
-            "zmq_sub",
-            Activation::NONE,
-            ThreadStopGuard(stop),
-            || (),
-            move |_g: &mut ThreadStopGuard,
-                  _s: &mut (),
-                  burst: &Burst<ZmqEvent<T>>,
-                  _ctx: &mut Ctx<'_>| { Ok(Tick::Value(burst.clone())) },
-        )
+    // Defer the socket connect and subscriber thread to graph **start**: the
+    // factory above did only pure wiring work (address parse / registry lookup /
+    // historical rejection), touching no socket. `setup` runs at `start()`,
+    // spawns the polling thread, and returns a [`StopHandle`] wrapping the
+    // [`ThreadStopGuard`] so the thread is signalled to stop at teardown.
+    let events = g.source_at_start::<ZmqEvent<T>, _>(move |sender| {
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = stop.clone();
+        let address = address.clone();
+        std::thread::Builder::new()
+            .name("zmq-sub".into())
+            .spawn(move || {
+                if let Err(e) = run_subscriber::<T>(&address, &sender, &thread_stop) {
+                    sender.send_error(e);
+                }
+            })
+            .context("zmq_sub: spawning subscriber thread")?;
+        Ok(StopHandle::new(ThreadStopGuard(stop)))
     });
 
     let data = events.map_filter(|burst: &Burst<ZmqEvent<T>>| {

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -31,7 +31,9 @@ use wingfoil::NanoTime;
 
 use crate::Burst;
 use crate::channel::ChannelSender;
-use crate::interp::{AsHandle, Builder, ExternalSource, FeedbackSink, Handle, Runner, SlotRef};
+use crate::interp::{
+    AsHandle, Builder, ExternalSource, FeedbackSink, Handle, Runner, SlotRef, StopHandle,
+};
 
 /// A graph under construction. Cheap to clone; all clones share the same
 /// underlying builder.
@@ -223,6 +225,20 @@ pub trait SourceOps {
         T: Clone + Default + 'static,
         F: Fn() -> Option<T> + 'static;
 
+    /// A [`channel`](SourceOps::channel)-fed source whose producer (thread /
+    /// socket) is established in `start()` rather than at wiring — the
+    /// **deferred-connection** primitive for I/O adapters. `setup` runs on each
+    /// run start, is handed the [`ChannelSender`], connects/spawns the live
+    /// producer, and returns a [`StopHandle`] dropped at teardown to stop it.
+    /// The factory itself does **no** I/O, so adapter wiring (address parse,
+    /// registry lookup, historical-mode rejection) stays pure and unit-testable;
+    /// a `setup` error aborts the run at start with node context. See
+    /// [`Builder::source_at_start`](crate::interp::Builder::source_at_start).
+    fn source_at_start<T, Setup>(&self, setup: Setup) -> Stream<Burst<T>>
+    where
+        T: Clone + Default + 'static,
+        Setup: FnMut(ChannelSender<T>) -> Result<StopHandle> + 'static;
+
     /// Open a feedback edge: a source stream (no upstreams — the graph stays
     /// acyclic) plus the [`FeedbackSink`] that feeds it. Close the loop with
     /// [`StreamOps::feedback`]; values arrive on the source one cycle later.
@@ -261,6 +277,15 @@ impl SourceOps for GraphBuilder {
         F: Fn() -> Option<T> + 'static,
     {
         self.source(|b| b.poll(f))
+    }
+
+    fn source_at_start<T, Setup>(&self, setup: Setup) -> Stream<Burst<T>>
+    where
+        T: Clone + Default + 'static,
+        Setup: FnMut(ChannelSender<T>) -> Result<StopHandle> + 'static,
+    {
+        let handle = self.with_builder(|b| b.source_at_start(setup));
+        self.wrap(handle)
     }
 
     fn feedback<T>(&self) -> (Stream<T>, FeedbackSink<T>)

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -307,7 +307,13 @@ impl<T> Clone for FeedbackSink<T> {
 /// `ThreadStopGuard` pattern, generalised and made start-scoped. Wrap any
 /// `'static` value whose `Drop` signals your producer to stop (a stop-flag
 /// guard, a `JoinHandle` wrapper, an owned socket).
-pub struct StopHandle(#[allow(dead_code)] Box<dyn Any>);
+pub struct StopHandle(
+    // Held only for its `Drop`; never read or downcast. Dropping the
+    // `Box<dyn Any>` runs the wrapped guard's own `Drop`, which is what stops
+    // the producer — `Any` (rather than, say, `Box<dyn FnOnce()>`) just so any
+    // `'static` guard type can be wrapped without naming it.
+    #[allow(dead_code)] Box<dyn Any>,
+);
 
 impl StopHandle {
     /// Wrap a teardown guard; its `Drop` runs when the run tears down.
@@ -632,6 +638,16 @@ impl Builder {
     /// waker are consumed by the first run, so — like `channel` — a graph built
     /// with this source is single-run for now (re-run is a documented follow-on;
     /// see `docs/source-lifecycle-defer-to-start.md`).
+    ///
+    /// **A historical producer must `close()` explicitly.** Unlike
+    /// [`channel`](Self::channel) — whose sender is handed to the caller — this
+    /// source *retains* a live [`ChannelSender`] for the whole run (it clones one
+    /// into `setup` at each start). A historical up-front collect therefore ends
+    /// only on an explicit `close()` / `EndOfStream`, never on the
+    /// all-senders-dropped path (the retained sender keeps the channel open), so
+    /// a producer that finishes by merely dropping its sender would deadlock the
+    /// collect. Realtime live sources — the primary use — are unaffected: they
+    /// terminate on `close()` or the run bound.
     pub fn source_at_start<T, Setup>(&mut self, setup: Setup) -> Handle<Burst<T>>
     where
         T: Clone + Default + 'static,
@@ -647,6 +663,11 @@ impl Builder {
         // realtime live source the collect branch is a no-op, so the order is
         // moot there.
         let mut prev_start = std::mem::replace(&mut node.start, Box::new(|_| Ok(())));
+        // Compose (don't clobber) the channel node's teardown as well: it is a
+        // no-op today, but replacing it outright would silently drop any teardown
+        // hook `channel` grows later. Our guard-drop runs first, then the
+        // previous teardown — symmetric with the `start` composition above.
+        let mut prev_teardown = std::mem::replace(&mut node.teardown, Box::new(|_| Ok(())));
         let mut setup = setup;
         // Holds the `setup`-returned guard for the duration of the run; the
         // teardown hook drops it to stop the producer.
@@ -657,10 +678,11 @@ impl Builder {
             *stop_at_start.borrow_mut() = Some(guard);
             prev_start(k)
         });
-        node.teardown = Box::new(move |_k| {
-            // Drop the StopHandle → its `Drop` signals the producer to stop.
+        node.teardown = Box::new(move |k| {
+            // Drop the StopHandle → its `Drop` signals the producer to stop,
+            // then run the channel node's own teardown.
             stop.borrow_mut().take();
-            Ok(())
+            prev_teardown(k)
         });
         handle
     }

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -301,6 +301,21 @@ impl<T> Clone for FeedbackSink<T> {
     }
 }
 
+/// The teardown handle a [`source_at_start`](Builder::source_at_start) `setup`
+/// returns. Whatever it wraps is held for the run and **dropped at teardown**,
+/// so its `Drop` is where a deferred producer stops — the zmq adapter's
+/// `ThreadStopGuard` pattern, generalised and made start-scoped. Wrap any
+/// `'static` value whose `Drop` signals your producer to stop (a stop-flag
+/// guard, a `JoinHandle` wrapper, an owned socket).
+pub struct StopHandle(#[allow(dead_code)] Box<dyn Any>);
+
+impl StopHandle {
+    /// Wrap a teardown guard; its `Drop` runs when the run tears down.
+    pub fn new(guard: impl Any) -> Self {
+        Self(Box::new(guard))
+    }
+}
+
 /// Wires a graph of [`Op`]s. Combinators mirror the classic fluent API but
 /// the engine — not the node — owns state, config and values.
 pub struct Builder {
@@ -590,6 +605,64 @@ impl Builder {
         );
         let sender = ChannelSender::new(tx, self.waker.clone(), idx);
         (self.make_handle(idx), sender)
+    }
+
+    /// A [`channel`](Self::channel)-fed source whose producer is established in
+    /// `start()` rather than at wiring — the **deferred-connection** primitive.
+    ///
+    /// The factory allocates the channel and stores `setup`, but performs **no**
+    /// I/O: no thread is spawned and no socket is connected while the graph is
+    /// merely being constructed. On each run, `start()` calls `setup`, handing
+    /// it the [`ChannelSender`]; `setup` connects/spawns the live producer and
+    /// returns a [`StopHandle`] that is dropped at teardown (running its `Drop`),
+    /// so the producer is torn down with the run (the `ThreadStopGuard` pattern,
+    /// generalised). A `setup` error aborts the run at start with node context —
+    /// classic-consistent: a connection failure surfaces when the run begins,
+    /// not at construction.
+    ///
+    /// This is what lets an adapter's wiring stay side-effect-free and
+    /// unit-testable: address parsing, registry lookup and historical-mode
+    /// rejection are pure `Result`-returning work done *before* calling this;
+    /// the socket/thread only exist during a run.
+    ///
+    /// Delivery reuses [`channel`](Self::channel), so the same realtime/historical
+    /// burst semantics apply. A *live* deferred source (a subscriber socket, say)
+    /// is realtime-only and its caller should reject historical at wiring, exactly
+    /// as [`channel`](Self::channel) callers do today. The receive channel and
+    /// waker are consumed by the first run, so — like `channel` — a graph built
+    /// with this source is single-run for now (re-run is a documented follow-on;
+    /// see `docs/source-lifecycle-defer-to-start.md`).
+    pub fn source_at_start<T, Setup>(&mut self, setup: Setup) -> Handle<Burst<T>>
+    where
+        T: Clone + Default + 'static,
+        Setup: FnMut(ChannelSender<T>) -> Result<StopHandle> + 'static,
+    {
+        let (handle, sender) = self.channel::<T>();
+        let idx = handle.idx;
+        let node = &mut self.nodes[idx];
+        // The channel node already carries a `start` hook (the historical
+        // collect). Compose the deferred `setup` **ahead** of it: `setup` spawns
+        // the producer first, so a historical deferred source's up-front collect
+        // sees a live producer instead of deadlocking on an unstarted one. For a
+        // realtime live source the collect branch is a no-op, so the order is
+        // moot there.
+        let mut prev_start = std::mem::replace(&mut node.start, Box::new(|_| Ok(())));
+        let mut setup = setup;
+        // Holds the `setup`-returned guard for the duration of the run; the
+        // teardown hook drops it to stop the producer.
+        let stop: Rc<RefCell<Option<StopHandle>>> = Rc::new(RefCell::new(None));
+        let stop_at_start = stop.clone();
+        node.start = Box::new(move |k| {
+            let guard = setup(sender.clone())?;
+            *stop_at_start.borrow_mut() = Some(guard);
+            prev_start(k)
+        });
+        node.teardown = Box::new(move |_k| {
+            // Drop the StopHandle → its `Drop` signals the producer to stop.
+            stop.borrow_mut().take();
+            Ok(())
+        });
+        handle
     }
 
     pub(crate) fn slot<T: 'static>(&self, h: Handle<T>) -> SlotRef<T> {

--- a/next/crates/wingfoil-next/tests/fluent_primitives.rs
+++ b/next/crates/wingfoil-next/tests/fluent_primitives.rs
@@ -1,14 +1,20 @@
 //! Focused tests for the shared adapter-support primitives on the fluent layer:
 //! `GraphBuilder::replay_results` (the historical replay engine behind the
-//! `lines`/`csv` sources) and `StreamOps::for_each_mut` (the `&mut`-writer sink
-//! behind their file sinks). The adapter tests cover them end-to-end through
-//! files; these exercise the primitives directly.
+//! `lines`/`csv` sources), `StreamOps::for_each_mut` (the `&mut`-writer sink
+//! behind their file sinks), and `SourceOps::source_at_start` (the
+//! deferred-connection source behind live adapters like `zmq_sub`). The adapter
+//! tests cover them end-to-end through files/sockets; these exercise the
+//! primitives directly.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use wingfoil::{NanoTime, RunFor, RunMode};
 use wingfoil_next::Burst;
+use wingfoil_next::channel::ChannelSender;
+use wingfoil_next::interp::StopHandle;
 use wingfoil_next::prelude::*;
 
 /// `replay_results` queues each `(value, time)` onto a historical source and
@@ -113,5 +119,78 @@ fn for_each_mut_error_aborts_the_run() {
     assert!(
         format!("{err:#}").contains("sink boom"),
         "unexpected error: {err:#}"
+    );
+}
+
+/// `source_at_start` performs **no** I/O at wiring: the `setup` closure runs at
+/// `start()`, not when the source factory is called. A spy counter proves the
+/// deferral — zero after wiring + `build()`, one after a run — and a stop guard
+/// whose `Drop` flips a flag proves the returned `StopHandle` is dropped at
+/// teardown. This is the acceptance test for the deferred-connection primitive
+/// (see `docs/source-lifecycle-defer-to-start.md`).
+#[test]
+fn source_at_start_defers_setup_to_run_and_stops_at_teardown() {
+    /// Its `Drop` (run when the `StopHandle` is dropped at teardown) flips the
+    /// shared flag — the generalised `ThreadStopGuard`.
+    struct Guard(Arc<AtomicBool>);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    let g = GraphBuilder::new();
+    let setups = Rc::new(Cell::new(0u32));
+    let stopped = Arc::new(AtomicBool::new(false));
+
+    let seen = setups.clone();
+    let stop_flag = stopped.clone();
+    let source = g.source_at_start::<u64, _>(move |sender: ChannelSender<u64>| {
+        seen.set(seen.get() + 1);
+        // Stand in for "connect + spawn the producer": feed one value, then
+        // close so the realtime run terminates promptly.
+        sender.send(7);
+        sender.close();
+        Ok(StopHandle::new(Guard(stop_flag.clone())))
+    });
+    let acc = source.collapse_accumulate();
+    let mut r = g.build();
+
+    // Nothing has run: wiring + build touched no producer.
+    assert_eq!(0, setups.get(), "setup must not run at wiring/build");
+    assert!(
+        !stopped.load(Ordering::Relaxed),
+        "no producer to stop before the run"
+    );
+
+    r.run(RunMode::RealTime, RunFor::Forever).unwrap();
+
+    assert_eq!(1, setups.get(), "setup runs once, at start");
+    assert_eq!(vec![7u64], r.value(&acc), "the deferred producer's value");
+    assert!(
+        stopped.load(Ordering::Relaxed),
+        "the StopHandle guard is dropped at teardown"
+    );
+}
+
+/// A `setup` error aborts the run at start with node context — a deferred
+/// connection failure surfaces when the run begins (classic-consistent), not at
+/// wiring. The factory call itself still succeeds.
+#[test]
+fn source_at_start_setup_error_aborts_the_run() {
+    let g = GraphBuilder::new();
+    let source =
+        g.source_at_start::<u64, _>(|_sender: ChannelSender<u64>| anyhow::bail!("connect boom"));
+    let _acc = source.collapse_accumulate();
+    let mut r = g.build();
+
+    let err = r
+        .run(RunMode::RealTime, RunFor::Cycles(1))
+        .expect_err("a setup error must abort the run");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("connect boom"), "unexpected error: {msg}");
+    assert!(
+        msg.contains("start"),
+        "error carries node start context: {msg}"
     );
 }

--- a/next/crates/wingfoil-next/tests/fluent_primitives.rs
+++ b/next/crates/wingfoil-next/tests/fluent_primitives.rs
@@ -194,3 +194,45 @@ fn source_at_start_setup_error_aborts_the_run() {
         "error carries node start context: {msg}"
     );
 }
+
+/// In historical mode `setup` is composed **ahead** of the channel node's own
+/// up-front collect (the `prev_start` composition), so a deferred producer that
+/// `send_at`s timestamped values and then `close()`s replays them on the graph
+/// clock at their timestamps — exactly like a plain `channel`. This also pins
+/// the documented contract that a historical producer must `close()` explicitly:
+/// the source retains a live sender, so `EndOfStream` (not sender-drop) is what
+/// ends the collect.
+#[test]
+fn source_at_start_historical_replays_timestamped_sends() {
+    let g = GraphBuilder::new();
+    let source = g.source_at_start::<u64, _>(|sender: ChannelSender<u64>| {
+        // Stand in for a deferred historical producer: emit timestamped values
+        // (same-instant ones group into one burst), then close so the up-front
+        // collect terminates. Dropping the sender alone would not — the source
+        // keeps one alive for the run.
+        sender.send_at(1, NanoTime::new(10));
+        sender.send_at(2, NanoTime::new(10));
+        sender.send_at(3, NanoTime::new(20));
+        sender.close();
+        Ok(StopHandle::new(()))
+    });
+    let stamped = source.with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+
+    let got: Vec<(NanoTime, Vec<u64>)> = r
+        .value(&stamped)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().copied().collect()))
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            (NanoTime::new(10), vec![1, 2]),
+            (NanoTime::new(20), vec![3]),
+        ],
+        "deferred historical sends replay grouped, on the graph clock",
+    );
+}

--- a/next/docs/source-lifecycle-defer-to-start.md
+++ b/next/docs/source-lifecycle-defer-to-start.md
@@ -1,9 +1,45 @@
 # Deferring I/O source establishment to `start()`
 
-Status: **proposal / not started.** This is a design plan for a handover — it
-describes a change to the wingfoil-next *source lifecycle model*, not a bug fix.
-Read `port-plan.md` §0.4 (the single-run decision) and §1 (the `reset` hook)
-first; this proposal revisits both.
+Status: **spike landed (steps 1 & the zmq migration); re-run still a follow-on.**
+This was a design plan for a handover — it describes a change to the
+wingfoil-next *source lifecycle model*, not a bug fix. Read `port-plan.md` §0.4
+(the single-run decision) and §1 (the `reset` hook) first; this proposal
+revisits both.
+
+## Implemented so far (the spike)
+
+The **deferred-connection primitive and the zmq migration** have landed, i.e.
+the "defer + testability" half of this plan (steps 1–2's spike, which the
+closing note below flags as legitimately landable ahead of re-run):
+
+- **`Builder::source_at_start` / `SourceOps::source_at_start`** (`interp.rs`,
+  `fluent.rs`) — a [`channel`]-fed source whose producer (thread/socket) is
+  established in `start()` rather than at wiring. The factory allocates the
+  channel and stores the `setup` closure but performs **no** I/O. On each run,
+  `start()` calls `setup(sender)`, which connects/spawns the live producer and
+  returns a **`StopHandle`** (a generalised, start-scoped `ThreadStopGuard`)
+  that is dropped at teardown to stop it. A `setup` error aborts the run at
+  start with node context (classic-consistent). Built on the existing `channel`
+  node, so it inherits the burst semantics and the current **single-run**
+  restriction (the receive channel + waker are consumed by the first run).
+- **`zmq_sub` migrated** (`adapters/zmq.rs`) — the SUB socket connect and the
+  polling thread now spawn in `setup` at graph start; wiring does only pure work
+  (address parse, registry lookup, historical-mode rejection). The bespoke
+  stop-guard passthrough op is gone — `source_at_start` owns the stop lifecycle.
+- **Acceptance tests** (`tests/fluent_primitives.rs`) — assert the factory runs
+  no `setup` at wiring/`build()`, that `setup` runs once at start, that the
+  `StopHandle` guard is dropped at teardown, and that a `setup` error aborts the
+  run at start with node context. The existing zmq integration/parity suites
+  cover the real-socket path unchanged.
+
+**Not yet done** (the higher-cost payoff, deliberately left as follow-ons — see
+"The hard part" and the closing note): re-run for I/O sources (the
+reset/channel-recreation interlock, which needs the §0.4 single-run decision
+reopened); and migrating `external`, the plain `channel` feeders, and
+`produce_async`/`produce_async_bounded` (etcd/kafka/redis/postgres) plus the
+`RunParams` simplification.
+
+[`channel`]: ../crates/wingfoil-next/src/interp.rs
 
 ## One-paragraph summary
 


### PR DESCRIPTION
## Summary

Implements the **"defer + testability" spike** from `next/docs/source-lifecycle-defer-to-start.md`: background I/O sources establish their thread/socket at graph run (`start()`) instead of at wiring time.

The design doc recommends doing this **spike-first** and explicitly notes it is "legitimate to land steps 1–2 (defer + testability) first and treat re-run … as a follow-on." This PR is exactly that scope. Re-run (the reset/channel-recreation interlock) additionally requires reopening the ratified §0.4 single-run decision — a maintainer call — so it is deliberately left out.

## What changed

- **New engine primitive `Builder::source_at_start` / `SourceOps::source_at_start`** (`interp.rs`, `fluent.rs`). A [`channel`]-fed source that allocates its channel and stores a `setup` closure at wiring but performs **no** I/O. At each run, `start()` calls `setup(sender)` — which connects/spawns the live producer and returns a **`StopHandle`** dropped at teardown to stop it (the zmq `ThreadStopGuard` pattern, generalised and made start-scoped). A `setup` error aborts the run at start with node context (classic-consistent: connection failures surface at run start, not construction). Built on the existing `channel` node, so burst semantics and the current single-run restriction are inherited.

- **`zmq_sub` migrated onto it** (`adapters/zmq.rs`). The SUB socket connect and polling thread now spawn at `start()`, leaving wiring pure (address parse, registry lookup, historical rejection). The bespoke stop-guard passthrough op is gone — `source_at_start` owns the stop lifecycle.

- **Acceptance tests** (`tests/fluent_primitives.rs`): assert no `setup` runs at wiring/`build()`, `setup` runs once at start, the `StopHandle` drops at teardown, and a `setup` error aborts the run with start context.

- **Doc updated** to mark the spike landed and list the outstanding follow-ons.

## Not in scope (documented follow-ons)

- Re-run for I/O sources (needs the §0.4 single-run decision reopened).
- Migrating `external`, plain `channel` feeders, and `produce_async`/`produce_async_bounded` (etcd/kafka/redis/postgres) plus the `RunParams` simplification.

## Testing

- `cargo fmt --all`, `cargo lint` (default features) — green.
- `cargo clippy -p wingfoil-next --all-features -- -D warnings` — green (scoped form the doc sanctions; full `lint-all` fails only on aeron's C/cmake build, untouched here and unbuildable in the sandbox).
- `cargo test -p wingfoil-next --features zmq` — green (full default suite + zmq unit tests).
- `cargo test -p wingfoil-next --features zmq-integration-test --test zmq_integration` — all 5 **real-socket** tests green, including `sub_stops_cleanly_without_publisher_endofstream` (teardown-stop path) and `first_message_not_dropped` (deferred spawn connects correctly).

[`channel`]: https://github.com/wingfoil-io/wingfoil/blob/next/next/crates/wingfoil-next/src/interp.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015gHZjQpTLKowhUddoWoyNu)_