### PR TITLE
next: move etcd_pub off the graph thread via a fallible consume_async teardown (B1)

### DIFF
--- a/next/crates/wingfoil-next/src/adapters/etcd.rs
+++ b/next/crates/wingfoil-next/src/adapters/etcd.rs
@@ -45,27 +45,33 @@
 //!
 //! ## Runtime requirement (a `block_on` footgun)
 //!
-//! Because the sink drives its writes with [`Handle::block_on`] on the graph
-//! thread (and the [`LeaseGuard`] revokes on `Drop` the same way), **the graph
-//! must be built, run, and dropped from a non-async thread** — the ordinary
-//! case (`main`, a `#[test]` fn). Driving it from *inside* an async context
-//! (e.g. `rt.block_on(async { g.build().run(..) })`) makes those `block_on`
-//! calls panic, and a panic in the `Drop` revoke during unwinding would abort.
-//! The producer and keepalive tasks, by contrast, run on the runtime's own
-//! workers via [`Handle::spawn`] and have no such constraint.
+//! The per-write PUTs run **off** the graph thread on the shared
+//! [`consume_async`](crate::async_source::consume_async) consumer task (see
+//! below); but the wiring-time `Client::connect`/`lease_grant` and the
+//! [`LeaseGuard`]'s revoke-on-`Drop` still drive the runtime with
+//! [`Handle::block_on`] on the graph thread, so **the graph must be built, run,
+//! and dropped from a non-async thread** — the ordinary case (`main`, a
+//! `#[test]` fn). Driving it from *inside* an async context (e.g.
+//! `rt.block_on(async { g.build().run(..) })`) makes those `block_on` calls
+//! panic, and a panic in the `Drop` revoke during unwinding would abort. This is
+//! the same constraint every `consume_async` sink carries. The producer and
+//! keepalive tasks, by contrast, run on the runtime's own workers via
+//! [`Handle::spawn`] and have no such constraint.
 //!
-//! ## Why `etcd_pub` still blocks the graph thread (deferred follow-up)
+//! ## Writes run off the graph thread (via `consume_async`)
 //!
-//! The general async-sink primitive [`consume_async`](crate::async_source::consume_async)
-//! now exists to move a networked sink's writes off the graph thread. `etcd_pub`
-//! does **not** yet use it: `consume_async` writes off-thread and surfaces a write
-//! error only on a *later* cycle (or swallows it in the teardown flush), whereas
-//! `etcd_pub`'s `force: false` conditional-write test aborts a **single-cycle**
-//! (`RunFor::Cycles(1)`) run on the very write that fails — a guarantee off-thread
-//! writes cannot preserve. Migrating `etcd_pub` to `consume_async` is a tracked
-//! follow-up (see `docs/port-plan.md`); until then the sink keeps its
-//! `Handle::block_on` per-write path so that per-write failures still abort the
-//! run deterministically.
+//! `etcd_pub` drives its PUTs through the shared async-sink primitive
+//! [`consume_async`](crate::async_source::consume_async), so the network writes
+//! run on a background consumer task rather than blocking a `cycle`. A single
+//! consumer awaits each write to completion before the next, preserving burst
+//! order. A `force: false` conditional-write conflict returns an error that
+//! aborts the run — surfaced on a later cycle, or, for the **final** write, by
+//! the sink's `flush` teardown (`consume_async` returns it, wired here as
+//! [`finally`](crate::fluent::StreamOps::finally)). That teardown-time surfacing
+//! is exactly how classic aborts a single-cycle (`RunFor::Cycles(1)`) run whose
+//! only write conflicts (`AsyncConsumerNode::teardown` joins the consumer and
+//! propagates its error), so the `force: false` guarantee is preserved without a
+//! per-write `block_on`.
 //!
 //! # Subscribing to a key prefix (the snapshot→watch handoff)
 //!
@@ -84,10 +90,10 @@
 //! # Sink
 //!
 //! [`EtcdSinkOps::etcd_pub`] connects at wiring time (a connection error surfaces
-//! before the run) and issues one PUT per [`EtcdEntry`] in each burst, blocking
-//! the graph thread on the runtime for the write so any failure aborts the run
-//! deterministically with context — matching the classic consumer's ordering
-//! guarantees.
+//! before the run) and issues one PUT per [`EtcdEntry`] in each burst on the
+//! off-thread [`consume_async`](crate::async_source::consume_async) consumer, in
+//! order, so any failure aborts the run with context — matching the classic
+//! consumer's ordering and error-surfacing guarantees.
 //!
 //! - `lease_ttl: None` writes plain keys that persist until deleted.
 //! - `lease_ttl: Some(ttl)` attaches an etcd lease with a background keepalive
@@ -117,7 +123,7 @@ use tokio::runtime::Handle;
 use wingfoil::{NanoTime, RunMode};
 
 use crate::Burst;
-use crate::async_source::{RunParams, produce_async};
+use crate::async_source::{RunParams, consume_async, produce_async};
 use crate::burst;
 use crate::fluent::{GraphBuilder, Stream, StreamOps};
 
@@ -460,51 +466,65 @@ impl EtcdSinkOps for Stream<Burst<EtcdEntry>> {
         };
 
         let lease_id = guard.as_ref().map(|g| g.lease_id);
-        let handle = handle.clone();
-        // `for_each` takes an `Fn`; the etcd `Client` needs `&mut` per PUT, so it
-        // lives behind a `RefCell`. The lease guard is moved in so its revoke
-        // fires when the sink is dropped at graph teardown.
-        let client = RefCell::new(client);
-        Ok(self.for_each(move |burst: &Burst<EtcdEntry>| {
-            // Load-bearing: referencing `guard` is what makes this `move` closure
-            // capture (and thus own) it, so the lease is revoked only when the
-            // sink is dropped at teardown — not immediately at the end of wiring.
-            let _lease = &guard;
-            let mut client = client.borrow_mut();
-            handle.block_on(async {
-                for entry in burst.iter() {
-                    let opts = lease_id.map(|id| PutOptions::new().with_lease(id));
-                    if force {
-                        client
-                            .put(entry.key.clone(), entry.value.clone(), opts)
-                            .await
-                            .with_context(|| format!("etcd_pub: PUT {} failed", entry.key))?;
-                    } else {
-                        // Conditional put: succeed only if the key is absent.
-                        // create_revision == 0 is etcd's canonical "key absent".
-                        let key_absent = vec![Compare::create_revision(
-                            entry.key.as_bytes(),
-                            CompareOp::Equal,
-                            0,
-                        )];
-                        let put_op =
-                            vec![TxnOp::put(entry.key.as_bytes(), entry.value.as_slice(), opts)];
-                        let txn = Txn::new().when(key_absent).and_then(put_op);
-                        let resp = client
-                            .txn(txn)
-                            .await
-                            .with_context(|| format!("etcd_pub: conditional PUT {} failed", entry.key))?;
-                        if !resp.succeeded() {
-                            anyhow::bail!(
-                                "etcd_pub: conditional write failed: key already exists (use force=true to overwrite): {}",
-                                entry.key
-                            );
-                        }
+
+        // Each `EtcdEntry` is written by the shared `consume_async` consumer task,
+        // off the graph thread (single consumer, so PUTs preserve burst order). A
+        // per-entry client clone is cheap (the etcd `Client` is an `Arc` inside)
+        // and lets each write own its `&mut`. A `force:false` conflict returns an
+        // error that aborts the run — on a later cycle, or, for the final write,
+        // via the `flush` teardown wired below (matching classic's teardown-time
+        // surfacing).
+        let write_client = client.clone();
+        let (sink, flush) = consume_async(&self.graph(), None, move |entry: EtcdEntry| {
+            let mut client = write_client.clone();
+            async move {
+                let opts = lease_id.map(|id| PutOptions::new().with_lease(id));
+                if force {
+                    client
+                        .put(entry.key.clone(), entry.value.clone(), opts)
+                        .await
+                        .with_context(|| format!("etcd_pub: PUT {} failed", entry.key))?;
+                } else {
+                    // Conditional put: succeed only if the key is absent.
+                    // create_revision == 0 is etcd's canonical "key absent".
+                    let key_absent = vec![Compare::create_revision(
+                        entry.key.as_bytes(),
+                        CompareOp::Equal,
+                        0,
+                    )];
+                    let put_op = vec![TxnOp::put(
+                        entry.key.as_bytes(),
+                        entry.value.as_slice(),
+                        opts,
+                    )];
+                    let txn = Txn::new().when(key_absent).and_then(put_op);
+                    let resp = client.txn(txn).await.with_context(|| {
+                        format!("etcd_pub: conditional PUT {} failed", entry.key)
+                    })?;
+                    if !resp.succeeded() {
+                        anyhow::bail!(
+                            "etcd_pub: conditional write failed: key already exists (use force=true to overwrite): {}",
+                            entry.key
+                        );
                     }
                 }
-                anyhow::Ok(())
-            })?;
-            Ok(())
+                Ok(())
+            }
+        })?;
+
+        // Teardown: drain every queued write (surfacing a final-cycle error),
+        // *then* drop the lease guard so its revoke fires only after the writes
+        // complete — the classic order (loop ends → abort keepalive → revoke).
+        // The guard revokes via `block_on` on the graph thread, so it must not
+        // drop inside the async consumer task; holding it here keeps it on the
+        // graph thread. Revoke runs regardless of a write error.
+        let guard_cell = RefCell::new(guard);
+        Ok(self.for_each(sink).finally(move |u: &()| {
+            let flush_result = flush(u);
+            // Load-bearing: `take()` drops the `LeaseGuard` (aborting keepalive
+            // and revoking the lease) here at teardown rather than at graph drop.
+            guard_cell.borrow_mut().take();
+            flush_result
         }))
     }
 }

--- a/next/crates/wingfoil-next/src/adapters/kafka.rs
+++ b/next/crates/wingfoil-next/src/adapters/kafka.rs
@@ -319,10 +319,11 @@ impl KafkaSinkOps for Stream<Burst<KafkaRecord>> {
 
         // `consume_async` drains each burst's records through a single consumer
         // task (order preserved) off the graph thread; a write error propagates
-        // back into the graph on the next cycle. The producer is cloned per send
-        // (it is an `Arc` internally, cheap to clone and `Send`). The graph owns
-        // the runtime the consumer task runs on.
-        let sink = consume_async(&self.graph(), None, move |record: KafkaRecord| {
+        // back into the graph on the next cycle, and the final cycle's error is
+        // surfaced by the `flush` teardown wired below. The producer is cloned
+        // per send (it is an `Arc` internally, cheap to clone and `Send`). The
+        // graph owns the runtime the consumer task runs on.
+        let (sink, flush) = consume_async(&self.graph(), None, move |record: KafkaRecord| {
             let producer = producer.clone();
             async move {
                 let mut fut_record = FutureRecord::to(&record.topic).payload(&record.value);
@@ -338,7 +339,7 @@ impl KafkaSinkOps for Stream<Burst<KafkaRecord>> {
                 Ok(())
             }
         })?;
-        Ok(self.for_each(sink))
+        Ok(self.for_each(sink).finally(flush))
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/otlp.rs
+++ b/next/crates/wingfoil-next/src/adapters/otlp.rs
@@ -109,7 +109,7 @@ use wingfoil::RunMode;
 
 use crate::async_source::consume_async;
 use crate::burst;
-use crate::fluent::Stream;
+use crate::fluent::{Stream, StreamOps};
 use crate::latency::{HasLatency, Latency};
 use crate::op::{Activation, Ctx, Tick};
 
@@ -211,7 +211,7 @@ where
         // dropped at teardown), never in historical mode (no value reaches here).
         let mut gauge: Option<opentelemetry::metrics::Gauge<f64>> = None;
         let mut provider: Option<SdkMeterProvider> = None;
-        let sink = consume_async(&self.graph(), None, move |value: T| {
+        let (sink, flush) = consume_async(&self.graph(), None, move |value: T| {
             let result = build_and_record(
                 &mut gauge,
                 &mut provider,
@@ -225,8 +225,9 @@ where
         // The run-mode guard rides `register_op1` (`for_each` cannot see the
         // `Ctx`). In historical mode the value is never handed to `consume_async`,
         // so the background task stays idle and makes no network calls — the
-        // prometheus-sink pattern.
-        Ok(self.wire(move |b, h| {
+        // prometheus-sink pattern. The `flush` teardown drains the consumer at
+        // run end and surfaces a final-cycle export error.
+        let sink_stream = self.wire(move |b, h| {
             b.register_op1(
                 h,
                 "otlp_push",
@@ -241,7 +242,8 @@ where
                     Ok(Tick::Value(()))
                 },
             )
-        }))
+        });
+        Ok(sink_stream.finally(flush))
     }
 }
 
@@ -405,7 +407,7 @@ where
         let mut tracer: Option<opentelemetry_sdk::trace::Tracer> = None;
         let mut provider: Option<SdkTracerProvider> = None;
         let mut attr_buffer = OtlpAttributeBuffer::default();
-        let sink = consume_async(&self.graph(), None, move |value: P| {
+        let (sink, flush) = consume_async(&self.graph(), None, move |value: P| {
             let result = build_and_emit(
                 &mut tracer,
                 &mut provider,
@@ -420,7 +422,7 @@ where
             async move { result }
         })?;
 
-        Ok(self.wire(move |b, h| {
+        let sink_stream = self.wire(move |b, h| {
             b.register_op1(
                 h,
                 "otlp_spans",
@@ -435,7 +437,8 @@ where
                     Ok(Tick::Value(()))
                 },
             )
-        }))
+        });
+        Ok(sink_stream.finally(flush))
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/postgres.rs
+++ b/next/crates/wingfoil-next/src/adapters/postgres.rs
@@ -724,7 +724,7 @@ where
         let stmt_cache: Arc<tokio::sync::Mutex<Option<Statement>>> =
             Arc::new(tokio::sync::Mutex::new(None));
 
-        let sink = consume_async(&g, buffer_size, move |batch: WriteBatch<T>| {
+        let (sink, flush) = consume_async(&g, buffer_size, move |batch: WriteBatch<T>| {
             let client = Arc::clone(&client);
             let stmt_cache = Arc::clone(&stmt_cache);
             let table_sql = table_sql.clone();
@@ -792,7 +792,8 @@ where
                     }]
                 },
             )
-            .for_each(sink))
+            .for_each(sink)
+            .finally(flush))
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/redis.rs
+++ b/next/crates/wingfoil-next/src/adapters/redis.rs
@@ -447,7 +447,7 @@ impl RedisSinkOps for Stream<Burst<RedisEntry>> {
             .block_on(client.get_multiplexed_async_connection())
             .with_context(|| format!("redis_pub: connecting to {:?}", conn.url))?;
 
-        let sink = consume_async(&g, buffer_size, move |entry: RedisEntry| {
+        let (sink, flush) = consume_async(&g, buffer_size, move |entry: RedisEntry| {
             let mut connection = connection.clone();
             async move {
                 redis::cmd("PUBLISH")
@@ -459,7 +459,7 @@ impl RedisSinkOps for Stream<Burst<RedisEntry>> {
                 Ok(())
             }
         })?;
-        Ok(self.for_each(sink))
+        Ok(self.for_each(sink).finally(flush))
     }
 }
 
@@ -519,7 +519,7 @@ impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
             .block_on(client.get_multiplexed_async_connection())
             .with_context(|| format!("redis_stream_write: connecting to {:?}", conn.url))?;
 
-        let sink = consume_async(&g, buffer_size, move |record: RedisStreamRecord| {
+        let (sink, flush) = consume_async(&g, buffer_size, move |record: RedisStreamRecord| {
             let mut connection = connection.clone();
             async move {
                 let mut cmd = redis::cmd("XADD");
@@ -535,7 +535,7 @@ impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
                 Ok(())
             }
         })?;
-        Ok(self.for_each(sink))
+        Ok(self.for_each(sink).finally(flush))
     }
 }
 

--- a/next/crates/wingfoil-next/src/async_source.rs
+++ b/next/crates/wingfoil-next/src/async_source.rs
@@ -58,7 +58,9 @@
 //! })?;
 //! ```
 
+use std::cell::RefCell;
 use std::future::Future;
+use std::rc::Rc;
 use std::sync::mpsc;
 
 use anyhow::Context;
@@ -311,14 +313,20 @@ where
 /// task *into* the graph, this hands each burst's values *out of* the graph to a
 /// background task.
 ///
-/// Returns a closure to plug into [`for_each`](crate::fluent::StreamOps::for_each):
+/// Returns **two** closures: a `sink` to plug into
+/// [`for_each`](crate::fluent::StreamOps::for_each) (one send per burst), and a
+/// `flush` to wire as the sink's [`finally`](crate::fluent::StreamOps::finally)
+/// teardown. The `flush` is what surfaces a final-cycle write error (see the
+/// teardown section) — **always wire it**, or the last cycle's write error is
+/// lost:
 ///
 /// ```ignore
 /// // The graph owns the runtime (lazily created); pass `&g`, not a `&Handle`.
 /// let g = GraphBuilder::new();
-/// let sink = some_burst_stream.for_each(consume_async(&g, Some(64), |v| async move {
+/// let (sink, flush) = consume_async(&g, Some(64), |v| async move {
 ///     write_somewhere(v).await // returns anyhow::Result<()>
-/// })?);
+/// })?;
+/// let node = some_burst_stream.for_each(sink).finally(flush);
 /// ```
 ///
 /// # Guarantees
@@ -343,38 +351,43 @@ where
 ///   context — mirroring how [`produce_async`] surfaces a producer error on the
 ///   next cycle rather than mid-await. A closed data channel (the consumer having
 ///   stopped after an error) is likewise turned into an aborting error on the
-///   next send.
+///   next send. The **final** cycle's write error — which has no later cycle to
+///   surface it — is caught by the `flush` teardown (below).
 ///
-/// # Teardown
+/// # Teardown — the `flush` closure surfaces the final write error
 ///
-/// The returned closure owns the sender and the consumer task's join handle; when
-/// the graph is dropped it drops the sender (so the consumer's `recv` ends) and
-/// **blocks until the consumer has drained every queued write**, so an offloaded
-/// sink is fully flushed at teardown rather than losing in-flight writes.
+/// The `flush` closure drops the sender (so the consumer's `recv` ends), **blocks
+/// until the consumer has drained every queued write**, then — unlike a `Drop`,
+/// which cannot return a `Result` — checks the error channel one last time and
+/// [aborts the run](anyhow::bail) if that final drain failed. Wired as the sink's
+/// [`finally`](crate::fluent::StreamOps::finally), it runs on the graph thread
+/// after the last cycle (even after a cycle error), and the engine folds its
+/// error into the run result. This is what lets a sink abort the run
+/// deterministically on the **last** write — e.g. etcd's `force:false` conditional
+/// under `RunFor::Cycles(1)` — matching classic's `teardown()`-time surfacing
+/// (`AsyncConsumerNode::teardown` does `block_on(handle)??`).
 ///
-/// # Limitation — a final-cycle write error is not surfaced
-///
-/// Because writes run off-thread and the error is observed on a *later* cycle,
-/// an error from the writes of the **last** cycle of a bounded run has no
-/// subsequent cycle to surface it, and the teardown flush cannot turn an
-/// already-`Ok` run into an `Err` (Drop returns no `Result`). Sinks that must
-/// abort the run deterministically on the final write (e.g. etcd's `force:false`
-/// conditional under `RunFor::Cycles(1)`) therefore cannot yet migrate to this
-/// primitive — see `docs/port-plan.md`.
+/// If `flush` is never wired, a [`Drop`] safety-net still drains every queued
+/// write at graph teardown (so nothing is lost), but — being a `Drop` — cannot
+/// surface that final error. Always wire `flush`.
 ///
 /// # Runtime requirement (the same `block_on` footgun as the etcd sink)
 ///
-/// The sink closure and the teardown flush drive the runtime with
+/// The sink closure and the `flush` teardown drive the runtime with
 /// [`Handle::block_on`] on the graph thread, so **the graph must be built, run,
 /// and dropped from a non-async thread** (`main`, a `#[test]` fn). Driving it
 /// from inside an async context makes those `block_on` calls panic.
 ///
 /// Gated behind the `async` feature, like [`produce_async`].
+#[allow(clippy::type_complexity)]
 pub fn consume_async<T, F, Fut>(
     g: &GraphBuilder,
     buffer_size: Option<usize>,
     run: F,
-) -> anyhow::Result<impl Fn(&Burst<T>) -> anyhow::Result<()> + use<T, F, Fut>>
+) -> anyhow::Result<(
+    Box<dyn Fn(&Burst<T>) -> anyhow::Result<()>>,
+    Box<dyn Fn(&()) -> anyhow::Result<()>>,
+)>
 where
     T: Clone + Default + Send + 'static,
     F: FnMut(T) -> Fut + Send + 'static,
@@ -382,12 +395,13 @@ where
 {
     // The graph owns the runtime (created lazily here on first async use, or a
     // caller override); the consumer task spawns onto it, and the sink closure /
-    // teardown flush drive it with `block_on` on the graph thread.
+    // flush teardown drive it with `block_on` on the graph thread.
     let handle = g.async_runtime_handle()?;
 
     // Error channel: the consumer task reports the first write error here; the
-    // sink closure polls it (non-blocking) each cycle and aborts the run. A
-    // channel — not a lock — keeps the graph execution path lock-free.
+    // sink closure polls it (non-blocking) each cycle and the flush teardown
+    // polls it once more after the final drain. A channel — not a lock — keeps
+    // the graph execution path lock-free.
     let (err_tx, err_rx) = mpsc::channel::<String>();
 
     // Bounded (back-pressure) or unbounded data channel, per `buffer_size`.
@@ -407,26 +421,33 @@ where
         }
     });
 
-    let state = SinkState {
+    // Shared between the sink and flush closures — both run on the graph thread,
+    // never concurrently (cycles finish before teardown), so an `Rc<RefCell<_>>`
+    // is sufficient and no lock touches the execution path.
+    let shared = Rc::new(RefCell::new(SinkShared {
         handle: handle.clone(),
         tx: Some(tx),
         task: Some(task),
-    };
+        err_rx,
+        flushed: false,
+    }));
+
     let send_handle = handle.clone();
-    Ok(move |burst: &Burst<T>| -> anyhow::Result<()> {
+    let send_shared = shared.clone();
+    let sink = move |burst: &Burst<T>| -> anyhow::Result<()> {
+        let s = send_shared.borrow();
         // Surface a prior async write error before doing more work.
-        if let Ok(msg) = err_rx.try_recv() {
+        if let Ok(msg) = s.err_rx.try_recv() {
             anyhow::bail!("consume_async: background sink write failed: {msg}");
         }
-        let tx = state
-            .tx
-            .as_ref()
-            .expect("invariant: sink sender present during the run");
+        let tx =
+            s.tx.as_ref()
+                .expect("invariant: sink sender present during the run");
         for item in burst.iter() {
             if tx.send_blocking(&send_handle, item.clone()).is_err() {
                 // A closed data channel means the consumer task stopped, which
                 // only happens after a write error; surface it with context.
-                return match err_rx.try_recv() {
+                return match s.err_rx.try_recv() {
                     Ok(msg) => Err(anyhow::anyhow!(
                         "consume_async: background sink write failed: {msg}"
                     )),
@@ -437,7 +458,58 @@ where
             }
         }
         Ok(())
-    })
+    };
+
+    let flush = move |_: &()| -> anyhow::Result<()> { shared.borrow_mut().flush() };
+
+    Ok((Box::new(sink), Box::new(flush)))
+}
+
+/// Shared teardown state for a [`consume_async`] sink: the sender to close, the
+/// consumer task to join, and the error channel to poll for the final write
+/// error. Held behind an `Rc<RefCell<_>>` by both the sink and flush closures.
+struct SinkShared<T> {
+    handle: Handle,
+    tx: Option<SinkTx<T>>,
+    task: Option<tokio::task::JoinHandle<()>>,
+    err_rx: mpsc::Receiver<String>,
+    flushed: bool,
+}
+
+impl<T> SinkShared<T> {
+    /// Close the sender, block until the consumer has drained every queued
+    /// write, then surface a final write error if the last drain failed.
+    /// Idempotent — the `flush`/`Drop` pair may both fire.
+    fn flush(&mut self) -> anyhow::Result<()> {
+        if self.flushed {
+            return Ok(());
+        }
+        self.flushed = true;
+        // Drop the sender so the consumer task's `recv()` returns `None` and it
+        // finishes draining every queued write.
+        self.tx.take();
+        if let Some(task) = self.task.take() {
+            // Runs on the (non-async) graph thread at teardown, so `block_on`
+            // is safe here. The joined task never touches `self`.
+            let _ = self.handle.block_on(task);
+        }
+        // Unlike a `Drop`, teardown can turn an already-`Ok` run into `Err`:
+        // surface a final-cycle write error the sink closure never got to see.
+        if let Ok(msg) = self.err_rx.try_recv() {
+            anyhow::bail!("consume_async: background sink write failed: {msg}");
+        }
+        Ok(())
+    }
+}
+
+impl<T> Drop for SinkShared<T> {
+    fn drop(&mut self) {
+        // Safety-net flush for a sink whose `flush` teardown was never wired:
+        // still drain every queued write at graph teardown so nothing is lost.
+        // A `Drop` cannot surface the final error (no `Result`) — that is what
+        // the `flush` teardown is for.
+        let _ = self.flush();
+    }
 }
 
 /// Sender half of the sink's data channel — bounded (back-pressured) or
@@ -484,26 +556,6 @@ fn sink_channel<T>(buffer_size: Option<usize>) -> (SinkTx<T>, SinkRx<T>) {
         None => {
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<T>();
             (SinkTx::Unbounded(tx), SinkRx::Unbounded(rx))
-        }
-    }
-}
-
-/// Owns the sink's sender and consumer-task handle so teardown can flush.
-struct SinkState<T> {
-    handle: Handle,
-    tx: Option<SinkTx<T>>,
-    task: Option<tokio::task::JoinHandle<()>>,
-}
-
-impl<T> Drop for SinkState<T> {
-    fn drop(&mut self) {
-        // Flush at teardown: drop the sender so the consumer task's `recv()`
-        // returns `None` and it finishes draining every queued write, then wait
-        // for the task to complete. Runs on the (non-async) graph thread, like
-        // produce_async's teardown, so `block_on` is safe here.
-        self.tx.take();
-        if let Some(task) = self.task.take() {
-            let _ = self.handle.block_on(task);
         }
     }
 }

--- a/next/crates/wingfoil-next/tests/consume_async.rs
+++ b/next/crates/wingfoil-next/tests/consume_async.rs
@@ -26,7 +26,7 @@ fn consume_async_preserves_order() {
         let g = GraphBuilder::new();
         // Unbounded buffer: every item is enqueued in one cycle, then drained in
         // order by the single consumer task.
-        let consume = consume_async(&g, None, move |v: u64| {
+        let (sink, flush) = consume_async(&g, None, move |v: u64| {
             let sink_values = sink_values.clone();
             async move {
                 sink_values
@@ -37,11 +37,13 @@ fn consume_async_preserves_order() {
             }
         })
         .unwrap();
-        let _sink = g.constant(burst![1u64, 2, 3, 4, 5]).for_each(consume);
+        let _sink = g
+            .constant(burst![1u64, 2, 3, 4, 5])
+            .for_each(sink)
+            .finally(flush);
         let mut r = g.build();
+        // The `flush` teardown drains every queued write before `run` returns.
         r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
-        // `r` drops here → the sink flushes (drains every queued write) before
-        // the scope ends.
     }
 
     assert_eq!(
@@ -65,7 +67,7 @@ fn consume_async_applies_backpressure() {
         // Twenty values through a bounded channel of 2, with a slow sink so the
         // channel keeps filling and the graph thread blocks on `send` until the
         // consumer drains — exercising the back-pressure path.
-        let consume = consume_async(&g, Some(2), move |v: u64| {
+        let (sink, flush) = consume_async(&g, Some(2), move |v: u64| {
             let sink_values = sink_values.clone();
             async move {
                 tokio::time::sleep(Duration::from_millis(1)).await;
@@ -82,7 +84,7 @@ fn consume_async_applies_backpressure() {
         for v in values {
             burst.push(v);
         }
-        let _sink = g.constant(burst).for_each(consume);
+        let _sink = g.constant(burst).for_each(sink).finally(flush);
         let mut r = g.build();
         r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
     }
@@ -116,7 +118,7 @@ fn consume_async_error_aborts_the_run() {
     // buffer_size = 1 so a send blocks until the consumer takes the prior value;
     // once the consumer errors on `2` and stops, a later send hits the closed
     // channel and the run aborts — no reliance on async timing.
-    let consume = consume_async(&g, Some(1), move |v: u64| {
+    let (sink, flush) = consume_async(&g, Some(1), move |v: u64| {
         let sink_values = sink_values.clone();
         async move {
             if v == 2 {
@@ -130,7 +132,7 @@ fn consume_async_error_aborts_the_run() {
         }
     })
     .unwrap();
-    let _sink = stream.for_each(consume);
+    let _sink = stream.for_each(sink).finally(flush);
 
     let mut r = g.build();
     let err = r
@@ -139,5 +141,72 @@ fn consume_async_error_aborts_the_run() {
     assert!(
         format!("{err:#}").contains("sink write blew up"),
         "the run aborts with the write error as context: {err:#}",
+    );
+}
+
+/// The **final** cycle's write error has no later cycle to surface it — only the
+/// `flush` teardown can. A single value on a one-cycle run whose write fails must
+/// still abort the run, via `finally(flush)` joining the consumer at teardown and
+/// propagating its error. This is the generic form of etcd's `force:false`
+/// conditional aborting a `RunFor::Cycles(1)` run (deviation-register B1), and the
+/// reason `flush` exists rather than a plain `Drop`.
+#[test]
+fn consume_async_final_write_error_surfaces_at_teardown() {
+    let g = GraphBuilder::new();
+    // A single value, delivered on the only cycle. Its write fails in the
+    // background task after the cycle has already returned `Ok`, so the sole path
+    // to surfacing it is the teardown flush.
+    let (sink, flush) = consume_async(&g, None, move |v: u64| async move {
+        anyhow::bail!("final-cycle write blew up on {v}");
+    })
+    .unwrap();
+    let _sink = g.constant(burst![1u64]).for_each(sink).finally(flush);
+
+    let mut r = g.build();
+    let err = r
+        .run(HISTORICAL, RunFor::Cycles(1))
+        .expect_err("a final-cycle write error must abort the run via the flush teardown");
+    assert!(
+        format!("{err:#}").contains("final-cycle write blew up"),
+        "the flush teardown surfaces the final write error: {err:#}",
+    );
+}
+
+/// Without the `flush` teardown wired, the `Drop` safety-net still drains every
+/// queued write (nothing is lost) — it just cannot surface the final error (a
+/// `Drop` returns no `Result`). The sink closure lives in a graph node owned by
+/// the `Runner`, which drops its nodes *before* the async runtime (see
+/// `AsyncRuntimeSlot`), so the `Drop`-time `block_on` drain runs on a live
+/// runtime. Proves the fallback path drains rather than dropping in-flight writes.
+#[test]
+fn consume_async_drop_safety_net_still_drains_without_flush() {
+    let collected = Arc::new(Mutex::new(Vec::<u64>::new()));
+    {
+        let sink_values = collected.clone();
+        let g = GraphBuilder::new();
+        let (sink, flush) = consume_async(&g, None, move |v: u64| {
+            let sink_values = sink_values.clone();
+            async move {
+                sink_values
+                    .lock()
+                    .expect("sink values mutex poisoned")
+                    .push(v);
+                Ok(())
+            }
+        })
+        .unwrap();
+        // Deliberately discard `flush` rather than wiring it — the caller forgot.
+        // The sink node's Drop safety-net must still drain every queued write.
+        drop(flush);
+        let _sink = g.constant(burst![10u64, 20, 30]).for_each(sink);
+        let mut r = g.build();
+        r.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
+        // `r` drops here → the sink node (holding the last shared handle) drops
+        // before the runtime, so the Drop safety-net drains the queued writes.
+    }
+    assert_eq!(
+        vec![10, 20, 30],
+        *collected.lock().expect("sink values mutex poisoned"),
+        "the Drop safety-net drains all queued writes even without an explicit flush",
     );
 }

--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -42,7 +42,7 @@ has its own decision record in
 
 | id | dev | class | notes / source |
 |---|---|:--:|---|
-| B1 | **`etcd_pub` blocks the graph thread** — `Handle::block_on` per burst. The `consume_async` reland was deferred. | 🔴 | The one place next puts blocking network I/O on the single-threaded engine. `adapters/etcd.rs` "Why `etcd_pub` still blocks the graph thread (deferred follow-up)". Needs a teardown-hook story for synchronous-error ops (the general problem `consume_async` couldn't cover — the `force:false` conditional write). |
+| B1 | ~~**`etcd_pub` blocks the graph thread** — `Handle::block_on` per burst.~~ | ✅ | **Resolved.** `consume_async` now returns a `flush` teardown (wired via `finally`) that closes the sink, joins the consumer task, and — unlike a `Drop` — surfaces the **final** write error as the run's `Err`. This is the "teardown-hook story for synchronous-error ops" B1 was blocked on: it lets `etcd_pub`'s `force:false` conditional abort a single-cycle run at teardown (exactly as classic's `AsyncConsumerNode::teardown` does), so the per-write `block_on` is gone and the PUTs run off the graph thread on the shared consumer task. The wiring-time connect + `LeaseGuard` revoke keep their (teardown-time, graph-thread) `block_on` — the ordinary `consume_async` footgun (A5a). The same `flush` upgrade also closes the "final-cycle write error swallowed" gap for kafka/postgres/redis/otlp. |
 | B2 | **Live sources reject `RunMode::HistoricalFrom` at wiring** (etcd/redis/kafka/postgres `_sub`, zmq_sub). | 🟡✅ | **Ratified — accepted deviation.** Classic *technically permitted* a historical run with wall-clock timestamps, but a live tail has no deterministic timeline to replay: wall-clock-stamped rows give neither reproducible values nor reproducible tick times, so the classic path was an unguarded footgun, not a real capability. Deterministic historical replay is served by the paired time-sliced `_read` sources (e.g. `postgres_read`). next rejects at wiring with a clear message pointing to the `_read` source — a strictly better failure mode than the block-collect deadlock at `start`. Wall-clock historical is **not** restored. |
 | B3 | **`kafka_pub` produces sequentially** (single ordered `consume_async` consumer, N roundtrips/burst) vs classic's concurrent `FuturesUnordered` (one roundtrip/burst). | 🟡 | Order-preserving but a throughput deviation. `adapters/kafka.rs` deviation #4. |
 | B4 | **csv reads the whole file up front** vs classic's lazy row streaming. | 🟡 | Unbounded-memory for a huge file under `RunFor::Forever`. `adapters/csv.rs` "consequences of using the channel source". |
@@ -77,17 +77,17 @@ has its own decision record in
    and the `zmq_sub` migration landed (#547); finish it by migrating the
    `produce_async` family + the plain `external`/`channel` feeders, then reopen
    §0.4 to make I/O sources **re-runnable** (A2) — the remaining structural win.
-2. **B1** — get `etcd_pub` off the graph thread. Blocked on a teardown-hook story
-   for synchronous-error ops; solving it generalises `consume_async`.
-3. **B2** — ratify historical-rejection for the cutover superset claim (accept as
-   documented, or restore wall-clock historical for live sources).
-4. **D5** — bump classic's opentelemetry to restore lockstep with next.
-5. **B3 / B4** — decide whether the throughput (kafka) / memory (csv) deviations
+2. **D5** — bump classic's opentelemetry to restore lockstep with next.
+3. **B3 / B4** — decide whether the throughput (kafka) / memory (csv) deviations
    matter for the "strict superset" claim, or are acceptable documented trade-offs.
-6. **A6** — measure the channel-sub startup latency to either explain or close it.
+4. **A6** — measure the channel-sub startup latency to either explain or close it.
 
-**Resolved since this register was written:** **A5** (graph-owned runtime, #548);
-**A1/A4 for `zmq_sub`** (deferred to `start()` via `source_at_start`, #547).
+**Resolved / ratified since this register was written:** **A5** (graph-owned
+runtime, #548); **A1/A4 for `zmq_sub`** (deferred to `start()` via
+`source_at_start`, #547); **B1** (`consume_async` `flush` teardown surfaces
+final-cycle write errors, so `etcd_pub` moved off the graph thread — also closes
+the swallowed-final-error gap for kafka/postgres/redis/otlp); **B2** (ratified as
+an accepted deviation — live sources reject `HistoricalFrom`, #557).
 
 ## Keeping this current
 


### PR DESCRIPTION
## Summary

Resolves deviation-register **B1** — `etcd_pub` was the one networked sink still driving its writes with `Handle::block_on` on the single-threaded engine.

It hadn't migrated to the shared `consume_async` primitive because a `force:false` conditional-write conflict must make the run return `Err` even on a `RunFor::Cycles(1)` run, and `consume_async`'s teardown flush lived in a `Drop` impl that **discarded** the consumer task's result — a `Drop` cannot return a `Result`, so the final cycle's write error was lost.

Classic surfaces that same error at teardown, not on the failing cycle (`AsyncConsumerNode::teardown` does `block_on(handle)??`), and next's engine already runs every node's fallible `teardown` and folds its error into the run result (`interp.rs`). So the fix is to give `consume_async` a real fallible teardown.

## Changes

- **`consume_async` now returns `(sink, flush)`.** `flush` closes the sender, joins the consumer task, and — unlike a `Drop` — surfaces the **final** write error as `Err`. It's wired via the existing `.finally()` combinator. A `Drop` safety-net still drains queued writes if `flush` is never wired (no data loss); it just cannot surface the final error.
- **`etcd_pub`'s per-entry PUTs now run on the off-thread consumer task.** The wiring-time connect and the `LeaseGuard` revoke keep their (teardown-time, graph-thread) `block_on` — the ordinary `consume_async` footgun (A5a). The `force:false` single-cycle abort is preserved via the flush teardown, matching classic's teardown-time surfacing.
- **The same `flush` upgrade closes the "final-cycle write error swallowed" gap for kafka/postgres/redis/otlp**, all migrated to `.finally(flush)`.

## Parity notes

- The lease revoke fires only **after** the writes drain, matching classic's order (loop ends → abort keepalive → revoke), and runs regardless of a write error.
- The existing `test_pub_force_false_fails_if_exists` integration test is the end-to-end B1 guard (`force:false` on an existing key under `RunFor::Cycles(1)`, asserting the run aborts naming the key **and** the original value is preserved). It runs in CI's etcd job (needs Docker).

## Tests

- Adds `consume_async_final_write_error_surfaces_at_teardown` — a Docker-free parity test proving a final-cycle write error surfaces at teardown (the generic `force:false`-on-`Cycles(1)` scenario, the reason `flush` exists rather than a plain `Drop`).
- Adds `consume_async_drop_safety_net_still_drains_without_flush` — proves the fallback path drains queued writes when `flush` is left unwired.
- Updates the three existing `consume_async` tests to the `(sink, flush)` API.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo lint` (default) and `cargo lint-all` (all features) — clean (`-D warnings`)
- `cargo test -p wingfoil-next` across `async`, `etcd`, `kafka`, `redis`, `postgres`, `otlp` — all green

Also updates the etcd module docs and marks **B1 resolved** in `next/docs/deviation-register.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QWPmR3wFSs5LVFMFm59EZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012QWPmR3wFSs5LVFMFm59EZ)_