### PR TITLE
next: incremental historical channel + spawn/spawn_map (graph_node port)

### DIFF
--- a/next/crates/wingfoil-next/examples/spawn.rs
+++ b/next/crates/wingfoil-next/examples/spawn.rs
@@ -1,0 +1,56 @@
+//! Thread-offload combinators: `spawn` (a producer sub-graph on a worker thread)
+//! and `spawn_map` (map an input stream through a worker sub-graph). These are
+//! next's ergonomic twins of classic `producer()` / `mapper()` (the `graph_node`
+//! node) — the channel + `send_at` + `close` + join plumbing the `threading`
+//! example spells out by hand, wrapped as one call each.
+//!
+//! Both run in both modes. Historical replay is deterministic — the two graphs
+//! run lock-step by graph time — so this prints the same numbers every run.
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example spawn
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+fn main() {
+    let period = Duration::from_millis(10);
+    let n = 5u32;
+
+    let g = GraphBuilder::new();
+
+    // `spawn`: a producer sub-graph (ticker → running count) runs on its own
+    // worker thread and feeds this graph a `Burst` per instant. Flatten the
+    // single-value bursts back to a plain stream for the next stage.
+    let counts: Stream<Burst<u64>> = g.spawn(move |wg| wg.ticker(period).count().limit(n));
+    let flat: Stream<u64> = counts.map(|b: &Burst<u64>| b.iter().sum::<u64>());
+
+    // `spawn_map`: map each value ×10 through a sub-graph on a *second* worker
+    // thread. `s` is the input, delivered into the worker over the channel layer.
+    let scaled: Stream<Burst<u64>> =
+        flat.spawn_map(|s: Stream<Burst<u64>>| s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10));
+
+    let collected = scaled.with_time().accumulate();
+    let mut runner = g.build();
+
+    // Bound the run; the workers inherit this bound. Historical replay races to
+    // the bound with no wall-clock waiting.
+    runner
+        .run(
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Duration(period * (n + 3)),
+        )
+        .expect("run");
+
+    for (t, v) in runner.value(&collected) {
+        println!("{:>3} ms: {:?}", u64::from(t) / 1_000_000, v);
+    }
+    // 0 ms: [10]
+    // 10 ms: [20]
+    // 20 ms: [30]
+    // 30 ms: [40]
+    // 40 ms: [50]
+}

--- a/next/crates/wingfoil-next/src/channel.rs
+++ b/next/crates/wingfoil-next/src/channel.rs
@@ -73,11 +73,40 @@ impl<T: PartialEq> PartialEq for Message<T> {
     }
 }
 
+/// The sending half of a channel — either the unbounded `mpsc::Sender` or the
+/// bounded `mpsc::SyncSender`. Both have an infallible-until-disconnected `send`;
+/// the bounded one **blocks** when the buffer is full (that block *is* the
+/// back-pressure). Kept private; callers see only [`ChannelSender`].
+pub(crate) enum Tx<T> {
+    Unbounded(std::sync::mpsc::Sender<Message<T>>),
+    Bounded(std::sync::mpsc::SyncSender<Message<T>>),
+}
+
+impl<T> Clone for Tx<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Tx::Unbounded(s) => Tx::Unbounded(s.clone()),
+            Tx::Bounded(s) => Tx::Bounded(s.clone()),
+        }
+    }
+}
+
+impl<T> Tx<T> {
+    fn send(&self, message: Message<T>) -> bool {
+        match self {
+            Tx::Unbounded(s) => s.send(message).is_ok(),
+            // Blocks here when the buffer is full — the graph-facing sink or the
+            // producer thread waits until the consuming graph drains.
+            Tx::Bounded(s) => s.send(message).is_ok(),
+        }
+    }
+}
+
 /// The write end of a [`channel`](crate::fluent::SourceOps::channel).
 /// Clone-able and `Send`, so it can be moved to any thread or async task.
 /// Every method wakes the paired receiver's kernel.
 pub struct ChannelSender<T> {
-    tx: std::sync::mpsc::Sender<Message<T>>,
+    tx: Tx<T>,
     waker: wingfoil::codegen::KernelWaker,
     index: usize,
 }
@@ -93,16 +122,12 @@ impl<T> Clone for ChannelSender<T> {
 }
 
 impl<T> ChannelSender<T> {
-    pub(crate) fn new(
-        tx: std::sync::mpsc::Sender<Message<T>>,
-        waker: wingfoil::codegen::KernelWaker,
-        index: usize,
-    ) -> Self {
+    pub(crate) fn new(tx: Tx<T>, waker: wingfoil::codegen::KernelWaker, index: usize) -> Self {
         Self { tx, waker, index }
     }
 
     fn deliver(&self, message: Message<T>) -> bool {
-        self.tx.send(message).is_ok() && self.waker.wake(self.index)
+        self.tx.send(message) && self.waker.wake(self.index)
     }
 
     /// Send a value (realtime) or a value at the current time (historical).

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -281,6 +281,19 @@ pub trait SourceOps {
     /// [`Builder::channel`](crate::interp::Builder::channel)).
     fn channel<T: Clone + Default + 'static>(&self) -> (Stream<Burst<T>>, ChannelSender<T>);
 
+    /// [`channel`](Self::channel) with an optional transport bound. `None` is the
+    /// unbounded default; `Some(n)` makes the producer→graph transport a bounded
+    /// `sync_channel(n)`, so a producer sending faster than the graph drains
+    /// **blocks** on `send` (back-pressure) instead of queueing an unbounded
+    /// backlog. **Do not** bound a producer that fills the buffer *before the run
+    /// starts* (e.g. a `replay_results` feed queued at wiring — with no running
+    /// consumer to drain it, a bounded send blocks at wiring); use plain
+    /// [`channel`](Self::channel) there.
+    fn channel_bounded<T: Clone + Default + 'static>(
+        &self,
+        buffer: Option<usize>,
+    ) -> (Stream<Burst<T>>, ChannelSender<T>);
+
     /// A busy-poll source: `f` runs once per engine cycle, ticking on `Some`.
     /// Lossless and ordered — one value per cycle, no coalescing. The graph
     /// becomes a busy-spin loop: the kernel never parks. Realtime runs only.
@@ -330,6 +343,15 @@ pub trait SourceOps {
     /// `graph_node`. It wraps the channel + `send_at` + `close` + join plumbing
     /// the `threading` example otherwise spells out by hand.
     fn spawn<U, F>(&self, build: F) -> Stream<Burst<U>>
+    where
+        U: Clone + Default + Send + 'static,
+        F: FnOnce(&GraphBuilder) -> Stream<U> + Send + 'static;
+
+    /// [`spawn`](Self::spawn) with an optional bound on the worker→graph channel:
+    /// `None` unbounded (default), `Some(n)` back-pressures the worker (it blocks
+    /// producing once `n` values are queued unread, in realtime — historical
+    /// drains in lock-step regardless).
+    fn spawn_bounded<U, F>(&self, buffer: Option<usize>, build: F) -> Stream<Burst<U>>
     where
         U: Clone + Default + Send + 'static,
         F: FnOnce(&GraphBuilder) -> Stream<U> + Send + 'static;
@@ -406,6 +428,7 @@ fn run_worker_map<I, O, F>(
     build: F,
     to_main: ChannelSender<O>,
     sender_back: std::sync::mpsc::Sender<ChannelSender<I>>,
+    buffer: Option<usize>,
     run_mode: RunMode,
     run_for: RunFor,
 ) where
@@ -416,7 +439,7 @@ fn run_worker_map<I, O, F>(
     let wg = GraphBuilder::new();
     // Lock-step input: one value per instant, no read-ahead, so the worker never
     // blocks on input the driving graph cannot send while it awaits this output.
-    let (in_handle, sender_in) = wg.with_builder(|b| b.channel_lockstep::<I>());
+    let (in_handle, sender_in) = wg.with_builder(|b| b.channel_lockstep::<I>(buffer));
     let in_stream: Stream<Burst<I>> = wg.wrap(in_handle);
     // Hand the input sender back; if the driving graph has gone, there is nothing
     // to run.
@@ -455,7 +478,14 @@ impl SourceOps for GraphBuilder {
     }
 
     fn channel<T: Clone + Default + 'static>(&self) -> (Stream<Burst<T>>, ChannelSender<T>) {
-        let (handle, sender) = self.with_builder(|b| b.channel::<T>());
+        self.channel_bounded(None)
+    }
+
+    fn channel_bounded<T: Clone + Default + 'static>(
+        &self,
+        buffer: Option<usize>,
+    ) -> (Stream<Burst<T>>, ChannelSender<T>) {
+        let (handle, sender) = self.with_builder(|b| b.channel_bounded::<T>(buffer));
         (self.wrap(handle), sender)
     }
 
@@ -493,13 +523,21 @@ impl SourceOps for GraphBuilder {
         U: Clone + Default + Send + 'static,
         F: FnOnce(&GraphBuilder) -> Stream<U> + Send + 'static,
     {
+        self.spawn_bounded(None, build)
+    }
+
+    fn spawn_bounded<U, F>(&self, buffer: Option<usize>, build: F) -> Stream<Burst<U>>
+    where
+        U: Clone + Default + Send + 'static,
+        F: FnOnce(&GraphBuilder) -> Stream<U> + Send + 'static,
+    {
         // `build` runs once, on the worker thread, at run start; wrap it so the
         // `FnMut` setup can move it out (the backing channel source is single-run,
         // so `setup` fires exactly once). The `Rc` stays on this thread; only the
         // moved-out `F` (which is `Send`) crosses to the worker.
         let build = Rc::new(RefCell::new(Some(build)));
         let handle = self.with_builder(move |b| {
-            b.source_at_start_with_params(move |sender, run_mode, run_for, _start_time| {
+            b.source_at_start_with_params(buffer, move |sender, run_mode, run_for, _start_time| {
                 let build = build.borrow_mut().take().expect(
                     "invariant: spawn worker built once per run (backing channel is single-run)",
                 );
@@ -925,6 +963,17 @@ pub trait StreamOps<T>: Sized {
         T: Clone + Default + Send + 'static,
         O: Clone + Default + Send + 'static,
         F: FnOnce(Stream<Burst<T>>) -> Stream<O> + Send + 'static;
+
+    /// [`spawn_map`](Self::spawn_map) with an optional bound (`None` unbounded,
+    /// the default) applied to **both** worker channels — this graph's input to
+    /// the worker and the worker's result back — so a slow side back-pressures the
+    /// other in realtime. Historical mode is already lock-step, so the bound only
+    /// caps in-flight messages there.
+    fn spawn_map_bounded<O, F>(&self, buffer: Option<usize>, build: F) -> Stream<Burst<O>>
+    where
+        T: Clone + Default + Send + 'static,
+        O: Clone + Default + Send + 'static,
+        F: FnOnce(Stream<Burst<T>>) -> Stream<O> + Send + 'static;
 }
 
 impl<T: 'static> StreamOps<T> for Stream<T> {
@@ -1246,6 +1295,15 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         O: Clone + Default + Send + 'static,
         F: FnOnce(Stream<Burst<T>>) -> Stream<O> + Send + 'static,
     {
+        self.spawn_map_bounded(None, build)
+    }
+
+    fn spawn_map_bounded<O, F>(&self, buffer: Option<usize>, build: F) -> Stream<Burst<O>>
+    where
+        T: Clone + Default + Send + 'static,
+        O: Clone + Default + Send + 'static,
+        F: FnOnce(Stream<Burst<T>>) -> Stream<O> + Send + 'static,
+    {
         // The worker's input sender, handed back at run start; the send-sink
         // reads it each cycle. Stays on this thread (not `Send`).
         let to_worker: Rc<RefCell<Option<ChannelSender<T>>>> = Rc::new(RefCell::new(None));
@@ -1260,8 +1318,12 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
             Ok(())
         });
         let trigger_idx = sink.handle.index();
-        // Triggered output receiver + the sender the worker writes results to.
-        let (out_handle, to_main) = self.inner.borrow_mut().channel_triggered::<O>(trigger_idx);
+        // Triggered output receiver + the sender the worker writes results to
+        // (the worker→graph direction of the bound).
+        let (out_handle, to_main) = self
+            .inner
+            .borrow_mut()
+            .channel_triggered::<O>(trigger_idx, buffer);
         let recv_idx = out_handle.index();
         // Launch the worker at run start (the run params are known only then); it
         // hands its input sender back over a one-shot, which we store for the sink.
@@ -1276,7 +1338,8 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
                 let (back_tx, back_rx) = std::sync::mpsc::channel::<ChannelSender<T>>();
                 let to_main = to_main.clone();
                 let worker = std::thread::spawn(move || {
-                    run_worker_map(build, to_main, back_tx, run_mode, run_for);
+                    // `buffer` bounds the graph→worker direction too.
+                    run_worker_map(build, to_main, back_tx, buffer, run_mode, run_for);
                 });
                 let sender_in = back_rx
                     .recv()

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -27,7 +27,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use anyhow::Result;
-use wingfoil::NanoTime;
+use wingfoil::{NanoTime, RunFor, RunMode};
 
 use crate::Burst;
 use crate::channel::ChannelSender;
@@ -314,6 +314,130 @@ pub trait SourceOps {
     /// trigger — e.g. a [`delay_with_reset`](StreamOps::delay_with_reset) that
     /// never resets behaves like a plain [`delay`](StreamOps::delay).
     fn never(&self) -> Stream<()>;
+
+    /// Run a producer sub-graph on its own worker thread and surface its output
+    /// here as a [`Burst`] stream.
+    ///
+    /// `build` runs **on the worker thread** at run start: it wires a fresh graph
+    /// with the [`GraphBuilder`] it is handed and returns the stream to forward.
+    /// The worker runs that graph under the *same* run mode and bound as this one
+    /// and sends each value back over the channel layer — timestamped, so a
+    /// historical replay stays deterministic (one value per instant, grouped into
+    /// the delivered burst). The worker thread is joined at teardown; a worker
+    /// error aborts this run.
+    ///
+    /// next's ergonomic twin of classic `producer()` — the thread-offload half of
+    /// `graph_node`. It wraps the channel + `send_at` + `close` + join plumbing
+    /// the `threading` example otherwise spells out by hand.
+    fn spawn<U, F>(&self, build: F) -> Stream<Burst<U>>
+    where
+        U: Clone + Default + Send + 'static,
+        F: FnOnce(&GraphBuilder) -> Stream<U> + Send + 'static;
+}
+
+/// Joins a [`SourceOps::spawn`] worker thread when the run tears down — held only
+/// for its `Drop` by a [`StopHandle`]. The `spawn` worker is a self-bounded
+/// producer (it ends at its inherited run bound), so a plain join suffices.
+struct JoinOnDrop(Option<std::thread::JoinHandle<()>>);
+
+impl Drop for JoinOnDrop {
+    fn drop(&mut self) {
+        if let Some(h) = self.0.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Tears down a [`StreamOps::spawn_map`] worker: closes its **input** so the
+/// lock-step reader sees end-of-stream and its run ends, *then* joins. Without the
+/// close the worker would block forever awaiting an input the driving graph has
+/// stopped sending (e.g. after a `limit`), and the join would hang.
+struct WorkerGuard<I> {
+    input: Rc<RefCell<Option<ChannelSender<I>>>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl<I> Drop for WorkerGuard<I> {
+    fn drop(&mut self) {
+        if let Some(s) = self.input.borrow().as_ref() {
+            s.close();
+        }
+        if let Some(h) = self.worker.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// The worker-thread body of [`SourceOps::spawn`]: wire the producer sub-graph,
+/// forward each timestamped value over `sender`, run under the caller's bound,
+/// and close (or surface a worker error) on the way out.
+fn run_worker_source<U, F>(build: F, sender: ChannelSender<U>, run_mode: RunMode, run_for: RunFor)
+where
+    U: Clone + Default + Send + 'static,
+    F: FnOnce(&GraphBuilder) -> Stream<U>,
+{
+    let wg = GraphBuilder::new();
+    let out = build(&wg);
+    let forward = sender.clone();
+    let _sink = out.with_time().for_each(move |tv: &(NanoTime, U)| {
+        // send_at replays deterministically at graph time in historical mode and
+        // is treated as a plain send (stamp ignored) in realtime.
+        forward.send_at(tv.1.clone(), tv.0);
+        Ok(())
+    });
+    let mut runner = wg.build();
+    match runner.run(run_mode, run_for) {
+        // Signal end-of-stream so the receiving graph winds down once drained.
+        Ok(()) => {
+            sender.close();
+        }
+        // Propagate the worker's failure into the driving graph, aborting its run.
+        Err(e) => {
+            sender.send_error(e);
+        }
+    }
+}
+
+/// The worker-thread body of [`StreamOps::spawn_map`]: build a graph whose source
+/// is a lock-step input channel (fed by the driving graph), run `build` over it,
+/// forward each timestamped result back over `to_main`, and hand the input sender
+/// back to the driving graph over `sender_back` so it can start feeding.
+fn run_worker_map<I, O, F>(
+    build: F,
+    to_main: ChannelSender<O>,
+    sender_back: std::sync::mpsc::Sender<ChannelSender<I>>,
+    run_mode: RunMode,
+    run_for: RunFor,
+) where
+    I: Clone + Default + Send + 'static,
+    O: Clone + Default + Send + 'static,
+    F: FnOnce(Stream<Burst<I>>) -> Stream<O>,
+{
+    let wg = GraphBuilder::new();
+    // Lock-step input: one value per instant, no read-ahead, so the worker never
+    // blocks on input the driving graph cannot send while it awaits this output.
+    let (in_handle, sender_in) = wg.with_builder(|b| b.channel_lockstep::<I>());
+    let in_stream: Stream<Burst<I>> = wg.wrap(in_handle);
+    // Hand the input sender back; if the driving graph has gone, there is nothing
+    // to run.
+    if sender_back.send(sender_in).is_err() {
+        return;
+    }
+    let out = build(in_stream);
+    let forward = to_main.clone();
+    let _sink = out.with_time().for_each(move |tv: &(NanoTime, O)| {
+        forward.send_at(tv.1.clone(), tv.0);
+        Ok(())
+    });
+    let mut runner = wg.build();
+    match runner.run(run_mode, run_for) {
+        Ok(()) => {
+            to_main.close();
+        }
+        Err(e) => {
+            to_main.send_error(e);
+        }
+    }
 }
 
 impl SourceOps for GraphBuilder {
@@ -362,6 +486,30 @@ impl SourceOps for GraphBuilder {
 
     fn never(&self) -> Stream<()> {
         self.source(|b| b.never())
+    }
+
+    fn spawn<U, F>(&self, build: F) -> Stream<Burst<U>>
+    where
+        U: Clone + Default + Send + 'static,
+        F: FnOnce(&GraphBuilder) -> Stream<U> + Send + 'static,
+    {
+        // `build` runs once, on the worker thread, at run start; wrap it so the
+        // `FnMut` setup can move it out (the backing channel source is single-run,
+        // so `setup` fires exactly once). The `Rc` stays on this thread; only the
+        // moved-out `F` (which is `Send`) crosses to the worker.
+        let build = Rc::new(RefCell::new(Some(build)));
+        let handle = self.with_builder(move |b| {
+            b.source_at_start_with_params(move |sender, run_mode, run_for, _start_time| {
+                let build = build.borrow_mut().take().expect(
+                    "invariant: spawn worker built once per run (backing channel is single-run)",
+                );
+                let worker = std::thread::spawn(move || {
+                    run_worker_source(build, sender, run_mode, run_for);
+                });
+                Ok(StopHandle::new(JoinOnDrop(Some(worker))))
+            })
+        });
+        self.wrap(handle)
     }
 }
 
@@ -755,6 +903,28 @@ pub trait StreamOps<T>: Sized {
     fn feedback(&self, sink: &FeedbackSink<T>) -> Stream<T>
     where
         T: Clone + Default + PartialEq + 'static;
+
+    /// Map this stream through a sub-graph running on its own worker thread,
+    /// surfacing the result here as a [`Burst`] stream.
+    ///
+    /// `build` runs **on the worker thread** at run start: it is handed a
+    /// [`Burst`] stream of this stream's values (delivered into the worker over
+    /// the channel layer) and returns the stream to send back. The worker runs
+    /// under the *same* run mode and bound as this graph and forwards each result
+    /// — timestamped — so a historical replay stays deterministic.
+    ///
+    /// next's ergonomic twin of classic `mapper()` (the map half of `graph_node`).
+    /// The two graphs run concurrently and touch only at the channel layer, in
+    /// lock-step by graph time: each instant, this graph sends the input value and
+    /// the worker sends the corresponding result. Like classic, the sub-graph is
+    /// expected to produce a result per input instant (a filtering/delaying
+    /// sub-graph desynchronises the lock-step); bound the run by duration (not a
+    /// raw cycle count) for exact historical parity — see `docs/port-plan.md`.
+    fn spawn_map<O, F>(&self, build: F) -> Stream<Burst<O>>
+    where
+        T: Clone + Default + Send + 'static,
+        O: Clone + Default + Send + 'static,
+        F: FnOnce(Stream<Burst<T>>) -> Stream<O> + Send + 'static;
 }
 
 impl<T: 'static> StreamOps<T> for Stream<T> {
@@ -1068,6 +1238,61 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         T: Clone + Default + PartialEq + 'static,
     {
         self.wire(|b, h| b.feedback_send(h, sink))
+    }
+
+    fn spawn_map<O, F>(&self, build: F) -> Stream<Burst<O>>
+    where
+        T: Clone + Default + Send + 'static,
+        O: Clone + Default + Send + 'static,
+        F: FnOnce(Stream<Burst<T>>) -> Stream<O> + Send + 'static,
+    {
+        // The worker's input sender, handed back at run start; the send-sink
+        // reads it each cycle. Stays on this thread (not `Send`).
+        let to_worker: Rc<RefCell<Option<ChannelSender<T>>>> = Rc::new(RefCell::new(None));
+        // Send-sink: forward each input value (timestamped, one per instant) to
+        // the worker. Being the receiver's trigger, its lower layer runs first
+        // each cycle, so the input is sent before the receiver blocks for output.
+        let cell = to_worker.clone();
+        let sink = self.with_time().for_each(move |tv: &(NanoTime, T)| {
+            if let Some(s) = cell.borrow().as_ref() {
+                s.send_at(tv.1.clone(), tv.0);
+            }
+            Ok(())
+        });
+        let trigger_idx = sink.handle.index();
+        // Triggered output receiver + the sender the worker writes results to.
+        let (out_handle, to_main) = self.inner.borrow_mut().channel_triggered::<O>(trigger_idx);
+        let recv_idx = out_handle.index();
+        // Launch the worker at run start (the run params are known only then); it
+        // hands its input sender back over a one-shot, which we store for the sink.
+        let build = Rc::new(RefCell::new(Some(build)));
+        self.inner.borrow_mut().compose_spawn_at_start(
+            recv_idx,
+            move |run_mode, run_for, _start_time| {
+                let build = build
+                    .borrow_mut()
+                    .take()
+                    .expect("invariant: spawn_map worker built once per run (single-run channels)");
+                let (back_tx, back_rx) = std::sync::mpsc::channel::<ChannelSender<T>>();
+                let to_main = to_main.clone();
+                let worker = std::thread::spawn(move || {
+                    run_worker_map(build, to_main, back_tx, run_mode, run_for);
+                });
+                let sender_in = back_rx
+                    .recv()
+                    .map_err(|_| anyhow::anyhow!("spawn_map: worker thread failed to start"))?;
+                *to_worker.borrow_mut() = Some(sender_in);
+                Ok(StopHandle::new(WorkerGuard {
+                    input: to_worker.clone(),
+                    worker: Some(worker),
+                }))
+            },
+        );
+        Stream {
+            inner: self.inner.clone(),
+            built: self.built.clone(),
+            handle: out_handle,
+        }
     }
 }
 

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -51,7 +51,7 @@ use anyhow::{Result, bail};
 static NEXT_BUILDER_ID: AtomicU64 = AtomicU64::new(0);
 
 use crate::Burst;
-use crate::channel::{ChannelSender, Message};
+use crate::channel::{ChannelSender, Message, Tx};
 use crate::latency::{HasLatency, LatencyReport, LatencyReportCfg, LatencyStats};
 use crate::op::{Activation, CompositePhase, Ctx, Op, Tick};
 use crate::ops::{
@@ -614,10 +614,25 @@ impl Builder {
     pub fn channel<T: Clone + Default + 'static>(
         &mut self,
     ) -> (Handle<Burst<T>>, ChannelSender<T>) {
+        self.channel_bounded(None)
+    }
+
+    /// [`channel`](Self::channel) with an optional transport bound. `None` is the
+    /// unbounded default; `Some(n)` makes the producer→graph transport a bounded
+    /// `sync_channel(n)`, so a producer sending faster than the graph drains
+    /// **blocks** on `send` (back-pressure) instead of accumulating an unbounded
+    /// backlog. **Do not** bound a producer that fills the buffer *before the run
+    /// starts* (e.g. `replay_results`, which queues its whole feed at wiring —
+    /// there is no running consumer to drain it, so a bounded send would block at
+    /// wiring); those keep the unbounded path.
+    pub fn channel_bounded<T: Clone + Default + 'static>(
+        &mut self,
+        buffer: Option<usize>,
+    ) -> (Handle<Burst<T>>, ChannelSender<T>) {
         // Self-driven, read-ahead: an independent producer may batch several
         // values at one instant, so read one timestamp past `now` to close the
         // same-time burst before delivering it.
-        self.channel_inner(None, true)
+        self.channel_inner(None, true, buffer)
     }
 
     /// A channel receiver driven by an upstream `trigger` node rather than
@@ -632,8 +647,9 @@ impl Builder {
     pub(crate) fn channel_triggered<T: Clone + Default + 'static>(
         &mut self,
         trigger: usize,
+        buffer: Option<usize>,
     ) -> (Handle<Burst<T>>, ChannelSender<T>) {
-        self.channel_inner(Some(trigger), false)
+        self.channel_inner(Some(trigger), false, buffer)
     }
 
     /// A self-driven channel receiver that delivers one instant at a time with
@@ -645,19 +661,32 @@ impl Builder {
     /// a single value per instant (no same-time burst to close).
     pub(crate) fn channel_lockstep<T: Clone + Default + 'static>(
         &mut self,
+        buffer: Option<usize>,
     ) -> (Handle<Burst<T>>, ChannelSender<T>) {
-        self.channel_inner(None, false)
+        self.channel_inner(None, false, buffer)
     }
 
     fn channel_inner<T: Clone + Default + 'static>(
         &mut self,
         trigger: Option<usize>,
         read_ahead: bool,
+        buffer: Option<usize>,
     ) -> (Handle<Burst<T>>, ChannelSender<T>) {
         let triggered = trigger.is_some();
         let idx = self.nodes.len();
         let out = self.new_slot(Burst::<T>::new());
-        let (tx, rx) = std::sync::mpsc::channel::<Message<T>>();
+        // Unbounded by default; `Some(n)` bounds the transport to `sync_channel(n)`
+        // so a producer outrunning the graph blocks on `send` (back-pressure).
+        let (tx, rx) = match buffer {
+            None => {
+                let (tx, rx) = std::sync::mpsc::channel::<Message<T>>();
+                (Tx::Unbounded(tx), rx)
+            }
+            Some(n) => {
+                let (tx, rx) = std::sync::mpsc::sync_channel::<Message<T>>(n);
+                (Tx::Bounded(tx), rx)
+            }
+        };
         self.has_channel = true;
         // The receiver is drained (historical) or waker-driven (realtime) by
         // the first run; a second run would see an empty channel.
@@ -831,7 +860,7 @@ impl Builder {
         T: Clone + Default + 'static,
         Setup: FnMut(ChannelSender<T>) -> Result<StopHandle> + 'static,
     {
-        self.source_at_start_with_params(move |sender, _run_mode, _run_for, _start_time| {
+        self.source_at_start_with_params(None, move |sender, _run_mode, _run_for, _start_time| {
             setup(sender)
         })
     }
@@ -843,12 +872,16 @@ impl Builder {
     /// its worker thread builds and runs its own graph and can only learn the run
     /// parameters here (they do not exist at wiring). The composed `start`/
     /// `teardown` semantics are identical to `source_at_start`.
-    pub(crate) fn source_at_start_with_params<T, Setup>(&mut self, setup: Setup) -> Handle<Burst<T>>
+    pub(crate) fn source_at_start_with_params<T, Setup>(
+        &mut self,
+        buffer: Option<usize>,
+        setup: Setup,
+    ) -> Handle<Burst<T>>
     where
         T: Clone + Default + 'static,
         Setup: FnMut(ChannelSender<T>, RunMode, RunFor, NanoTime) -> Result<StopHandle> + 'static,
     {
-        let (handle, sender) = self.channel::<T>();
+        let (handle, sender) = self.channel_bounded::<T>(buffer);
         let idx = handle.idx;
         let node = &mut self.nodes[idx];
         // The channel node already carries a `start` hook (the historical

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -105,6 +105,137 @@ impl<T> Handle<T> {
     }
 }
 
+/// A historical channel receiver's persistent read state: the time-grouped
+/// look-ahead buffer, an end-of-stream flag, and the highest timestamp seen so
+/// far (a group is known-complete once a strictly-later timestamp arrives or the
+/// stream ends). Carried in the channel node's shared cell across cycles.
+struct HistRead<T: Default> {
+    groups: VecDeque<(NanoTime, Burst<T>)>,
+    eof: bool,
+    seen_max: Option<NanoTime>,
+}
+
+impl<T: Default> Default for HistRead<T> {
+    fn default() -> Self {
+        Self {
+            groups: VecDeque::new(),
+            eof: false,
+            seen_max: None,
+        }
+    }
+}
+
+/// Incrementally drain a historical channel receiver into time-grouped
+/// look-ahead bursts — the streaming counterpart of the old block-collect.
+///
+/// Reads messages until either every group with time `<= upto` is known
+/// complete (a strictly-later timestamp has been seen, or the stream ended)
+/// or — when `blocking` is `false` — the channel is momentarily empty. This is
+/// the port of classic `ChannelReceiverStream`'s "block while behind, stop once
+/// caught up" loop (`wingfoil/src/nodes/channel.rs`): it holds at most one group
+/// of look-ahead, so memory is bounded and a producer that depends on the
+/// receiving graph's own output can make progress (the block-collect predecessor
+/// deadlocked it, which is why `spawn_map`'s historical mode was impossible).
+///
+/// `state` is the receiver's persistent read state (see [`HistRead`]). Timestamps
+/// must be `>= start_time` and non-decreasing (classic errors on either); a
+/// `Message::Error` aborts the run.
+///
+/// `read_past` distinguishes the two classic drive modes. A **self-driven**
+/// receiver reads *past* `upto` (`seen_max > upto`) so a same-time burst
+/// delivered as separate messages is drained whole before delivery. A
+/// **triggered** receiver (the `spawn_map` worker feed) stops as soon as it has
+/// the value *at* `upto` (`seen_max >= upto`) and never reads ahead — reading
+/// past would block on a value the producer cannot send until it receives more
+/// input from this very graph, the deadlock the block-collect had.
+fn pump_historical<T: Clone + Default>(
+    rx: &std::sync::mpsc::Receiver<Message<T>>,
+    state: &mut HistRead<T>,
+    start_time: NanoTime,
+    upto: NanoTime,
+    read_past: bool,
+    blocking: bool,
+) -> Result<()> {
+    use std::sync::mpsc::TryRecvError;
+    loop {
+        if state.eof {
+            break;
+        }
+        // Stop once everything at or before `upto` is buffered. Self-driven
+        // reads one strictly-later timestamp to close a same-time burst;
+        // triggered stops at the first message stamped `>= upto`.
+        if let Some(mx) = state.seen_max
+            && (if read_past { mx > upto } else { mx >= upto })
+        {
+            break;
+        }
+        let msg = if blocking {
+            match rx.recv() {
+                Ok(m) => m,
+                // All senders dropped without an explicit close.
+                Err(_) => {
+                    state.eof = true;
+                    break;
+                }
+            }
+        } else {
+            match rx.try_recv() {
+                Ok(m) => m,
+                // Nothing more buffered right now — a triggered receiver stops
+                // here rather than blocking (that is what avoids the deadlock).
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    state.eof = true;
+                    break;
+                }
+            }
+        };
+        let (t, v) = match msg {
+            Message::ValueAt(v, t) => (t, v),
+            // An unstamped value replays at the run's start time.
+            Message::Value(v) => (start_time, v),
+            // A progress marker carries no value; the historical block-collect
+            // predecessor ignored it, so we do too (it neither ticks nor groups).
+            Message::Checkpoint(_) => continue,
+            Message::EndOfStream => {
+                state.eof = true;
+                break;
+            }
+            Message::Error(e) => {
+                return Err(
+                    anyhow::anyhow!("{e:#}").context("channel receiver: producer sent an error")
+                );
+            }
+        };
+        // Reject a pre-start timestamp: the kernel schedules callbacks verbatim,
+        // so a time before `start_time` would rewind the run clock. Classic
+        // errors on any time behind the graph clock; we mirror that.
+        if t < start_time {
+            return Err(anyhow::anyhow!(
+                "channel receiver: historical send_at time {t} is before the run start time \
+                 {start_time} — timestamps must be at or after the start of the replay"
+            ));
+        }
+        // Enforce non-decreasing send order (the graph clock only advances, so
+        // an earlier timestamp is the equivalent of classic's behind-the-clock
+        // message).
+        if let Some(mx) = state.seen_max
+            && t < mx
+        {
+            return Err(anyhow::anyhow!(
+                "channel receiver: historical send_at time {t} is out of order (after {mx}) — \
+                 timestamped sends must be non-decreasing (classic errors on out-of-order)"
+            ));
+        }
+        state.seen_max = Some(t);
+        match state.groups.back_mut() {
+            Some((bt, burst)) if *bt == t => burst.push(v),
+            _ => state.groups.push_back((t, Burst::from([v]))),
+        }
+    }
+    Ok(())
+}
+
 impl Builder {
     /// Mint a [`Handle`] stamped with this builder's id.
     fn make_handle<T>(&self, idx: usize) -> Handle<T> {
@@ -482,6 +613,47 @@ impl Builder {
     pub fn channel<T: Clone + Default + 'static>(
         &mut self,
     ) -> (Handle<Burst<T>>, ChannelSender<T>) {
+        // Self-driven, read-ahead: an independent producer may batch several
+        // values at one instant, so read one timestamp past `now` to close the
+        // same-time burst before delivering it.
+        self.channel_inner(None, true)
+    }
+
+    /// A channel receiver driven by an upstream `trigger` node rather than
+    /// self-scheduling — the incremental, non-blocking counterpart used to feed
+    /// a `spawn_map` worker's output back into the graph. In historical mode it
+    /// reads only what is already due at the current time (blocking while behind
+    /// to stay deterministic, never reading ahead), so a producer that depends on
+    /// this graph's output — the worker — can make progress. The trigger must
+    /// tick at (at least) every instant the receiver should deliver at, and
+    /// should be sequenced *after* whatever sends the worker its input (wire the
+    /// send sink as the trigger, so its lower layer runs first each cycle).
+    pub(crate) fn channel_triggered<T: Clone + Default + 'static>(
+        &mut self,
+        trigger: usize,
+    ) -> (Handle<Burst<T>>, ChannelSender<T>) {
+        self.channel_inner(Some(trigger), false)
+    }
+
+    /// A self-driven channel receiver that delivers one instant at a time with
+    /// **no read-ahead** — for a producer feeding it in lock-step with this
+    /// graph's clock (a `spawn_map` worker's *input*, fed one value per instant by
+    /// the driving graph). Reading ahead would block on a value the producer
+    /// cannot send until this graph advances, which it cannot while the reader
+    /// blocks — the lock-step deadlock. Safe precisely because such a feed carries
+    /// a single value per instant (no same-time burst to close).
+    pub(crate) fn channel_lockstep<T: Clone + Default + 'static>(
+        &mut self,
+    ) -> (Handle<Burst<T>>, ChannelSender<T>) {
+        self.channel_inner(None, false)
+    }
+
+    fn channel_inner<T: Clone + Default + 'static>(
+        &mut self,
+        trigger: Option<usize>,
+        read_ahead: bool,
+    ) -> (Handle<Burst<T>>, ChannelSender<T>) {
+        let triggered = trigger.is_some();
         let idx = self.nodes.len();
         let out = self.new_slot(Burst::<T>::new());
         let (tx, rx) = std::sync::mpsc::channel::<Message<T>>();
@@ -489,33 +661,72 @@ impl Builder {
         // The receiver is drained (historical) or waker-driven (realtime) by
         // the first run; a second run would see an empty channel.
         self.re_runnable = false;
-        // Shared between the cycle and start adapters: the receiver, plus the
-        // time-grouped bursts the historical `start` fills.
-        let cs = Self::cell(rx, VecDeque::<(NanoTime, Burst<T>)>::new());
+        // Shared between the cycle and start adapters: the receiver plus the
+        // incremental historical read state (see `HistRead`). One-ahead, not
+        // block-collect (see `pump_historical`).
+        let cs = Self::cell(rx, HistRead::<T>::default());
         let cs2 = cs.clone();
         let finished = self.finished.clone();
         self.push_node(
-            Vec::new(),
+            trigger.map(|t| vec![t]).unwrap_or_default(),
             Activation {
-                schedules: true,
+                // A self-driven receiver re-arms its own callbacks; a triggered
+                // one is fired by its upstream (and a realtime waker), so it does
+                // not schedule.
+                schedules: !triggered,
                 threaded: true,
                 always: false,
             },
-            "channel",
+            if triggered {
+                "channel(triggered)"
+            } else {
+                "channel"
+            },
             Box::new(move |k| {
                 match k.run_mode() {
-                    // Historical: emit the burst grouped at the current time.
+                    // Historical: read incrementally up to the current time
+                    // (block while behind so a same-time burst arrives whole),
+                    // deliver the group due now, and — when self-driven — re-arm
+                    // at the next group's timestamp. Never block-collect.
                     RunMode::HistoricalFrom(_) => {
                         let now = k.time();
-                        let (_, groups) = &mut *cs.borrow_mut();
-                        match groups.front() {
+                        let start_time = k.start_time();
+                        let (rx, state) = &mut *cs.borrow_mut();
+                        // `read_ahead` false: stop at the value due now, never
+                        // read ahead (reading ahead would block on data the
+                        // producer cannot send until this graph advances — the
+                        // lock-step deadlock).
+                        pump_historical(rx, state, start_time, now, read_ahead, true)?;
+                        let ticked = match state.groups.front() {
                             Some((t, _)) if *t <= now => {
-                                let (_, burst) = groups.pop_front().expect("front checked");
+                                let (_, burst) = state.groups.pop_front().expect("front checked");
                                 *out.borrow_mut() = burst;
-                                Ok(true)
+                                true
                             }
-                            _ => Ok(false),
+                            _ => false,
+                        };
+                        // Self-driven only: re-arm at the next buffered group's
+                        // (always future) time; if none is buffered but the stream
+                        // is still open, wake at `now` so the next cycle blocks for
+                        // the next message. A triggered receiver is re-fired by its
+                        // upstream instead.
+                        if !triggered {
+                            match state.groups.front() {
+                                Some((t, _)) => k.schedule(idx, *t),
+                                // Nothing buffered ahead. If the stream is still
+                                // open, re-arm at `now` (the kernel bumps it one
+                                // tick forward) so the next cycle blocks for the
+                                // next message — classic's caught-up
+                                // `add_callback(now)` (channel.rs:238). A closed
+                                // (eof) stream just winds down.
+                                None => {
+                                    if !state.eof {
+                                        k.schedule(idx, now);
+                                    }
+                                }
+                            }
                         }
+                        Ok(ticked)
                     }
                     // Realtime: drain everything pending into one burst.
                     RunMode::RealTime => {
@@ -554,77 +765,21 @@ impl Builder {
                 }
             }),
             Box::new(move |k| {
-                // Historical: block-collect the whole timestamped stream up
-                // front (producer sends values then closes), group same-time
-                // values into bursts, and schedule one delivery per timestamp.
+                // Historical, self-driven only: seed the incremental read. Read
+                // just far enough to learn the first group's timestamp, then
+                // schedule the first wakeup at it; per-cycle `pump_historical`
+                // streams the rest on demand. No block-collect — bounded memory,
+                // and a producer that depends on this graph's output still gets to
+                // run (the deadlock the old block-collect documented is gone).
                 //
-                // KNOWN DEVIATION from classic (`wingfoil/src/nodes/channel.rs`),
-                // which reads incrementally and non-blocking once caught up:
-                // this `start` hook *blocks* until the producer closes and holds
-                // the entire feed in memory. It therefore (a) uses unbounded
-                // memory for large feeds, and (b) would deadlock a producer that
-                // depends on this graph's output (it never gets to run). Fine
-                // for the finite offline-replay case; a streaming/back-pressured
-                // variant is future work.
-                if let RunMode::HistoricalFrom(_) = k.run_mode() {
+                // A triggered receiver seeds nothing at start: it must not read
+                // before its trigger has sent the worker any input, and it is
+                // driven forward by that trigger, not by self-scheduled callbacks.
+                if !triggered && let RunMode::HistoricalFrom(_) = k.run_mode() {
                     let start_time = k.start_time();
-                    let mut collected: Vec<(NanoTime, T)> = Vec::new();
-                    {
-                        let (rx, _) = &mut *cs2.borrow_mut();
-                        loop {
-                            match rx.recv() {
-                                Ok(Message::ValueAt(v, t)) => {
-                                    // Reject a pre-start timestamp: the kernel
-                                    // schedules callbacks verbatim, so a time
-                                    // before `start_time` would rewind the run
-                                    // clock (the first cycle firing before
-                                    // `HistoricalFrom(start)`). Classic errors on
-                                    // any time behind the graph clock; we mirror
-                                    // that.
-                                    if t < start_time {
-                                        return Err(anyhow::anyhow!(
-                                            "channel receiver: historical send_at time {t} is \
-                                             before the run start time {start_time} — timestamps \
-                                             must be at or after the start of the replay"
-                                        ));
-                                    }
-                                    // Enforce non-decreasing send order (classic
-                                    // errors on a message stamped behind the graph
-                                    // clock; here the graph clock only advances,
-                                    // so out-of-order sends are the equivalent).
-                                    if let Some((prev, _)) = collected.last()
-                                        && t < *prev
-                                    {
-                                        return Err(anyhow::anyhow!(
-                                            "channel receiver: historical send_at time {t} is \
-                                             out of order (after {prev}) — timestamped sends must \
-                                             be non-decreasing (classic errors on out-of-order)"
-                                        ));
-                                    }
-                                    collected.push((t, v));
-                                }
-                                Ok(Message::Value(v)) => collected.push((start_time, v)),
-                                Ok(Message::Checkpoint(_)) => {}
-                                Ok(Message::EndOfStream) => break,
-                                Ok(Message::Error(e)) => {
-                                    return Err(anyhow::anyhow!("{e:#}")
-                                        .context("channel receiver: producer sent an error"));
-                                }
-                                // All senders dropped without an explicit close.
-                                Err(_) => break,
-                            }
-                        }
-                    }
-                    // Order is already validated non-decreasing above; group
-                    // consecutive equal timestamps into one burst.
-                    let (_, groups) = &mut *cs2.borrow_mut();
-                    for (t, v) in collected {
-                        match groups.back_mut() {
-                            Some((bt, burst)) if *bt == t => burst.push(v),
-                            _ => groups.push_back((t, Burst::from([v]))),
-                        }
-                    }
-                    for (t, _) in groups.iter() {
+                    let (rx, state) = &mut *cs2.borrow_mut();
+                    pump_historical(rx, state, start_time, start_time, read_ahead, true)?;
+                    if let Some((t, _)) = state.groups.front() {
                         k.schedule(idx, *t);
                     }
                 }
@@ -670,10 +825,27 @@ impl Builder {
     /// a producer that finishes by merely dropping its sender would deadlock the
     /// collect. Realtime live sources — the primary use — are unaffected: they
     /// terminate on `close()` or the run bound.
-    pub fn source_at_start<T, Setup>(&mut self, setup: Setup) -> Handle<Burst<T>>
+    pub fn source_at_start<T, Setup>(&mut self, mut setup: Setup) -> Handle<Burst<T>>
     where
         T: Clone + Default + 'static,
         Setup: FnMut(ChannelSender<T>) -> Result<StopHandle> + 'static,
+    {
+        self.source_at_start_with_params(move |sender, _run_mode, _run_for, _start_time| {
+            setup(sender)
+        })
+    }
+
+    /// Like [`source_at_start`](Self::source_at_start), but the `setup` closure
+    /// is also handed the run's [`RunMode`]/[`RunFor`]/`start_time` at start — the
+    /// bounds a producer needs when it must itself run a *sub-graph* under the
+    /// same bound. This is what [`spawn`](crate::fluent::SourceOps::spawn) rides:
+    /// its worker thread builds and runs its own graph and can only learn the run
+    /// parameters here (they do not exist at wiring). The composed `start`/
+    /// `teardown` semantics are identical to `source_at_start`.
+    pub(crate) fn source_at_start_with_params<T, Setup>(&mut self, setup: Setup) -> Handle<Burst<T>>
+    where
+        T: Clone + Default + 'static,
+        Setup: FnMut(ChannelSender<T>, RunMode, RunFor, NanoTime) -> Result<StopHandle> + 'static,
     {
         let (handle, sender) = self.channel::<T>();
         let idx = handle.idx;
@@ -696,7 +868,7 @@ impl Builder {
         let stop: Rc<RefCell<Option<StopHandle>>> = Rc::new(RefCell::new(None));
         let stop_at_start = stop.clone();
         node.start = Box::new(move |k| {
-            let guard = setup(sender.clone())?;
+            let guard = setup(sender.clone(), k.run_mode(), k.run_for(), k.start_time())?;
             *stop_at_start.borrow_mut() = Some(guard);
             prev_start(k)
         });
@@ -707,6 +879,34 @@ impl Builder {
             prev_teardown(k)
         });
         handle
+    }
+
+    /// Compose a worker-spawn onto an **existing** node's `start`/`teardown`
+    /// (unlike [`source_at_start_with_params`](Self::source_at_start_with_params),
+    /// which mints a fresh channel source). At run start `setup` is handed the run
+    /// params and returns a [`StopHandle`] held for the run and dropped at
+    /// teardown. Used by [`spawn_map`](crate::fluent::StreamOps::spawn_map) to
+    /// launch its worker off the *output receiver* node once the run bounds are
+    /// known. `idx` must be a valid node index in this builder.
+    pub(crate) fn compose_spawn_at_start<S>(&mut self, idx: usize, setup: S)
+    where
+        S: FnMut(RunMode, RunFor, NanoTime) -> Result<StopHandle> + 'static,
+    {
+        let node = &mut self.nodes[idx];
+        let mut prev_start = std::mem::replace(&mut node.start, Box::new(|_| Ok(())));
+        let mut prev_teardown = std::mem::replace(&mut node.teardown, Box::new(|_| Ok(())));
+        let mut setup = setup;
+        let stop: Rc<RefCell<Option<StopHandle>>> = Rc::new(RefCell::new(None));
+        let stop_at_start = stop.clone();
+        node.start = Box::new(move |k| {
+            let guard = setup(k.run_mode(), k.run_for(), k.start_time())?;
+            *stop_at_start.borrow_mut() = Some(guard);
+            prev_start(k)
+        });
+        node.teardown = Box::new(move |k| {
+            stop.borrow_mut().take();
+            prev_teardown(k)
+        });
     }
 
     /// Resolve the tokio runtime [`Handle`](tokio::runtime::Handle) the async

--- a/next/crates/wingfoil-next/tests/channel.rs
+++ b/next/crates/wingfoil-next/tests/channel.rs
@@ -152,3 +152,35 @@ fn message_equality_matches_classic() {
     let e2 = Message::<u64>::Error(std::sync::Arc::new(anyhow::anyhow!("x")));
     assert_ne!(e1, e2);
 }
+
+/// `channel_bounded(Some(n))`: a concurrent producer sends more values than the
+/// bound, so its `send` blocks (back-pressure) until the graph drains — yet the
+/// historical replay is lossless and deterministic, identical to the unbounded
+/// channel. (The producer runs on its own thread, so it is drained *during* the
+/// run; a producer that queued everything before the run must stay unbounded.)
+#[test]
+fn channel_bounded_applies_backpressure_without_changing_the_result() {
+    let g = GraphBuilder::new();
+    let (values, sender) = g.channel_bounded::<u64>(Some(2));
+    let acc = values.with_time().accumulate();
+    let mut r = g.build();
+
+    let producer = std::thread::spawn(move || {
+        // 8 values, buffer of 2 → the producer blocks after the 2nd until the
+        // graph reads, and so on. All must still arrive at their timestamps.
+        for i in 1..=8u64 {
+            sender.send_at(i * 10, NanoTime::new(i * 100));
+        }
+        sender.close();
+    });
+
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+        .unwrap();
+    producer.join().expect("producer thread");
+
+    let got = r.value(&acc);
+    let values: Vec<u64> = got.iter().flat_map(|(_, v)| v.clone()).collect();
+    let times: Vec<u64> = got.iter().map(|(t, _)| u64::from(*t)).collect();
+    assert_eq!(values, (1..=8).map(|i| i * 10).collect::<Vec<u64>>());
+    assert_eq!(times, (1..=8).map(|i| i * 100).collect::<Vec<u64>>());
+}

--- a/next/crates/wingfoil-next/tests/spawn.rs
+++ b/next/crates/wingfoil-next/tests/spawn.rs
@@ -137,3 +137,43 @@ fn spawn_map_delivers_all_values_in_realtime() {
     let flat: Vec<u64> = runner.value(&collected).into_iter().flatten().collect();
     assert_eq!(flat, vec![10, 20, 30, 40, 50]);
 }
+
+/// `spawn_bounded` / `spawn_map_bounded`: a small transport bound applies
+/// back-pressure but never changes the delivered values or tick times.
+#[test]
+fn bounded_spawn_and_spawn_map_match_the_unbounded_result() {
+    let period = Duration::from_millis(10);
+    let n = 5u64;
+
+    let g = GraphBuilder::new();
+    // Bound the producer→graph channel to 2 (worker blocks if it gets >2 ahead).
+    let counts: Stream<Burst<u64>> =
+        g.spawn_bounded(Some(2), move |wg| wg.ticker(period).count().limit(n as u32));
+    let flat = counts.map(|b: &Burst<u64>| b.iter().sum::<u64>());
+    // Bound both worker channels to 2 as well.
+    let scaled: Stream<Burst<u64>> = flat.spawn_map_bounded(Some(2), |s: Stream<Burst<u64>>| {
+        s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10)
+    });
+    let collected = scaled
+        .map(|b: &Burst<u64>| b.iter().copied().collect::<Vec<u64>>())
+        .with_time()
+        .accumulate();
+    let mut runner = g.build();
+
+    runner
+        .run(
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Duration(period * (n as u32 + 3)),
+        )
+        .expect("bounded historical run");
+
+    let out = runner.value(&collected);
+    let values: Vec<Vec<u64>> = out.iter().map(|(_, v)| v.clone()).collect();
+    let times: Vec<u64> = out.iter().map(|(t, _)| u64::from(*t)).collect();
+    assert_eq!(
+        values,
+        vec![vec![10], vec![20], vec![30], vec![40], vec![50]]
+    );
+    let p = period.as_nanos() as u64;
+    assert_eq!(times, vec![0, p, 2 * p, 3 * p, 4 * p]);
+}

--- a/next/crates/wingfoil-next/tests/spawn.rs
+++ b/next/crates/wingfoil-next/tests/spawn.rs
@@ -1,0 +1,139 @@
+//! Parity tests for `spawn` / `spawn_map` — the thread-offload combinators
+//! (next's twins of classic `producer()` / `mapper()`, the `graph_node` node).
+//!
+//! Historical assertions are exact (values *and* tick times); realtime
+//! assertions check values only (wall-clock burst grouping is timing-dependent),
+//! matching how classic's `graph_node_works` treats the two modes.
+//!
+//! The worker inherits the driving run's mode **and** bound (as classic
+//! `producer` does), so a perpetual producer (a ticker) is bounded by the run —
+//! these tests use bounded runs, never `Forever` with a ticker.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+/// `spawn`: a producer sub-graph (ticker → running count) runs on a worker
+/// thread; the main graph scales each value ×10. Historical replay is fully
+/// deterministic: one value per instant, delivered at the tick time.
+#[test]
+fn spawn_source_replays_deterministically_in_historical_mode() {
+    let period = Duration::from_millis(10);
+    let n = 6u64;
+
+    let g = GraphBuilder::new();
+    let counts: Stream<Burst<u64>> = g.spawn(move |wg| wg.ticker(period).count().limit(n as u32));
+    let scaled = counts
+        .map(|b: &Burst<u64>| b.iter().map(|x| x * 10).collect::<Vec<u64>>())
+        .with_time();
+    let collected = scaled.accumulate();
+    let mut runner = g.build();
+
+    // Bound generously past the producer's `limit`; historical replay is
+    // wall-clock-free, so the worker races to its bound and closes at once.
+    runner
+        .run(
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Duration(period * (n as u32 + 3)),
+        )
+        .expect("historical spawn run");
+
+    let out = runner.value(&collected);
+    let times: Vec<u64> = out.iter().map(|(t, _)| u64::from(*t)).collect();
+    let values: Vec<Vec<u64>> = out.iter().map(|(_, v)| v.clone()).collect();
+
+    // count() starts at 1; ×10 → 10,20,…,60. next's ticker fires at
+    // 0,p,2p,… (see catalog.rs), so the six values land at 0..5p.
+    assert_eq!(
+        values,
+        vec![vec![10], vec![20], vec![30], vec![40], vec![50], vec![60]]
+    );
+    let p = period.as_nanos() as u64;
+    assert_eq!(times, vec![0, p, 2 * p, 3 * p, 4 * p, 5 * p]);
+}
+
+/// The same producer in realtime: values are correct; wall-clock pacing may
+/// group several into a burst, so only the flattened value sequence is asserted.
+#[test]
+fn spawn_source_delivers_all_values_in_realtime() {
+    let period = Duration::from_millis(2);
+    let n = 6u64;
+
+    let g = GraphBuilder::new();
+    let counts: Stream<Burst<u64>> = g.spawn(move |wg| wg.ticker(period).count().limit(n as u32));
+    let collected = counts.accumulate();
+    let mut runner = g.build();
+
+    runner
+        .run(
+            RunMode::RealTime,
+            RunFor::Duration(Duration::from_millis(80)),
+        )
+        .expect("realtime spawn run");
+
+    let flat: Vec<u64> = runner.value(&collected).into_iter().flatten().collect();
+    assert_eq!(flat, vec![1, 2, 3, 4, 5, 6]);
+}
+
+/// `spawn_map`: the input (ticker → running count) is mapped ×10 through a
+/// sub-graph running on a worker thread. Both graphs run historical in lock-step
+/// by graph time, so the result is fully deterministic — the capability the
+/// incremental channel unblocked (block-collect deadlocked this).
+#[test]
+fn spawn_map_replays_deterministically_in_historical_mode() {
+    let period = Duration::from_millis(10);
+    let n = 5u64;
+
+    let g = GraphBuilder::new();
+    let input = g.ticker(period).count().limit(n as u32); // 1..5 at 0,p,2p,3p,4p
+    let scaled: Stream<Burst<u64>> =
+        input.spawn_map(|s: Stream<Burst<u64>>| s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10));
+    let collected = scaled
+        .map(|b: &Burst<u64>| b.iter().copied().collect::<Vec<u64>>())
+        .with_time()
+        .accumulate();
+    let mut runner = g.build();
+
+    runner
+        .run(
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Duration(period * (n as u32 + 3)),
+        )
+        .expect("historical spawn_map run");
+
+    let out = runner.value(&collected);
+    let times: Vec<u64> = out.iter().map(|(t, _)| u64::from(*t)).collect();
+    let values: Vec<Vec<u64>> = out.iter().map(|(_, v)| v.clone()).collect();
+
+    assert_eq!(
+        values,
+        vec![vec![10], vec![20], vec![30], vec![40], vec![50]]
+    );
+    let p = period.as_nanos() as u64;
+    assert_eq!(times, vec![0, p, 2 * p, 3 * p, 4 * p]);
+}
+
+/// The same mapper in realtime: values correct, grouping timing-dependent.
+#[test]
+fn spawn_map_delivers_all_values_in_realtime() {
+    let period = Duration::from_millis(2);
+    let n = 5u64;
+
+    let g = GraphBuilder::new();
+    let input = g.ticker(period).count().limit(n as u32);
+    let scaled: Stream<Burst<u64>> =
+        input.spawn_map(|s: Stream<Burst<u64>>| s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10));
+    let collected = scaled.accumulate();
+    let mut runner = g.build();
+
+    runner
+        .run(
+            RunMode::RealTime,
+            RunFor::Duration(Duration::from_millis(80)),
+        )
+        .expect("realtime spawn_map run");
+
+    let flat: Vec<u64> = runner.value(&collected).into_iter().flatten().collect();
+    assert_eq!(flat, vec![10, 20, 30, 40, 50]);
+}

--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -59,6 +59,11 @@ has its own decision record in
   bounded memory and unblocking concurrent producer↔consumer (this is what makes
   `spawn_map` historical possible). B4/B5 (csv/postgres reading everything at
   wiring) are now adapter-side pre-queueing, no longer amplified by the channel.
+  The transport itself is still unbounded by default, but opt-in back-pressure is
+  available — `SourceOps::channel_bounded` / `spawn_bounded` / `spawn_map_bounded`
+  take `Option<usize>` (`None` = unbounded, `Some(n)` = `sync_channel(n)`). Not for
+  producers that fill the buffer before the run starts (`replay_results`, csv,
+  `postgres_read`) — those stay on the unbounded path.
 
 ## C. Capability gaps — tracked, deferred by design
 

--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -43,6 +43,18 @@ deviation lists. All of Category A (except A6) is the subject of
 | B3 | **`kafka_pub` produces sequentially** (single ordered `consume_async` consumer, N roundtrips/burst) vs classic's concurrent `FuturesUnordered` (one roundtrip/burst). | 🟡 | Order-preserving but a throughput deviation. `adapters/kafka.rs` deviation #4. |
 | B4 | **csv reads the whole file up front** vs classic's lazy row streaming. | 🟡 | Unbounded-memory for a huge file under `RunFor::Forever`. `adapters/csv.rs` "consequences of using the channel source". |
 | B5 | **`postgres_read` queries all slices at wiring** onto `replay_results` vs classic's lazy `produce_async`. | 🟢🟡 | "Identical for a bounded historical run," but buffers the whole result set (memory). Same family as A1. `adapters/postgres.rs` deviation #2. |
+| B6 | **`spawn_map` historical is lock-step by graph time** (twin of classic `mapper()`). | 🟢🟡 | Values + tick times match classic. Two benign artifacts: (a) the sub-graph is expected to emit a result per input instant (a filtering/delaying sub-graph desynchronises the lock-step — classic's `graph_node` delay case likewise fails); (b) the lock-step reader spends one no-op poll cycle between instants (next's monotonic-clock re-arm), so bound runs by **duration**, not a raw cycle count. `fluent.rs::spawn_map`, `tests/spawn.rs`. |
+
+## Resolved
+
+- **Channel historical block-collect → incremental read.** The historical channel
+  source previously block-collected the entire feed into memory at `start()`
+  (documented deviation: unbounded memory + deadlocks a producer that depends on
+  the graph's output). Replaced with an incremental, timestamp-gated one-ahead
+  read (`interp.rs::pump_historical`, classic's block-while-behind loop), giving
+  bounded memory and unblocking concurrent producer↔consumer (this is what makes
+  `spawn_map` historical possible). B4/B5 (csv/postgres reading everything at
+  wiring) are now adapter-side pre-queueing, no longer amplified by the channel.
 
 ## C. Capability gaps — tracked, deferred by design
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -410,14 +410,33 @@ Inventory (classic `nodes/` → target), grouped by effort:
 | Scheduling | ✅ throttle, delay_with_reset, node_flow (node-level delay/filter/limit/throttle, run over the unit-stream path, `tests/catalog_flow.rs`) | `SCHEDULES`/time-gated; pattern proven by delay + throttle |
 | Multi-input | ✅ bimap (active/passive) + join, trimap + join3, try_* variants (`tests/catalog_ops.rs`) | passive `bimap` unlocked passive feedback; `trimap` is the 3-ary combine |
 | Engine-touching | always (→`ALWAYS`, done), ✅ never (`tests/catalog_flow.rs`), finally (needs teardown, done), callback stream, iterator_stream (replay source; needs 0.3), receiver, channel nodes (→Phase 3), async_io (→Phase 3) | |
-| Structural / deferred | demux, dynamic_group, graph_node | multi-output + dynamic-graph decisions below |
+| Structural / deferred | demux ✅, dynamic_group ✅, ✅ graph_node (→`spawn`/`spawn_map`, `tests/spawn.rs`) | multi-output + dynamic-graph notes below |
 
-**Dynamic graphs** (`graph_node`, `dynamic_group`, the dynamic examples):
-islands already cover *static* subgraphs composed procedurally (including in
-loops). Runtime graph *mutation* is a separate feature: either
-`Runner::extend` on the interpreted engine (design here, implement if the
-demand is real) or an explicit out-of-scope ruling for v1. Do not let this
-block the catalog — decide, document, move on.
+**`graph_node` (thread-offload) ✅ ported as `spawn` / `spawn_map`.** classic
+`graph_node` is two combinators — `producer()` (a source sub-graph on a worker
+thread) and `.mapper()` (map an input stream through a worker sub-graph). Their
+next twins are `SourceOps::spawn` and `StreamOps::spawn_map` (`fluent.rs`), riding
+the channel layer: the worker builds and runs its own graph at run start (under
+the driving run's inherited mode + bound) and exchanges timestamped values over
+the channel. Both run in **both** modes. Historical mode is deterministic and
+lock-step by graph time — which required replacing the channel's historical
+*block-collect* with an **incremental, timestamp-gated read** (classic's
+"block-while-behind / non-block-once-caught-up" loop, `interp.rs::pump_historical`)
+so a worker that depends on the driving graph's output no longer deadlocks. That
+incremental read also gives every channel bounded (one-ahead) memory. Parity
+tests in `tests/spawn.rs`; the classic `graph_node_works` oracle. *Lock-step
+caveat (matches classic):* the sub-graph is expected to emit a result per input
+instant; bound historical `spawn_map` runs by duration, not a raw cycle count
+(the lock-step reader spends one no-op poll cycle between instants — a next
+monotonic-clock artifact with no effect on values/times).
+
+**Dynamic graphs** (`dynamic_group`, the dynamic examples): distinct from
+`graph_node` above — this is runtime graph *mutation* (add/remove nodes mid-run),
+not thread-offload. islands already cover *static* subgraphs composed procedurally
+(including in loops); `dynamic_group`/`demux` landed behind `dynamic-graph`. The
+remaining open item is the general `Runner::extend` mutation surface — decide
+cutover-blocker vs v1 deviation (see the Phase 4.5 note); it does not block the
+catalog.
 
 **Engine coverage note:** `never`, `combine`, and `delay_with_reset` land as
 interpreted-engine (fluent) ports — like `feedback` — since a zero-input
@@ -459,10 +478,11 @@ values and tick times.
   deterministically on its final write cannot migrate to it yet (see etcd).
 - ✅ Classic `threading`/`async` examples re-implemented on next. `threading`
   (`examples/threading/`) offloads a producer sub-graph to a worker thread that
-  feeds the main graph over the channel layer — next's take on classic
-  `producer()`/`mapper()`, which stay out of the fluent vocabulary (the channel
-  primitive replaces the sugar) — and runs in both modes (realtime bursts,
-  deterministic historical replay). `async` (`examples/async/`, gated on the
+  feeds the main graph over the channel layer — the primitive under classic
+  `producer()`/`mapper()` (the `graph_node` node), which now **also** have direct
+  fluent twins, `SourceOps::spawn` / `StreamOps::spawn_map` (see the Phase 2
+  `graph_node` entry) — and runs in both modes (realtime bursts, deterministic
+  historical replay). `async` (`examples/async/`, gated on the
   `async` feature) drives the graph from a `produce_async` producer with the
   graph as consumer. Bounded-buffer back-pressure (`produce_async_bounded`) and
   wiring-time `RunParams` (validated against the real run in historical mode)

--- a/wingfoil/src/codegen.rs
+++ b/wingfoil/src/codegen.rs
@@ -152,6 +152,22 @@ impl Kernel {
         self.run_mode
     }
 
+    /// The run bound this kernel was built with, reconstructed from the derived
+    /// end-time / end-cycle sentinels (the mirror of [`run_mode`](Self::run_mode)).
+    /// Lets a source run a *sub-graph* under the same bound — e.g. a worker-thread
+    /// producer (`spawn`) whose graph must stop when the driving graph does.
+    pub fn run_for(&self) -> RunFor {
+        if self.end_cycle != u32::MAX {
+            RunFor::Cycles(self.end_cycle)
+        } else if self.end_time != NanoTime::MAX {
+            RunFor::Duration(Duration::from_nanos(
+                u64::from(self.end_time).saturating_sub(u64::from(self.start_time)),
+            ))
+        } else {
+            RunFor::Forever
+        }
+    }
+
     /// Whether this is the final cycle of the run (the run bound is about to
     /// stop it). Ops that buffer and flush on a boundary (window, buffer) use
     /// this to flush their pending contents before the run ends.


### PR DESCRIPTION
## Summary

Closes the **Gate 2 `graph_node` tail** — the last open item in the node catalog — by porting classic `graph_node`'s thread-offload combinators. Getting the map form to work in historical mode required fixing the channel source's historical read first, which is a worthwhile change on its own.

### 1. Incremental historical channel read (replaces block-collect)

The channel source's historical path previously **block-collected the entire feed into memory at `start()`** (a documented deviation: unbounded memory, and it deadlocked any producer that depends on the receiving graph's own output). It's replaced with an incremental, timestamp-gated **one-ahead** read — classic `ChannelReceiverStream`'s "block-while-behind / non-block-once-caught-up" loop (`interp.rs::pump_historical`).

- Every channel now has **bounded (one-ahead) decode memory** instead of a second full copy.
- A concurrent producer↔consumer no longer deadlocks — which is exactly what makes historical `spawn_map` possible.
- Results stay **byte-identical**: guarded by the existing channel / `produce_async` / `consume_async` / csv parity suites (all green).

### 2. `graph_node` → `spawn` / `spawn_map`

next's ergonomic twins of classic `producer()` / `mapper()`:

- **`SourceOps::spawn`** — run a producer sub-graph on a worker thread. The worker builds and runs its own graph at run start (under the driving run's inherited mode + bound) and forwards timestamped values over the channel layer.
- **`StreamOps::spawn_map`** — map an input stream through a worker sub-graph. The two graphs run concurrently, lock-step by graph time.

Both run in **both** run modes. Historical replay is deterministic — values **and** tick times match classic's `graph_node_works` oracle.

### 3. Opt-in bounded buffer / back-pressure

The transport was hardwired to an unbounded std mpsc (a fast producer could queue an unbounded backlog). Added an opt-in bound following the `produce_async_bounded` precedent — `Option<usize>`: `None` = unbounded (default), `Some(n)` = `sync_channel(n)`, so a producer outrunning the graph **blocks** on `send`.

- New surface: `SourceOps::channel_bounded` / `spawn_bounded` / `StreamOps::spawn_map_bounded` (the latter bounds both worker channels). The plain `channel`/`spawn`/`spawn_map` are now thin `None`-delegates.
- `ChannelSender` holds either an unbounded `Sender` or a bounded `SyncSender` (private `Tx` enum); the receive side and the incremental read are untouched.
- **Caveat (documented):** a bounded transport must not be used by a producer that fills the buffer *before the run starts* (`replay_results`, csv, `postgres_read`) — with no running consumer to drain it, a bounded send blocks at wiring. Those keep the unbounded path.

### Engine plumbing

- `channel_triggered` / `channel_lockstep` receiver variants (read-ahead decoupled from the drive mode) for the `spawn_map` output and worker-input channels.
- `Kernel::run_for()` accessor + `Builder::source_at_start_with_params` / `compose_spawn_at_start`, so a worker learns the run params at start (they don't exist at wiring).

## Test plan

- `tests/spawn.rs`: spawn / spawn_map × historical / realtime (historical asserts exact values **and** tick times), plus a bounded spawn+spawn_map test that matches the unbounded result.
- `tests/channel.rs`: a concurrent producer exceeding the bound back-pressures yet replays losslessly and deterministically.
- `wingfoil-next` default + `async` suites: green (58 test binaries). Classic `wingfoil` kernel tests: green.
- `cargo clippy` clean on every feature path this touches (default, `async`, `csv`); `cargo fmt --check` clean.
- `examples/spawn.rs` runs and prints the expected deterministic output.

> Note: `cargo lint-all` can't complete in the CI sandbox without CMake/clang (the aeron/iceoryx2/fluvio adapters) — unrelated to this change, which is all default-feature engine code plus the shared kernel.

## Docs

- `port-plan.md`: Phase 2 `graph_node` entry marked ✅; Phase 3 threading note updated.
- `deviation-register.md`: new **B6** (`spawn_map` lock-step caveat) + a **Resolved** note for the block-collect → incremental read, including the new opt-in back-pressure surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)