### PR TITLE
docs(next): consolidate next-port planning into the design docs

### DIFF
--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -55,6 +55,7 @@ has its own decision record in
 | C1 | **otlp trace/span export (`OtlpSpans`) not ported.** | ⚪ | Needs the `Traced`/`HasLatency`/`latency_stages!` infra (Phase 5). Metrics push is at full parity. `adapters/otlp.rs` deviation #3. |
 | C2 | **zmq cross-language interop not ported.** | ⚪ | The `bincode` wire envelope is next-local; not wire-compatible with a classic/Python peer. Deferred with the Python bindings (Phase 6). `adapters/zmq.rs`. |
 | C3 | **Structural gaps** — multi-output islands; runtime graph-mutation surface; (closed: `StreamStore`, `demux_it` in #529). | ⚪ | See `port-plan.md` Phase 4.5 "Known parity gaps" and Phase 1 multi-output note. |
+| C4 | **Compiled-path IO ingestion** — busy-poll (`ALWAYS`) sources + bursts are not expressible in `compiled()`/`graph!`. | ⚪ | Deliberate exclusion; IO stays at the interpreted boundary + compiled islands. Full design + the gating decision (wake channel vs busy-spin) in `port-plan.md` "Deferred / post-v1 work". (was #502/#503) |
 
 ## D. Cosmetic / API — deliberate-and-benign (low review priority)
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -414,10 +414,10 @@ Inventory (classic `nodes/` → target), grouped by effort:
 
 **Dynamic graphs** (`graph_node`, `dynamic_group`, the dynamic examples):
 islands already cover *static* subgraphs composed procedurally (including in
-loops). Runtime graph *mutation* is a separate feature: either
-`Runner::extend` on the interpreted engine (design here, implement if the
-demand is real) or an explicit out-of-scope ruling for v1. Do not let this
-block the catalog — decide, document, move on.
+loops). Runtime graph *mutation* has since landed as a separate feature
+(behind `dynamic-graph`): `Runner::run_dynamic` + an `Extension` scope
+(append / active-passive splice / remove / recycle), `Builder::dynamic_group`,
+and `Builder::demux` on the interpreted engine.
 
 **Engine coverage note:** `never`, `combine`, and `delay_with_reset` land as
 interpreted-engine (fluent) ports — like `feedback` — since a zero-input
@@ -997,7 +997,7 @@ tests covered — not "legacy pytest passes unchanged."
 | Burst/replay semantics drift | backtest determinism is the product | Phase 0.3 spike; classic tests as oracle; fallback design named in advance |
 | Feedback timing mismatch | correctness of feedback graphs | engine-level edge + classic's 4 feedback tests; fluent-only v1 |
 | Fallibility retrofit cost | touches every emitter | do it first (0.1); never retrofit later |
-| Dynamic graph expectations | `graph_node` users | dirty-list engine (the mutable-frontier enabler) has landed; the mutation feature (`Runner::extend`) is **not yet built** — open decision: cutover blocker vs documented v1 deviation. Islands cover static composition today |
+| Dynamic graph expectations | `graph_node` users | dirty-list engine (the mutable-frontier enabler) has landed; ✅ **the mutation feature has landed** (behind `dynamic-graph`): `Runner::run_dynamic` + an `Extension` scope (append / splice / remove / recycle), `Builder::dynamic_group`, and `Builder::demux`. Islands also cover static composition |
 | Python API change (next-python supersedes legacy `wingfoil-python`) | existing `import wingfoil` code must migrate — an accepted breaking change, not drift to avoid | new object-form binding at parity before cutover; next-python `test_interop.py` pytest as gate; migration guide + `wingfoil` module-name takeover at cutover |
 | Statistics adapter size | schedule risk, not design risk | it's first in Phase 4 precisely to surface state-porting friction early |
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -75,7 +75,8 @@ today's interpreted engine.
 
 ¹ Fluent layer only (engine-level `+1` edge); not expressible inside `graph!`.
 ² No burst *sources* exist in the macro vocabulary; the pattern is about IO
-  ingestion, which the compiled path excludes anyway.
+  ingestion, which the compiled path excludes anyway. Lifting this (with
+  busy-poll ingest) is deferred post-v1 — see "Deferred / post-v1 work".
 ³ Compiled runs its own loop with no external wake, so realtime is
   timer-driven only; historical/timer + data-via-consts is full.
 ⁴ `start` emitted; `stop`/`teardown` emitted once a macro-expressible op
@@ -1046,6 +1047,71 @@ tests covered — not "legacy pytest passes unchanged."
   dual-execution invariant. The op-declared form gets ~all the benefit with
   none of that. Rides on the Phase 4.5 arena (the slot-handle boundary is its
   natural home).
+
+## Deferred / post-v1 work (migrated from tracking issues)
+
+The items below were tracked as GitHub issues (#502, #503, #507) and folded back
+into this plan (2026-07-26) so all next-port planning lives in one place. Each is
+deferred by design, not dropped.
+
+### Compiled-path IO ingestion — busy-poll sources + bursts (was #502, #503)
+
+One theme: letting the `compiled()` / `graph!` path ingest external /
+timestamped data, which it excludes today (capability-matrix rows "Busy-poll
+ingest (`ALWAYS`)" and "Bursts (never latest-wins)", both ❌ for compiled;
+footnotes 2–3). Both work on the interpreted engine now (`wingfoil_next::Burst`,
+`poll`) and feed a compiled island through its inputs.
+
+**Busy-poll ingest (`ALWAYS` sources — classic `poll`/`producer`).**
+- *Current state:* excluded — `compiled()` runs its own closed monomorphized
+  loop with no external wake, and `graph!` forbids IO-edge sources; `poll` lives
+  at the fluent/interpreted layer and feeds a compiled island through its inputs.
+- *Why it's now more tractable:* after #496, per-op activation is a monomorphic
+  const (`__WF_OP__ACTIVATION`), so `ALWAYS` dispatch already folds correctly for
+  ops the compiled path drives (scheduling/always custom ops work). Remaining:
+  (a) let an IO-edge/source op live in the compiled graph, and (b) a driving loop
+  that re-polls each cycle at a realtime cadence.
+- *Open questions:* does compiled keep its "no external wake" character
+  (busy-spin only, realtime-timer-driven) or gain a wake channel? Interaction
+  with `run_mode` (historical replay of a poll source vs realtime busy-spin)?
+  Worth the complexity vs. keeping IO at the interpreted boundary + compiled
+  islands?
+
+**Bursts (never latest-wins) in compiled.**
+- Every value at one instant grouped and delivered atomically in one cycle —
+  never latest-wins, never dropped. Excluded from compiled because no burst
+  *sources* exist in the macro vocabulary and the burst pattern is about IO
+  ingestion (which compiled excludes). Works on the interpreted engine today
+  (`Burst`, matching classic `Burst`/`HistoricalValue`).
+- *Scope:* a burst-source shape the `graph!` macro can express and the compiled
+  path can drive, delivering same-time-grouped values in one cycle (identical to
+  interpreted/classic burst semantics — same-time values ride one burst, not
+  coalesced, not split by a monotonic bump).
+
+**Coupling & first decision:** these land together or the exclusion stays —
+burst sources are the natural payload of a busy-poll/IO ingest edge. The gating
+decision for both: does compiled gain a wake channel, or stay busy-spin +
+realtime-timer only? The busy-spin answer fits the compiled-perf story. Tracked
+as a capability gap in [`deviation-register.md`](./deviation-register.md) §C.
+
+### Engine architecture / orientation doc (was #507)
+
+An evidence-backed `docs/wingfoil-next-architecture.md` orienting a new
+contributor/agent to the Op-pattern engine, citing source at `file:line`.
+Deliberately a *current-state snapshot*, not a migration guide — so it is
+deferred until after the incoming refactor settles (a snapshot written now would
+go stale through it). Sections to regenerate against the post-refactor code:
+- The `Op` trait + engine-owned state; `Tick::{Value,Silent,Quiet}`; lifecycle
+  hooks.
+- The three execution tiers: interpreted sparse dirty-list (`Dispatch::Sparse`,
+  default) + full-sweep oracle; fully-monomorphized `compiled()`; `nested()`
+  islands.
+- Fluent API + `compat::Signal` facade.
+- Sources/edges (ticker/constant/poll/external/channel/feedback), bursts, the
+  shared `Kernel`.
+- Adapters + the "adding an op" recipe (post-#496 `#[op]` forwarder mechanism,
+  no macro op-table).
+- Testing strategy: parity-oracle vs classic + three-engine agreement.
 
 ## Sequencing and parallelism
 

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -249,6 +249,7 @@ form.
 | `#[pyop]` **proc** macro | reads an `Op` impl → `#[pyfunction]`; v1 stateless single-input concrete | ✅ done (`wingfoil-next-python-macros`) |
 | `#[pyop]` extensions | stateful/multi-input shapes; `Cfg`-tuple arg names | ⬜ |
 | `#[pyadapter]` / `#[pygraph]` macros | source/sink + wiring-reuse emission (needs burst/`Vec` edge erasure for channel sources) | ⬜ |
+| POC: call a fixed `compiled()` graph from Python | Wire `wingfoil-next` as a path dep; expose one fixed `graph!` wiring (`ticker → count → map(i*i) → accumulate`) as `compiled_squares`/`interpreted_squares` (both from a single wiring so they can't drift). Proved **compiled == interpreted output from Python** across cycle- and duration-bound runs; GIL released for the run; no `.unwrap()` in binding code. Honest limit: **one fixed, compile-time graph** — not general Python-defined-graph codegen (timing ~neutral at that ticker-bound size; a dispatch-heavy graph shows `compiled()`'s win). Consistent with the non-goal below (`compiled()`/`nested()` expose as single island nodes). Revisit against the post-refactor `compiled()` API. | ⬜ (was #506) |
 | Edge-conversion trait bounds | `PyElement <-> f64/i64/bool/String` shipped; `Trade`/user types via user impls | 🟡 scalars done |
 | Mutable-frontier engine (extend a *running* graph) | Phase 4.5 dirty-list; only needed for post-`run` mutation | 🟡 Phase 4.5 |
 


### PR DESCRIPTION
Folds the remaining next-port tracking issues back into the design docs so all next-port planning lives in one place, and corrects a stale roadmap line. Docs-only — no code changes.

## What changed

**`port-plan.md`**
- Fixed two stale references that still described `Runner::extend` as "not yet built" — runtime graph mutation has shipped (behind `dynamic-graph`) as `Runner::run_dynamic` + an `Extension` scope, `Builder::dynamic_group`, and `Builder::demux`. Updated the "Dynamic graphs" note and the risk-register row.
- Added a **"Deferred / post-v1 work (migrated from tracking issues)"** section capturing:
  - **Compiled-path IO ingestion — busy-poll sources + bursts** (from #502/#503): current-state exclusion, the post-#496 tractability analysis, and the gating decision (wake channel vs busy-spin + realtime timer). The two land together or the exclusion stays.
  - **Engine architecture / orientation doc** (from #507): the `docs/wingfoil-next-architecture.md` deliverable, its section outline, and why it stays deferred until after the incoming refactor.
- Cross-ref pointer added to the bursts capability-matrix footnote.

**`deviation-register.md`**
- Added §C row **C4** (compiled-path IO ingestion) to the cutover-audit capability-gap list, pointing at the port-plan section.

**`python-interop.md`**
- Added a build-list row for the **`compiled()`-from-Python POC** (from #506): the compiled == interpreted parity finding, the GIL/no-`.unwrap()` notes, and the honest one-fixed-compile-time-graph scope limit.

## Related issues

Closes the last four open next-port issues by migrating them into the docs above (each closed as *not planned* = tracked in docs, not as an issue): #502, #503, #506, #507. (The other three next-port issues — #499, #500, #501 — were closed separately as completed; #500's stale `Runner::extend` mention is the line fixed here.)

## Notes for reviewers

- Docs-only; no `cargo` surface touched, so fmt/lint/tests are unaffected.
- Rebased onto latest `next`; the C4 addition sits alongside the recent B2 ratification edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019tqDrbkDe1T6pYfpNSVa3c)_