### PR TITLE
next-python: add a values() source to feed a Python sequence into a graph

### DIFF
--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -31,7 +31,7 @@ use pyo3::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 use wingfoil_next::interp::{Builder, Handle, Runner, SlotRef};
 use wingfoil_next::op::{Activation, Ctx, Tick};
-use wingfoil_next::prelude::{GraphBuilder, SourceOps, Stream, StreamOps, Upstream};
+use wingfoil_next::prelude::{Burst, GraphBuilder, SourceOps, Stream, StreamOps, Upstream};
 use wingfoil_next::stats::StatisticsOps;
 
 use crate::PyElement;
@@ -86,6 +86,30 @@ impl PyGraph {
     pub fn counter(&self, period: Duration) -> PyStream {
         let counted = self.builder.ticker(period).count();
         self.wrap(counted.map(|n: &u64| PyElement::from(*n as i64)))
+    }
+
+    /// A source that replays a finite sequence of Python values, one per tick,
+    /// `period` apart (the first at t=0). This is how a Python caller feeds real
+    /// data into a graph rather than a synthetic `counter`/`constant`.
+    ///
+    /// Built on the historical-replay [`channel`](SourceOps::channel) layer, so
+    /// it replays **deterministically** in historical mode and a graph
+    /// containing it is single-run (the producer channel is consumed by the
+    /// first run). Distinct per-tick timestamps mean each value rides its own
+    /// cycle (no same-instant grouping).
+    pub fn values(&self, values: Vec<PyElement>, period: Duration) -> PyStream {
+        let step = period.as_nanos() as u64;
+        let rows = values
+            .into_iter()
+            .enumerate()
+            .map(move |(i, value)| Ok((value, NanoTime::from(i as u64 * step))));
+        let bursts = self.builder.replay_results(rows);
+        // Each burst holds exactly one value (timestamps are distinct); take it.
+        self.wrap(
+            bursts.map(|burst: &Burst<PyElement>| {
+                burst.last().cloned().unwrap_or_else(PyElement::none)
+            }),
+        )
     }
 
     /// Run the graph to its bound, storing the runner so retained
@@ -1010,6 +1034,43 @@ mod tests {
             .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
             .unwrap_err();
         assert!(format!("{err:#}").contains("Python inspect callable raised"));
+    }
+
+    #[test]
+    fn values_replays_a_sequence() {
+        let g = PyGraph::new();
+        let src = g.values(
+            vec![
+                PyElement::from(10_i64),
+                PyElement::from(20_i64),
+                PyElement::from(30_i64),
+            ],
+            Duration::from_nanos(100),
+        );
+        let acc = src.accumulate();
+        run_cycles(&g, 3);
+        let v: Vec<i64> = Python::attach(|py| acc.value().value().extract(py).unwrap());
+        assert_eq!(vec![10, 20, 30], v);
+    }
+
+    #[test]
+    fn values_source_feeds_downstream_ops() {
+        let g = PyGraph::new();
+        // Feed real data and run it through a combinator chain.
+        let doubled = g
+            .values(
+                vec![
+                    PyElement::from(1_i64),
+                    PyElement::from(2_i64),
+                    PyElement::from(3_i64),
+                ],
+                Duration::from_nanos(100),
+            )
+            .map(lambda("lambda x: x * 2"))
+            .sum();
+        run_cycles(&g, 3);
+        let v: f64 = (&doubled.value()).try_into().unwrap();
+        assert_eq!(12.0, v); // (1+2+3)*2
     }
 
     #[test]

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -50,6 +50,14 @@ impl Graph {
         Stream(self.0.counter(Duration::from_nanos(period_nanos)))
     }
 
+    /// A source that replays a finite list of values, one per tick,
+    /// `period_nanos` apart (first at t=0). The way to feed real data into a
+    /// graph from Python. A graph containing it is single-run.
+    fn values(&self, values: Vec<Py<PyAny>>, period_nanos: u64) -> Stream {
+        let elements: Vec<PyElement> = values.into_iter().map(PyElement::from).collect();
+        Stream(self.0.values(elements, Duration::from_nanos(period_nanos)))
+    }
+
     /// Run the graph to its bound.
     ///
     /// `realtime` selects wall-clock vs historical replay (from `start_nanos`).

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -18,6 +18,28 @@ def test_constant_maps_via_python_lambda():
     assert out.value() == 16.0
 
 
+def test_values_source_replays_a_sequence():
+    g = wf.Graph()
+    out = g.values([10, 20, 30], period_nanos=100).accumulate()
+    g.run(cycles=3)
+    assert out.value() == [10, 20, 30]
+
+
+def test_values_source_feeds_combinators():
+    # Feed real data from Python, run it through a chain.
+    g = wf.Graph()
+    out = g.values([1, 2, 3, 4], period_nanos=100).filter_value(lambda n: n % 2 == 0).sum()
+    g.run(cycles=4)
+    assert out.value() == 6.0  # keep 2, 4 -> cumulative sum 6
+
+
+def test_values_source_carries_strings():
+    g = wf.Graph()
+    out = g.values(["a", "b", "c"], period_nanos=100).map(lambda s: s.upper()).accumulate()
+    g.run(cycles=3)
+    assert out.value() == ["A", "B", "C"]
+
+
 def test_counter_source_ticks():
     g = wf.Graph()
     doubled = g.counter(period_nanos=100).map(lambda n: n * 2)


### PR DESCRIPTION
## Summary

Adds the data-input primitive Python users need beyond the synthetic `counter`/`constant` sources: `Graph.values(list, period_nanos)` replays a finite list of values into a graph, one per tick, so a caller can run **their own data** through the combinator surface.

Follows the combinator-surface work in #549/#551/#554.

## Key changes

- **`Graph.values(values, period_nanos)`** (`graph.rs`, `python.rs`) — a source that replays a finite list of Python values, one per tick, `period_nanos` apart (first at t=0).
  - Built on the historical-replay `channel` layer, so it replays **deterministically** in historical mode.
  - A graph containing it is **single-run** (the producer channel is consumed by the first run), consistent with the other channel-backed sources.
  - Distinct per-tick timestamps mean each value rides its own cycle, so the `Burst<PyElement>` the channel emits collapses cleanly to one value per tick (no same-instant data loss).

## Tests

Embedded-interpreter Rust tests + pytest cases (**41 Rust / 45 pytest pass** under maturin): replay a sequence, feed a combinator chain (`values → filter_value → sum`), and carry non-numeric (string) payloads. `cargo fmt`/`clippy` clean.

## Note

A timestamped `replay(rows)` source (arbitrary user nanoseconds) is deliberately **not** included here: with arbitrary timestamps, same-instant values form a burst, and collapsing that to a single value would silently drop data — a footgun for backtesting. A burst-preserving timestamped replay is a separate design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P)_