### PR TITLE
Add custom_node primitive and Python bindings for user-driven graph nodes

### DIFF
--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -28,9 +28,9 @@ use std::time::Duration;
 use anyhow::Result;
 use pyo3::prelude::*;
 use wingfoil::{RunFor, RunMode};
-use wingfoil_next::interp::{Builder, Runner};
+use wingfoil_next::interp::{Builder, Runner, SlotRef};
 use wingfoil_next::op::{Activation, Ctx, Tick};
-use wingfoil_next::prelude::{GraphBuilder, SourceOps, Stream, StreamOps};
+use wingfoil_next::prelude::{GraphBuilder, SourceOps, Stream, StreamOps, Upstream};
 
 use crate::PyElement;
 
@@ -90,6 +90,72 @@ impl PyGraph {
         slot.as_mut()
             .expect("runner set above")
             .run(run_mode, run_for)
+    }
+
+    /// Wire a **Python-defined custom node** — a Python object acting as a graph
+    /// node, the object-form twin of the classic `CustomStream`
+    /// (`MutableNode` + `StreamPeekRef`). This is the erased-boundary use of
+    /// [`GraphBuilder::custom_node`]: the node is activated by its `upstreams`'
+    /// ticks and, each activation, calls the Python object's protocol:
+    ///
+    /// - `cycle(values) -> bool` — invoked with the list of upstream current
+    ///   values; returns whether the node ticked this cycle (the classic
+    ///   `cycle() -> bool` decision). A not-yet-ticked upstream reads as Python
+    ///   `None`.
+    /// - `peek() -> value` — read only when `cycle` returned `True`, producing
+    ///   the node's output value.
+    ///
+    /// Upstream values are read from their value slots captured at wiring time,
+    /// so a custom node sees its inputs **without** re-entering the running
+    /// graph (the runner is mutably borrowed for the duration of a run, so a
+    /// Python `cycle` cannot read a sibling `PyStream.value()` — the values are
+    /// handed in instead). A raised exception aborts the run with context.
+    ///
+    /// A graph containing a custom node is single-run (caller-owned Python state
+    /// has no engine reset hook — see [`GraphBuilder::custom_node`]).
+    pub fn custom_node(&self, upstreams: Vec<PyStream>, obj: Py<PyAny>) -> PyStream {
+        // Capture each upstream's value slot at wiring time. Reading these
+        // during a cycle touches only the slot cells, never the runner, so a
+        // Python custom node reads its inputs with no re-entrancy hazard.
+        let slots: Vec<SlotRef<PyElement>> =
+            upstreams.iter().map(|s| s.stream.value_slot()).collect();
+        let active: Vec<Upstream> = upstreams.iter().map(|s| s.stream.upstream()).collect();
+        let stream = self.builder.custom_node::<PyElement, _>(
+            &active,
+            &[],
+            Activation::NONE,
+            move |_ctx: &mut Ctx<'_>| {
+                Python::attach(|py| {
+                    let values: Vec<Py<PyAny>> = slots
+                        .iter()
+                        .map(|slot| {
+                            let element = slot.borrow();
+                            if element.is_none() {
+                                py.None()
+                            } else {
+                                element.object().clone_ref(py)
+                            }
+                        })
+                        .collect();
+                    let ticked: bool = obj
+                        .call_method1(py, "cycle", (values,))
+                        .map_err(|err| anyhow::anyhow!("Python custom node cycle raised: {err}"))?
+                        .extract(py)
+                        .map_err(|err| {
+                            anyhow::anyhow!("Python custom node cycle must return bool: {err}")
+                        })?;
+                    if ticked {
+                        let value = obj.call_method0(py, "peek").map_err(|err| {
+                            anyhow::anyhow!("Python custom node peek raised: {err}")
+                        })?;
+                        Ok(Tick::Value(PyElement::new(value)))
+                    } else {
+                        Ok(Tick::Quiet)
+                    }
+                })
+            },
+        );
+        self.wrap(stream)
     }
 }
 
@@ -225,6 +291,18 @@ mod tests {
         })
     }
 
+    /// Execute `src` (which must bind a name `obj`) and return that object —
+    /// used to build a Python custom-node object with `cycle`/`peek` methods.
+    fn py_object(src: &str) -> Py<PyAny> {
+        use pyo3::types::PyDict;
+        Python::attach(|py| {
+            let globals = PyDict::new(py);
+            py.run(&std::ffi::CString::new(src).unwrap(), Some(&globals), None)
+                .unwrap();
+            globals.get_item("obj").unwrap().unwrap().unbind()
+        })
+    }
+
     fn run_cycles(g: &PyGraph, n: u32) {
         g.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(n))
             .unwrap();
@@ -299,6 +377,81 @@ mod tests {
             .unwrap_err();
         assert!(format!("{err:#}").contains("Python map callable raised"));
         let _ = out;
+    }
+
+    /// A Python object acting as a graph node: sums its two upstream counters
+    /// each cycle. Exercises the `cycle(values) -> bool` + `peek()` protocol and
+    /// that upstream values are handed in correctly.
+    #[test]
+    fn python_custom_node_sums_upstreams() {
+        let g = PyGraph::new();
+        let a = g.counter(Duration::from_nanos(100));
+        let b = g.counter(Duration::from_nanos(100));
+        let adder = py_object(
+            "class Adder:\n\
+            \x20   def __init__(self): self.total = 0\n\
+            \x20   def cycle(self, values): self.total = sum(values); return True\n\
+            \x20   def peek(self): return self.total\n\
+            obj = Adder()",
+        );
+        let summed = g.custom_node(vec![a, b], adder);
+
+        let seen = Rc::new(RefCell::new(Vec::<i64>::new()));
+        let sink = seen.clone();
+        let _observed = summed.stream.inspect(move |e: &PyElement| {
+            sink.borrow_mut().push(i64::try_from(e).unwrap());
+        });
+
+        run_cycles(&g, 3);
+        // Both counters tick together: 1+1, 2+2, 3+3.
+        assert_eq!(vec![2, 4, 6], *seen.borrow());
+    }
+
+    /// A custom node returning `False` from `cycle` stays quiet that cycle —
+    /// the classic "did I tick?" decision. Emits only on even counter values.
+    #[test]
+    fn python_custom_node_can_stay_quiet() {
+        let g = PyGraph::new();
+        let counter = g.counter(Duration::from_nanos(100));
+        let evens = py_object(
+            "class Evens:\n\
+            \x20   def __init__(self): self.v = 0\n\
+            \x20   def cycle(self, values):\n\
+            \x20       self.v = values[0]\n\
+            \x20       return self.v % 2 == 0\n\
+            \x20   def peek(self): return self.v\n\
+            obj = Evens()",
+        );
+        let filtered = g.custom_node(vec![counter], evens);
+
+        let seen = Rc::new(RefCell::new(Vec::<i64>::new()));
+        let sink = seen.clone();
+        let _observed = filtered.stream.inspect(move |e: &PyElement| {
+            sink.borrow_mut().push(i64::try_from(e).unwrap());
+        });
+
+        run_cycles(&g, 6);
+        assert_eq!(vec![2, 4, 6], *seen.borrow());
+    }
+
+    /// An exception raised inside a Python custom node's `cycle` aborts the run
+    /// with context, like a raising `map` callable.
+    #[test]
+    fn python_custom_node_error_aborts_run() {
+        let g = PyGraph::new();
+        let counter = g.counter(Duration::from_nanos(100));
+        let boom = py_object(
+            "class Boom:\n\
+            \x20   def cycle(self, values): raise ValueError('boom')\n\
+            \x20   def peek(self): return 0\n\
+            obj = Boom()",
+        );
+        let node = g.custom_node(vec![counter], boom);
+        let err = g
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("Python custom node cycle raised"));
+        let _ = node;
     }
 
     #[test]

--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -214,6 +214,57 @@ impl PyStream {
         self.wrap(self.stream.distinct())
     }
 
+    /// Emit the running tick count `1, 2, 3, …` (as an integer [`PyElement`]),
+    /// ignoring the values themselves.
+    pub fn count(&self) -> PyStream {
+        let counted = self.stream.map(|_: &PyElement| ()).count();
+        self.wrap(counted.map(|n: &u64| PyElement::from(*n as i64)))
+    }
+
+    /// Pass through the first `limit` values, then stay quiet.
+    pub fn limit(&self, limit: u32) -> PyStream {
+        self.wrap(self.stream.limit(limit))
+    }
+
+    /// Rate-limit: emit at most once per `interval`.
+    pub fn throttle(&self, interval: Duration) -> PyStream {
+        self.wrap(self.stream.throttle(interval))
+    }
+
+    /// Emit this stream's current value whenever `trigger` ticks (a passive
+    /// read of the value; `trigger`'s own value is ignored).
+    pub fn sample(&self, trigger: &PyStream) -> PyStream {
+        let unit = trigger.stream.map(|_: &PyElement| ());
+        self.wrap(self.stream.sample(&unit))
+    }
+
+    /// Emit the successive difference `value - previous` (quiet on the first
+    /// value). Uses [`PyElement`]'s `Sub`, i.e. Python `__sub__`.
+    pub fn difference(&self) -> PyStream {
+        self.wrap(self.stream.difference())
+    }
+
+    /// Negate each value with [`PyElement`]'s `Not`, which maps to Python
+    /// `__neg__` (arithmetic negation, e.g. `5 -> -5`) — matching the classic
+    /// `not` node's `T: Not` semantics. Named `not` on the Python side.
+    pub fn not_(&self) -> PyStream {
+        self.wrap(self.stream.not())
+    }
+
+    /// Observe each value with a Python callable, passing it through unchanged
+    /// (a debug tap). Routed through [`try_map`](StreamOps::try_map) so a raised
+    /// exception aborts the run with context rather than panicking.
+    pub fn inspect(&self, func: Py<PyAny>) -> PyStream {
+        let observed = self.stream.try_map(move |e: &PyElement| {
+            Python::attach(|py| {
+                func.call1(py, (e.value(),))
+                    .map_err(|err| anyhow::anyhow!("Python inspect callable raised: {err}"))?;
+                Ok(e.clone())
+            })
+        });
+        self.wrap(observed)
+    }
+
     /// Wire a **single-input op** onto this stream at the erased boundary — the
     /// extensibility primitive third-party ops (and the `pyop!` macro) build
     /// on. The op computes on its own concrete types: the input is extracted
@@ -317,6 +368,72 @@ mod tests {
         run_cycles(&g, 1);
         let v: f64 = (&out.value()).try_into().unwrap();
         assert_eq!(16.0, v);
+    }
+
+    #[test]
+    fn count_ignores_values() {
+        let g = PyGraph::new();
+        // Values are strings; count only counts ticks.
+        let counted = g
+            .counter(Duration::from_nanos(100))
+            .map(lambda("lambda n: 'x'"))
+            .count();
+        run_cycles(&g, 3);
+        let v: i64 = (&counted.value()).try_into().unwrap();
+        assert_eq!(3, v);
+    }
+
+    #[test]
+    fn limit_caps_ticks() {
+        let g = PyGraph::new();
+        let capped = g.counter(Duration::from_nanos(100)).limit(2);
+        run_cycles(&g, 5);
+        // The value stays at the last value passed before the cap.
+        let v: i64 = (&capped.value()).try_into().unwrap();
+        assert_eq!(2, v);
+    }
+
+    #[test]
+    fn difference_of_counter_is_one() {
+        let g = PyGraph::new();
+        let diff = g.counter(Duration::from_nanos(100)).difference();
+        run_cycles(&g, 4);
+        let v: i64 = (&diff.value()).try_into().unwrap();
+        assert_eq!(1, v); // 1,2,3,4 -> deltas 1,1,1
+    }
+
+    #[test]
+    fn not_negates_value() {
+        let g = PyGraph::new();
+        // `not` maps to __neg__ (arithmetic negation), matching the classic node.
+        let negated = g.constant(PyElement::from(5_i64)).not_();
+        run_cycles(&g, 1);
+        let v: i64 = (&negated.value()).try_into().unwrap();
+        assert_eq!(-5, v);
+    }
+
+    #[test]
+    fn inspect_taps_and_passes_through() {
+        let g = PyGraph::new();
+        let tapped = g
+            .counter(Duration::from_nanos(100))
+            .inspect(lambda("lambda v: None"));
+        run_cycles(&g, 3);
+        // Passes the value through unchanged.
+        let v: i64 = (&tapped.value()).try_into().unwrap();
+        assert_eq!(3, v);
+    }
+
+    #[test]
+    fn inspect_exception_aborts_run() {
+        let g = PyGraph::new();
+        let _tapped = g.counter(Duration::from_nanos(100)).inspect(lambda(
+            "lambda v: (_ for _ in ()).throw(ValueError('boom'))",
+        ));
+        let err = g
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("Python inspect callable raised"));
     }
 
     #[test]

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -134,6 +134,44 @@ impl Stream {
         Stream(self.0.distinct())
     }
 
+    /// Emit the running tick count `1, 2, 3, …`, ignoring the values.
+    fn count(&self) -> Stream {
+        Stream(self.0.count())
+    }
+
+    /// Pass through the first `limit` values, then stay quiet.
+    fn limit(&self, limit: u32) -> Stream {
+        Stream(self.0.limit(limit))
+    }
+
+    /// Rate-limit: emit at most once per `interval_nanos` nanoseconds.
+    fn throttle(&self, interval_nanos: u64) -> Stream {
+        Stream(self.0.throttle(Duration::from_nanos(interval_nanos)))
+    }
+
+    /// Emit this stream's current value whenever `trigger` ticks.
+    fn sample(&self, trigger: PyRef<'_, Stream>) -> Stream {
+        Stream(self.0.sample(&trigger.0))
+    }
+
+    /// Emit the successive difference `value - previous` (quiet on the first).
+    fn difference(&self) -> Stream {
+        Stream(self.0.difference())
+    }
+
+    /// Negate each value (arithmetic `__neg__`, e.g. `5 -> -5`). Exposed as
+    /// `not` (a Python keyword, so reach it with `getattr(stream, "not")()`).
+    #[pyo3(name = "not")]
+    fn not_(&self) -> Stream {
+        Stream(self.0.not_())
+    }
+
+    /// Observe each value with a Python callable, passing it through unchanged;
+    /// a raised exception aborts the run.
+    fn inspect(&self, func: Py<PyAny>) -> Stream {
+        Stream(self.0.inspect(func))
+    }
+
     /// The current value after the owning [`Graph`] has run.
     fn value(&self) -> Py<PyAny> {
         self.0.value().value()

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -75,6 +75,16 @@ impl Graph {
         };
         self.0.run(run_mode, run_for).map_err(to_pyerr)
     }
+
+    /// Wire a Python object as a graph node. The object is activated by its
+    /// `upstreams`' ticks and each cycle must implement the protocol
+    /// `cycle(values) -> bool` (given the upstreams' current values, return
+    /// whether it ticked) and `peek()` (its output value when it ticked). A
+    /// raised exception aborts the run. See [`PyGraph::custom_node`].
+    fn custom_node(&self, upstreams: Vec<PyRef<'_, Stream>>, obj: Py<PyAny>) -> Stream {
+        let ups: Vec<PyStream> = upstreams.iter().map(|s| s.0.clone()).collect();
+        Stream(self.0.custom_node(ups, obj))
+    }
 }
 
 /// A stream in a [`Graph`]. Combinators return new streams on the same graph;

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -156,3 +156,68 @@ def test_custom_node_exception_aborts_run():
     g.custom_node([g.counter(period_nanos=100)], Boom())
     with pytest.raises(RuntimeError, match="Python custom node cycle raised"):
         g.run(cycles=1)
+
+
+def test_count_ignores_values():
+    g = wf.Graph()
+    out = g.counter(period_nanos=100).map(lambda n: "x").count()
+    g.run(cycles=3)
+    assert out.value() == 3
+
+
+def test_limit_caps_ticks():
+    g = wf.Graph()
+    out = g.counter(period_nanos=100).limit(2)
+    g.run(cycles=5)
+    assert out.value() == 2  # last value passed before the cap
+
+
+def test_difference_of_counter_is_one():
+    g = wf.Graph()
+    out = g.counter(period_nanos=100).difference()
+    g.run(cycles=4)
+    assert out.value() == 1  # 1,2,3,4 -> deltas 1,1,1
+
+
+def test_not_negates_value():
+    # `not` is arithmetic negation (__neg__) and is a Python keyword.
+    g = wf.Graph()
+    out = getattr(g.constant(5), "not")()
+    g.run(cycles=1)
+    assert out.value() == -5
+
+
+def test_sample_emits_held_value_on_trigger():
+    # A constant (ticks once) sampled on every counter tick re-emits its value.
+    g = wf.Graph()
+    held = g.constant(42)
+    out = held.sample(g.counter(period_nanos=100))
+    g.run(cycles=3)
+    assert out.value() == 42
+
+
+def test_throttle_rate_limits():
+    # counter ticks 1..9 at 100..900; throttle(250) emits at 100, 400, 700.
+    g = wf.Graph()
+    out = g.counter(period_nanos=100).throttle(250)
+    g.run(cycles=9)
+    assert out.value() == 7  # last emission at t=700
+
+
+def test_inspect_taps_and_passes_through():
+    seen = []
+    g = wf.Graph()
+    out = g.counter(period_nanos=100).inspect(seen.append)
+    g.run(cycles=3)
+    assert seen == [1, 2, 3]
+    assert out.value() == 3
+
+
+def test_inspect_exception_aborts_run():
+    def boom(v):
+        raise ValueError("boom")
+
+    g = wf.Graph()
+    g.counter(period_nanos=100).inspect(boom)
+    with pytest.raises(RuntimeError, match="Python inspect callable raised"):
+        g.run(cycles=1)

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -101,3 +101,58 @@ def test_pyop_and_pyop_fn_compose():
     out = wf.scale(wf.square(g.counter(period_nanos=100)), 2.0)
     g.run(cycles=3)  # 3rd tick: 3^2 * 2
     assert out.value() == 18.0
+
+
+def test_custom_node_python_object_as_graph_node():
+    # A Python object acting as a graph node (the classic CustomStream shape):
+    # sum two upstream counters each cycle via the cycle(values)/peek protocol.
+    class Adder:
+        def __init__(self):
+            self.total = 0
+
+        def cycle(self, values):
+            self.total = sum(values)
+            return True
+
+        def peek(self):
+            return self.total
+
+    g = wf.Graph()
+    a = g.counter(period_nanos=100)
+    b = g.counter(period_nanos=100)
+    summed = g.custom_node([a, b], Adder())
+    g.run(cycles=3)
+    assert summed.value() == 6  # 3rd tick: 3 + 3
+
+
+def test_custom_node_can_stay_quiet():
+    # Returning False from cycle suppresses the tick (classic "did I tick?").
+    class Evens:
+        def __init__(self):
+            self.v = 0
+
+        def cycle(self, values):
+            self.v = values[0]
+            return self.v % 2 == 0
+
+        def peek(self):
+            return self.v
+
+    g = wf.Graph()
+    evens = g.custom_node([g.counter(period_nanos=100)], Evens())
+    g.run(cycles=6)
+    assert evens.value() == 6  # last even value passed through
+
+
+def test_custom_node_exception_aborts_run():
+    class Boom:
+        def cycle(self, values):
+            raise ValueError("boom")
+
+        def peek(self):
+            return 0
+
+    g = wf.Graph()
+    g.custom_node([g.counter(period_nanos=100)], Boom())
+    with pytest.raises(RuntimeError, match="Python custom node cycle raised"):
+        g.run(cycles=1)

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -32,6 +32,7 @@ use wingfoil::NanoTime;
 use crate::Burst;
 use crate::channel::ChannelSender;
 use crate::interp::{AsHandle, Builder, ExternalSource, FeedbackSink, Handle, Runner, SlotRef};
+use crate::op::{Activation, Ctx, Tick};
 
 /// A graph under construction. Cheap to clone; all clones share the same
 /// underlying builder.
@@ -150,6 +151,40 @@ impl GraphBuilder {
     pub fn combine<T: Clone + Default + 'static>(&self, streams: &[Stream<T>]) -> Stream<Burst<T>> {
         let handles: Vec<Handle<T>> = streams.iter().map(|s| s.handle()).collect();
         let handle = self.with_builder(|b| b.combine(&handles));
+        self.wrap(handle)
+    }
+
+    /// Wire a **custom node** — the public extension point for a caller-driven
+    /// graph node (the next equivalent of classic `MutableNode` +
+    /// `StreamPeekRef`). The node is activated by its `active` upstreams' ticks,
+    /// reads any upstream's `passive` value without being triggered by it, and
+    /// runs `cycle` each activation to produce a [`Tick<T>`].
+    ///
+    /// Upstreams are declared type-erased ([`Upstream`]), so inputs of different
+    /// value types mix freely — only their node indices matter for dispatch. To
+    /// read an upstream's value inside `cycle`, capture its
+    /// [`SlotRef`](crate::interp::SlotRef) via [`Stream::value_slot`] at wiring
+    /// time and `borrow()` it. `activation` declares scheduling behaviour
+    /// ([`Activation::NONE`] for tick-driven, [`Activation::SCHEDULES`] for
+    /// self-scheduling via [`Ctx::schedule`], …).
+    ///
+    /// A graph containing a custom node is single-run in v1 (caller-owned state
+    /// has no engine reset hook — see [`Builder::custom_node`]).
+    pub fn custom_node<T, F>(
+        &self,
+        active: &[Upstream],
+        passive: &[Upstream],
+        activation: Activation,
+        cycle: F,
+    ) -> Stream<T>
+    where
+        T: Clone + Default + 'static,
+        F: FnMut(&mut Ctx<'_>) -> Result<Tick<T>> + 'static,
+    {
+        let active_ups: Vec<usize> = active.iter().map(|u| u.idx).collect();
+        let passive_ups: Vec<usize> = passive.iter().map(|u| u.idx).collect();
+        let handle =
+            self.with_builder(|b| b.custom_node(active_ups, passive_ups, activation, cycle));
         self.wrap(handle)
     }
 
@@ -349,6 +384,47 @@ impl<T> Stream<T> {
         T: 'static,
     {
         self.inner.borrow().slot(self.handle)
+    }
+
+    /// The value slot backing this stream, for reading its current value from
+    /// inside a [`custom_node`](GraphBuilder::custom_node) cycle closure.
+    ///
+    /// Capture the returned [`SlotRef`] at wiring time and `borrow()` it each
+    /// cycle to read the upstream's current value — this is how a custom node
+    /// reaches its upstreams, the next analogue of a classic `MutableNode`
+    /// reading the `Rc<dyn Stream>`s it holds. The scheduler's single-fire,
+    /// layer-ordered dispatch guarantees the upstream has already written its
+    /// slot this cycle before the custom node reads it.
+    pub fn value_slot(&self) -> SlotRef<T>
+    where
+        T: 'static,
+    {
+        self.inner.borrow().slot(self.handle)
+    }
+
+    /// Erase this stream to an [`Upstream`] edge for
+    /// [`custom_node`](GraphBuilder::custom_node). A custom node's upstreams may
+    /// have different value types, so they are declared type-erased; only the
+    /// node index matters for dispatch.
+    pub fn upstream(&self) -> Upstream {
+        Upstream {
+            idx: self.handle.index(),
+        }
+    }
+}
+
+/// A type-erased reference to an already-wired node, used to declare a
+/// [`custom_node`](GraphBuilder::custom_node)'s upstream edges regardless of
+/// the upstreams' value types (only the node index matters for scheduling).
+/// Build one with [`Stream::upstream`] or the `From<&Stream<T>>` impl.
+#[derive(Clone, Copy)]
+pub struct Upstream {
+    idx: usize,
+}
+
+impl<T> From<&Stream<T>> for Upstream {
+    fn from(stream: &Stream<T>) -> Self {
+        stream.upstream()
     }
 }
 

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -2009,6 +2009,75 @@ impl Builder {
         self.make_handle(idx)
     }
 
+    /// Register a **custom node** — the public, general-purpose extension point
+    /// for a caller-driven graph node, the next equivalent of classic
+    /// `MutableNode` + `StreamPeekRef`. Where [`register_op1`](Self::register_op1)
+    /// / [`register_op2`](Self::register_op2) fix the arity (1 or 2 active
+    /// inputs) and own the op's state, `custom_node` declares an *arbitrary* set
+    /// of active and passive upstream edges (by node index, so upstreams of any
+    /// value type mix freely — only the indices matter for dispatch) and lets
+    /// the `cycle` closure own whatever state it needs.
+    ///
+    /// The closure produces a [`Tick<T>`] each activation; the engine writes it
+    /// into this node's output slot exactly as the op registrations do
+    /// (`Value` ⇒ tick, `Silent` ⇒ update the value slot without ticking,
+    /// `Quiet` ⇒ nothing). To *read* an upstream's current value, capture its
+    /// [`SlotRef`] at wiring time (via
+    /// [`Stream::value_slot`](crate::fluent::Stream::value_slot)) and
+    /// `borrow()` it inside the closure — the engine never delivers inputs
+    /// through [`Ctx`], which stays narrowed to time + self-scheduling. This
+    /// mirrors classic, where a `MutableNode` reaches its upstreams through the
+    /// `Rc<dyn Stream>`s it holds.
+    ///
+    /// `activation` declares scheduling behaviour ([`Activation::NONE`] for a
+    /// node driven purely by upstream ticks, [`Activation::SCHEDULES`] for one
+    /// that self-schedules via [`Ctx::schedule`], etc.).
+    ///
+    /// **Single-run (v1):** a custom node's state is caller-owned with no engine
+    /// `reset` hook, so — like a mounted island — a graph containing one is
+    /// single-run; a second [`Runner::run`] errors rather than silently
+    /// continuing stale state.
+    pub fn custom_node<T, F>(
+        &mut self,
+        active_ups: Vec<usize>,
+        passive_ups: Vec<usize>,
+        activation: Activation,
+        mut cycle: F,
+    ) -> Handle<T>
+    where
+        T: Clone + Default + 'static,
+        F: FnMut(&mut Ctx<'_>) -> Result<Tick<T>> + 'static,
+    {
+        let idx = self.nodes.len();
+        let out = self.new_slot(T::default());
+        // Caller-owned state has no engine reset hook, so a graph with a custom
+        // node is single-run — the same contract as a mounted island (see the
+        // re-run note in the port plan).
+        self.re_runnable = false;
+        self.push_node(
+            active_ups,
+            activation,
+            "custom",
+            Box::new(move |k| {
+                let mut ctx = Ctx::new(k, idx);
+                match cycle(&mut ctx)? {
+                    Tick::Value(v) => {
+                        *out.borrow_mut() = v;
+                        Ok(true)
+                    }
+                    Tick::Silent(v) => {
+                        *out.borrow_mut() = v;
+                        Ok(false)
+                    }
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        self.set_passive_ups(idx, passive_ups);
+        self.make_handle(idx)
+    }
+
     pub(crate) fn ticked_rc(&self) -> Rc<RefCell<Vec<bool>>> {
         self.ticked.clone()
     }

--- a/next/crates/wingfoil-next/src/lib.rs
+++ b/next/crates/wingfoil-next/src/lib.rs
@@ -92,7 +92,8 @@ pub mod stats;
 /// without naming each trait. Adapter-specific op traits stay opt-in — pull
 /// them in alongside, e.g. `use wingfoil_next::stats::StatisticsOps;`.
 pub mod prelude {
-    pub use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps};
+    pub use crate::fluent::{GraphBuilder, SourceOps, Stream, StreamOps, Upstream};
+    pub use crate::op::{Activation, Ctx, Tick};
     pub use crate::{Burst, burst};
 }
 

--- a/next/crates/wingfoil-next/tests/custom_node.rs
+++ b/next/crates/wingfoil-next/tests/custom_node.rs
@@ -1,0 +1,159 @@
+//! Parity tests for the public custom-node primitive
+//! ([`GraphBuilder::custom_node`]) — the next equivalent of classic
+//! `MutableNode` + `StreamPeekRef`, and the extension point the wingfoil-python
+//! `PyProxyStream` (a Python object acting as a graph node) is rewired onto.
+//!
+//! A custom node declares arbitrary active/passive upstream edges and a cycle
+//! closure producing a [`Tick`]. These tests assert it reproduces the
+//! observable behaviour (values **and** tick times) of the equivalent
+//! combinator graph — `map`, `map_filter`, and `sample` — so the primitive is
+//! a faithful twin of the classic node path it replaces.
+
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// A custom node reading its active upstream reproduces `map`, tick-for-tick.
+/// It reads the upstream value through a [`Stream::value_slot`] captured at
+/// wiring time — the next analogue of a classic `MutableNode` reaching its
+/// upstream `Rc<dyn Stream>`. Asserts values *and* tick times against a `map`
+/// twin wired into the same graph.
+#[test]
+fn custom_node_reading_upstream_matches_map() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count(); // 1,2,3,4
+
+    // Reference: the same transform expressed as a `map`.
+    let reference = count.map(|i| i * 10).with_time().accumulate();
+
+    // Custom node doing the same, reading the upstream slot itself.
+    let src = count.value_slot();
+    let custom: Stream<u64> =
+        g.custom_node(&[count.upstream()], &[], Activation::NONE, move |_ctx| {
+            Ok(Tick::Value(*src.borrow() * 10))
+        });
+    let got = custom.with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+
+    // Same values at the same tick times as the `map` twin.
+    assert_eq!(r.value(&reference), r.value(&got));
+}
+
+/// A custom node returning `Tick::Quiet` on some cycles suppresses the tick —
+/// the classic `cycle() -> bool` "did I tick?" shape the Python proxy uses.
+/// Reproduces `map_filter` keeping only even counts.
+#[test]
+fn custom_node_quiet_suppresses_tick_like_map_filter() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count(); // 1..=6
+
+    let reference = count
+        .map_filter(|i| (*i, i.is_multiple_of(2)))
+        .with_time()
+        .accumulate();
+
+    let src = count.value_slot();
+    let evens: Stream<u64> = g.custom_node(&[count.upstream()], &[], Activation::NONE, move |_| {
+        let v = *src.borrow();
+        Ok(if v.is_multiple_of(2) {
+            Tick::Value(v)
+        } else {
+            Tick::Quiet
+        })
+    });
+    let got = evens.with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+
+    assert_eq!(vec![2, 4, 6], evens_values(&r, &got));
+    assert_eq!(r.value(&reference), r.value(&got));
+}
+
+/// A custom node active on a slow trigger but *passively* reading a fast
+/// counter reproduces `sample`: the passive upstream is read at the active
+/// upstream's instants without triggering the node itself.
+#[test]
+fn custom_node_passive_upstream_matches_sample() {
+    let g = GraphBuilder::new();
+    let fast = g.ticker(Duration::from_nanos(10)).count(); // 1,2,3,... every 10ns
+    let slow = g.ticker(Duration::from_nanos(30)); // unit trigger every 30ns
+
+    // Reference: sample the fast counter on the slow trigger.
+    let reference = fast.sample(&slow).with_time().accumulate();
+
+    // Custom node: active on `slow`, passively reads `fast`'s current value.
+    let fast_slot = fast.value_slot();
+    let sampled: Stream<u64> = g.custom_node(
+        &[slow.upstream()],
+        &[fast.upstream()],
+        Activation::NONE,
+        move |_| Ok(Tick::Value(*fast_slot.borrow())),
+    );
+    let got = sampled.with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(9)).unwrap();
+
+    assert_eq!(r.value(&reference), r.value(&got));
+}
+
+/// A custom node may own arbitrary external state (as the Python proxy owns its
+/// Python object) rather than reading engine slots — here an accumulator held
+/// in a captured `Rc<RefCell>`, reproducing `fold`.
+#[test]
+fn custom_node_with_owned_state_matches_fold() {
+    use std::cell::RefCell;
+
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count(); // 1,2,3,4
+
+    let reference = count.fold(0u64, |acc, v| *acc += v).accumulate();
+
+    let src = count.value_slot();
+    let running = Rc::new(RefCell::new(0u64));
+    let sum: Stream<u64> = g.custom_node(&[count.upstream()], &[], Activation::NONE, move |_| {
+        let mut total = running.borrow_mut();
+        *total += *src.borrow();
+        Ok(Tick::Value(*total))
+    });
+    let got = sum.accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+
+    assert_eq!(vec![1, 3, 6, 10], r.value(&got));
+    assert_eq!(r.value(&reference), r.value(&got));
+}
+
+/// A graph containing a custom node is single-run in v1 (caller-owned state has
+/// no engine reset hook) — a second `run` errors rather than continuing stale
+/// state, the same contract as a mounted island / external source.
+#[test]
+fn custom_node_graph_is_single_run() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count();
+    let src = count.value_slot();
+    let c: Stream<u64> = g.custom_node(&[count.upstream()], &[], Activation::NONE, move |_| {
+        Ok(Tick::Value(*src.borrow()))
+    });
+    let _acc = c.accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert!(
+        r.run(HISTORICAL, RunFor::Cycles(3)).is_err(),
+        "a graph with a custom node must reject a second run"
+    );
+}
+
+/// Project the `u64` values out of a `Vec<(NanoTime, u64)>` accumulator.
+fn evens_values(r: &wingfoil_next::interp::Runner, s: &Stream<Vec<(NanoTime, u64)>>) -> Vec<u64> {
+    r.value(s).into_iter().map(|(_, v)| v).collect()
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -21,8 +21,11 @@ until cutover, so:
 
 - nodes/adapters port one at a time, with the classic test suite as a
   permanent parity oracle;
-- downstream users (including wingfoil-python) see no breakage until the
-  facade is deliberately deprecated;
+- Rust downstreams on the classic `wingfoil` API see no breakage until the
+  facade is deliberately deprecated at cutover. (The **Python** bindings are the
+  exception — they are *replaced*, not facaded: `wingfoil-next-python`
+  supersedes legacy `wingfoil-python`, a deliberate breaking change — see
+  Phase 6.);
 - the port can pause indefinitely at any phase boundary with everything
   shipped still correct.
 
@@ -873,18 +876,39 @@ dynamism is an interpreted-engine capability, matching classic.
   fluent method (only clean as inherent-on-`Stream`, deliberately deferred to
   keep it trait-based).
 
-## Phase 6 — facade, python, examples, benches
+## Phase 6 — Python bindings, examples, benches
 
-- **Facade** 🟡 *started*: `wingfoil_next::compat` proves the thesis — a
-  `Signal<T>` wrapping the fluent `Stream` + the shared graph + a runner
-  slot gives classic-idiom code (free `ticker`/`constant`, `stream.run(..)`,
-  `stream.peek_value()`) running on the new engine. `tests/compat.rs`
-  exercises counter / map-filter-accumulate / fold / constant+delay written
-  exactly as classic code. Remaining: the rest of the ~40-method
-  `StreamOperators`/`NodeOperators` surface (mechanical) and the true
-  `Rc<dyn Stream>` object form if binary-compat with classic is required.
-- **wingfoil-python**: rewire to the facade — should be near-transparent;
-  its pytest suite is the gate.
+**Decision (2026-07): `wingfoil-next-python` supersedes the legacy
+`wingfoil-python` bindings — it is not a compatibility facade over them.** The
+go-forward Python surface is the fresh object-form binding in
+`next/crates/wingfoil-next-python` (`PyGraph`/`PyStream` over the shared
+interpreted `GraphBuilder`, erased to `PyElement`, plus the
+`#[pyop]`/`pyop_fn!` plugin seams — see `docs/python-interop.md`). Legacy
+`wingfoil-python` (`import wingfoil`) is **retired at cutover**, not kept
+running unchanged, so this is a **breaking change** for Python users
+(`import wingfoil` → `import wingfoil_next`; next-python likely claims the
+`wingfoil` module name via a rename at cutover). The gate is next-python's own
+pytest suite (`test_interop.py`) reaching parity with the surface the legacy
+tests covered — not "legacy pytest passes unchanged."
+
+- **Object form** ✅ *landed*: `wingfoil-next-python` `PyGraph`/`PyStream`
+  (`graph.rs`) — the "true `Rc<dyn Stream>` object form" this plan previously
+  listed as remaining facade work — with `PyElement` erasure, re-runnable
+  graphs, and the `#[pyop]`/`pyop_fn!` op-authoring seams.
+- **Custom-node seam** ✅ *landed*: the public `GraphBuilder::custom_node`
+  primitive (the next twin of classic `MutableNode` + `StreamPeekRef`,
+  `tests/custom_node.rs`) plus its next-python exposure (`Graph.custom_node`,
+  a `cycle(values) -> bool` + `peek()` protocol), so a Python object can be a
+  graph node (legacy's `CustomStream`). Single-run in v1 (caller-owned Python
+  state has no engine reset hook); next-python *regular* graphs re-run.
+- **Surface build-out** 🟡 *in progress*: grow `PyStream`/`PyGraph` to cover
+  the legacy combinator surface (`fold`/`sample`/`count`/`limit`/`difference`/
+  `with_time`/`collect`/`buffer`/`window`/`not`, a `sum`/`mean` statistics
+  bridge), then the per-adapter Python bindings as each Rust adapter lands.
+- **`wingfoil_next::compat` (`Signal<T>`)** stays a *Rust-side* classic-idiom
+  ergonomic (free `ticker`/`constant`, `stream.run`/`peek_value`; `tests/
+  compat.rs`) — it is **not** the Python-binding path (that is the object-form
+  `PyStream` above).
 - **Examples**: port all (order_book, breadth_first, run_mode, latency,
   telemetry/tracing, per-adapter) to idiomatic next (fluent or `graph!`),
   keeping classic versions until Phase 7.
@@ -942,7 +966,7 @@ dynamism is an interpreted-engine capability, matching classic.
 | Feedback timing mismatch | correctness of feedback graphs | engine-level edge + classic's 4 feedback tests; fluent-only v1 |
 | Fallibility retrofit cost | touches every emitter | do it first (0.1); never retrofit later |
 | Dynamic graph expectations | `graph_node` users | dirty-list engine (the mutable-frontier enabler) has landed; the mutation feature (`Runner::extend`) is **not yet built** — open decision: cutover blocker vs documented v1 deviation. Islands cover static composition today |
-| Python API drift | downstream breakage | facade keeps bindings stable; pytest as gate |
+| Python API change (next-python supersedes legacy `wingfoil-python`) | existing `import wingfoil` code must migrate — an accepted breaking change, not drift to avoid | new object-form binding at parity before cutover; next-python `test_interop.py` pytest as gate; migration guide + `wingfoil` module-name takeover at cutover |
 | Statistics adapter size | schedule risk, not design risk | it's first in Phase 4 precisely to surface state-porting friction early |
 
 ## Explicitly out of scope (v1)
@@ -997,6 +1021,7 @@ Phases 0–1 are serial (contract work, ~15% of the effort). Phase 2 groups
 parallelize once the recipe is proven on one nontrivial node
 (suggested: throttle — scheduling + state + macro row). Phase 4 adapters
 are fully independent of each other; statistics can start as soon as
-Phase 1 lands. Phase 6 facade can be prototyped early (it only needs the
-Phase 1 contract) to de-risk the Python gate. One PR per node group /
-adapter; every PR carries its parity tests.
+Phase 1 lands. The Phase 6 Python binding (`wingfoil-next-python`, the
+object form) can be built out early (it only needs the Phase 1 contract) to
+de-risk the Python gate. One PR per node group / adapter; every PR carries its
+parity tests.

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -1,9 +1,15 @@
 # Python interop — user-authored Rust components, composed and extended from Python
 
-**Status:** design sketch. Post-Phase-6 / cutover-era capability. Distinct from
-the Phase 6 "keep the existing bindings stable" facade work (that keeps the
-*current* PyElement-authored surface running on the new engine; this adds a
-*new* capability on top).
+**Status:** partially landed (the plugin-SDK layer — `#[pyop]` and the object
+form — is built; `#[pyadapter]`/`#[pygraph]` remain). **`wingfoil-next-python`
+is the go-forward Python binding: it supersedes the legacy `wingfoil-python`
+bindings (decision 2026-07), it is not a new capability bolted beside a
+preserved legacy surface.** The erased object form and `#[pyop]` seam below are
+the foundation the legacy combinator / custom-stream / adapter surface is being
+re-homed onto; at cutover next-python replaces `import wingfoil` (a breaking
+change for Python users — see Phase 6 in `port-plan.md`). Earlier drafts framed
+this as "distinct from keep-the-bindings-stable facade work"; there is no
+separate legacy-facade track — this binding *is* the Python story.
 
 ## The goal
 


### PR DESCRIPTION
## Summary

Implements the public `custom_node` extension point for user-driven graph nodes — the next equivalent of classic `MutableNode` + `StreamPeekRef`. This is the foundation for Python objects to act as graph nodes (replacing legacy `CustomStream`) and enables arbitrary caller-owned state in the graph.

## Key Changes

- **Rust API (`fluent.rs`, `interp.rs`)**: 
  - Added `GraphBuilder::custom_node<T, F>` — declares active/passive upstream edges (type-erased via `Upstream`), runs a closure each activation to produce `Tick<T>`
  - Added `Stream::value_slot()` to capture upstream value slots at wiring time (the next analogue of classic `MutableNode` holding `Rc<dyn Stream>`s)
  - Added `Stream::upstream()` to erase a stream to type-erased `Upstream` for custom-node declarations
  - Closure reads upstreams via captured `SlotRef` (no re-entrancy hazard; slots are read-only during cycles)
  - Marked graphs containing custom nodes as single-run (caller-owned state has no engine reset hook)

- **Python bindings (`wingfoil-next-python/src/graph.rs`, `python.rs`)**:
  - Added `PyGraph::custom_node(upstreams, obj)` — wires a Python object as a graph node
  - Python protocol: `cycle(values) -> bool` (given upstream values, return whether node ticked) + `peek()` (output value when ticked)
  - Upstream values are handed into `cycle` as a list (avoiding re-entrancy; Python cannot call back into the running graph)
  - Exceptions in `cycle`/`peek` abort the run with context

- **Tests**:
  - `tests/custom_node.rs` (Rust): parity tests asserting custom nodes reproduce `map`, `map_filter`, `sample`, and `fold` tick-for-tick
  - `test_interop.py` (Python): custom node as adder, quiet suppression, exception handling
  - `wingfoil-next-python/tests/` (Rust): Python custom node summing upstreams, filtering, error propagation

## Notable Implementation Details

- Custom nodes are scheduled like any other node (active upstreams trigger, passive upstreams are read without triggering)
- The closure owns arbitrary state (captured in a closure or `Rc<RefCell<T>>` for shared state)
- Single-run constraint matches the mounted-island / external-source contract (no engine reset hook for caller-owned state)
- Python binding uses `SlotRef<PyElement>` to capture upstream slots; `cycle` receives `None` for not-yet-ticked upstreams
- Updated `port-plan.md` to clarify Phase 6: `wingfoil-next-python` supersedes legacy `wingfoil-python` (breaking change, not a facade)
- Updated `python-interop.md` status: object form and custom-node seam are landed; surface build-out in progress

https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P