### PR TITLE
next-python: complete the combinator surface (reduce/split/dataframe/merge_all)

### DIFF
--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -224,6 +224,14 @@ impl PyStream {
         self.wrap(self.stream.delay(delay))
     }
 
+    /// Merge with several other streams at once (the classic n-ary `merge`); on
+    /// any tick the earliest-supplied ticked input wins. Equivalent to a chain
+    /// of 2-ary [`merge`](Self::merge)s.
+    pub fn merge_all(&self, others: &[PyStream]) -> PyStream {
+        let refs: Vec<&Stream<PyElement>> = others.iter().map(|s| &s.stream).collect();
+        self.wrap(self.stream.merge_all(&refs))
+    }
+
     /// Suppress consecutive duplicate values (emit on change only).
     pub fn distinct(&self) -> PyStream {
         self.wrap(self.stream.distinct())
@@ -914,6 +922,23 @@ mod tests {
         let l: i64 = (&left.value()).try_into().unwrap();
         let r: i64 = (&right.value()).try_into().unwrap();
         assert_eq!((3, 30), (l, r));
+    }
+
+    #[test]
+    fn merge_all_earliest_supplied_wins_ties() {
+        let g = PyGraph::new();
+        let a = g.counter(Duration::from_nanos(300));
+        let b = g
+            .counter(Duration::from_nanos(300))
+            .map(lambda("lambda n: n + 100"));
+        let c = g
+            .counter(Duration::from_nanos(300))
+            .map(lambda("lambda n: n + 200"));
+        let merged = a.merge_all(&[b, c]);
+        run_cycles(&g, 3);
+        // All three tick together each instant; `a` (earliest) wins the tie.
+        let v: i64 = (&merged.value()).try_into().unwrap();
+        assert_eq!(3, v);
     }
 
     #[test]

--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -469,6 +469,53 @@ impl PyStream {
         self.wrap(joined)
     }
 
+    /// Build a pandas `DataFrame` (columns `time`, `value`) from every emitted
+    /// value paired with its engine time (the classic `dataframe`). The frame is
+    /// assembled **once, on the last cycle**, so the stream's final value is the
+    /// completed `DataFrame`; earlier cycles stay quiet. Rows are engine-owned
+    /// state re-seeded on a graph reset, so a re-run rebuilds cleanly.
+    ///
+    /// `pandas` is imported lazily here — only a graph that actually calls
+    /// `dataframe` needs it; if it is not importable the run aborts with context.
+    pub fn dataframe(&self) -> PyStream {
+        let framed = self.stream.with_time().wire(|b: &mut Builder, h| {
+            b.register_op1(
+                h,
+                "dataframe",
+                Activation::NONE,
+                (),
+                Vec::<(i64, Py<PyAny>)>::new, // state: accumulated (nanos, value) rows
+                move |_cfg: &mut (),
+                      rows: &mut Vec<(i64, Py<PyAny>)>,
+                      (time, value): &(NanoTime, PyElement),
+                      ctx| {
+                    Python::attach(|py| {
+                        rows.push((u64::from(*time) as i64, value.object().clone_ref(py)));
+                        if !ctx.is_last_cycle() {
+                            return Ok(Tick::Quiet);
+                        }
+                        let pandas = py
+                            .import("pandas")
+                            .map_err(|err| anyhow::anyhow!("dataframe() needs pandas: {err}"))?;
+                        let times: Vec<i64> = rows.iter().map(|(t, _)| *t).collect();
+                        let values: Vec<Py<PyAny>> =
+                            rows.iter().map(|(_, v)| v.clone_ref(py)).collect();
+                        let columns = pyo3::types::PyDict::new(py);
+                        columns
+                            .set_item("time", times)
+                            .and_then(|()| columns.set_item("value", values))
+                            .map_err(|err| anyhow::anyhow!("dataframe() column build: {err}"))?;
+                        let frame = pandas
+                            .call_method1("DataFrame", (columns,))
+                            .map_err(|err| anyhow::anyhow!("pandas.DataFrame raised: {err}"))?;
+                        Ok(Tick::Value(PyElement::new(frame.unbind())))
+                    })
+                },
+            )
+        });
+        self.wrap(framed)
+    }
+
     /// Reduce values with a Python callable, emitting the running result (the
     /// classic `reduce`). The **first** value seeds the accumulator and is
     /// emitted as-is; each later value emits `func(acc, value)`
@@ -807,6 +854,40 @@ mod tests {
         run_cycles(&g, 6);
         let v: i64 = (&kept.value()).try_into().unwrap();
         assert_eq!(6, v); // 2,4,6 pass; last is 6
+    }
+
+    #[test]
+    fn dataframe_builds_on_last_cycle() {
+        // Skip when pandas isn't installed (parity with pytest's importorskip),
+        // so this test doesn't fail in a bare CI environment.
+        if Python::attach(|py| py.import("pandas").is_err()) {
+            return;
+        }
+        let g = PyGraph::new();
+        let df = g.counter(Duration::from_nanos(100)).dataframe();
+        run_cycles(&g, 3);
+        // The final value is a pandas DataFrame with time/value columns.
+        let (times, values): (Vec<i64>, Vec<i64>) = Python::attach(|py| {
+            let frame = df.value().value();
+            let bound = frame.bind(py);
+            let t = bound
+                .call_method1("__getitem__", ("time",))
+                .unwrap()
+                .call_method0("tolist")
+                .unwrap()
+                .extract()
+                .unwrap();
+            let v = bound
+                .call_method1("__getitem__", ("value",))
+                .unwrap()
+                .call_method0("tolist")
+                .unwrap()
+                .extract()
+                .unwrap();
+            (t, v)
+        });
+        assert_eq!(vec![0, 100, 200], times);
+        assert_eq!(vec![1, 2, 3], values);
     }
 
     #[test]

--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -469,6 +469,64 @@ impl PyStream {
         self.wrap(joined)
     }
 
+    /// Reduce values with a Python callable, emitting the running result (the
+    /// classic `reduce`). The **first** value seeds the accumulator and is
+    /// emitted as-is; each later value emits `func(acc, value)`
+    /// (functools.reduce-style, no explicit initial). The accumulator is
+    /// engine-owned state re-seeded on a graph reset, so a re-run restarts. A
+    /// raised exception aborts the run with context.
+    pub fn reduce(&self, func: Py<PyAny>) -> PyStream {
+        let reduced = self.stream.wire(move |b: &mut Builder, h| {
+            b.register_op1(
+                h,
+                "reduce",
+                Activation::NONE,
+                func,                         // cfg: the Python reducer
+                || Option::<PyElement>::None, // state: accumulator, empty until the first value
+                move |func: &mut Py<PyAny>,
+                      acc: &mut Option<PyElement>,
+                      value: &PyElement,
+                      _ctx| {
+                    match acc.take() {
+                        None => {
+                            *acc = Some(value.clone());
+                            Ok(Tick::Value(value.clone()))
+                        }
+                        Some(current) => Python::attach(|py| {
+                            let next = func.call1(py, (current.value(), value.value())).map_err(
+                                |err| anyhow::anyhow!("Python reduce callable raised: {err}"),
+                            )?;
+                            let next = PyElement::new(next);
+                            *acc = Some(next.clone());
+                            Ok(Tick::Value(next))
+                        }),
+                    }
+                },
+            )
+        });
+        self.wrap(reduced)
+    }
+
+    /// Decompose a stream of 2-tuples into its two component streams (the
+    /// classic `split`); both branches tick whenever the source does. Reading a
+    /// non-indexable value aborts the run with context.
+    pub fn split(&self) -> (PyStream, PyStream) {
+        (self.item(0), self.item(1))
+    }
+
+    /// Project index `i` out of each (indexable) value — the per-branch half of
+    /// [`split`](Self::split).
+    fn item(&self, i: usize) -> PyStream {
+        self.wire_stateless("split", move |value| {
+            Python::attach(|py| {
+                let item = value.object().bind(py).get_item(i).map_err(|err| {
+                    anyhow::anyhow!("Python split: value is not indexable at {i}: {err}")
+                })?;
+                Ok(Tick::Value(PyElement::new(item.unbind())))
+            })
+        })
+    }
+
     /// Wire a **stateless, fallible** single-input op that maps each value to a
     /// [`Tick`] — the shared plumbing for `filter_map`/`filter_value`/
     /// `filter_none`. Runs over the engine's `register_op1` so a returned `Err`
@@ -749,6 +807,32 @@ mod tests {
         run_cycles(&g, 6);
         let v: i64 = (&kept.value()).try_into().unwrap();
         assert_eq!(6, v); // 2,4,6 pass; last is 6
+    }
+
+    #[test]
+    fn reduce_runs_from_first_value() {
+        let g = PyGraph::new();
+        // First value seeds; then max-so-far.
+        let running_max = g
+            .counter(Duration::from_nanos(100))
+            .map(lambda("lambda n: (n * 7) % 5")) // 2,4,1,3,0,2
+            .reduce(lambda("lambda acc, v: max(acc, v)"));
+        run_cycles(&g, 6);
+        let v: i64 = (&running_max.value()).try_into().unwrap();
+        assert_eq!(4, v);
+    }
+
+    #[test]
+    fn split_decomposes_tuples() {
+        let g = PyGraph::new();
+        let pairs = g
+            .counter(Duration::from_nanos(100))
+            .map(lambda("lambda n: (n, n * 10)"));
+        let (left, right) = pairs.split();
+        run_cycles(&g, 3);
+        let l: i64 = (&left.value()).try_into().unwrap();
+        let r: i64 = (&right.value()).try_into().unwrap();
+        assert_eq!((3, 30), (l, r));
     }
 
     #[test]

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -255,6 +255,13 @@ impl Stream {
         (Stream(a), Stream(b))
     }
 
+    /// Build a pandas `DataFrame` (columns `time`, `value`) from every value and
+    /// its engine time; the final value (after the run) is the frame. Requires
+    /// pandas at run time.
+    fn dataframe(&self) -> Stream {
+        Stream(self.0.dataframe())
+    }
+
     /// The current value after the owning [`Graph`] has run.
     fn value(&self) -> Py<PyAny> {
         self.0.value().value()

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -124,6 +124,13 @@ impl Stream {
         Stream(self.0.merge(&other.0))
     }
 
+    /// Merge with several other streams at once; the earliest-supplied ticked
+    /// input wins.
+    fn merge_all(&self, others: Vec<PyRef<'_, Stream>>) -> Stream {
+        let streams: Vec<PyStream> = others.iter().map(|s| s.0.clone()).collect();
+        Stream(self.0.merge_all(&streams))
+    }
+
     /// Re-emit each value `delay_nanos` nanoseconds later.
     fn delay(&self, delay_nanos: u64) -> Stream {
         Stream(self.0.delay(Duration::from_nanos(delay_nanos)))

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -243,6 +243,18 @@ impl Stream {
         Stream(self.0.bimap(&other.0, func))
     }
 
+    /// Reduce values with `func(acc, value)`, emitting the running result. The
+    /// first value seeds the accumulator; a raised exception aborts the run.
+    fn reduce(&self, func: Py<PyAny>) -> Stream {
+        Stream(self.0.reduce(func))
+    }
+
+    /// Decompose a stream of 2-tuples into its two component streams.
+    fn split(&self) -> (Stream, Stream) {
+        let (a, b) = self.0.split();
+        (Stream(a), Stream(b))
+    }
+
     /// The current value after the owning [`Graph`] has run.
     fn value(&self) -> Py<PyAny> {
         self.0.value().value()

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -332,6 +332,22 @@ def test_sum_of_non_numeric_aborts_run():
         g.run(cycles=1)
 
 
+def test_reduce_runs_from_first_value():
+    g = wf.Graph()
+    out = g.counter(period_nanos=100).reduce(lambda acc, v: acc + v)
+    g.run(cycles=3)
+    assert out.value() == 6  # 1, then 1+2=3, then 3+3=6
+
+
+def test_split_decomposes_tuples():
+    g = wf.Graph()
+    pairs = g.counter(period_nanos=100).map(lambda n: (n, n * 10))
+    left, right = pairs.split()
+    g.run(cycles=3)
+    assert left.value() == 3
+    assert right.value() == 30
+
+
 def test_bimap_combines_two_inputs():
     g = wf.Graph()
     a = g.counter(period_nanos=100)  # 1,2,3

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -332,6 +332,17 @@ def test_sum_of_non_numeric_aborts_run():
         g.run(cycles=1)
 
 
+def test_dataframe_from_stream():
+    pd = pytest.importorskip("pandas")
+    g = wf.Graph()
+    df = g.counter(period_nanos=100).dataframe()
+    g.run(cycles=3)
+    frame = df.value()
+    assert isinstance(frame, pd.DataFrame)
+    assert list(frame["time"]) == [0, 100, 200]
+    assert list(frame["value"]) == [1, 2, 3]
+
+
 def test_reduce_runs_from_first_value():
     g = wf.Graph()
     out = g.counter(period_nanos=100).reduce(lambda acc, v: acc + v)

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -332,6 +332,16 @@ def test_sum_of_non_numeric_aborts_run():
         g.run(cycles=1)
 
 
+def test_merge_all_combines_streams():
+    g = wf.Graph()
+    a = g.counter(period_nanos=300)  # ticks at 0,300,600
+    b = g.counter(period_nanos=300).map(lambda n: n + 100)
+    c = g.counter(period_nanos=300).map(lambda n: n + 200)
+    out = a.merge_all([b, c])
+    g.run(cycles=3)  # all tick together; earliest-supplied (a) wins the tie
+    assert out.value() == 3  # a's running count
+
+
 def test_dataframe_from_stream():
     pd = pytest.importorskip("pandas")
     g = wf.Graph()

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -243,6 +243,8 @@ form.
 | `PyElement` boundary type in a `wingfoil-next-python` crate | `Clone/Default/Debug/PartialEq` + `Add/Sub/Not` + scalar/`Py<PyAny>` edge conversions | ✅ done (`element.rs`) |
 | Python-held open `GraphBuilder` + erased `PyStream` object | `PyGraph`/`PyStream` over the `Rc`-shared builder + runner slot | ✅ done (`graph.rs`) |
 | `#[pyclass]` module (`Graph`/`Stream`) + maturin build + pytest | importable `wingfoil_next` module | ✅ done (`python.rs`, `pyproject.toml`) |
+| Built-in combinator surface on `PyStream` (legacy `test_streams` parity) | `map`/`filter`/`merge`/`merge_all`/`delay`/`distinct`/`count`/`limit`/`throttle`/`sample`/`difference`/`not`/`inspect`/`accumulate`/`buffer`/`window`/`with_time`/`collect`/`fold`/`reduce`/`filter_map`/`filter_value`/`filter_none`/`sum`/`mean`/`average`/`bimap`/`split`/`dataframe` — all with Python-exception propagation; `Vec`→list & `(nanos,value)` tuple edge conversions | ✅ done (`graph.rs`, `python.rs`; PRs #549/#551 + follow-ups) |
+| Python-defined custom node (legacy `CustomStream`) | `Graph.custom_node(upstreams, obj)` over `GraphBuilder::custom_node` (the `MutableNode`+`StreamPeekRef` twin); `cycle(values)->bool` + `peek()` protocol; single-run | ✅ done (`graph.rs`, PR #549) |
 | `pyop_fn!` seam + declarative macro | `PyStream::wire_op1` + `pyop_fn!` for stateless single-input ops | ✅ done (`macros.rs`) |
 | `#[pyop]` **proc** macro | reads an `Op` impl → `#[pyfunction]`; v1 stateless single-input concrete | ✅ done (`wingfoil-next-python-macros`) |
 | `#[pyop]` extensions | stateful/multi-input shapes; `Cfg`-tuple arg names | ⬜ |


### PR DESCRIPTION
## Summary

Completes the `wingfoil-next-python` object-form binding's built-in combinator surface, bringing it to full legacy `test_streams.py` parity. This is the last combinator batch for the Phase 6 Python gate (next-python supersedes legacy `wingfoil-python`); the remaining next-python work is the distinct `#[pyadapter]`/`#[pygraph]` plugin-SDK layer.

Follows #549 (custom-node primitive + first combinators) and #551 (collection/time ops).

## Key changes

- **`reduce(func)`** — functools.reduce-style running reduction: the first value seeds the accumulator and is emitted as-is, each later value emits `func(acc, value)`. Accumulator is engine-owned state re-seeded on a graph reset (re-run restarts). Raised exception aborts the run.
- **`split()`** — decompose a stream of 2-tuples into its two component streams; a non-indexable value aborts the run.
- **`dataframe()`** — accumulate each value with its engine time and, on the last cycle, build a pandas `DataFrame` (columns `time`, `value`) as the stream's final value. pandas is imported lazily (only a graph that calls it needs pandas); an unimportable pandas aborts the run. Tests skip when pandas is absent (Rust guards on import, pytest uses `importorskip`), so a bare CI env stays green.
- **`merge_all(others)`** — n-ary merge; earliest-supplied ticked input wins.
- **docs** — records the now-complete combinator surface + custom-node path in the interop build list.

## Surface after this PR

`PyStream` covers 30 combinators + `custom_node`, all with Python-exception propagation:

`map · filter · merge · merge_all · delay · distinct · count · limit · throttle · sample · difference · not · inspect · accumulate · buffer · window · with_time · collect · fold · reduce · filter_map · filter_value · filter_none · sum · mean · average · bimap · split · dataframe`

## Tests

Embedded-interpreter Rust tests + pytest cases for each op. **39 Rust lib tests + 42 pytest cases pass** (pytest under a local maturin build; pandas installed for the `dataframe` happy path). `cargo fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P)_