### PR TITLE
wingfoil-next: latency capture infrastructure + otlp trace/span export (Phase 5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,12 @@ rust-version = "1.88"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"
+# The `latency_stages!` derive unconditionally emits an
+# `#[cfg(feature = "iceoryx2")]` ZeroCopySend impl. Crates that invoke the
+# macro without an `iceoryx2` feature (e.g. wingfoil-next) would otherwise get
+# an `unexpected_cfgs` warning; declare the feature name as known so the gate
+# simply stays off there. `wingfoil` has a real `iceoryx2` feature already.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("iceoryx2"))'] }
 
 [workspace.lints.clippy]
 type_complexity = "allow"

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -132,10 +132,10 @@ zmq = { version = "0.10.0", optional = true }
 # stream values as OTLP gauge metrics over HTTP/protobuf to any OTLP-compatible
 # backend (Grafana Alloy, Datadog, Honeycomb, New Relic, …). Built on the async
 # `consume_async` ergonomic so exports run off the graph thread (the OTel SDK's
-# `rt-tokio` PeriodicReader needs a tokio runtime). Only the metrics features are
-# enabled (the classic trace/span exporter is a deferred deviation — it needs the
-# `Traced`/`HasLatency` latency infrastructure, not yet ported to next; see
-# `src/adapters/otlp.rs`).
+# `rt-tokio` PeriodicReader needs a tokio runtime). Both the `metrics` and
+# `trace` features are enabled: the metrics gauge sink (`otlp_push`) and the
+# trace/span exporter (`otlp_spans`, over the ported `Traced`/`HasLatency`
+# latency infrastructure) — see `src/adapters/otlp.rs`.
 #
 # NOTE — deliberate divergence from classic: next pins opentelemetry* 0.32 while
 # classic still ships 0.28. This is to clear GHSA-w9wp-h8wv-79jx (opentelemetry_sdk
@@ -146,12 +146,14 @@ zmq = { version = "0.10.0", optional = true }
 opentelemetry = { version = "0.32", optional = true }
 opentelemetry_sdk = { version = "0.32", features = [
     "metrics",
+    "trace",
     "rt-tokio",
 ], optional = true }
 opentelemetry-otlp = { version = "0.32", features = [
     "http-proto",
     "reqwest-blocking-client",
     "metrics",
+    "trace",
 ], optional = true }
 
 [dev-dependencies]

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -158,6 +158,9 @@ opentelemetry-otlp = { version = "0.32", features = [
 # Compile-fail tests pinning the `graph!` macro's key error paths.
 trybuild = "1"
 criterion = "0.8.1"
+# The `latency_stages!` macro derives serde on the generated record, so a crate
+# invoking it (here, the latency tests) needs serde in scope.
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = []

--- a/next/crates/wingfoil-next/src/adapters/otlp.rs
+++ b/next/crates/wingfoil-next/src/adapters/otlp.rs
@@ -11,11 +11,19 @@
 //! behind the `otlp` feature (it pulls in the OpenTelemetry Rust SDK plus the
 //! `async` feature). Bring in what you need explicitly:
 //!
-//! - **Sink** — the [`OtlpSinkOps`] extension trait on any `Stream<T>` whose
-//!   values are [`Display`](std::fmt::Display), enabled with
+//! - **Metrics sink** — the [`OtlpSinkOps`] extension trait on any `Stream<T>`
+//!   whose values are [`Display`](std::fmt::Display), enabled with
 //!   `use wingfoil_next::adapters::otlp::{OtlpConfig, OtlpSinkOps};`. Push a
 //!   stream as a gauge with [`otlp_push`](OtlpSinkOps::otlp_push) and add the
 //!   returned sink `Stream<()>` to the graph.
+//! - **Trace/span sink** — the [`OtlpSpanOps`] extension trait on any
+//!   `Stream<P>` whose values carry a latency record
+//!   ([`HasLatency`](crate::latency::HasLatency)), enabled with
+//!   `use wingfoil_next::adapters::otlp::{OtlpConfig, OtlpAttributeBuffer, OtlpSpanOps};`.
+//!   Emit one parent span per tick plus one child span per stage hop with
+//!   [`otlp_spans`](OtlpSpanOps::otlp_spans), routing high-cardinality
+//!   per-request data (session IDs, trace IDs) to a tracing backend (Tempo,
+//!   Jaeger, Honeycomb) without the Prometheus cardinality tax.
 //!
 //! # Sink (the off-thread export model)
 //!
@@ -64,13 +72,16 @@
 //!    `dyn Stream<T>`; next uses the sink-as-trait convention shared with
 //!    [`prometheus`](crate::adapters::prometheus): `stream.otlp_push(name,
 //!    config)` on a `Stream<T>`, returning the sink `Stream<()>`.
-//! 3. **The trace/span exporter is not yet ported.** Classic's `OtlpSpans` emits
-//!    OpenTelemetry spans from `Stream<P: HasLatency>` values. That path depends
-//!    on the `Traced` / `HasLatency` / `latency_stages!` latency infrastructure,
-//!    which has **not** been ported to next (a separate roadmap item — see
-//!    `next/docs/port-plan.md`). Until that lands, only the metrics push is
-//!    available here; the span export is a tracked capability gap. `otlp_push`
-//!    itself is fully at parity.
+//! 3. **The trace/span exporter uses the same off-thread model.** Classic's
+//!    `OtlpSpans` looped over the source inside its own `consume_async`
+//!    consumer, building the tracer provider once up front; next's
+//!    [`consume_async`](crate::async_source::consume_async) is per-value, so
+//!    [`otlp_spans`](OtlpSpanOps::otlp_spans) builds the provider lazily on the
+//!    first exported value (kept alive until teardown) — the same lazy-build,
+//!    provider-drop-flush shape as [`otlp_push`](OtlpSinkOps::otlp_push). Every
+//!    classic span capability is preserved: one parent span per tick, one child
+//!    per stage hop, caller-supplied attributes via [`OtlpAttributeBuffer`], and
+//!    the silent skip of all-zero / backwards timestamps.
 //!
 //! # Setup (integration test)
 //!
@@ -82,18 +93,24 @@
 //! docker run --rm -p 4318:4318 otel/opentelemetry-collector:0.149.0
 //! ```
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use opentelemetry::metrics::MeterProvider as _;
-use opentelemetry_otlp::{MetricExporter, WithExportConfig as _};
+use opentelemetry::trace::{
+    Span as _, SpanKind, TraceContextExt as _, Tracer as _, TracerProvider as _,
+};
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig as _};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use wingfoil::RunMode;
 
 use crate::async_source::consume_async;
 use crate::burst;
 use crate::fluent::Stream;
+use crate::latency::{HasLatency, Latency};
 use crate::op::{Activation, Ctx, Tick};
 
 /// The OTel SDK export flush interval. A short interval ensures at least one
@@ -268,6 +285,254 @@ fn build_and_record(
         .expect("invariant: gauge built above")
         .record(v, &[]);
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Trace/span sink
+// ---------------------------------------------------------------------------
+
+/// Reusable buffer for span attributes in [`OtlpSpanOps::otlp_spans`]. Avoids
+/// allocating a fresh `Vec<KeyValue>` per tick by pre-allocating once and
+/// reusing it — the attribute closure fills it via [`add`](Self::add).
+pub struct OtlpAttributeBuffer {
+    attrs: Vec<KeyValue>,
+}
+
+impl OtlpAttributeBuffer {
+    /// Add a key-value attribute. The buffer is reused across ticks, so this is
+    /// efficient even at high tick rates.
+    pub fn add(&mut self, key: &'static str, value: impl Into<opentelemetry::Value>) {
+        self.attrs.push(KeyValue::new(key, value));
+    }
+
+    fn clear(&mut self) {
+        self.attrs.clear();
+    }
+
+    fn take(&mut self) -> Vec<KeyValue> {
+        std::mem::take(&mut self.attrs)
+    }
+}
+
+impl Default for OtlpAttributeBuffer {
+    fn default() -> Self {
+        OtlpAttributeBuffer {
+            attrs: Vec::with_capacity(8),
+        }
+    }
+}
+
+/// A realtime, push-based OpenTelemetry **trace** sink — an extension trait on
+/// any `Stream<P>` whose values carry a latency record
+/// ([`HasLatency`](crate::latency::HasLatency)).
+///
+/// `use`ing it enables `stream.otlp_spans(name, config, attrs)` chaining,
+/// layered over the same
+/// [`register_op1`](crate::interp::Builder::register_op1) run-mode guard plus
+/// [`consume_async`](crate::async_source::consume_async) off-thread export as
+/// [`OtlpSinkOps`].
+pub trait OtlpSpanOps<P>
+where
+    P: HasLatency,
+{
+    /// Emit one parent span per upstream tick covering the full
+    /// `stamps[0] .. stamps[N-1]` interval, plus one child span per adjacent
+    /// stage pair (named `"<prev_stage>__<next_stage>"`), exporting to
+    /// `config`'s endpoint off the graph thread.
+    ///
+    /// The `attrs` closure is called once per tick to populate per-payload
+    /// attributes on the parent span via [`OtlpAttributeBuffer::add`]; the
+    /// buffer is pre-allocated and reused. Spans whose stamps are all zero, or
+    /// whose endpoints go backwards, are silently skipped, so a partially
+    /// stamped record never corrupts the trace.
+    ///
+    /// - `span_name`: the parent span name (a `&'static str`).
+    /// - `config`: the OTLP endpoint and service name (accepts an
+    ///   [`OtlpConfig`], or a `(endpoint, service_name)` tuple).
+    ///
+    /// The graph owns the tokio runtime (see the module docs — the graph must be
+    /// driven from a non-async thread).
+    ///
+    /// The sink is a **no-op** under
+    /// [`RunMode::HistoricalFrom`](wingfoil::RunMode::HistoricalFrom): no span
+    /// is exported and no tracer provider is built.
+    ///
+    /// The returned `Stream<()>` **must** be added to the graph for spans to be
+    /// exported.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error at wiring time only if the graph's async runtime cannot be
+    /// created.
+    #[must_use = "otlp_spans returns a sink Stream that must be added to the graph"]
+    fn otlp_spans<F>(
+        &self,
+        span_name: &'static str,
+        config: impl Into<OtlpConfig>,
+        attrs: F,
+    ) -> Result<Stream<()>>
+    where
+        F: Fn(&P, &mut OtlpAttributeBuffer) + Send + Sync + 'static;
+}
+
+impl<P> OtlpSpanOps<P> for Stream<P>
+where
+    P: HasLatency + Clone + Default + Send + 'static,
+{
+    fn otlp_spans<F>(
+        &self,
+        span_name: &'static str,
+        config: impl Into<OtlpConfig>,
+        attrs: F,
+    ) -> Result<Stream<()>>
+    where
+        F: Fn(&P, &mut OtlpAttributeBuffer) + Send + Sync + 'static,
+    {
+        let config = config.into();
+
+        // Stage layout is compile-time constant, so precompute the hop names
+        // once here rather than per tick.
+        let n = P::L::N;
+        let stage_names = P::L::stage_names();
+        let hop_names: Vec<String> = (1..n)
+            .map(|i| format!("{}__{}", stage_names[i - 1], stage_names[i]))
+            .collect();
+
+        // Built lazily on the first exported value (inside the consumer task's
+        // tokio context), kept alive so the batch exporter flushes when the
+        // task is dropped at teardown — never in historical mode (no value
+        // reaches here). Mirrors the otlp_push lazy-build/provider-drop shape.
+        let mut tracer: Option<opentelemetry_sdk::trace::Tracer> = None;
+        let mut provider: Option<SdkTracerProvider> = None;
+        let mut attr_buffer = OtlpAttributeBuffer::default();
+        let sink = consume_async(&self.graph(), None, move |value: P| {
+            let result = build_and_emit(
+                &mut tracer,
+                &mut provider,
+                &config,
+                span_name,
+                n,
+                &hop_names,
+                &attrs,
+                &mut attr_buffer,
+                &value,
+            );
+            async move { result }
+        })?;
+
+        Ok(self.wire(move |b, h| {
+            b.register_op1(
+                h,
+                "otlp_spans",
+                Activation::NONE,
+                sink,
+                || (),
+                move |sink: &mut _, _state: &mut (), value: &P, ctx: &mut Ctx<'_>| {
+                    if matches!(ctx.run_mode(), RunMode::HistoricalFrom(_)) {
+                        return Ok(Tick::Value(()));
+                    }
+                    sink(&burst![value.clone()])?;
+                    Ok(Tick::Value(()))
+                },
+            )
+        }))
+    }
+}
+
+/// Build the tracer provider on first use (kept alive in `provider`), then emit
+/// a parent span + one child per stamped hop for `value`. Runs inside the
+/// `consume_async` task's tokio context. A build error aborts the run (surfaced
+/// on a later cycle, per `consume_async`).
+#[allow(clippy::too_many_arguments)]
+fn build_and_emit<P, F>(
+    tracer: &mut Option<opentelemetry_sdk::trace::Tracer>,
+    provider: &mut Option<SdkTracerProvider>,
+    config: &OtlpConfig,
+    span_name: &'static str,
+    n: usize,
+    hop_names: &[String],
+    attrs: &F,
+    attr_buffer: &mut OtlpAttributeBuffer,
+    value: &P,
+) -> anyhow::Result<()>
+where
+    P: HasLatency,
+    F: Fn(&P, &mut OtlpAttributeBuffer),
+{
+    if tracer.is_none() {
+        let exporter = SpanExporter::builder()
+            .with_http()
+            .with_endpoint(&config.endpoint)
+            .build()
+            .map_err(|e| anyhow::anyhow!("otlp_spans: failed to build exporter: {e}"))?;
+        let resource = Resource::builder_empty()
+            .with_service_name(config.service_name.clone())
+            .build();
+        let built = SdkTracerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_resource(resource)
+            .build();
+        *tracer = Some(built.tracer("wingfoil"));
+        *provider = Some(built);
+    }
+    let tracer = tracer.as_ref().expect("invariant: tracer built above");
+    emit_spans(tracer, value, attrs, span_name, n, hop_names, attr_buffer);
+    Ok(())
+}
+
+/// Emit the parent + child spans for one value. Skips the whole trace if the
+/// full-journey endpoints are unstamped or backwards, and skips individual hops
+/// the same way, so a partially stamped record still produces the hops that
+/// were stamped.
+fn emit_spans<P, F>(
+    tracer: &opentelemetry_sdk::trace::Tracer,
+    value: &P,
+    attrs: &F,
+    span_name: &'static str,
+    n: usize,
+    hop_names: &[String],
+    attr_buffer: &mut OtlpAttributeBuffer,
+) where
+    P: HasLatency,
+    F: Fn(&P, &mut OtlpAttributeBuffer),
+{
+    let stamps = value.latency().stamps();
+    // A trace needs at least one real start/end pair.
+    if n < 2 || stamps[0] == 0 || stamps[n - 1] == 0 || stamps[n - 1] < stamps[0] {
+        return;
+    }
+
+    attr_buffer.clear();
+    attrs(value, attr_buffer);
+
+    let parent = tracer
+        .span_builder(span_name)
+        .with_kind(SpanKind::Server)
+        .with_start_time(ns_to_system_time(stamps[0]))
+        .with_attributes(attr_buffer.take())
+        .start(tracer);
+    let cx = Context::current_with_span(parent);
+
+    for i in 1..n {
+        let a = stamps[i - 1];
+        let b = stamps[i];
+        if a == 0 || b == 0 || b < a {
+            continue;
+        }
+        let mut child = tracer
+            .span_builder(hop_names[i - 1].clone())
+            .with_kind(SpanKind::Internal)
+            .with_start_time(ns_to_system_time(a))
+            .start_with_context(tracer, &cx);
+        child.end_with_timestamp(ns_to_system_time(b));
+    }
+
+    cx.span()
+        .end_with_timestamp(ns_to_system_time(stamps[n - 1]));
+}
+
+fn ns_to_system_time(ns: u64) -> SystemTime {
+    UNIX_EPOCH + Duration::from_nanos(ns)
 }
 
 #[cfg(test)]

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -52,6 +52,7 @@ static NEXT_BUILDER_ID: AtomicU64 = AtomicU64::new(0);
 
 use crate::Burst;
 use crate::channel::{ChannelSender, Message};
+use crate::latency::{HasLatency, LatencyReport, LatencyReportCfg, LatencyStats};
 use crate::op::{Activation, CompositePhase, Ctx, Op, Tick};
 use crate::ops::{
     Const, Delay, DelayState, DelayWithReset, DelayWithResetState, Filter, Finally, Fold, Join,
@@ -1987,6 +1988,74 @@ impl Builder {
         self.set_reset(Box::new(move || {
             cs_reset.borrow_mut().1 = TimedState::<T>::default();
             *out_reset.borrow_mut() = T::default();
+        }));
+        self.make_handle(idx)
+    }
+
+    /// The classic `latency_report`: a sink that observes each payload's
+    /// embedded latency record into the caller-provided `stats`, and prints a
+    /// summary at `stop` when `print_on_teardown`. Hand-written (not
+    /// `register_op1`) because it carries a stop hook. The stats handle is
+    /// passed in so the fluent [`LatencyReportOps`](crate::latency::LatencyReportOps)
+    /// method can return it to the caller alongside the sink stream.
+    pub fn latency_report<P>(
+        &mut self,
+        src: Handle<P>,
+        print_on_teardown: bool,
+        stats: Rc<RefCell<LatencyStats<P::L>>>,
+    ) -> Handle<()>
+    where
+        P: Clone + Default + HasLatency + 'static,
+    {
+        let idx = self.nodes.len();
+        let src_slot = self.slot(src);
+        let out = self.new_slot(());
+        let cs = Self::cell(
+            LatencyReportCfg {
+                stats,
+                print_on_teardown,
+            },
+            (),
+        );
+        let cs_stop = cs.clone();
+        let cs_reset = cs.clone();
+        self.push_node(
+            vec![src.idx],
+            LatencyReport::<P>::ACTIVATION,
+            "latency_report",
+            Box::new(move |k| {
+                let (cfg, state) = &mut *cs.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                let a = src_slot.borrow();
+                match LatencyReport::<P>::cycle(cfg, state, (&a,), &mut ctx)? {
+                    Tick::Value(v) => {
+                        drop(a);
+                        *out.borrow_mut() = v;
+                        Ok(true)
+                    }
+                    Tick::Silent(v) => {
+                        drop(a);
+                        *out.borrow_mut() = v;
+                        Ok(false)
+                    }
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        // `latency_report`'s summary prints at stop, after the last cycle.
+        let node = self
+            .nodes
+            .last_mut()
+            .expect("invariant: latency_report node just pushed");
+        node.stop = Box::new(move |k| {
+            let (cfg, state) = &mut *cs_stop.borrow_mut();
+            let mut ctx = Ctx::new(k, idx);
+            LatencyReport::<P>::stop(cfg, state, &mut ctx)
+        });
+        // On a second `Runner::run`, start the aggregation fresh.
+        self.set_reset(Box::new(move || {
+            *cs_reset.borrow_mut().0.stats.borrow_mut() = LatencyStats::new();
         }));
         self.make_handle(idx)
     }

--- a/next/crates/wingfoil-next/src/latency.rs
+++ b/next/crates/wingfoil-next/src/latency.rs
@@ -1,0 +1,308 @@
+//! Latency capture for wingfoil-next — the Phase 5 port of the classic
+//! [`wingfoil::latency`] infrastructure.
+//!
+//! Stamp wall-clock timestamps onto messages as they hop through ops (and
+//! across processes), then aggregate the per-stage deltas at the end of the
+//! pipeline.
+//!
+//! # What is reused vs. new
+//!
+//! The **data layer is reused wholesale** from the classic crate — `Traced`
+//! is just a `#[repr(C)]` payload, and the [`latency_stages!`] derive is
+//! engine-agnostic, so they are re-exported unchanged (per the port-plan:
+//! *"stamps ride values as today; latency_stages derive unchanged"*):
+//!
+//! - [`Traced<T, L>`] — payload `T` paired with a latency record `L`.
+//! - [`Latency`] / [`Stage`] / [`HasLatency`] — the record traits.
+//! - [`StageStats`] / [`LatencyStats`] — the non-allocating aggregators.
+//! - [`latency_stages!`] — declares a record + per-stage marker types.
+//!
+//! Only the **node layer** is re-implemented as [`Op`]s on the next engine:
+//! [`LatencyStreamOps::stamp`] / [`stamp_precise`](LatencyStreamOps::stamp_precise)
+//! and [`LatencyReportOps::latency_report`].
+//!
+//! # Time source
+//!
+//! Stamps always read the wall clock (never [`Ctx::time`](crate::op::Ctx::time),
+//! which is source-driven in historical mode and useless for latency):
+//!
+//! - [`stamp`](LatencyStreamOps::stamp) reads
+//!   [`Ctx::wall_time`](crate::op::Ctx::wall_time) — a cycle-start snap, one
+//!   `u64` load. Stages sharing an engine cycle get the same stamp.
+//! - [`stamp_precise`](LatencyStreamOps::stamp_precise) reads
+//!   [`Ctx::wall_time_precise`](crate::op::Ctx::wall_time_precise) — a fresh
+//!   TSC read, giving distinct stamps to stages in the same cycle.
+//!
+//! Both behave identically in realtime and historical mode.
+//!
+//! # Toggling
+//!
+//! Each method has an `_if` variant taking a bool and returning the upstream
+//! unchanged when disabled — no node inserted, zero runtime cost.
+//!
+//! # Deviation from classic
+//!
+//! Exposed via the **fluent (interpreted)** path only, matching classic
+//! (which offers latency solely through `LatencyStreamOps`). A stamp's stage
+//! is a compile-time *type* parameter, which does not map onto the
+//! `graph!`/compiled value-dispatch table; compiled/nested support is out of
+//! scope for this op family.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use wingfoil_next::prelude::*;
+//! use wingfoil_next::latency::*;
+//!
+//! latency_stages! {
+//!     pub TradeLatency { ingest, decode, strategy, publish }
+//! }
+//!
+//! fn build(stream: Stream<Traced<u64, TradeLatency>>) -> Stream<Traced<u64, TradeLatency>> {
+//!     stream
+//!         .stamp::<trade_latency::ingest>()
+//!         .stamp::<trade_latency::strategy>()
+//! }
+//! ```
+
+use std::cell::RefCell;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use anyhow::Result;
+
+use crate::fluent::Stream;
+use crate::op::{Activation, Ctx, Op, Tick};
+
+// The pure data layer is engine-agnostic and reused verbatim from the classic
+// crate (its serde/iceoryx2 impls are already compiled there).
+pub use wingfoil::{HasLatency, Latency, LatencyStats, Stage, StageStats, Traced, latency_stages};
+
+// ---------------------------------------------------------------------------
+// Stamp / StampPrecise — pass-through ops that stamp one stage
+// ---------------------------------------------------------------------------
+
+/// Op: forward the payload unchanged while stamping
+/// [`Ctx::wall_time`](crate::op::Ctx::wall_time) (cycle-start snap) into a
+/// single named stage `S` of the embedded [`Latency`] record. One `u64` store
+/// per tick, no allocation. The next twin of classic `StampStream`.
+pub struct Stamp<P, S>(PhantomData<fn() -> (P, S)>);
+
+impl<P, S> Op for Stamp<P, S>
+where
+    P: Clone + Default + HasLatency + 'static,
+    S: Stage<P::L> + 'static,
+{
+    type Cfg = ();
+    type State = ();
+    type In<'a> = (&'a P,);
+    type Out = P;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(_cfg: &mut (), _state: &mut (), input: (&P,), ctx: &mut Ctx<'_>) -> Result<Tick<P>> {
+        let mut value = input.0.clone();
+        S::stamp(value.latency_mut(), u64::from(ctx.wall_time()));
+        Ok(Tick::Value(value))
+    }
+}
+
+/// Like [`Stamp`] but reads
+/// [`Ctx::wall_time_precise`](crate::op::Ctx::wall_time_precise) — a fresh TSC
+/// snap on every tick — so stages running in the same engine cycle get
+/// distinct timestamps. The next twin of classic `StampPreciseStream`.
+pub struct StampPrecise<P, S>(PhantomData<fn() -> (P, S)>);
+
+impl<P, S> Op for StampPrecise<P, S>
+where
+    P: Clone + Default + HasLatency + 'static,
+    S: Stage<P::L> + 'static,
+{
+    type Cfg = ();
+    type State = ();
+    type In<'a> = (&'a P,);
+    type Out = P;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(_cfg: &mut (), _state: &mut (), input: (&P,), ctx: &mut Ctx<'_>) -> Result<Tick<P>> {
+        let mut value = input.0.clone();
+        S::stamp(value.latency_mut(), u64::from(ctx.wall_time_precise()));
+        Ok(Tick::Value(value))
+    }
+}
+
+/// Extension trait adding `.stamp::<Stage>()` and friends to streams whose
+/// values carry a [`Latency`] record.
+pub trait LatencyStreamOps<P>
+where
+    P: Clone + Default + HasLatency + 'static,
+{
+    /// Wrap in a [`Stamp`] op for stage `S`: each tick writes
+    /// [`Ctx::wall_time`](crate::op::Ctx::wall_time) into the stage's slot
+    /// before forwarding.
+    #[must_use]
+    fn stamp<S: Stage<P::L> + 'static>(&self) -> Stream<P>;
+
+    /// Conditional [`stamp`](Self::stamp): when `enabled` is false returns
+    /// `self` unchanged — no node inserted, zero runtime cost.
+    #[must_use]
+    fn stamp_if<S: Stage<P::L> + 'static>(&self, enabled: bool) -> Stream<P>;
+
+    /// Like [`stamp`](Self::stamp) but uses
+    /// [`Ctx::wall_time_precise`](crate::op::Ctx::wall_time_precise) for
+    /// intra-cycle resolution.
+    #[must_use]
+    fn stamp_precise<S: Stage<P::L> + 'static>(&self) -> Stream<P>;
+
+    /// Conditional [`stamp_precise`](Self::stamp_precise).
+    #[must_use]
+    fn stamp_precise_if<S: Stage<P::L> + 'static>(&self, enabled: bool) -> Stream<P>;
+}
+
+impl<P> LatencyStreamOps<P> for Stream<P>
+where
+    P: Clone + Default + HasLatency + 'static,
+{
+    fn stamp<S: Stage<P::L> + 'static>(&self) -> Stream<P> {
+        self.wire(|b, h| {
+            b.register_op1(
+                h,
+                "stamp",
+                Activation::NONE,
+                (),
+                || (),
+                move |cfg: &mut (), state: &mut (), value: &P, ctx: &mut Ctx<'_>| {
+                    Stamp::<P, S>::cycle(cfg, state, (value,), ctx)
+                },
+            )
+        })
+    }
+
+    fn stamp_if<S: Stage<P::L> + 'static>(&self, enabled: bool) -> Stream<P> {
+        if enabled {
+            self.stamp::<S>()
+        } else {
+            self.clone()
+        }
+    }
+
+    fn stamp_precise<S: Stage<P::L> + 'static>(&self) -> Stream<P> {
+        self.wire(|b, h| {
+            b.register_op1(
+                h,
+                "stamp_precise",
+                Activation::NONE,
+                (),
+                || (),
+                move |cfg: &mut (), state: &mut (), value: &P, ctx: &mut Ctx<'_>| {
+                    StampPrecise::<P, S>::cycle(cfg, state, (value,), ctx)
+                },
+            )
+        })
+    }
+
+    fn stamp_precise_if<S: Stage<P::L> + 'static>(&self, enabled: bool) -> Stream<P> {
+        if enabled {
+            self.stamp_precise::<S>()
+        } else {
+            self.clone()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LatencyReport — sink op aggregating per-stage delta statistics
+// ---------------------------------------------------------------------------
+
+/// Construction config for a [`LatencyReport`] sink: the shared stats
+/// accumulator plus whether to print a summary at [`stop`](Op::stop).
+pub struct LatencyReportCfg<L: Latency> {
+    pub stats: Rc<RefCell<LatencyStats<L>>>,
+    pub print_on_teardown: bool,
+}
+
+/// Sink op consuming a stream of `P: HasLatency`, accumulating per-stage delta
+/// statistics into a shared [`LatencyStats`]. At [`stop`](Op::stop) it prints
+/// the summary when configured. The next twin of classic `LatencyReport`.
+pub struct LatencyReport<P>(PhantomData<fn() -> P>);
+
+impl<P> Op for LatencyReport<P>
+where
+    P: Clone + Default + HasLatency + 'static,
+{
+    type Cfg = LatencyReportCfg<P::L>;
+    type State = ();
+    type In<'a> = (&'a P,);
+    type Out = ();
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut Self::Cfg,
+        _state: &mut (),
+        input: (&P,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<()>> {
+        cfg.stats.borrow_mut().observe(input.0.latency());
+        Ok(Tick::Value(()))
+    }
+
+    fn stop(cfg: &mut Self::Cfg, _state: &mut (), _ctx: &mut Ctx<'_>) -> Result<()> {
+        if cfg.print_on_teardown {
+            print!("{}", cfg.stats.borrow().format_report());
+        }
+        Ok(())
+    }
+}
+
+/// Extension methods to install a [`LatencyReport`] sink. Returns the sink
+/// stream plus the shared stats handle, so the caller can inspect the numbers
+/// after the run.
+pub trait LatencyReportOps<P>
+where
+    P: Clone + Default + HasLatency + 'static,
+{
+    /// Install a [`LatencyReport`] sink. `print_on_teardown` controls whether
+    /// a summary is printed at shutdown. Returns `(sink_stream, stats_handle)`.
+    fn latency_report(
+        &self,
+        print_on_teardown: bool,
+    ) -> (Stream<()>, Rc<RefCell<LatencyStats<P::L>>>);
+
+    /// Conditional variant. When `enabled` is false, installs a sink that
+    /// never ticks and returns an empty stats handle (counts stay at zero) —
+    /// letting a single config flag toggle aggregation without wiring edits.
+    fn latency_report_if(
+        &self,
+        enabled: bool,
+        print_on_teardown: bool,
+    ) -> (Stream<()>, Rc<RefCell<LatencyStats<P::L>>>);
+}
+
+impl<P> LatencyReportOps<P> for Stream<P>
+where
+    P: Clone + Default + HasLatency + 'static,
+{
+    fn latency_report(
+        &self,
+        print_on_teardown: bool,
+    ) -> (Stream<()>, Rc<RefCell<LatencyStats<P::L>>>) {
+        let stats = Rc::new(RefCell::new(LatencyStats::new()));
+        let stats_for_wire = stats.clone();
+        let stream = self.wire(move |b, h| b.latency_report(h, print_on_teardown, stats_for_wire));
+        (stream, stats)
+    }
+
+    fn latency_report_if(
+        &self,
+        enabled: bool,
+        print_on_teardown: bool,
+    ) -> (Stream<()>, Rc<RefCell<LatencyStats<P::L>>>) {
+        if enabled {
+            self.latency_report(print_on_teardown)
+        } else {
+            // A source that never ticks: nothing is observed, stats stay empty.
+            let stats = Rc::new(RefCell::new(LatencyStats::new()));
+            let stream = self.wire(|b, _h| b.never());
+            (stream, stats)
+        }
+    }
+}

--- a/next/crates/wingfoil-next/src/lib.rs
+++ b/next/crates/wingfoil-next/src/lib.rs
@@ -80,6 +80,7 @@ pub mod channel;
 pub mod compat;
 pub mod fluent;
 pub mod interp;
+pub mod latency;
 pub mod op;
 pub mod ops;
 pub mod stats;

--- a/next/crates/wingfoil-next/src/op.rs
+++ b/next/crates/wingfoil-next/src/op.rs
@@ -119,6 +119,7 @@ pub enum CompositePhase {
 /// private queue instead of the outer kernel.
 pub struct Ctx<'a> {
     time: NanoTime,
+    wall_time: NanoTime,
     start_time: NanoTime,
     is_last_cycle: bool,
     run_mode: RunMode,
@@ -141,6 +142,7 @@ impl<'a> Ctx<'a> {
     pub fn new(kernel: &'a mut Kernel, node: usize) -> Self {
         Self {
             time: kernel.time(),
+            wall_time: kernel.wall_time(),
             start_time: kernel.start_time(),
             is_last_cycle: kernel.is_last_cycle(),
             run_mode: kernel.run_mode(),
@@ -166,6 +168,10 @@ impl<'a> Ctx<'a> {
     ) -> Self {
         Self {
             time,
+            // A composite has no per-cycle wall snap of its own; latency ops
+            // are fluent/interpreted-only and never run inside an island, so a
+            // fresh snap here is a correct (if slightly pricier) fallback.
+            wall_time: NanoTime::now(),
             start_time,
             is_last_cycle: false,
             run_mode: RunMode::RealTime,
@@ -176,6 +182,24 @@ impl<'a> Ctx<'a> {
     /// Current engine time.
     pub fn time(&self) -> NanoTime {
         self.time
+    }
+
+    /// Wall-clock time snapped once at the start of the current cycle. The
+    /// same in both realtime and historical mode (unlike [`time`](Self::time),
+    /// which is source-driven in historical replay) — so latency stamps and
+    /// perf telemetry always mean "wall-clock time spent". One `u64` load;
+    /// ops that stamp in the same engine cycle share the value. Use
+    /// [`wall_time_precise`](Self::wall_time_precise) for intra-cycle
+    /// resolution.
+    pub fn wall_time(&self) -> NanoTime {
+        self.wall_time
+    }
+
+    /// Wall-clock time snapped fresh right now (a TSC read, ~5-10 ns on x86).
+    /// Gives distinct stamps to stages that run in the same engine cycle,
+    /// where [`wall_time`](Self::wall_time) would return one shared value.
+    pub fn wall_time_precise(&self) -> NanoTime {
+        NanoTime::now()
     }
 
     /// The run's start time.

--- a/next/crates/wingfoil-next/tests/latency.rs
+++ b/next/crates/wingfoil-next/tests/latency.rs
@@ -1,0 +1,243 @@
+//! Latency capture parity tests — ports the node-layer cases from classic
+//! `wingfoil::latency` to the wingfoil-next Op engine. The pure data layer
+//! (`Traced`/`Latency`/`Stage`/`StageStats`/`LatencyStats` layout + arithmetic)
+//! is reused verbatim from the classic crate and is covered by its own unit
+//! tests; here we assert the *engine* behaviour: that `stamp`/`stamp_precise`
+//! write wall-clock time (shared per cycle, fresh for `_precise`) and that
+//! `latency_report` aggregates per-stage deltas.
+//!
+//! Sources are synthesised with `ticker().count().map(..)` — the delivery time
+//! is irrelevant here (latency records ride inside the payload and stamps read
+//! the wall clock), so this avoids the burst-grouped `channel` source and its
+//! producer threads while exercising the identical stamping / aggregation path.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::latency::*;
+use wingfoil_next::prelude::*;
+
+latency_stages! {
+    pub TradeLatency {
+        ingest,
+        decode,
+        strategy,
+        publish,
+    }
+}
+
+/// A source of `count` fully-defaulted `Traced<u64, TradeLatency>` messages
+/// (payload = the 1-based tick index), with no latency stages set.
+fn traced_source(g: &GraphBuilder) -> Stream<Traced<u64, TradeLatency>> {
+    g.ticker(Duration::from_millis(1))
+        .count()
+        .map(|n: &u64| Traced::<u64, TradeLatency>::new(*n))
+}
+
+// ── Re-export / macro-in-next sanity ────────────────────────────────────────
+// The derive is engine-agnostic and re-exported unchanged; these confirm the
+// macro expands and the traits resolve inside the next crate.
+
+#[test]
+fn latency_stages_derive_works_in_next() {
+    assert_eq!(TradeLatency::N, 4);
+    assert_eq!(
+        TradeLatency::stage_names(),
+        &["ingest", "decode", "strategy", "publish"]
+    );
+    let l = TradeLatency {
+        ingest: 1,
+        decode: 2,
+        strategy: 3,
+        publish: 4,
+    };
+    assert_eq!(l.stamps(), &[1u64, 2, 3, 4]);
+    assert_eq!(<trade_latency::strategy as Stage<TradeLatency>>::INDEX, 2);
+}
+
+#[test]
+fn has_latency_round_trip() {
+    let mut t: Traced<u64, TradeLatency> = Traced::new(7);
+    t.latency_mut().strategy = 42;
+    assert_eq!(t.latency().strategy, 42);
+    assert_eq!(t.payload, 7);
+}
+
+// ── stamp ───────────────────────────────────────────────────────────────────
+
+/// Classic `stamp_stream_writes_wall_time_into_named_stage`: stamps use
+/// wall-clock time, so in historical mode we assert monotonicity, not exact
+/// values. Untouched stages stay zero; the payload passes through.
+#[test]
+fn stamp_writes_wall_time_into_named_stage() {
+    let g = GraphBuilder::new();
+    let acc = traced_source(&g)
+        .stamp::<trade_latency::strategy>()
+        .accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(2))
+        .unwrap();
+
+    let collected = r.value(&acc);
+    assert_eq!(collected.len(), 2);
+    assert_eq!(collected[0].payload, 1);
+    assert_eq!(collected[1].payload, 2);
+    // Untouched stages remain zero.
+    assert_eq!(collected[0].latency.ingest, 0);
+    assert_eq!(collected[1].latency.ingest, 0);
+    // Stamps are real wall-clock times: both non-zero, second >= first.
+    assert!(collected[0].latency.strategy > 0);
+    assert!(collected[1].latency.strategy >= collected[0].latency.strategy);
+}
+
+/// Classic `stamp_works_identically_in_historical_and_realtime`: same wiring,
+/// both run modes produce non-zero, monotonic wall-clock stamps.
+#[test]
+fn stamp_works_identically_in_historical_and_realtime() {
+    fn run_one(mode: RunMode) -> NanoTime {
+        let g = GraphBuilder::new();
+        let acc = traced_source(&g)
+            .stamp::<trade_latency::ingest>()
+            .stamp_precise::<trade_latency::publish>()
+            .accumulate();
+        let mut r = g.build();
+        r.run(mode, RunFor::Cycles(3)).unwrap();
+        let values = r.value(&acc);
+        assert!(!values.is_empty());
+        let l = values[0].latency;
+        assert!(l.ingest > 0, "ingest stamp should be populated");
+        assert!(l.publish >= l.ingest, "publish >= ingest");
+        NanoTime::new(l.ingest)
+    }
+    let historical = run_one(RunMode::HistoricalFrom(NanoTime::ZERO));
+    let realtime = run_one(RunMode::RealTime);
+    // Both modes stamp wall-clock nanos-since-epoch.
+    assert!(u64::from(historical) > 1_000_000_000);
+    assert!(u64::from(realtime) > 1_000_000_000);
+}
+
+/// Classic `stamp_if_disabled_inserts_no_node`: `stamp_if(false)` is identity —
+/// the stage it would have written stays zero.
+#[test]
+fn stamp_if_disabled_is_identity() {
+    let g = GraphBuilder::new();
+    let acc = traced_source(&g)
+        .stamp_if::<trade_latency::ingest>(false)
+        .accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+        .unwrap();
+
+    let collected = r.value(&acc);
+    assert_eq!(collected.len(), 1);
+    assert_eq!(collected[0].payload, 1);
+    // Disabled: no stamp written.
+    assert_eq!(collected[0].latency.ingest, 0);
+}
+
+/// Classic `stamp_precise_writes_fresh_timestamps`: two `stamp_precise`
+/// wrappers in series both produce non-zero, ordered stamps.
+#[test]
+fn stamp_precise_writes_fresh_timestamps() {
+    let g = GraphBuilder::new();
+    let acc = traced_source(&g)
+        .stamp_precise::<trade_latency::ingest>()
+        .stamp_precise::<trade_latency::publish>()
+        .accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+        .unwrap();
+
+    let collected = r.value(&acc);
+    assert_eq!(collected.len(), 1);
+    let l = collected[0].latency;
+    assert!(l.ingest > 0);
+    assert!(l.publish >= l.ingest);
+}
+
+/// Classic `multiple_stamps_compose`: three cached-`stamp` wrappers in the same
+/// engine cycle share the cycle-start wall snap — the key check that
+/// `Ctx::wall_time` is snapped once per cycle (the Kernel change).
+#[test]
+fn multiple_stamps_compose() {
+    let g = GraphBuilder::new();
+    let acc = traced_source(&g)
+        .stamp::<trade_latency::ingest>()
+        .stamp::<trade_latency::strategy>()
+        .stamp::<trade_latency::publish>()
+        .accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+        .unwrap();
+
+    let collected = r.value(&acc);
+    assert_eq!(collected.len(), 1);
+    let l = collected[0].latency;
+    // All three run in one engine cycle and share the cycle-start snap.
+    assert!(l.ingest > 0);
+    assert_eq!(l.strategy, l.ingest);
+    assert_eq!(l.publish, l.ingest);
+    assert_eq!(l.decode, 0);
+}
+
+// ── latency_report ──────────────────────────────────────────────────────────
+
+/// Classic `latency_report_aggregates_across_ticks`: three fully-stamped
+/// messages give exact per-stage delta means. The latency records are set on
+/// the payload (deltas 10 / 20 / 30 ns), so aggregation is deterministic.
+#[test]
+fn latency_report_aggregates_across_ticks() {
+    let g = GraphBuilder::new();
+    let source = g.ticker(Duration::from_millis(1)).count().map(|n: &u64| {
+        let base = n * 100; // 100, 200, 300
+        Traced::with_latency(
+            *n,
+            TradeLatency {
+                ingest: base,
+                decode: base + 10,
+                strategy: base + 30,
+                publish: base + 60,
+            },
+        )
+    });
+    let (_sink, stats) = source.latency_report(false);
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+
+    let s = stats.borrow();
+    // 3 messages, each contributes one delta per non-zero stage transition.
+    assert_eq!(s.stages[1].count, 3); // ingest → decode (10ns each)
+    assert_eq!(s.stages[1].mean_ns(), 10);
+    assert_eq!(s.stages[2].count, 3); // decode → strategy (20ns each)
+    assert_eq!(s.stages[2].mean_ns(), 20);
+    assert_eq!(s.stages[3].count, 3); // strategy → publish (30ns each)
+    assert_eq!(s.stages[3].mean_ns(), 30);
+}
+
+/// `latency_report_if(false)` installs no observing sink — the stats handle
+/// stays at zero counts.
+#[test]
+fn latency_report_if_disabled_stays_empty() {
+    let g = GraphBuilder::new();
+    let source = g.ticker(Duration::from_millis(1)).count().map(|n: &u64| {
+        Traced::with_latency(
+            *n,
+            TradeLatency {
+                ingest: 100,
+                decode: 110,
+                strategy: 130,
+                publish: 160,
+            },
+        )
+    });
+    let (_sink, stats) = source.latency_report_if(false, false);
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+
+    let s = stats.borrow();
+    for i in 1..TradeLatency::N {
+        assert_eq!(s.stages[i].count, 0, "stage {i} should be unobserved");
+    }
+}

--- a/next/crates/wingfoil-next/tests/otlp_adapter.rs
+++ b/next/crates/wingfoil-next/tests/otlp_adapter.rs
@@ -12,8 +12,23 @@
 use std::time::Duration;
 
 use wingfoil::{NanoTime, RunFor, RunMode};
-use wingfoil_next::adapters::otlp::{OtlpConfig, OtlpSinkOps};
+use wingfoil_next::adapters::otlp::{OtlpConfig, OtlpSinkOps, OtlpSpanOps};
+use wingfoil_next::latency::{Latency, Stage, Traced, latency_stages};
 use wingfoil_next::prelude::*;
+
+latency_stages! {
+    pub TestLatency {
+        a,
+        b,
+        c,
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+struct TestPayload {
+    session: u64,
+}
 
 /// Parity of classic `historical_mode_drains_without_connecting`: with no
 /// collector running, a historical run must complete without any network calls
@@ -54,6 +69,35 @@ fn bad_endpoint_is_handled_gracefully() {
 
     // Errors from the background exporter are non-fatal; ignore the result.
     let _ = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
+}
+
+/// Parity of classic `traces::historical_mode_drains_without_connecting`: an
+/// `otlp_spans` sink in historical mode must complete without building a tracer
+/// provider or making any network calls — the sink no-ops under
+/// `RunMode::HistoricalFrom`.
+#[test]
+fn spans_historical_mode_drains_without_connecting() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let config = OtlpConfig::new("http://127.0.0.1:1", "test");
+
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let source = g
+        .ticker(Duration::from_millis(10))
+        .count()
+        .map(|i: &u64| Traced::<TestPayload, TestLatency>::new(TestPayload { session: *i }));
+    let _sink = source
+        .otlp_spans(
+            "test_span",
+            config,
+            |_p: &Traced<TestPayload, TestLatency>, attrs| {
+                attrs.add("k", "v");
+            },
+        )
+        .unwrap();
+
+    g.build()
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
 }
 
 /// A `(endpoint, service_name)` tuple resolves to an `OtlpConfig` via

--- a/next/crates/wingfoil-next/tests/otlp_integration.rs
+++ b/next/crates/wingfoil-next/tests/otlp_integration.rs
@@ -14,8 +14,23 @@ use std::time::Duration;
 
 use testcontainers::{GenericImage, core::WaitFor, runners::SyncRunner};
 use wingfoil::{RunFor, RunMode};
-use wingfoil_next::adapters::otlp::{OtlpConfig, OtlpSinkOps};
+use wingfoil_next::adapters::otlp::{OtlpConfig, OtlpSinkOps, OtlpSpanOps};
+use wingfoil_next::latency::{Latency, Stage, Traced, latency_stages};
 use wingfoil_next::prelude::*;
+
+latency_stages! {
+    pub IntegrationLatency {
+        ingress,
+        process,
+        egress,
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+struct TestPayload {
+    session: u64,
+}
 
 const COLLECTOR_IMAGE: &str = "otel/opentelemetry-collector";
 const COLLECTOR_TAG: &str = "0.149.0";
@@ -43,6 +58,37 @@ fn otlp_push_sends_successfully() -> anyhow::Result<()> {
         .ticker(Duration::from_millis(100))
         .count()
         .otlp_push("wingfoil_next_integration_counter", config)?;
+
+    g.build()
+        .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(1)))?;
+    Ok(())
+}
+
+/// A realtime run exports trace spans to the collector without error. Parity of
+/// classic `otlp_spans_sends_successfully`: each tick carries a fully-stamped
+/// latency record, so `otlp_spans` emits a parent span plus one child per hop.
+#[test]
+fn otlp_spans_sends_successfully() -> anyhow::Result<()> {
+    let (_container, endpoint) = start_collector()?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let config = OtlpConfig::new(endpoint, "wingfoil-next-test-spans");
+
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let source = g.ticker(Duration::from_millis(100)).count().map(|i: &u64| {
+        let mut traced =
+            Traced::<TestPayload, IntegrationLatency>::new(TestPayload { session: *i });
+        *traced.latency.stamp_mut(0) = 1000; // ingress
+        *traced.latency.stamp_mut(1) = 2000; // process
+        *traced.latency.stamp_mut(2) = 3000; // egress
+        traced
+    });
+    let _sink = source.otlp_spans(
+        "integration_span",
+        config,
+        |p: &Traced<TestPayload, IntegrationLatency>, attrs| {
+            attrs.add("session_id", p.payload.session.to_string());
+        },
+    )?;
 
     g.build()
         .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(1)))?;

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -698,7 +698,7 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    `anyhow::Result<u16>` with `.context`, not `Result<u16, io::Error>`. The one
    engine addition is `Ctx::run_mode()` (a realtime-only IO sink needs to see the
    run mode; reported as `RealTime` inside an island, like `is_last_cycle`).
-   ✅ **otlp** *(metrics done; traces deferred)*: a realtime, push-based
+   ✅ **otlp** *(metrics + traces done)*: a realtime, push-based
    OpenTelemetry metrics **sink** — the `OtlpSinkOps::otlp_push` extension trait
    on any `Stream<T: Display>` exports each tick as an OTLP `f64` gauge over
    HTTP/protobuf, behind the `otlp` feature. Built on `consume_async` so the OTel
@@ -715,13 +715,17 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    `&tokio::runtime::Handle` (the etcd/`consume_async` convention), so the graph
    must be driven from a non-async thread; (b) the sink is the `OtlpSinkOps`
    extension trait (`stream.otlp_push(&handle, name, config)`), not a classic
-   `OtlpPush` on `dyn Stream<T>`. **Capability gap — trace/span export
-   (`OtlpSpans`) not ported:** classic's span exporter emits OTel spans from
-   `Stream<P: HasLatency>` values; that path depends on the `Traced` /
-   `HasLatency` / `latency_stages!` latency infrastructure, which ✅ **has now
-   landed** (Phase 5, `src/latency.rs`). `otlp_spans` can now port mechanically
-   onto the same `consume_async` shape; until it does, only the metrics push is
-   available, and `otlp_push` itself is at full parity.
+   `OtlpPush` on `dyn Stream<T>`. **Trace/span export ✅ ported** (`OtlpSpanOps::otlp_spans`):
+   emits one parent span per tick plus one child span per stage hop from
+   `Stream<P: HasLatency>` values (now that the Phase 5 latency infrastructure
+   has landed), with caller-supplied attributes via `OtlpAttributeBuffer` and
+   the silent skip of all-zero / backwards timestamps. Same off-thread
+   `consume_async` model as `otlp_push` (the tracer provider is built lazily on
+   the first exported value and dropped at teardown to flush; no-op under
+   historical replay); the same `&tokio::runtime::Handle` and extension-trait
+   deviations apply. Parity tests: `spans_historical_mode_drains_without_connecting`
+   in `tests/otlp_adapter.rs` and `otlp_spans_sends_successfully` in
+   `tests/otlp_integration.rs`.
 8. **aeron, iceoryx2, fluvio** last — build-environment pain (CMake/clang);
    their ring-buffer polling is the natural `ALWAYS`-cap shape.
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -876,7 +876,10 @@ dynamism is an interpreted-engine capability, matching classic.
   latency solely through `LatencyStreamOps`); a stamp's stage is a compile-time
   *type* parameter, which does not map onto the `graph!` value-dispatch table,
   so compiled/nested support is out of scope for this op family.
-- **Graph export**: GML from `Builder` topology + debug labels.
+- **Graph export**: ❌ **not doing this** (GML from `Builder` topology + debug
+  labels). Deferred deliberately — we want a better introspection/visualization
+  story than a one-off GML dump, to be designed and scoped separately later
+  rather than ported as-is from classic.
 - **`#[node]` retirement**: replaced by `Op` impls.
 - **`#[op]` tooling** ✅ **landed**: `#[op(build = name)]` generates the
   interpreted `Builder` method (over `register_op1`) for single-input ops;

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -718,11 +718,10 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    `OtlpPush` on `dyn Stream<T>`. **Capability gap — trace/span export
    (`OtlpSpans`) not ported:** classic's span exporter emits OTel spans from
    `Stream<P: HasLatency>` values; that path depends on the `Traced` /
-   `HasLatency` / `latency_stages!` latency infrastructure, which is **not yet
-   ported to next** (a separate roadmap item; latency stamps "ride values as a
-   payload" per the Phase 6 notes). Once the latency types land, `otlp_spans`
-   ports mechanically onto the same `consume_async` shape. Until then only the
-   metrics push is available; `otlp_push` itself is at full parity.
+   `HasLatency` / `latency_stages!` latency infrastructure, which ✅ **has now
+   landed** (Phase 5, `src/latency.rs`). `otlp_spans` can now port mechanically
+   onto the same `consume_async` shape; until it does, only the metrics push is
+   available, and `otlp_push` itself is at full parity.
 8. **aeron, iceoryx2, fluvio** last — build-environment pain (CMake/clang);
    their ring-buffer polling is the natural `ALWAYS`-cap shape.
 
@@ -861,9 +860,18 @@ dynamism is an interpreted-engine capability, matching classic.
 
 ## Phase 5 — infrastructure
 
-- **Latency**: stamps ride values as today (`Traced` is just a payload);
-  `Ctx` gains a wall-clock accessor for `stamp_precise`-style ops.
-  `latency_stages` derive unchanged.
+- **Latency** ✅ **landed** (`src/latency.rs`): stamps ride values as today
+  (`Traced` is just a payload, re-exported from classic together with
+  `Latency`/`Stage`/`HasLatency`/`StageStats`/`LatencyStats` and the
+  `latency_stages!` derive — all engine-agnostic, unchanged). `Ctx` gained
+  `wall_time()` (a per-cycle snap, from a new `Kernel::wall_time`) and
+  `wall_time_precise()` (fresh TSC read); the node layer is re-implemented as
+  ops — `stamp`/`stamp_precise` (over `register_op1`) and the `latency_report`
+  sink — exposed via the `LatencyStreamOps`/`LatencyReportOps` fluent traits.
+  **Deviation**: fluent/interpreted only (matching classic, which exposes
+  latency solely through `LatencyStreamOps`); a stamp's stage is a compile-time
+  *type* parameter, which does not map onto the `graph!` value-dispatch table,
+  so compiled/nested support is out of scope for this op family.
 - **Graph export**: GML from `Builder` topology + debug labels.
 - **`#[node]` retirement**: replaced by `Op` impls.
 - **`#[op]` tooling** ✅ **landed**: `#[op(build = name)]` generates the

--- a/wingfoil/src/codegen.rs
+++ b/wingfoil/src/codegen.rs
@@ -59,6 +59,10 @@ pub struct Kernel {
     end_time: NanoTime,
     end_cycle: u32,
     time: NanoTime,
+    /// Wall-clock snap taken once at the start of each cycle (see
+    /// [`Kernel::wall_time`]). Distinct from `time`, which is source-driven
+    /// (logical) in historical mode.
+    wall_time: NanoTime,
     first_cycle: bool,
     is_last_cycle: bool,
     cycles: u32,
@@ -104,6 +108,7 @@ impl Kernel {
             end_time,
             end_cycle,
             time: NanoTime::ZERO,
+            wall_time: NanoTime::ZERO,
             first_cycle: true,
             is_last_cycle: false,
             cycles: 0,
@@ -144,6 +149,17 @@ impl Kernel {
     /// Current engine time.
     pub fn time(&self) -> NanoTime {
         self.time
+    }
+
+    /// Wall-clock time snapped once at the start of the current cycle.
+    ///
+    /// The same in both realtime and historical mode — always a wall-clock
+    /// snap — so latency stamping and perf telemetry mean "wall-clock time
+    /// spent" regardless of run mode. Mirrors classic `GraphState::wall_time`.
+    /// Never use for business logic (use [`time`](Self::time) for
+    /// deterministic replay).
+    pub fn wall_time(&self) -> NanoTime {
+        self.wall_time
     }
 
     /// The run mode (realtime vs historical) — lets a source op choose
@@ -205,6 +221,7 @@ impl Kernel {
                     if !progressed {
                         return false;
                     }
+                    self.wall_time = NanoTime::now();
                     return true;
                 }
                 RunMode::RealTime => {
@@ -218,6 +235,7 @@ impl Kernel {
                         while let Some(ix) = self.scheduled.pop_if_pending(self.time) {
                             dirty[ix] = true;
                         }
+                        self.wall_time = NanoTime::now();
                         return true;
                     }
                     if !progressed {
@@ -293,6 +311,7 @@ impl Kernel {
                         progressed = true;
                     }
                     if progressed {
+                        self.wall_time = NanoTime::now();
                         return true;
                     }
                     // Nothing due yet (e.g. woke at the end bound): re-check


### PR DESCRIPTION
## Summary

Two related pieces of Phase 5 infrastructure for wingfoil-next, in dependency order:

1. **Latency capture infrastructure** — ports classic `wingfoil::latency` onto the Op engine.
2. **OTLP trace/span export (`otlp_spans`)** — the classic `OtlpSpans` sink, which depended on the latency infrastructure above and was the last tracked gap in the otlp adapter.

---

## Part 1 — Latency capture (`src/latency.rs`)

The pure data layer is engine-agnostic and reused from the classic crate unchanged; only the node layer is re-implemented as ops.

- **`Kernel` (shared engine core, `wingfoil/src/codegen.rs`)** — gains a per-cycle wall-clock snap plus a `wall_time()` accessor, mirroring classic `GraphState::wall_time`. Distinct from the source-driven logical `time`, so stamps mean "wall-clock time spent" in both realtime and historical mode. Pure-additive change.
- **`Ctx` (`op.rs`)** — exposes `wall_time()` (cached per-cycle snap; stages in one cycle share it) and `wall_time_precise()` (fresh TSC read).
- **`src/latency.rs`** — re-exports the data layer (`Traced`, `Latency`, `Stage`, `HasLatency`, `StageStats`, `LatencyStats`, `latency_stages!`) from classic unchanged, and implements `Stamp`/`StampPrecise` pass-through ops (over `register_op1`) and the `LatencyReport` sink op (a `Builder` method with a stop hook). Exposed via `LatencyStreamOps` (`stamp`/`stamp_if`/`stamp_precise`/`stamp_precise_if`) and `LatencyReportOps` (`latency_report`/`latency_report_if`).
- **`tests/latency.rs`** — 9 node-layer parity tests (wall-clock stamping, shared-per-cycle vs fresh stamps, per-stage delta aggregation, the `_if` toggles).
- **`Cargo.toml` (workspace)** — declares `iceoryx2` as a known cfg (the `latency_stages!` derive emits that gate unconditionally); additive, `wingfoil` already has the real feature.

**Deviation**: fluent/interpreted only, matching classic — a stamp's stage is a compile-time *type* parameter that does not map onto the `graph!` value-dispatch table, so compiled/nested support is out of scope for this op family.

## Part 2 — OTLP trace/span export (`otlp_spans`)

- New `OtlpSpanOps` extension trait + `OtlpAttributeBuffer` in `src/adapters/otlp.rs`, alongside the existing `OtlpSinkOps` metrics sink. `stream.otlp_spans(&handle, name, config, attrs)` emits one parent span per tick plus one child span per stage hop.
- Same off-thread `consume_async` model as `otlp_push`: tracer provider built lazily on the first exported value and dropped at teardown to flush; a no-op under `RunMode::HistoricalFrom`.
- Every classic span capability preserved (parent + per-hop children, caller-supplied attributes, silent skip of all-zero / backwards timestamps). Adds the `trace` feature to the OTel deps, mirroring classic.
- Tests: `spans_historical_mode_drains_without_connecting` (`tests/otlp_adapter.rs`) and `otlp_spans_sends_successfully` (testcontainers, `tests/otlp_integration.rs`).

---

## Docs

`next/docs/port-plan.md` — Phase 5 Latency item marked landed; the otlp adapter status updated to *(metrics + traces done)*.

## Testing

- `cargo fmt --all` / `cargo lint` / `cargo lint-all` — all clean.
- `cargo test -p wingfoil-next` (default) and `--features otlp` — all pass, including the 9 latency tests and 4 otlp-adapter tests.
- `cargo test -p wingfoil --lib` — all 260 classic lib tests pass (guards the shared `Kernel` change).
- The `otlp_integration.rs` span test compiles under `otlp-integration-test` (needs a Docker collector to run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)