### PR TITLE
next: GraphBuilder owns the async runtime (drop caller-passed &Handle) + skill updates

### DIFF
--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -38,6 +38,20 @@ a **strict superset of legacy wingfoil**. If a classic adapter named
 If no classic adapter exists, you are defining new surface: keep the naming
 and layering conventions below so a future legacy backport stays mechanical.
 
+## Feed lessons back into this skill
+
+Adapter development keeps surfacing things this skill doesn't yet capture — a
+recurring pitfall, a CI gate you didn't expect, a pattern worth codifying, a
+deviation that should be a rule. **When you hit one, consider baking it into
+this file** (`.claude/commands/new-adapter-next.md`), ideally in the same PR, or
+flag it for a follow-up skill update. This skill is meant to grow with every
+port: several rules below (credential redaction, live-source rejection, the
+slicer cfg-gate reuse, the dependency-review gate) were added exactly this way
+after a port hit them. Record cross-cutting classic↔next differences in
+`next/docs/deviation-register.md`, and note open design items you brushed up
+against (e.g. `next/docs/source-lifecycle-defer-to-start.md`,
+`next/docs/runtime-ownership.md`).
+
 ## Invariants
 
 These rules apply to every step below.
@@ -243,6 +257,24 @@ testcontainers = { version = "0.27", features = ["blocking"], optional = true }
   gate dev-deps). Skip the `-integration-test` flag entirely for file-based
   and pure-compute adapters (Option C in step 10).
 - A dependency-free adapter (like `lines`) needs no feature at all.
+
+**The `dependency-review` gate — expect it, and prefer rolling forward.** CI's
+`dependency-review` job (`.github/workflows/security-audit.yml`, fails on
+`moderate`+) flags a **newly added** dependency that carries a known advisory —
+**even if the classic `wingfoil` crate already ships that exact version**,
+because it's new *to this PR's diff*. So pinning to classic's version can still
+turn the gate red. Two fixes, in order of preference:
+1. **Roll the dependency forward** to a fixed version if one exists, and note the
+   deliberate divergence from classic in the dep's Cargo.toml comment (then bump
+   classic to match in a follow-up, to restore lockstep). This is the real fix —
+   the advisory is gone, not suppressed. (otlp did this: opentelemetry 0.28→0.32
+   for GHSA-w9wp-h8wv-79jx.)
+2. If you genuinely can't roll forward, **allowlist the specific advisory** with
+   `allow-ghsas: GHSA-…` in the workflow and a comment explaining *why it's safe*
+   (e.g. classic already ships it; the vulnerable code path is unused). A
+   last resort, not the default.
+Run `cargo audit` too (a separate CI job) — it catches advisories
+`dependency-review` may not, and vice-versa.
 
 **Pluggable backends behind their own feature.** If the adapter can swap an
 underlying library for the *same* concern — a discovery backend, a TLS
@@ -460,6 +492,18 @@ at **wiring** time, so `params` must describe the run the caller will actually
 invoke — historical `start_time` mismatches are validated and abort the run;
 use `produce_async_bounded` when a fast realtime producer needs `buffer_size`
 back-pressure (not applied in historical mode, by design).
+
+**Runtime ownership — current convention, with a pending change.** Today async
+adapters take the caller's `&tokio::runtime::Handle` (caller-owned runtime), and
+the graph must be built, run, and dropped from a **non-async thread** (a
+`block_on` footgun — see the etcd/postgres module docs). Follow that convention
+for now. But be aware of an **open design proposal** to move to a
+`Runner`/`Graph`-owned runtime *with an override* — which would drop the
+`&Handle`/`RunParams` factory params and hand the handle to the adapter at
+`start()` instead (it's coupled to the defer-I/O-to-`start()` change). See
+`next/docs/runtime-ownership.md` and `next/docs/source-lifecycle-defer-to-start.md`;
+if you're adding an async adapter while that's in flight, check whether the new
+primitive has landed before hardcoding the `&Handle` signature.
 
 If the service supports **snapshot + watch** (etcd-like), use watch-before-get
 to avoid races: open the watch first, read the snapshot and its

--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -474,16 +474,15 @@ as a tiny `Drop` that sets the stop flag (the zmq adapter's is the template).
 ```rust
 pub fn $ARGUMENTS_sub(
     g: &GraphBuilder,
-    handle: &tokio::runtime::Handle,
     params: RunParams,
     conn: <Name>Config,
-) -> Stream<Burst<<Name>Event>> {
-    produce_async(g, handle, params, move |_p| async move {
+) -> anyhow::Result<Stream<Burst<<Name>Event>>> {
+    produce_async(g, params, move |_p| async move {
         // connect; optionally snapshot-then-watch (see below)
         Ok(async_stream::stream! {
             // yield Ok((NanoTime, event)); yield Err(e) to abort the run
         })
-    })
+    }) // returns Result — propagate with `?` (runtime creation is fallible)
 }
 ```
 
@@ -493,17 +492,22 @@ invoke — historical `start_time` mismatches are validated and abort the run;
 use `produce_async_bounded` when a fast realtime producer needs `buffer_size`
 back-pressure (not applied in historical mode, by design).
 
-**Runtime ownership — current convention, with a pending change.** Today async
-adapters take the caller's `&tokio::runtime::Handle` (caller-owned runtime), and
-the graph must be built, run, and dropped from a **non-async thread** (a
-`block_on` footgun — see the etcd/postgres module docs). Follow that convention
-for now. But be aware of an **open design proposal** to move to a
-`Runner`/`Graph`-owned runtime *with an override* — which would drop the
-`&Handle`/`RunParams` factory params and hand the handle to the adapter at
-`start()` instead (it's coupled to the defer-I/O-to-`start()` change). See
-`next/docs/runtime-ownership.md` and `next/docs/source-lifecycle-defer-to-start.md`;
-if you're adding an async adapter while that's in flight, check whether the new
-primitive has landed before hardcoding the `&Handle` signature.
+**Runtime ownership — the graph owns the runtime; pass no `&Handle`.** The
+`GraphBuilder` owns one tokio runtime, created lazily on first async use and
+dropped at teardown, shared by every async adapter in the graph
+(`next/docs/runtime-ownership.md`, landed). So your factory takes **no**
+`&tokio::runtime::Handle`: `produce_async` / `produce_async_bounded` /
+`consume_async` pull the handle from `g` themselves and return `Result` (the
+first, owned-runtime creation is the only fallible part — propagate with `?`).
+For a **sink trait** (method on `Stream<…>`, no `&g` in hand), get a builder
+view with `self.graph()` and, if you need the handle directly for a wiring-time
+`block_on` connect, `self.graph().async_runtime_handle()?`. The graph must still
+be built, run, and dropped from a **non-async thread** (the `block_on` footgun —
+see the etcd/postgres module docs). A caller embeds their own runtime with
+`GraphBuilder::new().with_async_runtime(handle)` (the override). `RunParams` is
+still a source factory param (the producer spawns at wiring); it will fall away
+only if/when the `produce_async` family also defers to `start()`
+(`next/docs/source-lifecycle-defer-to-start.md`).
 
 If the service supports **snapshot + watch** (etcd-like), use watch-before-get
 to avoid races: open the watch first, read the snapshot and its
@@ -584,9 +588,11 @@ errors back into the graph to abort the run on the next cycle, and flushes
 queued writes at teardown — all off the graph thread. Wire it via `for_each`:
 
 ```rust
-let sink = consume_async(handle, Some(buffer_size), move |value| async move {
+// `consume_async` takes the graph (not a `&Handle`) and returns `Result`; from a
+// sink trait method use `&self.graph()`. Propagate with `?`.
+let sink = consume_async(&self.graph(), Some(buffer_size), move |value| async move {
     client.write(value).await.context("$ARGUMENTS: writing")
-});
+})?;
 Ok(self.for_each(sink))
 ```
 

--- a/next/crates/wingfoil-next/examples/async/README.md
+++ b/next/crates/wingfoil-next/examples/async/README.md
@@ -16,8 +16,8 @@ The key call is **`produce_async`**, which maps an async `futures::Stream` of
 `(NanoTime, T)` onto a graph source. The graph itself is the consumer: classic
 hands the stream to an async `consume_async` closure, whereas on next an
 on-graph `for_each` plays that role — keeping the consumer in the
-explicitly-timed, breadth-first world. The producer runs on the caller's tokio
-runtime and each yielded value wakes the kernel.
+explicitly-timed, breadth-first world. The producer runs on the graph's own tokio
+runtime (created lazily) and each yielded value wakes the kernel.
 
 `produce_async` also carries the two guarantees classic gives for free:
 **back-pressure** (`produce_async_bounded` bounds how far a realtime producer

--- a/next/crates/wingfoil-next/examples/async/main.rs
+++ b/next/crates/wingfoil-next/examples/async/main.rs
@@ -27,7 +27,7 @@ use wingfoil_next::async_source::{RunParams, produce_async};
 use wingfoil_next::prelude::*;
 
 fn main() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    // The graph owns the tokio runtime (created lazily); no `&Handle` to pass.
     let g = GraphBuilder::new();
 
     let period = Duration::from_millis(10);
@@ -44,7 +44,7 @@ fn main() {
     // The async producer: it awaits between yields (as a socket read would),
     // emitting timestamped values. A finite feed of 8 values that ends —
     // closing the stream, which stops the graph.
-    let quotes = produce_async(&g, rt.handle(), params, move |_p| async move {
+    let quotes = produce_async(&g, params, move |_p| async move {
         Ok(futures::stream::unfold(0u32, move |i| async move {
             if i >= 8 {
                 return None;
@@ -55,7 +55,8 @@ fn main() {
             // arrival); a historical producer would drive replay off it.
             Some((Ok((NanoTime::now(), value)), i + 1))
         }))
-    });
+    })
+    .expect("produce_async");
 
     // The consumer, on the graph: print every value in each arriving burst.
     let _printed = quotes.for_each(|burst: &Burst<u32>| {

--- a/next/crates/wingfoil-next/examples/etcd_adapter.rs
+++ b/next/crates/wingfoil-next/examples/etcd_adapter.rs
@@ -7,8 +7,10 @@
 //! - `round_trip` — watches the source prefix, uppercases each value, and writes
 //!   the result to a destination prefix.
 //!
-//! Unlike classic, the runtime is the caller's: we build a tokio runtime and
-//! hand its `handle()` to `etcd_sub` / `etcd_pub` (see the module docs).
+//! The graph owns the tokio runtime the adapters spawn on. This example builds
+//! its own runtime and installs it as the override via `with_async_runtime` (so
+//! it controls the runtime's lifetime); the simplest usage omits that and lets
+//! the graph create one lazily (see the module docs).
 //!
 //! # Prerequisites
 //!
@@ -37,10 +39,12 @@ const DEST_PREFIX: &str = "/example/dest/";
 
 fn main() -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
-    let handle = rt.handle();
     let conn = EtcdConnection::new(ENDPOINT);
 
-    let g = GraphBuilder::new();
+    // The graph owns the runtime the adapters spawn on. Here we hand it our own
+    // (the override) so this example controls the runtime's lifetime; omit
+    // `.with_async_runtime(..)` to let the graph create and own one lazily.
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
 
     // Seed the source prefix with two keys, once.
     let _seed = g
@@ -54,7 +58,7 @@ fn main() -> anyhow::Result<()> {
                 value: b"world".to_vec(),
             },
         ])
-        .etcd_pub(handle, conn.clone(), None, true)?;
+        .etcd_pub(conn.clone(), None, true)?;
 
     // Watch the source prefix, uppercase each value, write to the dest prefix.
     let params = RunParams {
@@ -62,7 +66,7 @@ fn main() -> anyhow::Result<()> {
         run_for: RunFor::Cycles(3),
         start_time: NanoTime::ZERO,
     };
-    let _round_trip = etcd_sub(&g, handle, params, conn.clone(), SOURCE_PREFIX)?
+    let _round_trip = etcd_sub(&g, params, conn.clone(), SOURCE_PREFIX)?
         .map(|burst: &Burst<_>| {
             burst
                 .iter()
@@ -86,7 +90,7 @@ fn main() -> anyhow::Result<()> {
                 })
                 .collect::<Burst<EtcdEntry>>()
         })
-        .etcd_pub(handle, conn, None, true)?;
+        .etcd_pub(conn, None, true)?;
 
     g.build().run(RunMode::RealTime, RunFor::Cycles(3))?;
     Ok(())

--- a/next/crates/wingfoil-next/examples/kafka_adapter.rs
+++ b/next/crates/wingfoil-next/examples/kafka_adapter.rs
@@ -7,8 +7,10 @@
 //! - `round_trip` — consumes the source topic, uppercases each value, and writes
 //!   the result to a destination topic.
 //!
-//! Unlike classic, the runtime is the caller's: we build a tokio runtime and
-//! hand its `handle()` to `kafka_sub` / `kafka_pub` (see the module docs).
+//! The graph owns the tokio runtime the adapters spawn on. This example builds
+//! its own runtime and installs it as the override via `with_async_runtime`;
+//! the simplest usage omits that and lets the graph create one lazily (see the
+//! module docs).
 //!
 //! # Prerequisites
 //!
@@ -37,9 +39,11 @@ const DEST_TOPIC: &str = "example-dest";
 
 fn main() -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
-    let handle = rt.handle();
 
-    let g = GraphBuilder::new();
+    // The graph owns the runtime the adapters spawn on. Here we hand it our own
+    // (the override); omit `.with_async_runtime(..)` to let the graph create and
+    // own one lazily.
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
 
     // Seed the source topic with two messages, once.
     let _seed = g
@@ -55,7 +59,7 @@ fn main() -> anyhow::Result<()> {
                 value: b"world".to_vec(),
             },
         ])
-        .kafka_pub(handle, BROKERS)?;
+        .kafka_pub(BROKERS)?;
 
     // Consume the source topic, uppercase each value, write to the dest topic.
     let params = RunParams {
@@ -63,7 +67,7 @@ fn main() -> anyhow::Result<()> {
         run_for: RunFor::Cycles(3),
         start_time: NanoTime::ZERO,
     };
-    let _round_trip = kafka_sub(&g, handle, params, BROKERS, SOURCE_TOPIC, "example-group")?
+    let _round_trip = kafka_sub(&g, params, BROKERS, SOURCE_TOPIC, "example-group")?
         .map(|burst: &Burst<KafkaEvent>| {
             burst
                 .iter()
@@ -82,7 +86,7 @@ fn main() -> anyhow::Result<()> {
                 })
                 .collect::<Burst<KafkaRecord>>()
         })
-        .kafka_pub(handle, BROKERS)?;
+        .kafka_pub(BROKERS)?;
 
     g.build().run(RunMode::RealTime, RunFor::Cycles(3))?;
     Ok(())

--- a/next/crates/wingfoil-next/examples/otlp_adapter.rs
+++ b/next/crates/wingfoil-next/examples/otlp_adapter.rs
@@ -7,8 +7,8 @@
 //! same counter, so metrics can be consumed by both Prometheus scrapers and any
 //! OTLP-compatible backend (Grafana Alloy, Datadog, Honeycomb, New Relic, …).
 //!
-//! Unlike classic, the tokio runtime is the caller's: we build one and hand its
-//! `handle()` to `otlp_push` (see the adapter module docs). The graph is driven
+//! The graph owns the tokio runtime `otlp_push` exports on — created lazily, so
+//! no `&Handle` is threaded in (see the adapter module docs). The graph is driven
 //! from this (non-async) `main`, as `consume_async` requires.
 //!
 //! # Setup
@@ -34,8 +34,6 @@ use wingfoil_next::adapters::prometheus::{PrometheusExporter, PrometheusSinkOps}
 use wingfoil_next::prelude::*;
 
 fn main() -> anyhow::Result<()> {
-    let rt = tokio::runtime::Runtime::new()?;
-
     // ── Prometheus exporter (pull) ─────────────────────────────────────────
     let exporter = PrometheusExporter::new("0.0.0.0:9091");
     let port = exporter.serve()?;
@@ -49,7 +47,7 @@ fn main() -> anyhow::Result<()> {
     let g = GraphBuilder::new();
     let counter = g.ticker(Duration::from_secs(1)).count();
     let _prometheus = counter.prometheus_gauge(&exporter, "wingfoil_ticks_total");
-    let _otlp = counter.otlp_push(rt.handle(), "wingfoil_ticks_total", config);
+    let _otlp = counter.otlp_push("wingfoil_ticks_total", config)?;
 
     println!("Pushing OTLP metrics to {endpoint}");
     g.build().run(RunMode::RealTime, RunFor::Forever)?;

--- a/next/crates/wingfoil-next/examples/postgres_adapter/README.md
+++ b/next/crates/wingfoil-next/examples/postgres_adapter/README.md
@@ -7,11 +7,10 @@ example onto the next engine. Demonstrates the on-graph time model
 (`(NanoTime, T)` tuples) and the shared time-slicing logic used for historical
 replay.
 
-Unlike classic, the tokio runtime is the caller's: this example builds a
-`tokio::runtime::Runtime` and hands its `handle()` to `postgres_read` /
-`postgres_write` (see the module docs). Because the reader and sink drive the
-async client with `Handle::block_on`, each graph is built, run, and dropped from
-the (non-async) main thread.
+The graph owns the tokio runtime the adapters use — created lazily, so no
+`&Handle` is threaded in (see the module docs). Because the reader and sink drive
+the async client with `Handle::block_on`, each graph is built, run, and dropped
+from the (non-async) main thread.
 
 ## Setup
 
@@ -28,22 +27,21 @@ cargo run -p wingfoil-next --example postgres_adapter --features postgres
 ## Code
 
 ```rust
-let rt = tokio::runtime::Runtime::new()?;
 let start = NanoTime::from_kdb_timestamp(0);
 
 // Write — replay generated trades at their timestamps into the table.
 {
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new(); // owns the tokio runtime lazily
     let rows = baseline.iter().cloned().map(|(time, trade)| Ok((trade, time)));
     let _sink = g
         .replay_results(rows)
-        .postgres_write(rt.handle(), conn.clone(), "example_trades", None)?;
+        .postgres_write(conn.clone(), "example_trades", None)?;
     g.build().run(run_mode, run_for)?;
 }
 
 // Read — time-sliced, one query per day (a single 24h slice covers the run).
 let params = RunParams { run_mode, run_for, start_time: start };
-let read = postgres_read::<Trade>(&g, rt.handle(), params, conn,
+let read = postgres_read::<Trade>(&g, params, conn,
     Duration::from_secs(86400),
     |(t0, t1), _date, _iter| format!(
         "SELECT time, sym, price, qty FROM example_trades \

--- a/next/crates/wingfoil-next/examples/postgres_adapter/main.rs
+++ b/next/crates/wingfoil-next/examples/postgres_adapter/main.rs
@@ -87,9 +87,9 @@ fn main() -> Result<()> {
     );
     let num_rows = 10;
     let start = NanoTime::from_kdb_timestamp(0);
-    // The caller owns the tokio runtime; each graph is built, run, and dropped on
-    // this (non-async) thread so the reader/sink `block_on`s are safe.
-    let rt = tokio::runtime::Runtime::new()?;
+    // The graph owns the tokio runtime (created lazily); each graph is built,
+    // run, and dropped on this (non-async) thread so the reader/sink `block_on`s
+    // are safe.
 
     reset_table(&conn)?;
 
@@ -103,9 +103,9 @@ fn main() -> Result<()> {
             .iter()
             .cloned()
             .map(|(time, trade)| Ok((trade, time)));
-        let _sink =
-            g.replay_results(rows)
-                .postgres_write(rt.handle(), conn.clone(), TABLE, None)?;
+        let _sink = g
+            .replay_results(rows)
+            .postgres_write(conn.clone(), TABLE, None)?;
         let mut runner = g.build();
         runner.run(
             RunMode::HistoricalFrom(start),
@@ -122,7 +122,6 @@ fn main() -> Result<()> {
     };
     let read = postgres_read::<Trade>(
         &g,
-        rt.handle(),
         params,
         conn,
         Duration::from_secs(86400),

--- a/next/crates/wingfoil-next/examples/produce_async_feed.rs
+++ b/next/crates/wingfoil-next/examples/produce_async_feed.rs
@@ -12,7 +12,7 @@ use wingfoil_next::async_source::{RunParams, produce_async};
 use wingfoil_next::prelude::*;
 
 fn main() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    // The graph owns the tokio runtime (created lazily); no `&Handle` to pass.
     let g = GraphBuilder::new();
 
     let params = RunParams {
@@ -23,7 +23,7 @@ fn main() {
 
     // A producer that awaits (like a socket read) and yields timestamped
     // quotes — a finite feed that closes when exhausted.
-    let quotes = produce_async(&g, rt.handle(), params, |_p| async {
+    let quotes = produce_async(&g, params, |_p| async {
         Ok(futures::stream::unfold(
             (0u32, 100.0_f64),
             |(i, price)| async move {
@@ -37,7 +37,8 @@ fn main() {
                 Some((Ok((t, price)), (i + 1, price)))
             },
         ))
-    });
+    })
+    .expect("produce_async");
 
     let mean = quotes
         .collapse_accumulate()

--- a/next/crates/wingfoil-next/examples/redis_adapter.rs
+++ b/next/crates/wingfoil-next/examples/redis_adapter.rs
@@ -11,10 +11,10 @@
 //! - **verifier**  — subscribes to `dest` and prints what it receives.
 //! - **publisher** — publishes two messages to `source`.
 //!
-//! Unlike classic, the runtime is the caller's: each thread builds a tokio
-//! runtime and hands its `handle()` to `redis_sub` / `redis_pub` (see the module
-//! docs). Because the sinks drive writes with `Handle::block_on`, each graph is
-//! built, run, and dropped from its (non-async) thread.
+//! The graph owns the tokio runtime the adapters spawn on — created lazily, so
+//! no `&Handle` is threaded in (see the module docs). Because the sinks drive
+//! writes with `Handle::block_on`, each graph is built, run, and dropped from
+//! its (non-async) thread.
 //!
 //! # Prerequisites
 //!
@@ -55,9 +55,9 @@ fn main() -> anyhow::Result<()> {
     // processor: source -> uppercase -> dest
     let processor_conn = conn.clone();
     let processor = std::thread::spawn(move || -> anyhow::Result<()> {
-        let rt = tokio::runtime::Runtime::new()?;
+        // The graph owns the tokio runtime (created lazily); no `&Handle` to pass.
         let g = GraphBuilder::new();
-        let _sink = redis_sub(&g, rt.handle(), realtime(2), processor_conn.clone(), SOURCE)?
+        let _sink = redis_sub(&g, realtime(2), processor_conn.clone(), SOURCE)?
             .map(|burst: &Burst<_>| {
                 burst
                     .iter()
@@ -74,7 +74,7 @@ fn main() -> anyhow::Result<()> {
                     })
                     .collect::<Burst<RedisEntry>>()
             })
-            .redis_pub(rt.handle(), processor_conn, None)?;
+            .redis_pub(processor_conn, None)?;
         g.build()
             .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
         Ok(())
@@ -83,9 +83,9 @@ fn main() -> anyhow::Result<()> {
     // verifier: print everything that lands on dest
     let verifier_conn = conn.clone();
     let verifier = std::thread::spawn(move || -> anyhow::Result<()> {
-        let rt = tokio::runtime::Runtime::new()?;
+        // The graph owns the tokio runtime (created lazily); no `&Handle` to pass.
         let g = GraphBuilder::new();
-        let _print = redis_sub(&g, rt.handle(), realtime(2), verifier_conn, DEST)?
+        let _print = redis_sub(&g, realtime(2), verifier_conn, DEST)?
             .collapse()
             .for_each(|event: &wingfoil_next::adapters::redis::RedisEvent| {
                 println!(
@@ -103,7 +103,7 @@ fn main() -> anyhow::Result<()> {
     // Give both subscribers time to register before publishing.
     std::thread::sleep(Duration::from_millis(500));
 
-    let rt = tokio::runtime::Runtime::new()?;
+    // The graph owns the tokio runtime (created lazily); no `&Handle` to pass.
     let g = GraphBuilder::new();
     let _pub = g
         .constant(burst![
@@ -116,7 +116,7 @@ fn main() -> anyhow::Result<()> {
                 payload: b"world".to_vec(),
             },
         ])
-        .redis_pub(rt.handle(), conn, None)?;
+        .redis_pub(conn, None)?;
     g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
 
     processor.join().expect("processor thread panicked")?;

--- a/next/crates/wingfoil-next/src/adapters/etcd.rs
+++ b/next/crates/wingfoil-next/src/adapters/etcd.rs
@@ -22,14 +22,15 @@
 //! and revoke-on-shutdown, the `force` conditional write) is preserved. The
 //! surface differs in three deliberate ways:
 //!
-//! 1. **The tokio runtime is the caller's.** Classic `etcd_sub`/`etcd_pub` hide
-//!    a global runtime inside `produce_async`/`consume_async`. Next's
-//!    [`produce_async`](crate::async_source::produce_async) (and its sink
-//!    counterpart [`consume_async`](crate::async_source::consume_async)) take
-//!    the runtime [`Handle`](tokio::runtime::Handle) and [`RunParams`]
-//!    explicitly (the producer task is spawned at wiring time, before the run).
-//!    Both functions here follow that convention: the caller owns a
-//!    `tokio::runtime::Runtime` and hands in its `handle()`.
+//! 1. **The graph owns the tokio runtime.** Classic `etcd_sub`/`etcd_pub` hide a
+//!    never-dropped global runtime inside `produce_async`/`consume_async`. Next's
+//!    `GraphBuilder` instead owns one runtime, created lazily on first async use
+//!    and dropped at teardown, shared by every async adapter in the graph — so
+//!    the common call needs no `&Handle` and there is no leaked global (see
+//!    `docs/runtime-ownership.md`). `etcd_sub` still takes [`RunParams`] (the
+//!    producer task spawns at wiring time, before the run). To embed the graph in
+//!    an existing runtime, install it as an override with
+//!    [`GraphBuilder::with_async_runtime`](crate::fluent::GraphBuilder::with_async_runtime).
 //! 2. **The sink connects eagerly, at wiring time.** `etcd_pub` returns
 //!    `Result` and a connection (or `lease_grant`) failure surfaces *before* the
 //!    run, whereas classic connected lazily inside the async consumer so the
@@ -210,8 +211,8 @@ pub struct EtcdEvent {
 /// `mod_revision <= snapshot_rev` is filtered out as a duplicate of the
 /// snapshot.
 ///
-/// `handle` is the caller's tokio runtime handle and `params` describes the run
-/// the graph will be driven with (see [`produce_async`] and the module docs).
+/// `params` describes the run the graph will be driven with (see
+/// [`produce_async`] and the module docs); the graph owns the tokio runtime.
 /// Use `.collapse()` for single-event processing.
 ///
 /// # Errors
@@ -223,7 +224,6 @@ pub struct EtcdEvent {
 /// `start`. Run `etcd_sub` under [`RunMode::RealTime`].
 pub fn etcd_sub(
     g: &GraphBuilder,
-    handle: &Handle,
     params: RunParams,
     conn: impl Into<EtcdConnection>,
     prefix: impl Into<String>,
@@ -237,112 +237,107 @@ pub fn etcd_sub(
     }
     let conn = conn.into();
     let prefix = prefix.into();
-    Ok(produce_async(
-        g,
-        handle,
-        params,
-        move |_p: RunParams| async move {
-            let mut client = Client::connect(&conn.endpoints, None)
-                .await
-                .with_context(|| format!("etcd_sub: connecting to etcd at {:?}", conn.endpoints))?;
+    produce_async(g, params, move |_p: RunParams| async move {
+        let mut client = Client::connect(&conn.endpoints, None)
+            .await
+            .with_context(|| format!("etcd_sub: connecting to etcd at {:?}", conn.endpoints))?;
 
-            // 1. Open the watch BEFORE the GET to prevent the snapshot/watch race.
-            let watch_opts = WatchOptions::new().with_prefix();
-            let mut watch_stream = client
-                .watch(prefix.as_bytes(), Some(watch_opts))
-                .await
-                .map_err(|e| anyhow::anyhow!("etcd watch failed: {e}"))?;
+        // 1. Open the watch BEFORE the GET to prevent the snapshot/watch race.
+        let watch_opts = WatchOptions::new().with_prefix();
+        let mut watch_stream = client
+            .watch(prefix.as_bytes(), Some(watch_opts))
+            .await
+            .map_err(|e| anyhow::anyhow!("etcd watch failed: {e}"))?;
 
-            // 2. Read the snapshot and capture its revision.
-            let get_opts = GetOptions::new().with_prefix();
-            let get_resp = client
-                .get(prefix.as_bytes(), Some(get_opts))
-                .await
-                .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
-            let snapshot_rev = get_resp.header().map(|h| h.revision()).unwrap_or(0);
+        // 2. Read the snapshot and capture its revision.
+        let get_opts = GetOptions::new().with_prefix();
+        let get_resp = client
+            .get(prefix.as_bytes(), Some(get_opts))
+            .await
+            .map_err(|e| anyhow::anyhow!("etcd get failed: {e}"))?;
+        let snapshot_rev = get_resp.header().map(|h| h.revision()).unwrap_or(0);
 
-            // 3. Collect snapshot KVs into owned data to move into the stream.
-            let snapshot: Vec<EtcdEvent> = get_resp
-                .kvs()
-                .iter()
-                .map(|kv| EtcdEvent {
-                    kind: EtcdEventKind::Put,
-                    entry: EtcdEntry {
-                        key: String::from_utf8_lossy(kv.key()).into_owned(),
-                        value: kv.value().to_vec(),
-                    },
-                    revision: snapshot_rev,
-                })
-                .collect();
+        // 3. Collect snapshot KVs into owned data to move into the stream.
+        let snapshot: Vec<EtcdEvent> = get_resp
+            .kvs()
+            .iter()
+            .map(|kv| EtcdEvent {
+                kind: EtcdEventKind::Put,
+                entry: EtcdEntry {
+                    key: String::from_utf8_lossy(kv.key()).into_owned(),
+                    value: kv.value().to_vec(),
+                },
+                revision: snapshot_rev,
+            })
+            .collect();
 
-            // 4. Return the combined snapshot + live stream. `watch_stream` is moved
-            //    in and kept alive for the stream's lifetime so the watch stays open.
-            Ok(async_stream::stream! {
-                // Phase 1: emit the snapshot as a single atomic burst. Every
-                // snapshot KV shares ONE timestamp so they are grouped into one
-                // burst (never latest-wins, never split across cycles) — matching
-                // classic's single `HistoricalValue` snapshot burst. Stamping each
-                // event with its own `NanoTime::now()` would scatter them across
-                // distinct instants, so a bounded run (e.g. `RunFor::Cycles(1)`)
-                // could observe only the first key — an intermittent "missing key"
-                // under load.
-                let snapshot_time = NanoTime::now();
-                for event in snapshot {
-                    yield Ok((snapshot_time, event));
-                }
+        // 4. Return the combined snapshot + live stream. `watch_stream` is moved
+        //    in and kept alive for the stream's lifetime so the watch stays open.
+        Ok(async_stream::stream! {
+            // Phase 1: emit the snapshot as a single atomic burst. Every
+            // snapshot KV shares ONE timestamp so they are grouped into one
+            // burst (never latest-wins, never split across cycles) — matching
+            // classic's single `HistoricalValue` snapshot burst. Stamping each
+            // event with its own `NanoTime::now()` would scatter them across
+            // distinct instants, so a bounded run (e.g. `RunFor::Cycles(1)`)
+            // could observe only the first key — an intermittent "missing key"
+            // under load.
+            let snapshot_time = NanoTime::now();
+            for event in snapshot {
+                yield Ok((snapshot_time, event));
+            }
 
-                // Phase 2: drain the watch stream, deduplicating against the snapshot.
-                loop {
-                    match watch_stream.next().await {
-                        Some(Ok(resp)) => {
-                            // Skip the initial "watch created" confirmation (no events).
-                            if resp.created() {
+            // Phase 2: drain the watch stream, deduplicating against the snapshot.
+            loop {
+                match watch_stream.next().await {
+                    Some(Ok(resp)) => {
+                        // Skip the initial "watch created" confirmation (no events).
+                        if resp.created() {
+                            continue;
+                        }
+                        if resp.canceled() {
+                            yield Err(anyhow::anyhow!(
+                                "etcd watch cancelled: {}",
+                                resp.cancel_reason()
+                            ));
+                            break;
+                        }
+                        for event in resp.events() {
+                            let kv = match event.kv() {
+                                Some(kv) => kv,
+                                None => continue,
+                            };
+                            let mod_rev = kv.mod_revision();
+                            // Skip events already covered by the snapshot.
+                            if mod_rev <= snapshot_rev {
                                 continue;
                             }
-                            if resp.canceled() {
-                                yield Err(anyhow::anyhow!(
-                                    "etcd watch cancelled: {}",
-                                    resp.cancel_reason()
-                                ));
-                                break;
-                            }
-                            for event in resp.events() {
-                                let kv = match event.kv() {
-                                    Some(kv) => kv,
-                                    None => continue,
-                                };
-                                let mod_rev = kv.mod_revision();
-                                // Skip events already covered by the snapshot.
-                                if mod_rev <= snapshot_rev {
-                                    continue;
-                                }
-                                let kind = match event.event_type() {
-                                    etcd_client::EventType::Put => EtcdEventKind::Put,
-                                    etcd_client::EventType::Delete => EtcdEventKind::Delete,
-                                };
-                                yield Ok((NanoTime::now(), EtcdEvent {
-                                    kind,
-                                    entry: EtcdEntry {
-                                        key: String::from_utf8_lossy(kv.key()).into_owned(),
-                                        value: kv.value().to_vec(),
-                                    },
-                                    revision: mod_rev,
-                                }));
-                            }
-                        }
-                        Some(Err(e)) => {
-                            yield Err(anyhow::anyhow!("etcd watch error: {e}"));
-                            break;
-                        }
-                        None => {
-                            yield Err(anyhow::anyhow!("etcd watch stream closed unexpectedly"));
-                            break;
+                            let kind = match event.event_type() {
+                                etcd_client::EventType::Put => EtcdEventKind::Put,
+                                etcd_client::EventType::Delete => EtcdEventKind::Delete,
+                            };
+                            yield Ok((NanoTime::now(), EtcdEvent {
+                                kind,
+                                entry: EtcdEntry {
+                                    key: String::from_utf8_lossy(kv.key()).into_owned(),
+                                    value: kv.value().to_vec(),
+                                },
+                                revision: mod_rev,
+                            }));
                         }
                     }
+                    Some(Err(e)) => {
+                        yield Err(anyhow::anyhow!("etcd watch error: {e}"));
+                        break;
+                    }
+                    None => {
+                        yield Err(anyhow::anyhow!("etcd watch stream closed unexpectedly"));
+                        break;
+                    }
                 }
-            })
-        },
-    ))
+            }
+        })
+    })
 }
 
 /// Holds a granted lease alive and revokes it on drop.
@@ -385,12 +380,13 @@ impl Drop for LeaseGuard {
 pub trait EtcdSinkOps {
     /// Write this stream to etcd via PUT. Returns the sink `Stream<()>`.
     ///
-    /// - `handle`: the caller's tokio runtime handle (see the module docs).
     /// - `lease_ttl`: `None` for plain writes; `Some(duration)` to attach a lease
     ///   with automatic keepalive renewal (keys vanish on sink teardown via
     ///   revoke).
     /// - `force`: `true` silently overwrites existing keys; `false` aborts the
     ///   run, naming the key, if it already exists (a conditional transaction).
+    ///
+    /// The graph owns the tokio runtime (see the module docs).
     ///
     /// # Errors
     ///
@@ -399,7 +395,6 @@ pub trait EtcdSinkOps {
     /// `force: false` conflict) aborts the run with context.
     fn etcd_pub(
         &self,
-        handle: &Handle,
         conn: impl Into<EtcdConnection>,
         lease_ttl: Option<Duration>,
         force: bool,
@@ -409,12 +404,13 @@ pub trait EtcdSinkOps {
 impl EtcdSinkOps for Stream<Burst<EtcdEntry>> {
     fn etcd_pub(
         &self,
-        handle: &Handle,
         conn: impl Into<EtcdConnection>,
         lease_ttl: Option<Duration>,
         force: bool,
     ) -> Result<Stream<()>> {
         let conn = conn.into();
+        // The graph owns the runtime; the sink connects/keepalives on it.
+        let handle = self.graph().async_runtime_handle()?;
         // Connect at wiring time so a connection error surfaces before the run.
         let mut client = handle
             .block_on(Client::connect(&conn.endpoints, None))
@@ -516,13 +512,12 @@ impl EtcdSinkOps for Stream<Burst<EtcdEntry>> {
 impl EtcdSinkOps for Stream<EtcdEntry> {
     fn etcd_pub(
         &self,
-        handle: &Handle,
         conn: impl Into<EtcdConnection>,
         lease_ttl: Option<Duration>,
         force: bool,
     ) -> Result<Stream<()>> {
         self.map(|entry: &EtcdEntry| burst![entry.clone()])
-            .etcd_pub(handle, conn, lease_ttl, force)
+            .etcd_pub(conn, lease_ttl, force)
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/kafka.rs
+++ b/next/crates/wingfoil-next/src/adapters/kafka.rs
@@ -22,14 +22,15 @@
 //! background auto-commit, multi-topic writes from one sink) is preserved. The
 //! surface differs in these deliberate ways:
 //!
-//! 1. **The tokio runtime is the caller's.** Classic `kafka_sub`/`kafka_pub`
-//!    hide a global runtime inside `produce_async`/`consume_async`. Next's
-//!    [`produce_async`](crate::async_source::produce_async) and its sink
-//!    counterpart [`consume_async`](crate::async_source::consume_async) take the
-//!    runtime [`Handle`](tokio::runtime::Handle) explicitly (and `kafka_sub` a
-//!    [`RunParams`], since the producer task spawns at wiring time). Both
-//!    functions here follow that convention: the caller owns a
-//!    `tokio::runtime::Runtime` and hands in its `handle()`.
+//! 1. **The graph owns the tokio runtime.** Classic `kafka_sub`/`kafka_pub` hide
+//!    a never-dropped global runtime inside `produce_async`/`consume_async`.
+//!    Next's `GraphBuilder` owns one runtime, created lazily on first async use
+//!    and dropped at teardown, shared by every async adapter — so the common call
+//!    needs no `&Handle` and there is no leaked global (see
+//!    `docs/runtime-ownership.md`). `kafka_sub` still takes a [`RunParams`]
+//!    (the producer task spawns at wiring time). Embed in an existing runtime by
+//!    installing an override with
+//!    [`GraphBuilder::with_async_runtime`](crate::fluent::GraphBuilder::with_async_runtime).
 //! 2. **`kafka_sub` is realtime-only, rejected at wiring time under historical
 //!    replay.** The consumer is a live, unbounded, wall-clock-stamped stream
 //!    with no historical timeline to replay: its `recv()` loop never ends, so
@@ -95,7 +96,6 @@ use rdkafka::error::KafkaError;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::types::RDKafkaErrorCode;
 use std::time::Duration;
-use tokio::runtime::Handle;
 use wingfoil::{NanoTime, RunMode};
 
 use crate::Burst;
@@ -216,7 +216,6 @@ impl KafkaEvent {
 /// front and deadlock at `start`. Run `kafka_sub` under [`RunMode::RealTime`].
 pub fn kafka_sub(
     g: &GraphBuilder,
-    handle: &Handle,
     params: RunParams,
     conn: impl Into<KafkaConnection>,
     topic: impl Into<String>,
@@ -232,47 +231,42 @@ pub fn kafka_sub(
     let conn = conn.into();
     let topic = topic.into();
     let group_id = group_id.into();
-    Ok(produce_async(
-        g,
-        handle,
-        params,
-        move |_p: RunParams| async move {
-            let consumer: StreamConsumer = ClientConfig::new()
-                .set("bootstrap.servers", &conn.brokers)
-                .set("group.id", &group_id)
-                .set("auto.offset.reset", "earliest")
-                .set("enable.auto.commit", "true")
-                .set("session.timeout.ms", "6000")
-                .create()
-                .context("kafka_sub: creating consumer")?;
+    produce_async(g, params, move |_p: RunParams| async move {
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("bootstrap.servers", &conn.brokers)
+            .set("group.id", &group_id)
+            .set("auto.offset.reset", "earliest")
+            .set("enable.auto.commit", "true")
+            .set("session.timeout.ms", "6000")
+            .create()
+            .context("kafka_sub: creating consumer")?;
 
-            consumer
-                .subscribe(&[&topic])
-                .with_context(|| format!("kafka_sub: subscribing to {topic}"))?;
+        consumer
+            .subscribe(&[&topic])
+            .with_context(|| format!("kafka_sub: subscribing to {topic}"))?;
 
-            Ok(async_stream::stream! {
-                loop {
-                    match consumer.recv().await {
-                        Ok(msg) => {
-                            let event = KafkaEvent {
-                                topic: msg.topic().to_string(),
-                                partition: msg.partition(),
-                                offset: msg.offset(),
-                                key: msg.key().map(|k| k.to_vec()),
-                                value: msg.payload().unwrap_or_default().to_vec(),
-                            };
-                            yield Ok((NanoTime::now(), event));
-                        }
-                        Err(e) if is_transient_subscribe_error(&e) => continue,
-                        Err(e) => {
-                            yield Err(anyhow::anyhow!("kafka_sub: consume error: {e}"));
-                            break;
-                        }
+        Ok(async_stream::stream! {
+            loop {
+                match consumer.recv().await {
+                    Ok(msg) => {
+                        let event = KafkaEvent {
+                            topic: msg.topic().to_string(),
+                            partition: msg.partition(),
+                            offset: msg.offset(),
+                            key: msg.key().map(|k| k.to_vec()),
+                            value: msg.payload().unwrap_or_default().to_vec(),
+                        };
+                        yield Ok((NanoTime::now(), event));
+                    }
+                    Err(e) if is_transient_subscribe_error(&e) => continue,
+                    Err(e) => {
+                        yield Err(anyhow::anyhow!("kafka_sub: consume error: {e}"));
+                        break;
                     }
                 }
-            })
-        },
-    ))
+            }
+        })
+    })
 }
 
 /// `UnknownTopicOrPartition` is reported while the broker is still catching up on
@@ -296,7 +290,7 @@ pub trait KafkaSinkOps {
     /// target topic, so one sink can write to many topics. Returns the sink
     /// `Stream<()>`.
     ///
-    /// - `handle`: the caller's tokio runtime handle (see the module docs).
+    /// The graph owns the tokio runtime (see the module docs).
     ///
     /// Records are drained off the graph thread and produced in order, each
     /// awaited to its delivery confirmation. A delivery failure aborts the run
@@ -308,11 +302,11 @@ pub trait KafkaSinkOps {
     /// created (a client-config error). librdkafka connects lazily, so an
     /// unreachable broker surfaces as a produce failure during the run, not at
     /// wiring.
-    fn kafka_pub(&self, handle: &Handle, conn: impl Into<KafkaConnection>) -> Result<Stream<()>>;
+    fn kafka_pub(&self, conn: impl Into<KafkaConnection>) -> Result<Stream<()>>;
 }
 
 impl KafkaSinkOps for Stream<Burst<KafkaRecord>> {
-    fn kafka_pub(&self, handle: &Handle, conn: impl Into<KafkaConnection>) -> Result<Stream<()>> {
+    fn kafka_pub(&self, conn: impl Into<KafkaConnection>) -> Result<Stream<()>> {
         let conn = conn.into();
         // Create the producer at wiring time so a config error surfaces before
         // the run (librdkafka connects lazily; a bad broker surfaces on the
@@ -326,8 +320,9 @@ impl KafkaSinkOps for Stream<Burst<KafkaRecord>> {
         // `consume_async` drains each burst's records through a single consumer
         // task (order preserved) off the graph thread; a write error propagates
         // back into the graph on the next cycle. The producer is cloned per send
-        // (it is an `Arc` internally, cheap to clone and `Send`).
-        let sink = consume_async(handle, None, move |record: KafkaRecord| {
+        // (it is an `Arc` internally, cheap to clone and `Send`). The graph owns
+        // the runtime the consumer task runs on.
+        let sink = consume_async(&self.graph(), None, move |record: KafkaRecord| {
             let producer = producer.clone();
             async move {
                 let mut fut_record = FutureRecord::to(&record.topic).payload(&record.value);
@@ -342,15 +337,15 @@ impl KafkaSinkOps for Stream<Burst<KafkaRecord>> {
                     })?;
                 Ok(())
             }
-        });
+        })?;
         Ok(self.for_each(sink))
     }
 }
 
 impl KafkaSinkOps for Stream<KafkaRecord> {
-    fn kafka_pub(&self, handle: &Handle, conn: impl Into<KafkaConnection>) -> Result<Stream<()>> {
+    fn kafka_pub(&self, conn: impl Into<KafkaConnection>) -> Result<Stream<()>> {
         self.map(|record: &KafkaRecord| burst![record.clone()])
-            .kafka_pub(handle, conn)
+            .kafka_pub(conn)
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/otlp.rs
+++ b/next/crates/wingfoil-next/src/adapters/otlp.rs
@@ -52,18 +52,18 @@
 //! non-numeric-records-`0.0` fallback, the historical no-op, provider-drop
 //! flush) is preserved. The surface differs in three deliberate ways:
 //!
-//! 1. **The tokio runtime is the caller's.** Classic hid a global runtime inside
-//!    its own `consume_async`; next's
-//!    [`consume_async`](crate::async_source::consume_async) takes the runtime
-//!    [`Handle`](tokio::runtime::Handle) explicitly, so
-//!    [`otlp_push`](OtlpSinkOps::otlp_push) takes a `&tokio::runtime::Handle` —
-//!    the same convention as [`etcd`](crate::adapters::etcd). The graph must be
-//!    built, run, and dropped from a non-async thread (a `consume_async`
-//!    footgun; see its docs).
+//! 1. **The graph owns the tokio runtime.** Classic hid a never-dropped global
+//!    runtime inside its own `consume_async`; next's `GraphBuilder` owns one
+//!    runtime, created lazily on first async use and dropped at teardown, shared
+//!    by every async adapter — so [`otlp_push`](OtlpSinkOps::otlp_push) takes no
+//!    `&Handle` (see `docs/runtime-ownership.md`; embed in your own runtime with
+//!    [`GraphBuilder::with_async_runtime`](crate::fluent::GraphBuilder::with_async_runtime)).
+//!    The graph must be built, run, and dropped from a non-async thread (a
+//!    `consume_async` footgun; see its docs).
 //! 2. **The sink is an extension trait.** Classic exposed an `OtlpPush` trait on
 //!    `dyn Stream<T>`; next uses the sink-as-trait convention shared with
-//!    [`prometheus`](crate::adapters::prometheus): `stream.otlp_push(&handle,
-//!    name, config)` on a `Stream<T>`, returning the sink `Stream<()>`.
+//!    [`prometheus`](crate::adapters::prometheus): `stream.otlp_push(name,
+//!    config)` on a `Stream<T>`, returning the sink `Stream<()>`.
 //! 3. **The trace/span exporter is not yet ported.** Classic's `OtlpSpans` emits
 //!    OpenTelemetry spans from `Stream<P: HasLatency>` values. That path depends
 //!    on the `Traced` / `HasLatency` / `latency_stages!` latency infrastructure,
@@ -84,11 +84,11 @@
 
 use std::time::Duration;
 
+use anyhow::Result;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry_otlp::{MetricExporter, WithExportConfig as _};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
-use tokio::runtime::Handle;
 use wingfoil::RunMode;
 
 use crate::async_source::consume_async;
@@ -149,10 +149,11 @@ pub trait OtlpSinkOps<T> {
     /// `T::to_string().parse::<f64>()`; a value that does not format as a bare
     /// number records `0.0` and emits a `log::warn`.
     ///
-    /// - `handle`: the caller's tokio runtime handle (see the module docs — the
-    ///   graph must be driven from a non-async thread).
     /// - `config`: the OTLP endpoint and service name (accepts an
     ///   [`OtlpConfig`], or a `(endpoint, service_name)` tuple).
+    ///
+    /// The graph owns the tokio runtime (see the module docs — the graph must be
+    /// driven from a non-async thread).
     ///
     /// The sink is a **no-op** under
     /// [`RunMode::HistoricalFrom`](wingfoil::RunMode::HistoricalFrom): no value
@@ -161,13 +162,17 @@ pub trait OtlpSinkOps<T> {
     ///
     /// The returned `Stream<()>` **must** be added to the graph (or built and
     /// run) for metrics to be exported.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error at wiring time only if the graph's async runtime cannot be
+    /// created.
     #[must_use = "otlp_push returns a sink Stream that must be added to the graph"]
     fn otlp_push(
         &self,
-        handle: &Handle,
         metric_name: &'static str,
         config: impl Into<OtlpConfig>,
-    ) -> Stream<()>;
+    ) -> Result<Stream<()>>;
 }
 
 impl<T> OtlpSinkOps<T> for Stream<T>
@@ -176,21 +181,20 @@ where
 {
     fn otlp_push(
         &self,
-        handle: &Handle,
         metric_name: &'static str,
         config: impl Into<OtlpConfig>,
-    ) -> Stream<()> {
+    ) -> Result<Stream<()>> {
         let config = config.into();
 
         // The off-thread export. `consume_async`'s consumer task runs on the
-        // caller's runtime, so building the `rt-tokio` PeriodicReader and
+        // graph's runtime, so building the `rt-tokio` PeriodicReader and
         // recording on the gauge both happen inside a tokio context. The meter
         // provider is built lazily on the first value (kept alive in `provider`
         // so it flushes when this closure — and thus the consumer task — is
         // dropped at teardown), never in historical mode (no value reaches here).
         let mut gauge: Option<opentelemetry::metrics::Gauge<f64>> = None;
         let mut provider: Option<SdkMeterProvider> = None;
-        let sink = consume_async(handle, None, move |value: T| {
+        let sink = consume_async(&self.graph(), None, move |value: T| {
             let result = build_and_record(
                 &mut gauge,
                 &mut provider,
@@ -199,13 +203,13 @@ where
                 &value.to_string(),
             );
             async move { result }
-        });
+        })?;
 
         // The run-mode guard rides `register_op1` (`for_each` cannot see the
         // `Ctx`). In historical mode the value is never handed to `consume_async`,
         // so the background task stays idle and makes no network calls — the
         // prometheus-sink pattern.
-        self.wire(move |b, h| {
+        Ok(self.wire(move |b, h| {
             b.register_op1(
                 h,
                 "otlp_push",
@@ -220,7 +224,7 @@ where
                     Ok(Tick::Value(()))
                 },
             )
-        })
+        }))
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/postgres.rs
+++ b/next/crates/wingfoil-next/src/adapters/postgres.rs
@@ -30,7 +30,7 @@
 //! routine the KDB+ reader will reuse), and calls `query_fn` once per slice with
 //! `((t0, t1), date, iteration)`. Each query must filter on `time >= t0 AND time
 //! < t1` and `ORDER BY time`. All slices are queried at **wiring** time (the
-//! async client is driven with [`Handle::block_on`]); the decoded, in-window
+//! async client is driven with [`Handle::block_on`](tokio::runtime::Handle::block_on)); the decoded, in-window
 //! rows are then fed to the finite [`replay_results`](crate::fluent::GraphBuilder::replay_results)
 //! source, so replay is deterministic and needs no producer thread.
 //!
@@ -74,12 +74,16 @@
 //! preserved. The surface differs in four deliberate ways, mirroring the
 //! [`etcd`](crate::adapters::etcd) / [`redis`](crate::adapters::redis) ports:
 //!
-//! 1. **The tokio runtime is the caller's.** `postgres_read` / `postgres_sub` /
-//!    `postgres_write` take the runtime [`Handle`] explicitly (and the sources a
-//!    [`RunParams`]), matching next's async convention rather than classic's
-//!    hidden global runtime. The reader and the sink drive the client with
-//!    [`Handle::block_on`], so the graph must be built, run, and dropped from a
-//!    **non-async thread** (`main`, a `#[test]` fn).
+//! 1. **The graph owns the tokio runtime.** `postgres_read` / `postgres_sub` /
+//!    `postgres_write` no longer take a `&Handle`: the `GraphBuilder` owns one
+//!    runtime, created lazily on first async use and dropped at teardown, shared
+//!    by every async adapter — replacing classic's hidden never-dropped global
+//!    (see `docs/runtime-ownership.md`; embed in your own runtime with
+//!    [`GraphBuilder::with_async_runtime`](crate::fluent::GraphBuilder::with_async_runtime)).
+//!    The sources still take a [`RunParams`]. The reader and the sink drive the
+//!    client with [`Handle::block_on`](tokio::runtime::Handle::block_on), so the
+//!    graph must be built, run, and dropped from a **non-async thread** (`main`,
+//!    a `#[test]` fn).
 //! 2. **The reader queries at wiring time onto `replay_results`.** Classic
 //!    `postgres_read` streams rows lazily through `produce_async`; next queries
 //!    every slice up front and feeds the finite row set to `replay_results`.
@@ -112,7 +116,6 @@ use chrono::NaiveDateTime;
 use futures::StreamExt;
 use futures::channel::mpsc;
 use log::info;
-use tokio::runtime::Handle;
 use tokio_postgres::{AsyncMessage, NoTls, Statement};
 use wingfoil::{NanoTime, RunFor, RunMode};
 
@@ -299,7 +302,8 @@ impl PostgresRowExt for Row {
 /// midnight-aligned slices of length `period`. `query_fn` is called once per
 /// slice with `((t0, t1), date, iteration)` and must return a SQL query filtering
 /// on `time >= t0 AND time < t1`, ordered by time. Every slice is queried at
-/// wiring time (the async client is driven with [`Handle::block_on`]); the
+/// wiring time (the async client is driven with
+/// [`Handle::block_on`](tokio::runtime::Handle::block_on)); the
 /// decoded rows are clamped to the run window and fed to
 /// [`replay_results`](crate::fluent::GraphBuilder::replay_results).
 ///
@@ -319,7 +323,6 @@ impl PostgresRowExt for Row {
 /// `replay_results` and **aborts the run** (not wiring).
 pub fn postgres_read<T>(
     g: &GraphBuilder,
-    handle: &Handle,
     params: RunParams,
     connection: impl Into<PostgresConnection>,
     period: Duration,
@@ -329,6 +332,8 @@ where
     T: PostgresDeserialize + Clone + Default + 'static,
 {
     let connection = connection.into();
+    // The graph owns the runtime; the reader block_on's it at wiring.
+    let handle = g.async_runtime_handle()?;
     // The authoritative run start (a RealTime run yields ZERO, which the shared
     // validator rejects with a "use RunMode::HistoricalFrom" message).
     let start_time = match params.run_mode {
@@ -513,7 +518,6 @@ pub fn postgres_notify_trigger_sql(table: &str, channel: &str) -> String {
 /// the run with context (the connection string is redacted).
 pub fn postgres_sub<T, F>(
     g: &GraphBuilder,
-    handle: &Handle,
     params: RunParams,
     connection: impl Into<PostgresConnection>,
     channel: impl Into<String>,
@@ -534,94 +538,89 @@ where
     }
     let connection = connection.into();
     let channel = channel.into();
-    Ok(produce_async(
-        g,
-        handle,
-        params,
-        move |_p: RunParams| async move {
-            let mut query_fn = query_fn;
-            let (client, mut conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
-                .await
-                .with_context(|| {
-                    format!("postgres_sub: failed to connect: {}", connection.redacted())
-                })?;
+    produce_async(g, params, move |_p: RunParams| async move {
+        let mut query_fn = query_fn;
+        let (client, mut conn) = tokio_postgres::connect(&connection.conn_str, NoTls)
+            .await
+            .with_context(|| {
+                format!("postgres_sub: failed to connect: {}", connection.redacted())
+            })?;
 
-            // Drive the connection and forward notification wake-ups. Polling
-            // `poll_message` (rather than awaiting the plain connection future) is
-            // what surfaces `AsyncMessage::Notification`s.
-            let (tx, mut rx) = mpsc::unbounded::<()>();
-            tokio::spawn(async move {
-                let mut messages = futures::stream::poll_fn(move |cx| conn.poll_message(cx));
-                while let Some(message) = messages.next().await {
-                    match message {
-                        Ok(AsyncMessage::Notification(_)) => {
-                            if tx.unbounded_send(()).is_err() {
-                                break; // subscriber gone
-                            }
-                        }
-                        Ok(_) => {}
-                        Err(e) => {
-                            log::error!("postgres_sub connection error: {e}");
-                            break;
+        // Drive the connection and forward notification wake-ups. Polling
+        // `poll_message` (rather than awaiting the plain connection future) is
+        // what surfaces `AsyncMessage::Notification`s.
+        let (tx, mut rx) = mpsc::unbounded::<()>();
+        tokio::spawn(async move {
+            let mut messages = futures::stream::poll_fn(move |cx| conn.poll_message(cx));
+            while let Some(message) = messages.next().await {
+                match message {
+                    Ok(AsyncMessage::Notification(_)) => {
+                        if tx.unbounded_send(()).is_err() {
+                            break; // subscriber gone
                         }
                     }
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::error!("postgres_sub connection error: {e}");
+                        break;
+                    }
                 }
-            });
+            }
+        });
 
-            // LISTEN before the catch-up query so an insert committed in the
-            // handoff window still produces a wake-up (watch-before-get).
-            client
-                .batch_execute(&format!("LISTEN {}", quote_ident(&channel)))
-                .await
-                .with_context(|| format!("postgres_sub: LISTEN on channel `{channel}` failed"))?;
+        // LISTEN before the catch-up query so an insert committed in the
+        // handoff window still produces a wake-up (watch-before-get).
+        client
+            .batch_execute(&format!("LISTEN {}", quote_ident(&channel)))
+            .await
+            .with_context(|| format!("postgres_sub: LISTEN on channel `{channel}` failed"))?;
 
-            Ok(async_stream::stream! {
-                let mut cursor = start_from;
-                loop {
-                    // Drain everything past the cursor. The first pass is the
-                    // catch-up from `start_from`; later passes fetch what the
-                    // wake-up announced.
-                    let query = query_fn(cursor);
-                    info!("postgres_sub query: {query}");
-                    let rows = match client.query(&query, &[]).await {
-                        Ok(rows) => rows,
-                        Err(e) => {
-                            yield Err(anyhow::Error::new(e).context("postgres_sub query failed"));
-                            break;
-                        }
+        Ok(async_stream::stream! {
+            let mut cursor = start_from;
+            loop {
+                // Drain everything past the cursor. The first pass is the
+                // catch-up from `start_from`; later passes fetch what the
+                // wake-up announced.
+                let query = query_fn(cursor);
+                info!("postgres_sub query: {query}");
+                let rows = match client.query(&query, &[]).await {
+                    Ok(rows) => rows,
+                    Err(e) => {
+                        yield Err(anyhow::Error::new(e).context("postgres_sub query failed"));
+                        break;
+                    }
+                };
+                if !rows.is_empty() {
+                    info!("postgres_sub: {} new rows", rows.len());
+                }
+                for row in &rows {
+                    let (time, record) = match T::from_row(row) {
+                        Ok(r) => r,
+                        Err(e) => { yield Err(e); return; }
                     };
-                    if !rows.is_empty() {
-                        info!("postgres_sub: {} new rows", rows.len());
+                    if time > cursor {
+                        cursor = time;
                     }
-                    for row in &rows {
-                        let (time, record) = match T::from_row(row) {
-                            Ok(r) => r,
-                            Err(e) => { yield Err(e); return; }
-                        };
-                        if time > cursor {
-                            cursor = time;
-                        }
-                        yield Ok((time, record));
-                    }
+                    yield Ok((time, record));
+                }
 
-                    // Wait for the next wake-up; coalesce any that queued while we
-                    // were querying (they all mean the same thing: re-query).
-                    match rx.next().await {
-                        Some(()) => {
-                            // Coalesce queued wake-ups; each means "re-query".
-                            while rx.try_recv().is_ok() {}
-                        }
-                        None => {
-                            yield Err(anyhow::anyhow!(
-                                "postgres_sub: connection to postgres closed"
-                            ));
-                            break;
-                        }
+                // Wait for the next wake-up; coalesce any that queued while we
+                // were querying (they all mean the same thing: re-query).
+                match rx.next().await {
+                    Some(()) => {
+                        // Coalesce queued wake-ups; each means "re-query".
+                        while rx.try_recv().is_ok() {}
+                    }
+                    None => {
+                        yield Err(anyhow::anyhow!(
+                            "postgres_sub: connection to postgres closed"
+                        ));
+                        break;
                     }
                 }
-            })
-        },
-    ))
+            }
+        })
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -665,10 +664,11 @@ pub trait PostgresSinkOps<T> {
     /// line up positionally: `(timestamp, <business columns in to_params()
     /// order>)`. Returns the sink `Stream<()>`.
     ///
-    /// - `handle`: the caller's tokio runtime handle (see the module docs).
     /// - `buffer_size`: back-pressure bound handed to
     ///   [`consume_async`](crate::async_source::consume_async) — `Some(n)` blocks
     ///   the graph once ~`n` bursts are unwritten; `None` is unbounded.
+    ///
+    /// The graph owns the tokio runtime (see the module docs).
     ///
     /// # Errors
     ///
@@ -677,7 +677,6 @@ pub trait PostgresSinkOps<T> {
     /// context on a subsequent cycle.
     fn postgres_write(
         &self,
-        handle: &Handle,
         conn: impl Into<PostgresConnection>,
         table: &str,
         buffer_size: Option<usize>,
@@ -690,7 +689,6 @@ where
 {
     fn postgres_write(
         &self,
-        handle: &Handle,
         conn: impl Into<PostgresConnection>,
         table: &str,
         buffer_size: Option<usize>,
@@ -700,6 +698,9 @@ where
         // reserved-word table names work; also closes the interpolation hole.
         let table_sql = quote_table(table);
 
+        // The graph owns the runtime; the sink connects/drives/writes on it.
+        let g = self.graph();
+        let handle = g.async_runtime_handle()?;
         // Connect at wiring time so a connection error surfaces before the run.
         let (client, driver) = handle
             .block_on(tokio_postgres::connect(&connection.conn_str, NoTls))
@@ -723,7 +724,7 @@ where
         let stmt_cache: Arc<tokio::sync::Mutex<Option<Statement>>> =
             Arc::new(tokio::sync::Mutex::new(None));
 
-        let sink = consume_async(handle, buffer_size, move |batch: WriteBatch<T>| {
+        let sink = consume_async(&g, buffer_size, move |batch: WriteBatch<T>| {
             let client = Arc::clone(&client);
             let stmt_cache = Arc::clone(&stmt_cache);
             let table_sql = table_sql.clone();
@@ -779,7 +780,7 @@ where
                     .with_context(|| format!("postgres_write: insert into {table_sql} failed"))?;
                 Ok(())
             }
-        });
+        })?;
 
         Ok(self
             .with_time()

--- a/next/crates/wingfoil-next/src/adapters/redis.rs
+++ b/next/crates/wingfoil-next/src/adapters/redis.rs
@@ -31,13 +31,14 @@
 //! append, all four value types) is preserved. The surface differs in three
 //! deliberate ways, mirroring the [`etcd`](crate::adapters::etcd) port:
 //!
-//! 1. **The tokio runtime is the caller's.** Classic hides a global runtime
-//!    inside `produce_async`/`consume_async`. Next's
-//!    [`produce_async`](crate::async_source::produce_async) and
-//!    [`consume_async`](crate::async_source::consume_async) take the runtime
-//!    [`Handle`](tokio::runtime::Handle) explicitly (and the sources a
-//!    [`RunParams`]), so the caller owns a `tokio::runtime::Runtime` and hands
-//!    in its `handle()`.
+//! 1. **The graph owns the tokio runtime.** Classic hides a never-dropped global
+//!    runtime inside `produce_async`/`consume_async`. Next's `GraphBuilder` owns
+//!    one runtime, created lazily on first async use and dropped at teardown,
+//!    shared by every async adapter — so the common call needs no `&Handle` and
+//!    there is no leaked global (see `docs/runtime-ownership.md`). The sources
+//!    still take a [`RunParams`]. Embed in an existing runtime by installing an
+//!    override with
+//!    [`GraphBuilder::with_async_runtime`](crate::fluent::GraphBuilder::with_async_runtime).
 //! 2. **The sinks connect eagerly, at wiring time.** `redis_pub` /
 //!    `redis_stream_write` return `Result` and a connection failure surfaces
 //!    *before* the run, whereas classic connected lazily inside the async
@@ -97,7 +98,6 @@ use anyhow::{Context, Result};
 use futures::StreamExt;
 use redis::AsyncCommands;
 use redis::streams::{StreamId, StreamRangeReply, StreamReadOptions, StreamReadReply};
-use tokio::runtime::Handle;
 use wingfoil::{NanoTime, RunMode};
 
 use crate::async_source::{RunParams, consume_async, produce_async};
@@ -261,7 +261,6 @@ fn to_event(key: &str, id: &StreamId) -> RedisStreamEvent {
 /// [`RunMode::RealTime`].
 pub fn redis_sub(
     g: &GraphBuilder,
-    handle: &Handle,
     params: RunParams,
     conn: impl Into<RedisConnection>,
     channel: impl Into<String>,
@@ -275,38 +274,33 @@ pub fn redis_sub(
     }
     let conn = conn.into();
     let channel = channel.into();
-    Ok(produce_async(
-        g,
-        handle,
-        params,
-        move |_p: RunParams| async move {
-            let client = redis::Client::open(conn.url.as_str())
-                .with_context(|| format!("redis_sub: opening client for {:?}", conn.url))?;
-            let mut pubsub = client
-                .get_async_pubsub()
-                .await
-                .with_context(|| format!("redis_sub: connecting to {:?}", conn.url))?;
-            pubsub
-                .subscribe(channel.as_str())
-                .await
-                .with_context(|| format!("redis_sub: subscribing to {channel:?}"))?;
+    produce_async(g, params, move |_p: RunParams| async move {
+        let client = redis::Client::open(conn.url.as_str())
+            .with_context(|| format!("redis_sub: opening client for {:?}", conn.url))?;
+        let mut pubsub = client
+            .get_async_pubsub()
+            .await
+            .with_context(|| format!("redis_sub: connecting to {:?}", conn.url))?;
+        pubsub
+            .subscribe(channel.as_str())
+            .await
+            .with_context(|| format!("redis_sub: subscribing to {channel:?}"))?;
 
-            Ok(async_stream::stream! {
-                let mut messages = pubsub.on_message();
-                while let Some(msg) = messages.next().await {
-                    let event = RedisEvent {
-                        channel: msg.get_channel_name().to_string(),
-                        payload: msg.get_payload_bytes().to_vec(),
-                    };
-                    yield Ok((NanoTime::now(), event));
-                }
-                // `on_message` ends only when the connection drops.
-                yield Err(anyhow::anyhow!(
-                    "redis_sub: subscription stream closed unexpectedly"
-                ));
-            })
-        },
-    ))
+        Ok(async_stream::stream! {
+            let mut messages = pubsub.on_message();
+            while let Some(msg) = messages.next().await {
+                let event = RedisEvent {
+                    channel: msg.get_channel_name().to_string(),
+                    payload: msg.get_payload_bytes().to_vec(),
+                };
+                yield Ok((NanoTime::now(), event));
+            }
+            // `on_message` ends only when the connection drops.
+            yield Err(anyhow::anyhow!(
+                "redis_sub: subscription stream closed unexpectedly"
+            ));
+        })
+    })
 }
 
 /// Read a Redis stream `key`: emit a snapshot of all existing entries, then tail
@@ -319,8 +313,8 @@ pub fn redis_sub(
 /// exact snapshot boundary, no entry is missed or duplicated in the handoff. Use
 /// `.collapse()` for single-event processing.
 ///
-/// `handle` is the caller's tokio runtime handle and `params` describes the run
-/// the graph will be driven with (see [`produce_async`] and the module docs).
+/// `params` describes the run the graph will be driven with (see
+/// [`produce_async`] and the module docs); the graph owns the tokio runtime.
 ///
 /// # Errors
 ///
@@ -331,7 +325,6 @@ pub fn redis_sub(
 /// at `start`. Run under [`RunMode::RealTime`].
 pub fn redis_stream_read(
     g: &GraphBuilder,
-    handle: &Handle,
     params: RunParams,
     conn: impl Into<RedisConnection>,
     key: impl Into<String>,
@@ -346,66 +339,61 @@ pub fn redis_stream_read(
     }
     let conn = conn.into();
     let key = key.into();
-    Ok(produce_async(
-        g,
-        handle,
-        params,
-        move |_p: RunParams| async move {
-            let client = redis::Client::open(conn.url.as_str())
-                .with_context(|| format!("redis_stream_read: opening client for {:?}", conn.url))?;
-            let mut connection = client
-                .get_multiplexed_async_connection()
-                .await
-                .with_context(|| format!("redis_stream_read: connecting to {:?}", conn.url))?;
+    produce_async(g, params, move |_p: RunParams| async move {
+        let client = redis::Client::open(conn.url.as_str())
+            .with_context(|| format!("redis_stream_read: opening client for {:?}", conn.url))?;
+        let mut connection = client
+            .get_multiplexed_async_connection()
+            .await
+            .with_context(|| format!("redis_stream_read: connecting to {:?}", conn.url))?;
 
-            // 1. Snapshot all existing entries and capture the last ID.
-            let snapshot: StreamRangeReply = connection
-                .xrange(&key, "-", "+")
-                .await
-                .with_context(|| format!("redis_stream_read: XRANGE on {key:?} failed"))?;
-            // "0" means "from the beginning" — used when the stream is empty so the
-            // tail picks up the very first appended entry.
-            let mut last_id = snapshot
-                .ids
-                .last()
-                .map(|id| id.id.clone())
-                .unwrap_or_else(|| "0".to_string());
-            let snapshot_events: Vec<RedisStreamEvent> =
-                snapshot.ids.iter().map(|id| to_event(&key, id)).collect();
+        // 1. Snapshot all existing entries and capture the last ID.
+        let snapshot: StreamRangeReply = connection
+            .xrange(&key, "-", "+")
+            .await
+            .with_context(|| format!("redis_stream_read: XRANGE on {key:?} failed"))?;
+        // "0" means "from the beginning" — used when the stream is empty so the
+        // tail picks up the very first appended entry.
+        let mut last_id = snapshot
+            .ids
+            .last()
+            .map(|id| id.id.clone())
+            .unwrap_or_else(|| "0".to_string());
+        let snapshot_events: Vec<RedisStreamEvent> =
+            snapshot.ids.iter().map(|id| to_event(&key, id)).collect();
 
-            Ok(async_stream::stream! {
-                // Phase 1: emit the snapshot as one atomic burst — every entry
-                // shares ONE timestamp so a bounded run cannot observe only the
-                // first (the etcd snapshot-burst reasoning).
-                let snapshot_time = NanoTime::now();
-                for event in snapshot_events {
-                    yield Ok((snapshot_time, event));
-                }
+        Ok(async_stream::stream! {
+            // Phase 1: emit the snapshot as one atomic burst — every entry
+            // shares ONE timestamp so a bounded run cannot observe only the
+            // first (the etcd snapshot-burst reasoning).
+            let snapshot_time = NanoTime::now();
+            for event in snapshot_events {
+                yield Ok((snapshot_time, event));
+            }
 
-                // Phase 2: tail live appends from the snapshot boundary.
-                let opts = StreamReadOptions::default().block(0);
-                loop {
-                    let reply: redis::RedisResult<StreamReadReply> =
-                        connection.xread_options(&[&key], &[&last_id], &opts).await;
-                    match reply {
-                        Ok(reply) => {
-                            for stream_key in &reply.keys {
-                                for id in &stream_key.ids {
-                                    last_id = id.id.clone();
-                                    yield Ok((NanoTime::now(), to_event(&stream_key.key, id)));
-                                }
+            // Phase 2: tail live appends from the snapshot boundary.
+            let opts = StreamReadOptions::default().block(0);
+            loop {
+                let reply: redis::RedisResult<StreamReadReply> =
+                    connection.xread_options(&[&key], &[&last_id], &opts).await;
+                match reply {
+                    Ok(reply) => {
+                        for stream_key in &reply.keys {
+                            for id in &stream_key.ids {
+                                last_id = id.id.clone();
+                                yield Ok((NanoTime::now(), to_event(&stream_key.key, id)));
                             }
                         }
-                        Err(e) => {
-                            yield Err(anyhow::Error::new(e)
-                                .context(format!("redis_stream_read: XREAD on {key:?} failed")));
-                            break;
-                        }
+                    }
+                    Err(e) => {
+                        yield Err(anyhow::Error::new(e)
+                            .context(format!("redis_stream_read: XREAD on {key:?} failed")));
+                        break;
                     }
                 }
-            })
-        },
-    ))
+            }
+        })
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -422,14 +410,14 @@ pub trait RedisSinkOps {
     /// Publish this stream to Redis via `PUBLISH`, issuing one `PUBLISH` per
     /// [`RedisEntry`] to the channel it names. Returns the sink `Stream<()>`.
     ///
-    /// - `handle`: the caller's tokio runtime handle (see the module docs).
     /// - `buffer_size`: back-pressure bound handed to
     ///   [`consume_async`](crate::async_source::consume_async) — `Some(n)` blocks
     ///   the graph once ~`n` entries are unwritten; `None` is unbounded.
     ///
-    /// Publishing runs off the graph thread; writes land in order and are flushed
-    /// at teardown. `PUBLISH` returns the number of clients that received the
-    /// message (which may be zero); this count is not surfaced.
+    /// The graph owns the tokio runtime (see the module docs). Publishing runs
+    /// off the graph thread; writes land in order and are flushed at teardown.
+    /// `PUBLISH` returns the number of clients that received the message (which
+    /// may be zero); this count is not surfaced.
     ///
     /// # Errors
     ///
@@ -437,7 +425,6 @@ pub trait RedisSinkOps {
     /// publish failure aborts the run with context on a subsequent cycle.
     fn redis_pub(
         &self,
-        handle: &Handle,
         conn: impl Into<RedisConnection>,
         buffer_size: Option<usize>,
     ) -> Result<Stream<()>>;
@@ -446,11 +433,13 @@ pub trait RedisSinkOps {
 impl RedisSinkOps for Stream<Burst<RedisEntry>> {
     fn redis_pub(
         &self,
-        handle: &Handle,
         conn: impl Into<RedisConnection>,
         buffer_size: Option<usize>,
     ) -> Result<Stream<()>> {
         let conn = conn.into();
+        // The graph owns the runtime; the sink connects/publishes on it.
+        let g = self.graph();
+        let handle = g.async_runtime_handle()?;
         let client = redis::Client::open(conn.url.as_str())
             .with_context(|| format!("redis_pub: opening client for {:?}", conn.url))?;
         // Connect at wiring time so a connection error surfaces before the run.
@@ -458,7 +447,7 @@ impl RedisSinkOps for Stream<Burst<RedisEntry>> {
             .block_on(client.get_multiplexed_async_connection())
             .with_context(|| format!("redis_pub: connecting to {:?}", conn.url))?;
 
-        let sink = consume_async(handle, buffer_size, move |entry: RedisEntry| {
+        let sink = consume_async(&g, buffer_size, move |entry: RedisEntry| {
             let mut connection = connection.clone();
             async move {
                 redis::cmd("PUBLISH")
@@ -469,7 +458,7 @@ impl RedisSinkOps for Stream<Burst<RedisEntry>> {
                     .with_context(|| format!("redis_pub: PUBLISH to {:?} failed", entry.channel))?;
                 Ok(())
             }
-        });
+        })?;
         Ok(self.for_each(sink))
     }
 }
@@ -477,12 +466,11 @@ impl RedisSinkOps for Stream<Burst<RedisEntry>> {
 impl RedisSinkOps for Stream<RedisEntry> {
     fn redis_pub(
         &self,
-        handle: &Handle,
         conn: impl Into<RedisConnection>,
         buffer_size: Option<usize>,
     ) -> Result<Stream<()>> {
         self.map(|entry: &RedisEntry| burst![entry.clone()])
-            .redis_pub(handle, conn, buffer_size)
+            .redis_pub(conn, buffer_size)
     }
 }
 
@@ -497,12 +485,11 @@ pub trait RedisStreamSinkOps {
     /// per [`RedisStreamRecord`] (Redis assigns the entry ID). Returns the sink
     /// `Stream<()>`.
     ///
-    /// - `handle`: the caller's tokio runtime handle (see the module docs).
     /// - `buffer_size`: back-pressure bound handed to
     ///   [`consume_async`](crate::async_source::consume_async).
     ///
-    /// Appending runs off the graph thread; writes land in order and are flushed
-    /// at teardown.
+    /// The graph owns the tokio runtime (see the module docs). Appending runs off
+    /// the graph thread; writes land in order and are flushed at teardown.
     ///
     /// # Errors
     ///
@@ -510,7 +497,6 @@ pub trait RedisStreamSinkOps {
     /// append failure aborts the run with context on a subsequent cycle.
     fn redis_stream_write(
         &self,
-        handle: &Handle,
         conn: impl Into<RedisConnection>,
         buffer_size: Option<usize>,
     ) -> Result<Stream<()>>;
@@ -519,11 +505,13 @@ pub trait RedisStreamSinkOps {
 impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
     fn redis_stream_write(
         &self,
-        handle: &Handle,
         conn: impl Into<RedisConnection>,
         buffer_size: Option<usize>,
     ) -> Result<Stream<()>> {
         let conn = conn.into();
+        // The graph owns the runtime; the sink connects/appends on it.
+        let g = self.graph();
+        let handle = g.async_runtime_handle()?;
         let client = redis::Client::open(conn.url.as_str())
             .with_context(|| format!("redis_stream_write: opening client for {:?}", conn.url))?;
         // Connect at wiring time so a connection error surfaces before the run.
@@ -531,7 +519,7 @@ impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
             .block_on(client.get_multiplexed_async_connection())
             .with_context(|| format!("redis_stream_write: connecting to {:?}", conn.url))?;
 
-        let sink = consume_async(handle, buffer_size, move |record: RedisStreamRecord| {
+        let sink = consume_async(&g, buffer_size, move |record: RedisStreamRecord| {
             let mut connection = connection.clone();
             async move {
                 let mut cmd = redis::cmd("XADD");
@@ -546,7 +534,7 @@ impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
                     })?;
                 Ok(())
             }
-        });
+        })?;
         Ok(self.for_each(sink))
     }
 }
@@ -554,12 +542,11 @@ impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
 impl RedisStreamSinkOps for Stream<RedisStreamRecord> {
     fn redis_stream_write(
         &self,
-        handle: &Handle,
         conn: impl Into<RedisConnection>,
         buffer_size: Option<usize>,
     ) -> Result<Stream<()>> {
         self.map(|record: &RedisStreamRecord| burst![record.clone()])
-            .redis_stream_write(handle, conn, buffer_size)
+            .redis_stream_write(conn, buffer_size)
     }
 }
 

--- a/next/crates/wingfoil-next/src/async_source.rs
+++ b/next/crates/wingfoil-next/src/async_source.rs
@@ -3,7 +3,7 @@
 //! [`channel`](crate::fluent::SourceOps::channel) layer.
 //!
 //! The closure returns a [`futures::Stream`] of `Result<(NanoTime, T)>`. A
-//! task spawned on the caller's tokio runtime drives it, forwarding each
+//! task spawned on the graph's tokio runtime drives it, forwarding each
 //! value to the channel (timestamped, so it works in **both** run modes —
 //! deterministic historical replay on the graph clock, or live realtime) and
 //! closing at end-of-stream. A producer error propagates into the graph and
@@ -47,26 +47,87 @@
 //!   without limit. See [`produce_async`] for the historical caveat.
 //!
 //! ```ignore
-//! let rt = tokio::runtime::Runtime::new()?;
+//! // The graph owns the runtime (lazily created); no `&Handle` to pass. To
+//! // embed in your own runtime instead: `GraphBuilder::new().with_async_runtime(rt.handle().clone())`.
 //! let g = GraphBuilder::new();
-//! let quotes = produce_async_bounded(&g, rt.handle(), params, Some(64), |_p| async {
+//! let quotes = produce_async_bounded(&g, params, Some(64), |_p| async {
 //!     Ok(futures::stream::iter(vec![
 //!         Ok((NanoTime::new(100), 1.0)),
 //!         Ok((NanoTime::new(200), 2.0)),
 //!     ]))
-//! });
+//! })?;
 //! ```
 
 use std::future::Future;
 use std::sync::mpsc;
 
+use anyhow::Context;
 use futures::{SinkExt, StreamExt};
-use tokio::runtime::Handle;
+use tokio::runtime::{Handle, Runtime};
 use wingfoil::{NanoTime, RunFor, RunMode};
 
 use crate::Burst;
 use crate::fluent::{GraphBuilder, SourceOps, Stream};
 use crate::op::{Activation, Tick};
+
+/// The async runtime a graph's async adapters spawn onto, owned by the graph.
+///
+/// Legacy wingfoil hides a global `lazy_static` runtime; wingfoil-next used to
+/// make every async adapter take a caller-supplied `&Handle`. This is the middle
+/// ground (see `docs/runtime-ownership.md`): the `GraphBuilder` owns **one**
+/// runtime, created lazily the first time an async adapter asks for a handle and
+/// dropped at teardown — so all async adapters in a graph share it, the common
+/// call needs no `&Handle`, and there is no never-dropped global. A caller can
+/// still inject their own runtime via
+/// [`GraphBuilder::with_async_runtime`](crate::fluent::GraphBuilder::with_async_runtime)
+/// (the override) to embed the graph in an existing async application.
+///
+/// Held in the executor-free core only as an opaque
+/// [`AsyncRuntimeSlot`](crate::interp::AsyncRuntimeSlot); all tokio types stay
+/// behind the `async` feature here.
+#[derive(Default)]
+pub struct GraphRuntime {
+    /// Caller override; when set, adapters use this handle and the graph owns
+    /// (and drops) nothing.
+    override_handle: Option<Handle>,
+    /// The graph's own runtime, created lazily on first use when no override is
+    /// set. Dropped when this slot is dropped — i.e. at [`Runner`] teardown,
+    /// after every node — which stops any still-running producer tasks.
+    ///
+    /// [`Runtime`]: tokio::runtime::Runtime
+    /// [`Runner`]: crate::interp::Runner
+    owned: Option<Runtime>,
+    /// Cached handle to `owned`, so repeated `handle()` calls hand every adapter
+    /// the *same* runtime rather than standing up a new one each time.
+    cached: Option<Handle>,
+}
+
+impl GraphRuntime {
+    /// Resolve the handle to spawn async work onto: the caller override if set,
+    /// otherwise the graph's own runtime (created lazily and cached here on first
+    /// use). Fallible only on the first, owned-runtime creation.
+    pub fn handle(&mut self) -> anyhow::Result<Handle> {
+        if let Some(handle) = &self.override_handle {
+            return Ok(handle.clone());
+        }
+        if let Some(handle) = &self.cached {
+            return Ok(handle.clone());
+        }
+        let runtime = Runtime::new()
+            .context("creating the graph-owned tokio runtime for wingfoil-next async adapters")?;
+        let handle = runtime.handle().clone();
+        self.owned = Some(runtime);
+        self.cached = Some(handle.clone());
+        Ok(handle)
+    }
+
+    /// Install a caller-supplied runtime handle as the override. Adapters wired
+    /// afterwards spawn onto it, and the graph creates/owns no runtime of its
+    /// own.
+    pub fn set_override(&mut self, handle: Handle) {
+        self.override_handle = Some(handle);
+    }
+}
 
 /// The run parameters handed to a producer closure (mirrors classic
 /// `RunParams`), so a producer can choose a historical vs live data source.
@@ -100,17 +161,16 @@ pub struct RunParams {
 /// apply `buffer_size` back-pressure in realtime.
 pub fn produce_async<T, F, Fut, S>(
     g: &GraphBuilder,
-    handle: &tokio::runtime::Handle,
     params: RunParams,
     run: F,
-) -> Stream<Burst<T>>
+) -> anyhow::Result<Stream<Burst<T>>>
 where
     T: Clone + Default + Send + 'static,
     F: FnOnce(RunParams) -> Fut + Send + 'static,
     Fut: Future<Output = anyhow::Result<S>> + Send + 'static,
     S: futures::Stream<Item = anyhow::Result<(NanoTime, T)>> + Send + 'static,
 {
-    produce_async_bounded(g, handle, params, None, run)
+    produce_async_bounded(g, params, None, run)
 }
 
 /// [`produce_async`] with `buffer_size` back-pressure (mirrors classic
@@ -131,17 +191,19 @@ where
 /// up-front collection.
 pub fn produce_async_bounded<T, F, Fut, S>(
     g: &GraphBuilder,
-    handle: &tokio::runtime::Handle,
     params: RunParams,
     buffer_size: Option<usize>,
     run: F,
-) -> Stream<Burst<T>>
+) -> anyhow::Result<Stream<Burst<T>>>
 where
     T: Clone + Default + Send + 'static,
     F: FnOnce(RunParams) -> Fut + Send + 'static,
     Fut: Future<Output = anyhow::Result<S>> + Send + 'static,
     S: futures::Stream<Item = anyhow::Result<(NanoTime, T)>> + Send + 'static,
 {
+    // The graph owns the runtime (created lazily here on first async use, or a
+    // caller override); the producer task spawns onto it at wiring time.
+    let handle = g.async_runtime_handle()?;
     let (stream, sender) = g.channel::<T>();
 
     // Realtime backpressure: a bounded permit channel. The producer takes a
@@ -236,7 +298,7 @@ where
             }
         }
     });
-    validated
+    Ok(validated)
 }
 
 // ---------------------------------------------------------------------------
@@ -252,11 +314,11 @@ where
 /// Returns a closure to plug into [`for_each`](crate::fluent::StreamOps::for_each):
 ///
 /// ```ignore
-/// let rt = tokio::runtime::Runtime::new()?;
+/// // The graph owns the runtime (lazily created); pass `&g`, not a `&Handle`.
 /// let g = GraphBuilder::new();
-/// let sink = some_burst_stream.for_each(consume_async(rt.handle(), Some(64), |v| async move {
+/// let sink = some_burst_stream.for_each(consume_async(&g, Some(64), |v| async move {
 ///     write_somewhere(v).await // returns anyhow::Result<()>
-/// }));
+/// })?);
 /// ```
 ///
 /// # Guarantees
@@ -309,15 +371,20 @@ where
 ///
 /// Gated behind the `async` feature, like [`produce_async`].
 pub fn consume_async<T, F, Fut>(
-    handle: &Handle,
+    g: &GraphBuilder,
     buffer_size: Option<usize>,
     run: F,
-) -> impl Fn(&Burst<T>) -> anyhow::Result<()> + use<T, F, Fut>
+) -> anyhow::Result<impl Fn(&Burst<T>) -> anyhow::Result<()> + use<T, F, Fut>>
 where
     T: Clone + Default + Send + 'static,
     F: FnMut(T) -> Fut + Send + 'static,
     Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
 {
+    // The graph owns the runtime (created lazily here on first async use, or a
+    // caller override); the consumer task spawns onto it, and the sink closure /
+    // teardown flush drive it with `block_on` on the graph thread.
+    let handle = g.async_runtime_handle()?;
+
     // Error channel: the consumer task reports the first write error here; the
     // sink closure polls it (non-blocking) each cycle and aborts the run. A
     // channel — not a lock — keeps the graph execution path lock-free.
@@ -346,7 +413,7 @@ where
         task: Some(task),
     };
     let send_handle = handle.clone();
-    move |burst: &Burst<T>| -> anyhow::Result<()> {
+    Ok(move |burst: &Burst<T>| -> anyhow::Result<()> {
         // Surface a prior async write error before doing more work.
         if let Ok(msg) = err_rx.try_recv() {
             anyhow::bail!("consume_async: background sink write failed: {msg}");
@@ -370,7 +437,7 @@ where
             }
         }
         Ok(())
-    }
+    })
 }
 
 /// Sender half of the sink's data channel — bounded (back-pressured) or

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -89,6 +89,35 @@ impl GraphBuilder {
         f(&mut self.inner.borrow_mut())
     }
 
+    /// Resolve the tokio runtime handle the async adapters spawn onto: the
+    /// caller override installed via [`with_async_runtime`](Self::with_async_runtime)
+    /// if any, otherwise a runtime this graph creates lazily and owns for its
+    /// lifetime (one per graph — every async adapter shares it, dropped at
+    /// teardown). Used by [`produce_async`](crate::async_source::produce_async)
+    /// and [`consume_async`](crate::async_source::consume_async); adapters rarely
+    /// call it directly. See `docs/runtime-ownership.md`.
+    #[cfg(feature = "async")]
+    pub fn async_runtime_handle(&self) -> Result<tokio::runtime::Handle> {
+        self.assert_not_built();
+        self.inner.borrow_mut().async_runtime_handle()
+    }
+
+    /// Embed the graph's async adapters in a caller-supplied runtime instead of
+    /// the graph's own. The override escape hatch (see `docs/runtime-ownership.md`):
+    /// by default a graph lazily creates and owns one runtime shared by all its
+    /// async adapters; call this to point them at your existing runtime for
+    /// embedding in an async application or a custom runtime configuration.
+    ///
+    /// ```ignore
+    /// let rt = tokio::runtime::Runtime::new()?;
+    /// let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    /// ```
+    #[cfg(feature = "async")]
+    pub fn with_async_runtime(self, handle: tokio::runtime::Handle) -> Self {
+        self.inner.borrow_mut().set_async_runtime_override(handle);
+        self
+    }
+
     /// Wrap a handle from this builder as a [`Stream`].
     pub fn wrap<T>(&self, handle: Handle<T>) -> Stream<T> {
         Stream {
@@ -339,6 +368,18 @@ impl<T> Stream<T> {
     /// The underlying engine handle (for [`Runner::value`]).
     pub fn handle(&self) -> Handle<T> {
         self.handle
+    }
+
+    /// A [`GraphBuilder`] view onto the same graph this stream belongs to.
+    /// Sink combinators (e.g. the async adapter `*_pub`/`*_write` traits) use it
+    /// to reach builder-level services such as the graph-owned async runtime,
+    /// since they receive `self: Stream`, not the builder. Cheap — clones the two
+    /// shared `Rc`s.
+    pub fn graph(&self) -> GraphBuilder {
+        GraphBuilder {
+            inner: self.inner.clone(),
+            built: self.built.clone(),
+        }
     }
 
     /// Extension point for combinator traits ([`StreamOps`],

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -322,6 +322,23 @@ impl StopHandle {
     }
 }
 
+/// Graph-scoped ownership of the async runtime the async adapters spawn onto.
+///
+/// The executor-free core never names a runtime; all tokio-specific state lives
+/// in [`GraphRuntime`](crate::async_source::GraphRuntime), reached only under the
+/// `async` feature. The slot is a field on every [`Builder`]/[`Runner`] (so the
+/// struct shape is uniform regardless of feature) but is inert — zero-sized and
+/// doing nothing — unless `async` is on. When on, it holds the lazily-created
+/// owned runtime, is carried from the builder into the [`Runner`] at
+/// [`build`](Builder::build), and — because it is the **last** field of `Runner`
+/// — is dropped only *after* every node, so an offloaded sink's teardown
+/// `block_on` still has a live runtime. See `docs/runtime-ownership.md`.
+#[derive(Default)]
+pub(crate) struct AsyncRuntimeSlot {
+    #[cfg(feature = "async")]
+    inner: crate::async_source::GraphRuntime,
+}
+
 /// Wires a graph of [`Op`]s. Combinators mirror the classic fluent API but
 /// the engine — not the node — owns state, config and values.
 pub struct Builder {
@@ -371,6 +388,10 @@ pub struct Builder {
     /// Set when any [`demux`](Builder::demux) node is wired, so the dispatch
     /// loop knows to drain `marks`. Off (and the drain skipped) otherwise.
     has_marks: bool,
+    /// Graph-owned async runtime (with caller override) for the async adapters.
+    /// Inert unless the `async` feature is on; carried into the [`Runner`] at
+    /// [`build`](Self::build). See [`AsyncRuntimeSlot`].
+    async_rt: AsyncRuntimeSlot,
 }
 
 impl Default for Builder {
@@ -391,6 +412,7 @@ impl Default for Builder {
             pending: Rc::new(RefCell::new(Vec::new())),
             marks: Rc::new(RefCell::new(Vec::new())),
             has_marks: false,
+            async_rt: AsyncRuntimeSlot::default(),
         }
     }
 }
@@ -685,6 +707,26 @@ impl Builder {
             prev_teardown(k)
         });
         handle
+    }
+
+    /// Resolve the tokio runtime [`Handle`](tokio::runtime::Handle) the async
+    /// adapters spawn onto: the caller override if one was installed via
+    /// [`set_async_runtime_override`](Self::set_async_runtime_override),
+    /// otherwise a runtime this graph creates lazily on first use and owns for
+    /// its lifetime (one per graph — every async adapter shares it). See
+    /// `docs/runtime-ownership.md`.
+    #[cfg(feature = "async")]
+    pub fn async_runtime_handle(&mut self) -> Result<tokio::runtime::Handle> {
+        self.async_rt.inner.handle()
+    }
+
+    /// Install a caller-supplied runtime handle as the override, so the async
+    /// adapters spawn onto the caller's runtime instead of the graph's own. The
+    /// escape hatch for embedding in an existing async application or a custom
+    /// runtime configuration.
+    #[cfg(feature = "async")]
+    pub fn set_async_runtime_override(&mut self, handle: tokio::runtime::Handle) {
+        self.async_rt.inner.set_override(handle);
     }
 
     pub(crate) fn slot<T: 'static>(&self, h: Handle<T>) -> SlotRef<T> {
@@ -2188,6 +2230,7 @@ impl Builder {
             dispatch: Dispatch::default(),
             re_runnable: self.re_runnable,
             has_run: false,
+            async_rt: self.async_rt,
         }
     }
 }
@@ -2280,6 +2323,15 @@ pub struct Runner {
     /// Set after the first [`run`](Runner::run); a subsequent run first calls
     /// [`reset`](Runner::reset) to restore state.
     has_run: bool,
+    /// The graph-owned async runtime (or caller override), moved here from the
+    /// [`Builder`] at [`build`](Builder::build). **Declared last on purpose:**
+    /// Rust drops fields top-to-bottom, so `nodes` — and any offloaded sink whose
+    /// teardown `Drop` does a `block_on` on this runtime's handle — is dropped
+    /// *before* the runtime, keeping the runtime alive through teardown. Inert
+    /// unless the `async` feature is on. Held only for its `Drop` (which stops
+    /// producer tasks by dropping the owned runtime), never read.
+    #[allow(dead_code)]
+    async_rt: AsyncRuntimeSlot,
 }
 
 impl Runner {

--- a/next/crates/wingfoil-next/tests/consume_async.rs
+++ b/next/crates/wingfoil-next/tests/consume_async.rs
@@ -19,7 +19,6 @@ const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
 /// queued writes have landed before the run returns.
 #[test]
 fn consume_async_preserves_order() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let collected = Arc::new(Mutex::new(Vec::<u64>::new()));
 
     {
@@ -27,7 +26,7 @@ fn consume_async_preserves_order() {
         let g = GraphBuilder::new();
         // Unbounded buffer: every item is enqueued in one cycle, then drained in
         // order by the single consumer task.
-        let consume = consume_async(rt.handle(), None, move |v: u64| {
+        let consume = consume_async(&g, None, move |v: u64| {
             let sink_values = sink_values.clone();
             async move {
                 sink_values
@@ -36,7 +35,8 @@ fn consume_async_preserves_order() {
                     .push(v);
                 Ok(())
             }
-        });
+        })
+        .unwrap();
         let _sink = g.constant(burst![1u64, 2, 3, 4, 5]).for_each(consume);
         let mut r = g.build();
         r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
@@ -57,7 +57,6 @@ fn consume_async_preserves_order() {
 /// (nothing dropped, no deadlock).
 #[test]
 fn consume_async_applies_backpressure() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let collected = Arc::new(Mutex::new(Vec::<u64>::new()));
 
     {
@@ -66,7 +65,7 @@ fn consume_async_applies_backpressure() {
         // Twenty values through a bounded channel of 2, with a slow sink so the
         // channel keeps filling and the graph thread blocks on `send` until the
         // consumer drains — exercising the back-pressure path.
-        let consume = consume_async(rt.handle(), Some(2), move |v: u64| {
+        let consume = consume_async(&g, Some(2), move |v: u64| {
             let sink_values = sink_values.clone();
             async move {
                 tokio::time::sleep(Duration::from_millis(1)).await;
@@ -76,7 +75,8 @@ fn consume_async_applies_backpressure() {
                     .push(v);
                 Ok(())
             }
-        });
+        })
+        .unwrap();
         let values: Vec<u64> = (1..=20).collect();
         let mut burst = wingfoil::Burst::new();
         for v in values {
@@ -100,7 +100,6 @@ fn consume_async_applies_backpressure() {
 /// the failure deterministically.
 #[test]
 fn consume_async_error_aborts_the_run() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let collected = Arc::new(Mutex::new(Vec::<u64>::new()));
 
     let sink_values = collected.clone();
@@ -117,7 +116,7 @@ fn consume_async_error_aborts_the_run() {
     // buffer_size = 1 so a send blocks until the consumer takes the prior value;
     // once the consumer errors on `2` and stops, a later send hits the closed
     // channel and the run aborts — no reliance on async timing.
-    let consume = consume_async(rt.handle(), Some(1), move |v: u64| {
+    let consume = consume_async(&g, Some(1), move |v: u64| {
         let sink_values = sink_values.clone();
         async move {
             if v == 2 {
@@ -129,7 +128,8 @@ fn consume_async_error_aborts_the_run() {
                 .push(v);
             Ok(())
         }
-    });
+    })
+    .unwrap();
     let _sink = stream.for_each(consume);
 
     let mut r = g.build();

--- a/next/crates/wingfoil-next/tests/etcd_adapter.rs
+++ b/next/crates/wingfoil-next/tests/etcd_adapter.rs
@@ -17,14 +17,14 @@ use wingfoil_next::prelude::*;
 #[test]
 fn sub_connection_refused_aborts_the_run() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::RealTime,
         run_for: RunFor::Cycles(1),
         start_time: NanoTime::ZERO,
     };
     let conn = EtcdConnection::new("http://127.0.0.1:59999");
-    let _events = etcd_sub(&g, rt.handle(), params, conn, "/x/")
+    let _events = etcd_sub(&g, params, conn, "/x/")
         .expect("realtime etcd_sub wires without error")
         .collapse_accumulate();
 
@@ -43,14 +43,14 @@ fn sub_connection_refused_aborts_the_run() {
 #[test]
 fn sub_rejects_historical_mode() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::HistoricalFrom(NanoTime::ZERO),
         run_for: RunFor::Cycles(1),
         start_time: NanoTime::ZERO,
     };
     let conn = EtcdConnection::new("http://127.0.0.1:2379");
-    let err = match etcd_sub(&g, rt.handle(), params, conn, "/x/") {
+    let err = match etcd_sub(&g, params, conn, "/x/") {
         Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
         Err(e) => e,
     };
@@ -68,14 +68,14 @@ fn sub_rejects_historical_mode() {
 #[test]
 fn pub_connection_refused_surfaces_an_error() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let source = g.constant(burst![EtcdEntry {
         key: "/x/k".to_string(),
         value: b"v".to_vec(),
     }]);
     let conn = EtcdConnection::new("http://127.0.0.1:59999");
 
-    let outcome = match source.etcd_pub(rt.handle(), conn, None, true) {
+    let outcome = match source.etcd_pub(conn, None, true) {
         // Errored at wiring (eager connect) — acceptable.
         Err(_) => return,
         // Connected lazily: the failure must surface when the first PUT runs.

--- a/next/crates/wingfoil-next/tests/etcd_integration.rs
+++ b/next/crates/wingfoil-next/tests/etcd_integration.rs
@@ -95,15 +95,9 @@ fn test_sub_empty_snapshot_then_live_write() -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     let (_container, endpoint) = start_etcd()?;
 
-    let g = GraphBuilder::new();
-    let events = etcd_sub(
-        &g,
-        rt.handle(),
-        realtime(1),
-        EtcdConnection::new(&endpoint),
-        "/empty/",
-    )?
-    .collapse_accumulate();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let events =
+        etcd_sub(&g, realtime(1), EtcdConnection::new(&endpoint), "/empty/")?.collapse_accumulate();
 
     let endpoint_clone = endpoint.clone();
     let writer = std::thread::spawn(move || {
@@ -129,15 +123,9 @@ fn test_sub_snapshot_with_existing_keys() -> anyhow::Result<()> {
     let (_container, endpoint) = start_etcd()?;
     seed_keys(&endpoint, &[("/snap/a", "1"), ("/snap/b", "2")])?;
 
-    let g = GraphBuilder::new();
-    let events = etcd_sub(
-        &g,
-        rt.handle(),
-        realtime(1),
-        EtcdConnection::new(&endpoint),
-        "/snap/",
-    )?
-    .collapse_accumulate();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let events =
+        etcd_sub(&g, realtime(1), EtcdConnection::new(&endpoint), "/snap/")?.collapse_accumulate();
 
     let mut runner = g.build();
     runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
@@ -165,15 +153,9 @@ fn test_sub_live_updates() -> anyhow::Result<()> {
         seed_keys(&endpoint_clone, &[("/live/x", "hello")]).unwrap();
     });
 
-    let g = GraphBuilder::new();
-    let events = etcd_sub(
-        &g,
-        rt.handle(),
-        realtime(1),
-        EtcdConnection::new(&endpoint),
-        "/live/",
-    )?
-    .collapse_accumulate();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let events =
+        etcd_sub(&g, realtime(1), EtcdConnection::new(&endpoint), "/live/")?.collapse_accumulate();
 
     let mut runner = g.build();
     runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
@@ -200,16 +182,10 @@ fn test_sub_delete_events() -> anyhow::Result<()> {
         delete_key(&endpoint_clone, "/del/k").unwrap();
     });
 
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     // Cycles(2): 1 snapshot Put + 1 live Delete.
-    let events = etcd_sub(
-        &g,
-        rt.handle(),
-        realtime(2),
-        EtcdConnection::new(&endpoint),
-        "/del/",
-    )?
-    .collapse_accumulate();
+    let events =
+        etcd_sub(&g, realtime(2), EtcdConnection::new(&endpoint), "/del/")?.collapse_accumulate();
 
     let mut runner = g.build();
     runner.run(RunMode::RealTime, RunFor::Cycles(2))?;
@@ -237,15 +213,9 @@ fn test_sub_no_race_between_snapshot_and_watch() -> anyhow::Result<()> {
     });
     writer.join().unwrap();
 
-    let g = GraphBuilder::new();
-    let events = etcd_sub(
-        &g,
-        rt.handle(),
-        realtime(1),
-        EtcdConnection::new(&endpoint),
-        "/race/",
-    )?
-    .collapse_accumulate();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let events =
+        etcd_sub(&g, realtime(1), EtcdConnection::new(&endpoint), "/race/")?.collapse_accumulate();
 
     let mut runner = g.build();
     runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
@@ -268,9 +238,8 @@ fn test_pub_round_trip() -> anyhow::Result<()> {
     let (_container, endpoint) = start_etcd()?;
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g.constant(burst![entry("/rt/key1", b"value1")]).etcd_pub(
-            rt.handle(),
             EtcdConnection::new(&endpoint),
             None,
             true,
@@ -292,10 +261,10 @@ fn test_pub_no_lease_keys_persist() -> anyhow::Result<()> {
     let (_container, endpoint) = start_etcd()?;
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![entry("/nolease/k1", b"persist")])
-            .etcd_pub(rt.handle(), EtcdConnection::new(&endpoint), None, true)?;
+            .etcd_pub(EtcdConnection::new(&endpoint), None, true)?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -314,10 +283,9 @@ fn test_pub_lease_keys_expire_after_revoke() -> anyhow::Result<()> {
     let (_container, endpoint) = start_etcd()?;
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         // A 30s TTL — the key must still vanish on revoke, not wait 30s.
         let _sink = g.constant(burst![entry("/lease/k1", b"hello")]).etcd_pub(
-            rt.handle(),
             EtcdConnection::new(&endpoint),
             Some(Duration::from_secs(30)),
             true,
@@ -363,7 +331,7 @@ fn test_pub_lease_keepalive_extends_ttl() -> anyhow::Result<()> {
     });
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         // Drive the write from a ticker rather than a bare `constant`: under
         // `RunFor::Duration` a `constant` source emits no wake, so the graph
         // would never run the cycle that fires the PUT. Re-writing the same key
@@ -375,7 +343,6 @@ fn test_pub_lease_keepalive_extends_ttl() -> anyhow::Result<()> {
             .ticker(Duration::from_millis(500))
             .map(|_: &()| burst![entry("/lease/heartbeat", b"alive")])
             .etcd_pub(
-                rt.handle(),
                 EtcdConnection::new(&endpoint),
                 Some(Duration::from_secs(3)),
                 true,
@@ -396,9 +363,8 @@ fn test_pub_force_true_overwrites() -> anyhow::Result<()> {
     seed_keys(&endpoint, &[("/force/k", "original")])?;
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g.constant(burst![entry("/force/k", b"updated")]).etcd_pub(
-            rt.handle(),
             EtcdConnection::new(&endpoint),
             None,
             true,
@@ -420,10 +386,10 @@ fn test_pub_force_false_fails_if_exists() -> anyhow::Result<()> {
     let (_container, endpoint) = start_etcd()?;
     seed_keys(&endpoint, &[("/noforce/k", "original")])?;
 
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let _sink = g
         .constant(burst![entry("/noforce/k", b"should-not-overwrite")])
-        .etcd_pub(rt.handle(), EtcdConnection::new(&endpoint), None, false)?;
+        .etcd_pub(EtcdConnection::new(&endpoint), None, false)?;
     let result = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
 
     assert!(result.is_err(), "expected error when key already exists");
@@ -448,10 +414,10 @@ fn test_pub_force_false_succeeds_if_absent() -> anyhow::Result<()> {
     let (_container, endpoint) = start_etcd()?;
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![entry("/noforce/new", b"value")])
-            .etcd_pub(rt.handle(), EtcdConnection::new(&endpoint), None, false)?;
+            .etcd_pub(EtcdConnection::new(&endpoint), None, false)?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 

--- a/next/crates/wingfoil-next/tests/kafka_adapter.rs
+++ b/next/crates/wingfoil-next/tests/kafka_adapter.rs
@@ -22,7 +22,7 @@ use wingfoil_next::prelude::*;
 #[test]
 fn sub_rejects_historical_mode() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::HistoricalFrom(NanoTime::ZERO),
         run_for: RunFor::Cycles(1),
@@ -30,7 +30,6 @@ fn sub_rejects_historical_mode() {
     };
     let err = match kafka_sub(
         &g,
-        rt.handle(),
         params,
         KafkaConnection::new("127.0.0.1:9092"),
         "topic",
@@ -54,7 +53,7 @@ fn sub_rejects_historical_mode() {
 #[test]
 fn sub_connection_refused_terminates() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::RealTime,
         run_for: RunFor::Duration(Duration::from_secs(3)),
@@ -62,7 +61,6 @@ fn sub_connection_refused_terminates() {
     };
     let _events = kafka_sub(
         &g,
-        rt.handle(),
         params,
         KafkaConnection::new("127.0.0.1:59999"),
         "nonexistent",
@@ -85,13 +83,13 @@ fn sub_connection_refused_terminates() {
 #[test]
 fn pub_wires_from_single_record_stream() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let _sink = g
         .constant(KafkaRecord {
             topic: "t".to_string(),
             key: Some(b"k".to_vec()),
             value: b"v".to_vec(),
         })
-        .kafka_pub(rt.handle(), "127.0.0.1:9092")
+        .kafka_pub("127.0.0.1:9092")
         .expect("kafka_pub wires from a single-record stream");
 }

--- a/next/crates/wingfoil-next/tests/kafka_integration.rs
+++ b/next/crates/wingfoil-next/tests/kafka_integration.rs
@@ -167,21 +167,14 @@ fn consume_with_sub(
     secs: u64,
 ) -> anyhow::Result<Vec<KafkaEvent>> {
     let rt = tokio::runtime::Runtime::new()?;
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::RealTime,
         run_for: RunFor::Duration(Duration::from_secs(secs)),
         start_time: NanoTime::ZERO,
     };
-    let events = kafka_sub(
-        &g,
-        rt.handle(),
-        params,
-        KafkaConnection::new(brokers),
-        topic,
-        group,
-    )?
-    .collapse_accumulate();
+    let events =
+        kafka_sub(&g, params, KafkaConnection::new(brokers), topic, group)?.collapse_accumulate();
     let mut runner = g.build();
     runner.run(
         RunMode::RealTime,
@@ -264,14 +257,14 @@ fn test_pub_round_trip() -> anyhow::Result<()> {
 
     {
         let rt = tokio::runtime::Runtime::new()?;
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![KafkaRecord {
                 topic: topic.to_string(),
                 key: Some(b"rt-key".to_vec()),
                 value: b"rt-value".to_vec(),
             }])
-            .kafka_pub(rt.handle(), KafkaConnection::new(&brokers))?;
+            .kafka_pub(KafkaConnection::new(&brokers))?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -291,7 +284,7 @@ fn test_pub_multiple_records_in_burst() -> anyhow::Result<()> {
 
     {
         let rt = tokio::runtime::Runtime::new()?;
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![
                 KafkaRecord {
@@ -305,7 +298,7 @@ fn test_pub_multiple_records_in_burst() -> anyhow::Result<()> {
                     value: b"v2".to_vec(),
                 },
             ])
-            .kafka_pub(rt.handle(), KafkaConnection::new(&brokers))?;
+            .kafka_pub(KafkaConnection::new(&brokers))?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -327,14 +320,14 @@ fn test_pub_round_trip_via_sub() -> anyhow::Result<()> {
 
     {
         let rt = tokio::runtime::Runtime::new()?;
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![KafkaRecord {
                 topic: topic.to_string(),
                 key: Some(b"key".to_vec()),
                 value: b"payload".to_vec(),
             }])
-            .kafka_pub(rt.handle(), KafkaConnection::new(&brokers))?;
+            .kafka_pub(KafkaConnection::new(&brokers))?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 

--- a/next/crates/wingfoil-next/tests/otlp_adapter.rs
+++ b/next/crates/wingfoil-next/tests/otlp_adapter.rs
@@ -24,11 +24,12 @@ fn historical_mode_drains_without_connecting() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let config = OtlpConfig::new("http://127.0.0.1:1", "test");
 
-    let g = GraphBuilder::new();
-    let _sink =
-        g.ticker(Duration::from_millis(10))
-            .count()
-            .otlp_push(rt.handle(), "test_metric", config);
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let _sink = g
+        .ticker(Duration::from_millis(10))
+        .count()
+        .otlp_push("test_metric", config)
+        .unwrap();
 
     g.build()
         .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5))
@@ -44,12 +45,12 @@ fn bad_endpoint_is_handled_gracefully() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let config = OtlpConfig::new("http://127.0.0.1:1", "test");
 
-    let g = GraphBuilder::new();
-    let _sink = g.ticker(Duration::from_millis(50)).count().otlp_push(
-        rt.handle(),
-        "bad_endpoint_metric",
-        config,
-    );
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let _sink = g
+        .ticker(Duration::from_millis(50))
+        .count()
+        .otlp_push("bad_endpoint_metric", config)
+        .unwrap();
 
     // Errors from the background exporter are non-fatal; ignore the result.
     let _ = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
@@ -62,12 +63,12 @@ fn bad_endpoint_is_handled_gracefully() {
 fn config_accepts_a_tuple() {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    let g = GraphBuilder::new();
-    let _sink = g.ticker(Duration::from_millis(10)).count().otlp_push(
-        rt.handle(),
-        "tuple_metric",
-        ("http://127.0.0.1:1", "test"),
-    );
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let _sink = g
+        .ticker(Duration::from_millis(10))
+        .count()
+        .otlp_push("tuple_metric", ("http://127.0.0.1:1", "test"))
+        .unwrap();
 
     g.build()
         .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))

--- a/next/crates/wingfoil-next/tests/otlp_integration.rs
+++ b/next/crates/wingfoil-next/tests/otlp_integration.rs
@@ -38,12 +38,11 @@ fn otlp_push_sends_successfully() -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     let config = OtlpConfig::new(endpoint, "wingfoil-next-test");
 
-    let g = GraphBuilder::new();
-    let _sink = g.ticker(Duration::from_millis(100)).count().otlp_push(
-        rt.handle(),
-        "wingfoil_next_integration_counter",
-        config,
-    );
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let _sink = g
+        .ticker(Duration::from_millis(100))
+        .count()
+        .otlp_push("wingfoil_next_integration_counter", config)?;
 
     g.build()
         .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(1)))?;

--- a/next/crates/wingfoil-next/tests/postgres_adapter.rs
+++ b/next/crates/wingfoil-next/tests/postgres_adapter.rs
@@ -74,22 +74,15 @@ fn historical(start: NanoTime, secs: u64) -> RunParams {
 #[test]
 fn read_rejects_realtime_mode() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::RealTime,
         run_for: RunFor::Duration(HOUR),
         start_time: NanoTime::ZERO,
     };
-    let err = postgres_read::<TestTrade>(
-        &g,
-        rt.handle(),
-        params,
-        "host=127.0.0.1 dbname=db",
-        HOUR,
-        read_query,
-    )
-    .err()
-    .expect("RealTime must be rejected");
+    let err = postgres_read::<TestTrade>(&g, params, "host=127.0.0.1 dbname=db", HOUR, read_query)
+        .err()
+        .expect("RealTime must be rejected");
     let msg = format!("{err:#}");
     assert!(msg.contains("postgres_read"), "names the adapter: {msg}");
     assert!(
@@ -102,22 +95,15 @@ fn read_rejects_realtime_mode() {
 #[test]
 fn read_rejects_forever() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
         run_for: RunFor::Forever,
         start_time: NanoTime::from_kdb_timestamp(0),
     };
-    let err = postgres_read::<TestTrade>(
-        &g,
-        rt.handle(),
-        params,
-        "host=127.0.0.1 dbname=db",
-        HOUR,
-        read_query,
-    )
-    .err()
-    .expect("Forever must be rejected");
+    let err = postgres_read::<TestTrade>(&g, params, "host=127.0.0.1 dbname=db", HOUR, read_query)
+        .err()
+        .expect("Forever must be rejected");
     assert!(format!("{err:#}").contains("RunFor::Forever"));
 }
 
@@ -125,22 +111,15 @@ fn read_rejects_forever() {
 #[test]
 fn read_rejects_cycles() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
         run_for: RunFor::Cycles(1),
         start_time: NanoTime::from_kdb_timestamp(0),
     };
-    let err = postgres_read::<TestTrade>(
-        &g,
-        rt.handle(),
-        params,
-        "host=127.0.0.1 dbname=db",
-        HOUR,
-        read_query,
-    )
-    .err()
-    .expect("Cycles must be rejected");
+    let err = postgres_read::<TestTrade>(&g, params, "host=127.0.0.1 dbname=db", HOUR, read_query)
+        .err()
+        .expect("Cycles must be rejected");
     assert!(format!("{err:#}").contains("RunFor::Cycles"));
 }
 
@@ -149,13 +128,12 @@ fn read_rejects_cycles() {
 #[test]
 fn read_connection_refused_redacts_password() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let conn = PostgresConnection::new(
         "host=127.0.0.1 port=59999 user=postgres password=s3cr3t dbname=postgres connect_timeout=2",
     );
     let err = postgres_read::<TestTrade>(
         &g,
-        rt.handle(),
         historical(NanoTime::from_kdb_timestamp(0), 86400),
         conn,
         HOUR,
@@ -175,7 +153,7 @@ fn read_connection_refused_redacts_password() {
 #[test]
 fn sub_rejects_historical_mode() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let params = RunParams {
         run_mode: RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
         run_for: RunFor::Cycles(1),
@@ -183,7 +161,6 @@ fn sub_rejects_historical_mode() {
     };
     let err = match postgres_sub::<TestTrade, _>(
         &g,
-        rt.handle(),
         params,
         "host=127.0.0.1 dbname=db",
         "chan",
@@ -208,7 +185,7 @@ fn sub_rejects_historical_mode() {
 #[test]
 fn write_connection_refused_redacts_password() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let source = g.constant(burst![TestTrade {
         sym: "T".into(),
         price: 1.0,
@@ -218,7 +195,7 @@ fn write_connection_refused_redacts_password() {
         "host=127.0.0.1 port=59999 user=postgres password=hunter2 dbname=postgres connect_timeout=2",
     );
     let err = source
-        .postgres_write(rt.handle(), conn, "trades", None)
+        .postgres_write(conn, "trades", None)
         .err()
         .expect("an unreachable endpoint must abort at wiring");
     let msg = format!("{err:#}");

--- a/next/crates/wingfoil-next/tests/postgres_integration.rs
+++ b/next/crates/wingfoil-next/tests/postgres_integration.rs
@@ -142,8 +142,8 @@ fn collect_hourly_read(
         run_for: RunFor::Duration(dur),
         start_time: start,
     };
-    let g = GraphBuilder::new();
-    let acc = postgres_read::<TestTrade>(&g, handle, params, conn, HOUR, read_query)?
+    let g = GraphBuilder::new().with_async_runtime(handle.clone());
+    let acc = postgres_read::<TestTrade>(&g, params, conn, HOUR, read_query)?
         .collapse()
         .with_time()
         .accumulate();
@@ -270,7 +270,7 @@ fn test_write_round_trip() -> anyhow::Result<()> {
     // them, then drop the runner so the off-thread sink flushes at teardown.
     let start = NanoTime::from_kdb_timestamp(0);
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let rows = (0..3i64).map(|i| {
             Ok((
                 TestTrade {
@@ -281,9 +281,9 @@ fn test_write_round_trip() -> anyhow::Result<()> {
                 NanoTime::from_kdb_timestamp(i * HOUR_NANOS),
             ))
         });
-        let _sink =
-            g.replay_results(rows)
-                .postgres_write(rt.handle(), conn.clone(), "trades", None)?;
+        let _sink = g
+            .replay_results(rows)
+            .postgres_write(conn.clone(), "trades", None)?;
         let mut runner = g.build();
         runner.run(
             RunMode::HistoricalFrom(start),
@@ -313,7 +313,7 @@ fn test_write_burst_multi_row() -> anyhow::Result<()> {
 
     // A single burst with two records — both share the graph timestamp.
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![
                 TestTrade {
@@ -327,7 +327,7 @@ fn test_write_burst_multi_row() -> anyhow::Result<()> {
                     qty: 2
                 },
             ])
-            .postgres_write(rt.handle(), conn.clone(), "trades", None)?;
+            .postgres_write(conn.clone(), "trades", None)?;
         let mut runner = g.build();
         runner.run(
             RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
@@ -376,11 +376,10 @@ fn test_sub_catch_up_then_live_inserts() -> anyhow::Result<()> {
         run_for: RunFor::Duration(Duration::from_secs(3)),
         start_time: NanoTime::ZERO,
     };
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     // Collect whole bursts: in real-time several rows can arrive in one cycle.
     let acc = postgres_sub::<TestTrade, _>(
         &g,
-        rt.handle(),
         params,
         conn,
         "trades_feed",

--- a/next/crates/wingfoil-next/tests/produce_async.rs
+++ b/next/crates/wingfoil-next/tests/produce_async.rs
@@ -2,6 +2,9 @@
 //! timestamped values, matching classic `produce_async`. Same producer runs
 //! deterministically in historical mode (replayed on the graph clock) and
 //! propagates a mid-stream error into the graph. Gated by the `async` feature.
+//!
+//! The runtime is the **graph's** (owned lazily, dropped at teardown), so no
+//! `&Handle` is threaded in; the final test pins the caller-override escape hatch.
 #![cfg(feature = "async")]
 
 use std::time::Duration;
@@ -24,15 +27,15 @@ fn params() -> RunParams {
 /// the graph clock — the classic `produce_async` historical contract.
 #[test]
 fn produce_async_replays_deterministically() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let g = GraphBuilder::new();
-    let values = produce_async(&g, rt.handle(), params(), |_p| async {
+    let values = produce_async(&g, params(), |_p| async {
         Ok(futures::stream::iter(vec![
             Ok((NanoTime::new(100), 1u64)),
             Ok((NanoTime::new(200), 2u64)),
             Ok((NanoTime::new(300), 3u64)),
         ]))
-    });
+    })
+    .unwrap();
     let acc = values.with_time().accumulate();
     let mut r = g.build();
     r.run(HISTORICAL, RunFor::Forever).unwrap();
@@ -55,15 +58,15 @@ fn produce_async_replays_deterministically() {
 /// Same-timestamp values from the producer arrive as one atomic burst.
 #[test]
 fn produce_async_groups_same_time_into_a_burst() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let g = GraphBuilder::new();
-    let values = produce_async(&g, rt.handle(), params(), |_p| async {
+    let values = produce_async(&g, params(), |_p| async {
         Ok(futures::stream::iter(vec![
             Ok((NanoTime::new(100), 1u64)),
             Ok((NanoTime::new(100), 2u64)),
             Ok((NanoTime::new(100), 3u64)),
         ]))
-    });
+    })
+    .unwrap();
     let acc = values.collapse_accumulate();
     let mut r = g.build();
     r.run(HISTORICAL, RunFor::Forever).unwrap();
@@ -73,14 +76,14 @@ fn produce_async_groups_same_time_into_a_burst() {
 /// A mid-stream producer error aborts the run with context.
 #[test]
 fn produce_async_error_aborts_the_run() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let g = GraphBuilder::new();
-    let values = produce_async(&g, rt.handle(), params(), |_p| async {
+    let values = produce_async(&g, params(), |_p| async {
         Ok(futures::stream::iter(vec![
             Ok((NanoTime::new(100), 1u64)),
             Err(anyhow::anyhow!("feed dropped")),
         ]))
-    });
+    })
+    .unwrap();
     let _acc = values.collapse_accumulate();
     let mut r = g.build();
     let err = r
@@ -97,7 +100,6 @@ fn produce_async_error_aborts_the_run() {
 /// not use aborts the run with context naming the mismatch.
 #[test]
 fn produce_async_rejects_mismatched_start_time() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let g = GraphBuilder::new();
     // Caller declares start_time = 999, but the run below starts at ZERO.
     let bogus = RunParams {
@@ -105,9 +107,10 @@ fn produce_async_rejects_mismatched_start_time() {
         run_for: RunFor::Forever,
         start_time: NanoTime::new(999),
     };
-    let values = produce_async(&g, rt.handle(), bogus, |_p| async {
+    let values = produce_async(&g, bogus, |_p| async {
         Ok(futures::stream::iter(vec![Ok((NanoTime::new(100), 1u64))]))
-    });
+    })
+    .unwrap();
     let _acc = values.collapse_accumulate();
     let mut r = g.build();
     let err = r
@@ -126,15 +129,15 @@ fn produce_async_rejects_mismatched_start_time() {
 /// so the bound is simply not applied in historical replay.
 #[test]
 fn produce_async_buffer_size_ignored_in_historical() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let g = GraphBuilder::new();
-    let values = produce_async_bounded(&g, rt.handle(), params(), Some(1), |_p| async {
+    let values = produce_async_bounded(&g, params(), Some(1), |_p| async {
         Ok(futures::stream::iter(vec![
             Ok((NanoTime::new(100), 1u64)),
             Ok((NanoTime::new(200), 2u64)),
             Ok((NanoTime::new(300), 3u64)),
         ]))
-    });
+    })
+    .unwrap();
     let acc = values.collapse_accumulate();
     let mut r = g.build();
     r.run(HISTORICAL, RunFor::Forever).unwrap();
@@ -146,7 +149,6 @@ fn produce_async_buffer_size_ignored_in_historical() {
 /// as the graph consumes and returns permits (back-pressure, not loss).
 #[test]
 fn produce_async_realtime_bounded_buffer_delivers_all_in_order() {
-    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
     let g = GraphBuilder::new();
     let realtime = RunParams {
         run_mode: RunMode::RealTime,
@@ -154,7 +156,7 @@ fn produce_async_realtime_bounded_buffer_delivers_all_in_order() {
         start_time: NanoTime::ZERO,
     };
     // buffer_size = 2, but ten values must all arrive across the run.
-    let values = produce_async_bounded(&g, rt.handle(), realtime, Some(2), |_p| async {
+    let values = produce_async_bounded(&g, realtime, Some(2), |_p| async {
         Ok(futures::stream::unfold(1u64, |i| async move {
             if i > 10 {
                 return None;
@@ -164,7 +166,8 @@ fn produce_async_realtime_bounded_buffer_delivers_all_in_order() {
             tokio::time::sleep(Duration::from_millis(1)).await;
             Some((Ok((NanoTime::new(i), i)), i + 1))
         }))
-    });
+    })
+    .unwrap();
     let acc = values.collapse_accumulate();
     let mut r = g.build();
     // Generous cycle bound: with a burst source nothing is dropped, so all ten
@@ -177,4 +180,24 @@ fn produce_async_realtime_bounded_buffer_delivers_all_in_order() {
         got,
         "all values, in order, under back-pressure"
     );
+}
+
+/// The caller-runtime override: a producer wired onto a graph built with
+/// [`GraphBuilder::with_async_runtime`] spawns on the caller's runtime, not a
+/// graph-created one — the escape hatch for embedding in an existing async app.
+#[test]
+fn produce_async_honours_caller_runtime_override() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let values = produce_async(&g, params(), |_p| async {
+        Ok(futures::stream::iter(vec![
+            Ok((NanoTime::new(100), 1u64)),
+            Ok((NanoTime::new(200), 2u64)),
+        ]))
+    })
+    .unwrap();
+    let acc = values.collapse_accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Forever).unwrap();
+    assert_eq!(vec![1, 2], r.value(&acc));
 }

--- a/next/crates/wingfoil-next/tests/redis_adapter.rs
+++ b/next/crates/wingfoil-next/tests/redis_adapter.rs
@@ -38,9 +38,9 @@ fn historical() -> RunParams {
 #[test]
 fn sub_connection_refused_aborts_the_run() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let conn = RedisConnection::new("redis://127.0.0.1:59999");
-    let _events = redis_sub(&g, rt.handle(), realtime(1), conn, "ch")
+    let _events = redis_sub(&g, realtime(1), conn, "ch")
         .expect("realtime redis_sub wires without error")
         .collapse_accumulate();
 
@@ -56,9 +56,9 @@ fn sub_connection_refused_aborts_the_run() {
 #[test]
 fn stream_read_connection_refused_aborts_the_run() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let conn = RedisConnection::new("redis://127.0.0.1:59999");
-    let _events = redis_stream_read(&g, rt.handle(), realtime(1), conn, "key")
+    let _events = redis_stream_read(&g, realtime(1), conn, "key")
         .expect("realtime redis_stream_read wires without error")
         .collapse_accumulate();
 
@@ -75,9 +75,9 @@ fn stream_read_connection_refused_aborts_the_run() {
 #[test]
 fn sub_rejects_historical_mode() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let conn = RedisConnection::new("redis://127.0.0.1:6379");
-    let err = match redis_sub(&g, rt.handle(), historical(), conn, "ch") {
+    let err = match redis_sub(&g, historical(), conn, "ch") {
         Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
         Err(e) => e,
     };
@@ -93,9 +93,9 @@ fn sub_rejects_historical_mode() {
 #[test]
 fn stream_read_rejects_historical_mode() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let conn = RedisConnection::new("redis://127.0.0.1:6379");
-    let err = match redis_stream_read(&g, rt.handle(), historical(), conn, "key") {
+    let err = match redis_stream_read(&g, historical(), conn, "key") {
         Ok(_) => panic!("HistoricalFrom must be rejected at wiring time"),
         Err(e) => e,
     };
@@ -115,14 +115,14 @@ fn stream_read_rejects_historical_mode() {
 #[test]
 fn pub_connection_refused_surfaces_an_error() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let source = g.constant(burst![RedisEntry {
         channel: "ch".to_string(),
         payload: b"v".to_vec(),
     }]);
     let conn = RedisConnection::new("redis://127.0.0.1:59999");
 
-    let outcome = match source.redis_pub(rt.handle(), conn, None) {
+    let outcome = match source.redis_pub(conn, None) {
         Err(_) => return, // errored at wiring (eager connect) — acceptable
         Ok(_sink) => g.build().run(RunMode::RealTime, RunFor::Cycles(1)),
     };
@@ -136,11 +136,11 @@ fn pub_connection_refused_surfaces_an_error() {
 #[test]
 fn stream_write_connection_refused_surfaces_an_error() {
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let source = g.constant(burst![RedisStreamRecord::single("key", "f", b"v".to_vec())]);
     let conn = RedisConnection::new("redis://127.0.0.1:59999");
 
-    let outcome = match source.redis_stream_write(rt.handle(), conn, None) {
+    let outcome = match source.redis_stream_write(conn, None) {
         Err(_) => return, // errored at wiring (eager connect) — acceptable
         Ok(_sink) => g.build().run(RunMode::RealTime, RunFor::Cycles(1)),
     };

--- a/next/crates/wingfoil-next/tests/redis_integration.rs
+++ b/next/crates/wingfoil-next/tests/redis_integration.rs
@@ -136,15 +136,9 @@ fn test_sub_live_message() -> anyhow::Result<()> {
 
     let (done, publisher) = spawn_publisher(&url, "live", b"hello");
 
-    let g = GraphBuilder::new();
-    let events = redis_sub(
-        &g,
-        rt.handle(),
-        realtime(1),
-        RedisConnection::new(&url),
-        "live",
-    )?
-    .collapse_accumulate();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let events =
+        redis_sub(&g, realtime(1), RedisConnection::new(&url), "live")?.collapse_accumulate();
     let mut runner = g.build();
     runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
 
@@ -174,13 +168,13 @@ fn test_pub_round_trip() -> anyhow::Result<()> {
     }
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![RedisEntry {
                 channel: "rt".to_string(),
                 payload: b"value1".to_vec(),
             }])
-            .redis_pub(rt.handle(), RedisConnection::new(&url), None)?;
+            .redis_pub(RedisConnection::new(&url), None)?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -203,7 +197,7 @@ fn test_pub_multiple_entries_in_burst() -> anyhow::Result<()> {
     }
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![
                 RedisEntry {
@@ -219,7 +213,7 @@ fn test_pub_multiple_entries_in_burst() -> anyhow::Result<()> {
                     payload: b"c".to_vec(),
                 },
             ])
-            .redis_pub(rt.handle(), RedisConnection::new(&url), None)?;
+            .redis_pub(RedisConnection::new(&url), None)?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -240,20 +234,20 @@ fn test_stream_write_and_read_snapshot() -> anyhow::Result<()> {
     let conn = RedisConnection::new(&url);
 
     {
-        let g = GraphBuilder::new();
+        let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![
                 RedisStreamRecord::single("events", "kind", b"login".to_vec()),
                 RedisStreamRecord::single("events", "kind", b"logout".to_vec()),
             ])
-            .redis_stream_write(rt.handle(), conn.clone(), None)?;
+            .redis_stream_write(conn.clone(), None)?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
-    let g = GraphBuilder::new();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     // `.accumulate()` keeps whole bursts (the snapshot rides one burst), then we
     // flatten — `.collapse_accumulate()` would drop all but the last entry.
-    let bursts = redis_stream_read(&g, rt.handle(), realtime(1), conn, "events")?.accumulate();
+    let bursts = redis_stream_read(&g, realtime(1), conn, "events")?.accumulate();
     let mut runner = g.build();
     runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
 
@@ -282,9 +276,8 @@ fn test_stream_read_live_tail() -> anyhow::Result<()> {
         xadd(&url_writer, "tail", "msg", b"live").unwrap();
     });
 
-    let g = GraphBuilder::new();
-    let events =
-        redis_stream_read(&g, rt.handle(), realtime(1), conn, "tail")?.collapse_accumulate();
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let events = redis_stream_read(&g, realtime(1), conn, "tail")?.collapse_accumulate();
     let mut runner = g.build();
     runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
     writer.join().unwrap();

--- a/next/docs/runtime-ownership.md
+++ b/next/docs/runtime-ownership.md
@@ -5,6 +5,15 @@ Status: **proposal.** Coupled to
 these two should be decided and executed together. Tracks deviation **A5** in
 [`deviation-register.md`](./deviation-register.md).
 
+> **Update (spike landed):** the `source_at_start` primitive from the
+> lifecycle plan has since landed on `next` (PR #547) and `zmq_sub` now
+> establishes its socket + producer thread in `start()`. That directly
+> unblocks the runtime work below — the migration can build on the *landed*
+> primitive rather than a proposed one. The `produce_async` / `consume_async`
+> family (etcd/redis/kafka/postgres/otlp) still spawns at wiring and still
+> takes `&Handle`, so the analysis and recommendation are unchanged; only the
+> "current state" and "migration sketch" are updated to reflect the spike.
+
 ## The question
 
 Legacy wingfoil **owns** a tokio runtime (with an override to inject your own).
@@ -17,11 +26,17 @@ wingfoil-next instead makes every async adapter take a caller-supplied
   (`next/crates/wingfoil-next/src/async_source.rs`) take a
   `&tokio::runtime::Handle` (sources also take `RunParams`). The async adapters
   — etcd, redis, kafka, postgres, otlp — all thread that handle through their
-  factories.
+  factories, and each still **spawns/connects at wiring time**.
 - Each adapter documents this as deviation #1: *"The tokio runtime is the
   caller's … classic hides a global runtime … next takes the `Handle`
   explicitly."* The stated rationale is (a) no hidden global state, and (b)
   **the producer task spawns at wiring time, so the factory needs a handle**.
+- **Exception since #547**: `zmq_sub` no longer spawns at wiring. It uses the
+  `source_at_start` primitive (`fluent.rs` / `interp.rs`) — the socket connect
+  and producer thread now run in `start()`, wiring stays pure. `zmq_sub` is
+  channel-fed, not `produce_async`-based, so it never took a `&Handle`; but it
+  is the proof that deferring I/O establishment to `start()` works in the
+  engine today, which is exactly the mechanism this plan relies on.
 
 ## Analysis
 
@@ -80,13 +95,21 @@ the engine simply hands each adapter its owned runtime's handle at `start()`.
 The `&Handle`-at-wiring parameter then **disappears as a side effect** of that
 refactor — the two changes are one decision, not two.
 
+The `source_at_start` spike (#547) has already carved out the source half of
+this for the channel-fed path: `zmq_sub`'s I/O now runs in `start()`, so the
+engine already owns a "establish this adapter's I/O when the run begins" hook.
+Extending the same hook to the `produce_async` family is what lets the engine
+supply the handle at `start()` instead of the caller supplying it at wiring.
+
 ## Migration sketch
 
 1. `Runner` gains an optional runtime: `Option<tokio::runtime::Runtime>` created
    lazily on first async-adapter registration, plus an override slot for a
    caller `Handle`. Drop it at teardown.
 2. Expose the handle to adapters at `start()` — via the `start` hook signature
-   (or `Ctx`), alongside the `source_at_start` primitive from the lifecycle plan.
+   (or `Ctx`), reusing the **landed** `source_at_start` primitive (#547) that
+   already runs adapter setup in `start()`. `consume_async` sinks need the same
+   deferral, which is still outstanding.
 3. Drop the `&Handle` (and wiring-time `RunParams`) parameters from
    `produce_async` / `consume_async` and the async adapter factories; the async
    closures capture the engine-provided handle at `start()`.

--- a/next/docs/runtime-ownership.md
+++ b/next/docs/runtime-ownership.md
@@ -1,159 +1,71 @@
-# Async runtime ownership: caller-passed `&Handle` → Graph-owned with override
+# Async runtime ownership: the graph owns the tokio runtime (with override)
 
-Status: **implemented.** Tracks deviation **A5** in
+Status: **implemented** (decision record). Tracks deviation **A5** in
 [`deviation-register.md`](./deviation-register.md).
-
-> **Landed.** The recommendation below shipped: the `GraphBuilder` owns a
-> tokio runtime — created lazily on first async use, dropped at teardown — with
-> a caller override. The `&Handle` parameter is gone from every async adapter
-> factory and from `produce_async` / `produce_async_bounded` / `consume_async`.
->
-> **What shipped (and where it differs from the original plan below):**
-> - `GraphBuilder` carries an `AsyncRuntimeSlot` (executor-free core: it is an
->   opaque field until the `async` feature names the tokio types). On first
->   `async_runtime_handle()` call it lazily creates one `tokio::runtime::Runtime`
->   and caches its handle; every async adapter in the graph shares it.
-> - The runtime is **carried into the `Runner`** at `build()` and is the
->   `Runner`'s **last field**, so it is dropped only *after* the nodes — an
->   offloaded sink's teardown `block_on` still sees a live runtime.
-> - Override: `GraphBuilder::with_async_runtime(handle)` installs a caller
->   runtime; the graph then creates/owns nothing.
-> - **Decoupled from defer-to-start.** The plan framed runtime-ownership and
->   [defer-to-start](./source-lifecycle-defer-to-start.md) as "one decision."
->   In fact they separated cleanly: `produce_async` / `consume_async` still
->   spawn/connect at **wiring**, but now on the *graph's* runtime rather than a
->   caller-passed handle — so the ergonomic win landed without waiting for
->   defer-to-start. `zmq_sub` already defers via `source_at_start` (#547); when
->   the `produce_async` family follows, it will pull its handle from the engine
->   at `start()` instead of the builder at wiring, and the wiring-time
->   `RunParams` will fall away — but that is now a *further* refinement, not a
->   prerequisite.
->
-> The original proposal is kept below as the design record.
 
 ## The question
 
 Legacy wingfoil **owns** a tokio runtime (with an override to inject your own).
-wingfoil-next instead makes every async adapter take a caller-supplied
-`&tokio::runtime::Handle`. Which is right — and is next's change justified?
+Early wingfoil-next instead made every async adapter take a caller-supplied
+`&tokio::runtime::Handle`. Which is right?
 
-## Current state (what next does today)
+## The decision
 
-- `produce_async` / `produce_async_bounded` / `consume_async`
-  (`next/crates/wingfoil-next/src/async_source.rs`) take a
-  `&tokio::runtime::Handle` (sources also take `RunParams`). The async adapters
-  — etcd, redis, kafka, postgres, otlp — all thread that handle through their
-  factories, and each still **spawns/connects at wiring time**.
-- Each adapter documents this as deviation #1: *"The tokio runtime is the
-  caller's … classic hides a global runtime … next takes the `Handle`
-  explicitly."* The stated rationale is (a) no hidden global state, and (b)
-  **the producer task spawns at wiring time, so the factory needs a handle**.
-- **Exception since #547**: `zmq_sub` no longer spawns at wiring. It uses the
-  `source_at_start` primitive (`fluent.rs` / `interp.rs`) — the socket connect
-  and producer thread now run in `start()`, wiring stays pure. `zmq_sub` is
-  channel-fed, not `produce_async`-based, so it never took a `&Handle`; but it
-  is the proof that deferring I/O establishment to `start()` works in the
-  engine today, which is exactly the mechanism this plan relies on.
+Neither legacy's hidden *global* nor next's *handle-everywhere*, but the middle:
 
-## Analysis
+> **The `GraphBuilder` owns one tokio runtime** — created lazily when the first
+> async adapter asks for a handle, shared by every async adapter in the graph,
+> and dropped at teardown — **with an override** to inject a caller-supplied
+> `Handle`.
 
-**Sharing across adapters.** Both models can share one runtime; they differ in
-the *default*. Legacy's owned runtime shares across all adapters with zero
-caller effort. next's `&Handle` shares only if the caller threads the *same*
-handle to every adapter — and nothing stops a caller from standing up several.
-Sharing is a mild point *for* owned-by-default, not a reason to pass handles.
+This gives legacy's simple default API (no `&Handle` in the common call),
+automatic sharing across adapters, a clean **non-global** lifecycle (owned by
+the graph, not a `lazy_static`), and the override for embedding in a caller's
+async app or custom runtime.
 
-**API simplicity.** `etcd_sub(conn, prefix)` beats
-`etcd_sub(&g, &handle, params, conn)`. next pays this verbosity at every async
-call site; an owned-with-override runtime keeps the simple default and still
-allows the explicit case.
+## Why (the rationale the code encodes)
 
-**Is next's change justified?** The steelman is real but narrow:
-- *"Libraries shouldn't own runtimes"* is a genuine Rust design principle, and a
-  `lazy_static` global runtime is exactly the spooky global state next's engine
-  is built to avoid (never dropped cleanly, pollutes test isolation,
-  shutdown-ordering hazards). This is the one thing next was **right** to avoid.
-- Explicit-in-the-signature: the async dependency is visible in the type.
+- **Sharing.** Both models *can* share one runtime; they differ in the default.
+  An owned runtime shares across all adapters with zero caller effort; `&Handle`
+  shares only if the caller is disciplined enough to thread the *same* handle
+  everywhere. A mild point *for* owned-by-default.
+- **API simplicity.** `etcd_sub(&g, conn, prefix)` beats
+  `etcd_sub(&g, &handle, params, conn, prefix)` at every async call site; the
+  override keeps the explicit case available.
+- **What next was right to avoid** was a `lazy_static` **global** runtime —
+  spooky global state (never dropped cleanly, pollutes test isolation,
+  shutdown-ordering hazards). A graph-owned runtime keeps that win: it is owned,
+  scoped, and dropped deterministically, without leaking a global.
+- **The one real constraint** — next's `block_on` on the graph thread requires
+  the graph thread to be **non-async** — is satisfied identically by an owned
+  runtime (its workers are separate threads either way), so it never forced
+  caller-passed handles.
 
-But the concrete rationale next documents — *the wiring-time spawn needs a
-handle* — **dissolves under the defer-to-start change.** If adapters establish
-their I/O in `start()` rather than at wiring, the handle is needed at
-`start()` — which is the *engine's* moment, not the caller's. So the strongest
-reason for `&Handle`-at-wiring goes away exactly when we do the lifecycle work
-we already want.
+## What shipped
 
-**The one shared constraint.** next's `block_on`-on-the-graph-thread means the
-graph thread must be **non-async**. But an owned runtime satisfies this
-identically — its worker threads are separate from the graph thread either way.
-So this constraint does **not** force caller-passed handles.
+- `GraphBuilder`/`Runner` carry an executor-free `AsyncRuntimeSlot`
+  (`interp.rs`) — an opaque field until the `async` feature names the tokio
+  types. On the first `async_runtime_handle()` call it lazily creates one
+  `tokio::runtime::Runtime` (`GraphRuntime`, `async_source.rs`) and caches the
+  handle every async adapter then shares.
+- The runtime is moved into the `Runner` at `build()` and is the `Runner`'s
+  **last field**, so it is dropped only *after* the nodes — an offloaded sink's
+  teardown `block_on` still sees a live runtime.
+- Override: `GraphBuilder::with_async_runtime(handle)` installs a caller runtime
+  (the graph then owns nothing). Sink traits reach the runtime through
+  `Stream::graph()`.
+- `produce_async` / `produce_async_bounded` / `consume_async` and every async
+  adapter factory dropped their `&Handle`; the three primitives return `Result`
+  (the lazy `Runtime::new()` is the only fallible part).
 
-## Recommendation
+## Decoupled from defer-to-start
 
-Adopt neither legacy's hidden *global* nor next's *handle-everywhere*, but the
-middle that captures the best of both:
-
-> **The `Runner`/`Graph` owns a tokio runtime** — created lazily when the first
-> async adapter registers, dropped at teardown — **with an override** to inject
-> a caller-supplied `Handle`. Adapters receive the handle from the engine at
-> `start()`.
-
-This gives:
-- legacy's simple default API (no `&Handle` in the common call),
-- automatic sharing across adapters (they all get the graph's one runtime),
-- a **clean, non-global lifecycle** (owned by the runner, not a `lazy_static`) —
-  the real thing next was right to avoid,
-- and the override for embedding in a caller's async app / custom runtime config
-  / tests.
-
-## Coupling to defer-to-start (do them together)
-
-Once sources and sinks establish I/O in `start()` (the source-lifecycle plan),
-the engine simply hands each adapter its owned runtime's handle at `start()`.
-The `&Handle`-at-wiring parameter then **disappears as a side effect** of that
-refactor — the two changes are one decision, not two.
-
-The `source_at_start` spike (#547) has already carved out the source half of
-this for the channel-fed path: `zmq_sub`'s I/O now runs in `start()`, so the
-engine already owns a "establish this adapter's I/O when the run begins" hook.
-Extending the same hook to the `produce_async` family is what lets the engine
-supply the handle at `start()` instead of the caller supplying it at wiring.
-
-## Migration sketch
-
-1. `Runner` gains an optional runtime: `Option<tokio::runtime::Runtime>` created
-   lazily on first async-adapter registration, plus an override slot for a
-   caller `Handle`. Drop it at teardown.
-2. Expose the handle to adapters at `start()` — via the `start` hook signature
-   (or `Ctx`), reusing the **landed** `source_at_start` primitive (#547) that
-   already runs adapter setup in `start()`. `consume_async` sinks need the same
-   deferral, which is still outstanding.
-3. Drop the `&Handle` (and wiring-time `RunParams`) parameters from
-   `produce_async` / `consume_async` and the async adapter factories; the async
-   closures capture the engine-provided handle at `start()`.
-4. Override mechanism: `GraphBuilder::with_runtime(handle)` (or a `RunParams`
-   field) — keep passing a `Handle` available as the escape hatch, so nothing
-   is *lost* relative to today.
-5. Migrate the async adapters (etcd/redis/kafka/postgres/otlp) and their tests
-   (which today each construct a runtime and pass its handle).
-
-## Decisions to ratify
-
-- **Runner-owned vs `GraphBuilder`-owned** runtime (lifecycle boundary).
-- **Override surface** — a builder method vs a `RunParams` field.
-- Whether `&Handle` stays as the documented override (recommended: yes).
-- Confirm no interaction with **B1** (etcd_pub's `block_on` on the graph thread):
-  the owned runtime's workers are separate from the graph thread, so `block_on`
-  from the graph thread is fine — but verify no nested-runtime panic if the
-  caller drives the graph from inside their own runtime (that's the existing
-  "drive from a non-async thread" rule, unchanged).
-
-## Acceptance criteria
-
-- An async adapter can be wired **without** the caller passing a handle.
-- All async adapters in one graph share **one** runtime.
-- An override injects a caller-supplied `Handle` (embedding / custom config).
-- The runtime is dropped at teardown — no leaked worker threads across runs.
-- No nested-runtime panics; the "drive from a non-async thread" rule is the only
-  remaining constraint, documented as today.
-- All existing async-adapter parity/integration tests pass (rewritten to drop
-  the explicit handle where they now rely on the default).
+The original plan framed this as one decision with
+[defer-to-start](./source-lifecycle-defer-to-start.md). In practice they
+separated cleanly: `produce_async` / `consume_async` still spawn/connect at
+**wiring**, but now on the *graph's* runtime rather than a caller handle — so
+the ergonomic win landed without waiting for the lifecycle change. `zmq_sub`
+already defers via `source_at_start` (#547). When the `produce_async` family
+follows, it will pull its handle from the engine at `start()` rather than the
+builder at wiring, and the wiring-time `RunParams` will fall away — a *further*
+refinement on top of this, not a prerequisite for it.

--- a/next/docs/runtime-ownership.md
+++ b/next/docs/runtime-ownership.md
@@ -1,0 +1,119 @@
+# Async runtime ownership: caller-passed `&Handle` → Graph-owned with override
+
+Status: **proposal.** Coupled to
+[`source-lifecycle-defer-to-start.md`](./source-lifecycle-defer-to-start.md) —
+these two should be decided and executed together. Tracks deviation **A5** in
+[`deviation-register.md`](./deviation-register.md).
+
+## The question
+
+Legacy wingfoil **owns** a tokio runtime (with an override to inject your own).
+wingfoil-next instead makes every async adapter take a caller-supplied
+`&tokio::runtime::Handle`. Which is right — and is next's change justified?
+
+## Current state (what next does today)
+
+- `produce_async` / `produce_async_bounded` / `consume_async`
+  (`next/crates/wingfoil-next/src/async_source.rs`) take a
+  `&tokio::runtime::Handle` (sources also take `RunParams`). The async adapters
+  — etcd, redis, kafka, postgres, otlp — all thread that handle through their
+  factories.
+- Each adapter documents this as deviation #1: *"The tokio runtime is the
+  caller's … classic hides a global runtime … next takes the `Handle`
+  explicitly."* The stated rationale is (a) no hidden global state, and (b)
+  **the producer task spawns at wiring time, so the factory needs a handle**.
+
+## Analysis
+
+**Sharing across adapters.** Both models can share one runtime; they differ in
+the *default*. Legacy's owned runtime shares across all adapters with zero
+caller effort. next's `&Handle` shares only if the caller threads the *same*
+handle to every adapter — and nothing stops a caller from standing up several.
+Sharing is a mild point *for* owned-by-default, not a reason to pass handles.
+
+**API simplicity.** `etcd_sub(conn, prefix)` beats
+`etcd_sub(&g, &handle, params, conn)`. next pays this verbosity at every async
+call site; an owned-with-override runtime keeps the simple default and still
+allows the explicit case.
+
+**Is next's change justified?** The steelman is real but narrow:
+- *"Libraries shouldn't own runtimes"* is a genuine Rust design principle, and a
+  `lazy_static` global runtime is exactly the spooky global state next's engine
+  is built to avoid (never dropped cleanly, pollutes test isolation,
+  shutdown-ordering hazards). This is the one thing next was **right** to avoid.
+- Explicit-in-the-signature: the async dependency is visible in the type.
+
+But the concrete rationale next documents — *the wiring-time spawn needs a
+handle* — **dissolves under the defer-to-start change.** If adapters establish
+their I/O in `start()` rather than at wiring, the handle is needed at
+`start()` — which is the *engine's* moment, not the caller's. So the strongest
+reason for `&Handle`-at-wiring goes away exactly when we do the lifecycle work
+we already want.
+
+**The one shared constraint.** next's `block_on`-on-the-graph-thread means the
+graph thread must be **non-async**. But an owned runtime satisfies this
+identically — its worker threads are separate from the graph thread either way.
+So this constraint does **not** force caller-passed handles.
+
+## Recommendation
+
+Adopt neither legacy's hidden *global* nor next's *handle-everywhere*, but the
+middle that captures the best of both:
+
+> **The `Runner`/`Graph` owns a tokio runtime** — created lazily when the first
+> async adapter registers, dropped at teardown — **with an override** to inject
+> a caller-supplied `Handle`. Adapters receive the handle from the engine at
+> `start()`.
+
+This gives:
+- legacy's simple default API (no `&Handle` in the common call),
+- automatic sharing across adapters (they all get the graph's one runtime),
+- a **clean, non-global lifecycle** (owned by the runner, not a `lazy_static`) —
+  the real thing next was right to avoid,
+- and the override for embedding in a caller's async app / custom runtime config
+  / tests.
+
+## Coupling to defer-to-start (do them together)
+
+Once sources and sinks establish I/O in `start()` (the source-lifecycle plan),
+the engine simply hands each adapter its owned runtime's handle at `start()`.
+The `&Handle`-at-wiring parameter then **disappears as a side effect** of that
+refactor — the two changes are one decision, not two.
+
+## Migration sketch
+
+1. `Runner` gains an optional runtime: `Option<tokio::runtime::Runtime>` created
+   lazily on first async-adapter registration, plus an override slot for a
+   caller `Handle`. Drop it at teardown.
+2. Expose the handle to adapters at `start()` — via the `start` hook signature
+   (or `Ctx`), alongside the `source_at_start` primitive from the lifecycle plan.
+3. Drop the `&Handle` (and wiring-time `RunParams`) parameters from
+   `produce_async` / `consume_async` and the async adapter factories; the async
+   closures capture the engine-provided handle at `start()`.
+4. Override mechanism: `GraphBuilder::with_runtime(handle)` (or a `RunParams`
+   field) — keep passing a `Handle` available as the escape hatch, so nothing
+   is *lost* relative to today.
+5. Migrate the async adapters (etcd/redis/kafka/postgres/otlp) and their tests
+   (which today each construct a runtime and pass its handle).
+
+## Decisions to ratify
+
+- **Runner-owned vs `GraphBuilder`-owned** runtime (lifecycle boundary).
+- **Override surface** — a builder method vs a `RunParams` field.
+- Whether `&Handle` stays as the documented override (recommended: yes).
+- Confirm no interaction with **B1** (etcd_pub's `block_on` on the graph thread):
+  the owned runtime's workers are separate from the graph thread, so `block_on`
+  from the graph thread is fine — but verify no nested-runtime panic if the
+  caller drives the graph from inside their own runtime (that's the existing
+  "drive from a non-async thread" rule, unchanged).
+
+## Acceptance criteria
+
+- An async adapter can be wired **without** the caller passing a handle.
+- All async adapters in one graph share **one** runtime.
+- An override injects a caller-supplied `Handle` (embedding / custom config).
+- The runtime is dropped at teardown — no leaked worker threads across runs.
+- No nested-runtime panics; the "drive from a non-async thread" rule is the only
+  remaining constraint, documented as today.
+- All existing async-adapter parity/integration tests pass (rewritten to drop
+  the explicit handle where they now rely on the default).

--- a/next/docs/runtime-ownership.md
+++ b/next/docs/runtime-ownership.md
@@ -1,18 +1,35 @@
 # Async runtime ownership: caller-passed `&Handle` → Graph-owned with override
 
-Status: **proposal.** Coupled to
-[`source-lifecycle-defer-to-start.md`](./source-lifecycle-defer-to-start.md) —
-these two should be decided and executed together. Tracks deviation **A5** in
+Status: **implemented.** Tracks deviation **A5** in
 [`deviation-register.md`](./deviation-register.md).
 
-> **Update (spike landed):** the `source_at_start` primitive from the
-> lifecycle plan has since landed on `next` (PR #547) and `zmq_sub` now
-> establishes its socket + producer thread in `start()`. That directly
-> unblocks the runtime work below — the migration can build on the *landed*
-> primitive rather than a proposed one. The `produce_async` / `consume_async`
-> family (etcd/redis/kafka/postgres/otlp) still spawns at wiring and still
-> takes `&Handle`, so the analysis and recommendation are unchanged; only the
-> "current state" and "migration sketch" are updated to reflect the spike.
+> **Landed.** The recommendation below shipped: the `GraphBuilder` owns a
+> tokio runtime — created lazily on first async use, dropped at teardown — with
+> a caller override. The `&Handle` parameter is gone from every async adapter
+> factory and from `produce_async` / `produce_async_bounded` / `consume_async`.
+>
+> **What shipped (and where it differs from the original plan below):**
+> - `GraphBuilder` carries an `AsyncRuntimeSlot` (executor-free core: it is an
+>   opaque field until the `async` feature names the tokio types). On first
+>   `async_runtime_handle()` call it lazily creates one `tokio::runtime::Runtime`
+>   and caches its handle; every async adapter in the graph shares it.
+> - The runtime is **carried into the `Runner`** at `build()` and is the
+>   `Runner`'s **last field**, so it is dropped only *after* the nodes — an
+>   offloaded sink's teardown `block_on` still sees a live runtime.
+> - Override: `GraphBuilder::with_async_runtime(handle)` installs a caller
+>   runtime; the graph then creates/owns nothing.
+> - **Decoupled from defer-to-start.** The plan framed runtime-ownership and
+>   [defer-to-start](./source-lifecycle-defer-to-start.md) as "one decision."
+>   In fact they separated cleanly: `produce_async` / `consume_async` still
+>   spawn/connect at **wiring**, but now on the *graph's* runtime rather than a
+>   caller-passed handle — so the ergonomic win landed without waiting for
+>   defer-to-start. `zmq_sub` already defers via `source_at_start` (#547); when
+>   the `produce_async` family follows, it will pull its handle from the engine
+>   at `start()` instead of the builder at wiring, and the wiring-time
+>   `RunParams` will fall away — but that is now a *further* refinement, not a
+>   prerequisite.
+>
+> The original proposal is kept below as the design record.
 
 ## The question
 


### PR DESCRIPTION
Implements the runtime-ownership change (`next/docs/runtime-ownership.md`) and brings the `new-adapter-next` skill in line. Previously a design doc; now the design is **shipped**.

## Runtime ownership — implemented
The `GraphBuilder` now owns **one** tokio runtime — created lazily on first async use, carried into the `Runner`, and dropped at teardown — shared by every async adapter, replacing next's per-adapter caller-passed `&Handle` (and classic's never-dropped global). A caller override is available for embedding.

**Engine (`interp.rs`)** — an executor-free `AsyncRuntimeSlot` on `Builder`/`Runner` (tokio types only under `async`). It's moved into the `Runner` at `build()` and declared as the `Runner`'s **last field**, so it drops *after* the nodes — an offloaded sink's teardown `block_on` still sees a live runtime. Accessors `async_runtime_handle()` / `set_async_runtime_override()`.

**`async_source.rs`** — new `GraphRuntime` holder (override → cached lazy `Runtime::new()`). `produce_async` / `produce_async_bounded` / `consume_async` drop their `&Handle`, resolve the handle from the graph, and return `Result`.

**`fluent.rs`** — `GraphBuilder::async_runtime_handle()`, `with_async_runtime(handle)` (the override), and `Stream::graph()` (a builder view so sink traits can reach the runtime).

**5 adapters** (etcd/redis/kafka/postgres/otlp) — dropped `&Handle` from every source/sink factory and trait; resolve the handle from the graph internally (including the direct `handle.spawn` and wiring-time `block_on` connect sites). `otlp_push` now returns `Result`. Each adapter's "deviation #1" doc rewritten to *"the graph owns the tokio runtime"*.

**Decoupled from defer-to-start.** The design framed this as one decision with #544/#547; in practice it separated cleanly — `produce_async`/`consume_async` still spawn at wiring, but on the *graph's* runtime rather than a caller handle, so the ergonomic win landed now. When the `produce_async` family later defers to `start()` (building on the landed `source_at_start`, #547), it will pull the handle from the engine and the wiring-time `RunParams` falls away — a further refinement, not a prerequisite.

### API before / after
```rust
// before
let rt = tokio::runtime::Runtime::new()?;
let sub = etcd_sub(&g, rt.handle(), params, conn, prefix)?;
let sink = stream.kafka_pub(rt.handle(), brokers)?;

// after — graph owns the runtime; nothing to thread
let sub = etcd_sub(&g, params, conn, prefix)?;
let sink = stream.kafka_pub(brokers)?;

// embed in your own runtime (the override)
let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
```

### Validation
- `cargo clippy` clean across lib + tests + examples (async adapter features).
- Runnable tests green: `produce_async` (7, incl. a new caller-override test), `consume_async` (3), 34 lib unit tests, 21 adapter unit tests, doctests. Docker-gated `*_integration` tests compile clean (not run here).

## Skill updates (`.claude/commands/new-adapter-next.md`)
1. **"Feed lessons back into this skill"** — standing instruction to bake surfaced pitfalls/patterns/deviations into the skill (or the deviation register) in the same PR.
2. **The `dependency-review` gate** — flags a newly-added dep with a known advisory even when classic ships that version; prefer rolling the dep forward over an `allow-ghsas` allowlist. From the otlp/opentelemetry episode.
3. **Runtime ownership** — the async template + `produce_async`/`consume_async`/sink guidance rewritten to the **no-`&Handle`** convention (graph owns the runtime; `self.graph()` from sink traits; `with_async_runtime` override).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEQvysabaSKTnYyQDgPDTt)_