### PR TITLE
next-python: add #[pyadapter] — expose a Rust source adapter to Python

### DIFF
--- a/next/crates/wingfoil-next-python-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-python-macros/src/lib.rs
@@ -43,8 +43,8 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{
-    Error, FnArg, GenericArgument, Ident, ImplItem, ItemFn, ItemImpl, PathArguments, ReturnType,
-    Token, Type, parse_macro_input,
+    Error, FnArg, GenericArgument, Ident, ImplItem, ItemFn, ItemImpl, Pat, PathArguments,
+    ReturnType, Token, Type, parse_macro_input,
 };
 
 /// Parsed `#[pyop(name = <fn>, [arg = <cfg param>])]`.
@@ -203,6 +203,136 @@ fn expand_pygraph(args: &PyGraphArgs, func: &ItemFn) -> syn::Result<TokenStream2
             let __typed = __obj.typed_input::<#t_ty>();
             let __out = #fn_name(&__typed);
             ::wingfoil_next_python::Stream::from(__obj.erased_output::<#u_ty>(__out))
+        }
+    })
+}
+
+/// Parsed `#[pyadapter(name = <py fn>, source)]`.
+struct PyAdapterArgs {
+    name: Ident,
+    is_source: bool,
+}
+
+impl Parse for PyAdapterArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut name = None;
+        let mut is_source = false;
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            match key.to_string().as_str() {
+                "name" => {
+                    input.parse::<Token![=]>()?;
+                    name = Some(input.parse()?);
+                }
+                "source" => is_source = true,
+                other => {
+                    return Err(Error::new(
+                        key.span(),
+                        format!("unknown #[pyadapter] key `{other}`; expected `name` or `source`"),
+                    ));
+                }
+            }
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        let name = name.ok_or_else(|| {
+            Error::new(input.span(), "#[pyadapter] requires `name = <py fn name>`")
+        })?;
+        Ok(PyAdapterArgs { name, is_source })
+    }
+}
+
+/// `#[pyadapter(name = ..., source)]` — expose a user **source** adapter method
+/// (`impl Trait for GraphBuilder { fn m(&self, args…) -> Stream<T> }`) as a
+/// Python callable `module.name(graph, args…)` that runs the adapter's native
+/// wiring on the caller's graph and returns the erased output (`T:
+/// Into<PyElement>`). v1 covers single-value source methods; sink/transform and
+/// burst (`Stream<Burst<T>>`) sources are not yet emitted.
+#[proc_macro_attribute]
+pub fn pyadapter(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as PyAdapterArgs);
+    let imp = parse_macro_input!(item as ItemImpl);
+    match expand_pyadapter(&args, &imp) {
+        Ok(extra) => quote! { #imp #extra }.into(),
+        Err(e) => {
+            let e = e.to_compile_error();
+            quote! { #imp #e }.into()
+        }
+    }
+}
+
+fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
+    if !args.is_source {
+        return Err(Error::new(
+            args.name.span(),
+            "#[pyadapter] v1 supports source adapters only; add the `source` marker \
+             (`#[pyadapter(name = ..., source)]`)",
+        ));
+    }
+    // The single adapter method in the impl.
+    let mut methods = imp.items.iter().filter_map(|it| match it {
+        ImplItem::Fn(f) => Some(f),
+        _ => None,
+    });
+    let method = methods.next().ok_or_else(|| {
+        Error::new(
+            imp.span(),
+            "#[pyadapter] impl must contain the adapter method",
+        )
+    })?;
+    if methods.next().is_some() {
+        return Err(Error::new(
+            imp.span(),
+            "#[pyadapter] v1 expects exactly one adapter method in the impl",
+        ));
+    }
+    let method_name = &method.sig.ident;
+
+    // Non-receiver params: (name, type), forwarded to the method verbatim.
+    let mut param_decls = Vec::new();
+    let mut param_names = Vec::new();
+    for arg in &method.sig.inputs {
+        match arg {
+            FnArg::Receiver(_) => {}
+            FnArg::Typed(pt) => {
+                let name = match &*pt.pat {
+                    Pat::Ident(pi) => pi.ident.clone(),
+                    _ => {
+                        return Err(Error::new(
+                            pt.pat.span(),
+                            "#[pyadapter] method params must be simple identifiers",
+                        ));
+                    }
+                };
+                let ty = &pt.ty;
+                param_decls.push(quote! { #name: #ty });
+                param_names.push(name);
+            }
+        }
+    }
+
+    let out_ty = match &method.sig.output {
+        ReturnType::Type(_, ty) => &**ty,
+        ReturnType::Default => {
+            return Err(Error::new(
+                method.sig.span(),
+                "#[pyadapter] source method must return `Stream<T>`",
+            ));
+        }
+    };
+    let t_ty = stream_inner(out_ty)?;
+    let py_name = &args.name;
+
+    Ok(quote! {
+        #[pyo3::pyfunction]
+        fn #py_name(
+            graph: pyo3::PyRef<'_, ::wingfoil_next_python::Graph>,
+            #(#param_decls),*
+        ) -> ::wingfoil_next_python::Stream {
+            let __obj = graph.object();
+            let __typed = __obj.builder().#method_name(#(#param_names),*);
+            ::wingfoil_next_python::Stream::from(__obj.erase_source::<#t_ty>(__typed))
         }
     })
 }

--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -112,6 +112,24 @@ impl PyGraph {
         )
     }
 
+    /// The underlying fluent [`GraphBuilder`] — the seam a `#[pyadapter]` source
+    /// method wires onto. The adapter runs its native wiring against this
+    /// builder (splicing into the same graph), then the typed result is erased
+    /// with [`erase_source`](Self::erase_source).
+    pub fn builder(&self) -> &GraphBuilder {
+        &self.builder
+    }
+
+    /// Erase a natively-typed source `Stream<T>` to a [`PyStream`] on this graph
+    /// — the output half of the `#[pyadapter]` source seam (the interior stays
+    /// native `T`; only the Python-facing edge erases).
+    pub fn erase_source<T>(&self, typed: Stream<T>) -> PyStream
+    where
+        T: Clone + Into<PyElement> + 'static,
+    {
+        self.wrap(typed.map(|v: &T| v.clone().into()))
+    }
+
     /// Run the graph to its bound, storing the runner so retained
     /// [`PyStream`]s can be read with [`PyStream::value`].
     ///

--- a/next/crates/wingfoil-next-python/src/lib.rs
+++ b/next/crates/wingfoil-next-python/src/lib.rs
@@ -43,6 +43,11 @@ pub use wingfoil_next_python_macros::pyop;
 /// graph. See [`wingfoil_next_python_macros::pygraph`].
 pub use wingfoil_next_python_macros::pygraph;
 
+/// Expose a user **source** adapter (`impl Trait for GraphBuilder { fn m(&self,
+/// …) -> Stream<T> }`) as a Python callable `module.m(graph, …)`. See
+/// [`wingfoil_next_python_macros::pyadapter`].
+pub use wingfoil_next_python_macros::pyadapter;
+
 // Re-exported so third-party op crates (and the `pyop!`/`#[pyop]` macros) can
 // name the op vocabulary without depending on `wingfoil-next` directly.
 pub use wingfoil_next::op::{Activation, Ctx, Op, Tick};

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -21,7 +21,7 @@ use pyo3::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
 use crate::graph::{PyGraph, PyStream};
-use crate::{Activation, Ctx, Op, PyElement, Tick, pygraph, pyop};
+use crate::{Activation, Ctx, Op, PyElement, Tick, pyadapter, pygraph, pyop};
 
 fn to_pyerr(err: anyhow::Error) -> PyErr {
     PyRuntimeError::new_err(format!("{err:#}"))
@@ -31,6 +31,15 @@ fn to_pyerr(err: anyhow::Error) -> PyErr {
 /// [`Stream`] combinators, then [`run`](Graph::run).
 #[pyclass(name = "Graph", unsendable)]
 pub struct Graph(PyGraph);
+
+impl Graph {
+    /// The underlying erased object form — the seam a `#[pyadapter]` source
+    /// `#[pyfunction]` in any crate uses to reach the builder and erase its
+    /// result.
+    pub fn object(&self) -> &PyGraph {
+        &self.0
+    }
+}
 
 #[pymethods]
 impl Graph {
@@ -376,6 +385,26 @@ fn build_doubled_running_total(
     input.map(|x: &f64| x * 2.0).cumulative_sum()
 }
 
+// `ramp_source` — a **source `#[pyadapter]`**: a user-style adapter trait
+// implemented on `GraphBuilder`, exposed as `module.ramp_source(graph, start,
+// step)`. This synthetic source (no real IO) emits `start, start+step, …` as
+// `f64` every tick; a real adapter would open a socket/consumer here instead.
+// The fluent `Stream`/`GraphBuilder` are named fully-qualified to avoid the
+// `Stream` pyclass clash in this module.
+trait RampSourceOps {
+    fn ramp_source(&self, start: f64, step: f64) -> ::wingfoil_next::prelude::Stream<f64>;
+}
+
+#[pyadapter(name = ramp_source, source)]
+impl RampSourceOps for ::wingfoil_next::prelude::GraphBuilder {
+    fn ramp_source(&self, start: f64, step: f64) -> ::wingfoil_next::prelude::Stream<f64> {
+        use ::wingfoil_next::prelude::{SourceOps, StreamOps};
+        self.ticker(Duration::from_nanos(100))
+            .count()
+            .map(move |n: &u64| start + step * ((*n - 1) as f64))
+    }
+}
+
 /// The `wingfoil_next` Python module.
 #[pymodule]
 fn wingfoil_next(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -386,5 +415,6 @@ fn wingfoil_next(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(running_total, m)?)?;
     m.add_function(wrap_pyfunction!(weighted_add, m)?)?;
     m.add_function(wrap_pyfunction!(doubled_running_total, m)?)?;
+    m.add_function(wrap_pyfunction!(ramp_source, m)?)?;
     Ok(())
 }

--- a/next/crates/wingfoil-next-python/tests/plugin_seam.rs
+++ b/next/crates/wingfoil-next-python/tests/plugin_seam.rs
@@ -5,8 +5,11 @@
 
 use std::time::Duration;
 
+use pyo3::Python;
 use wingfoil::{NanoTime, RunFor, RunMode};
-use wingfoil_next_python::{Activation, Ctx, Op, PyElement, PyGraph, Tick, pygraph, pyop};
+use wingfoil_next_python::{
+    Activation, Ctx, Op, PyElement, PyGraph, Tick, pyadapter, pygraph, pyop,
+};
 
 // Compile-level proof that `#[pyop]` works from an *external* crate: the paths
 // the macro emits (`::wingfoil_next_python::...`) resolve here, and the
@@ -94,6 +97,40 @@ fn build_triple_subgraph(
 ) -> wingfoil_next::prelude::Stream<f64> {
     use wingfoil_next::prelude::StreamOps;
     input.map(|x: &f64| x * 3.0)
+}
+
+// A source `#[pyadapter]` authored from an external crate: a trait on
+// `GraphBuilder` exposed to Python. Proves the macro emits the source
+// `#[pyfunction]` and the builder/erase_source seam works cross-crate.
+trait CountUpOps {
+    fn count_up(&self, from: f64) -> wingfoil_next::prelude::Stream<f64>;
+}
+
+#[pyadapter(name = count_up, source)]
+impl CountUpOps for wingfoil_next::prelude::GraphBuilder {
+    fn count_up(&self, from: f64) -> wingfoil_next::prelude::Stream<f64> {
+        use wingfoil_next::prelude::{SourceOps, StreamOps};
+        self.ticker(Duration::from_nanos(100))
+            .count()
+            .map(move |n: &u64| from + (*n as f64))
+    }
+}
+
+#[test]
+fn pyadapter_source_from_an_external_crate() {
+    // The generated function exists (compile proof).
+    let _f = count_up;
+
+    // The builder/erase_source seam it builds on splices a native source in
+    // (`count_up` is the trait method above, in scope in this file).
+    let g = PyGraph::new();
+    let typed = g.builder().count_up(100.0);
+    let src = g.erase_source::<f64>(typed);
+    let acc = src.accumulate();
+    g.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(2))
+        .unwrap();
+    let v: Vec<f64> = Python::attach(|py| acc.value().value().extract(py).unwrap());
+    assert_eq!(vec![101.0, 102.0], v);
 }
 
 #[test]

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -134,6 +134,22 @@ def test_pyop_stateful_state_reseeds_on_rerun():
     assert out.value() == 6.0
 
 
+def test_pyadapter_source():
+    # ramp_source is a Rust source adapter (#[pyadapter]) exposed as a callable.
+    g = wf.Graph()
+    out = wf.ramp_source(g, 10.0, 2.0).accumulate()
+    g.run(cycles=3)
+    # start=10, step=2 -> 10, 12, 14
+    assert out.value() == [10.0, 12.0, 14.0]
+
+
+def test_pyadapter_source_feeds_combinators():
+    g = wf.Graph()
+    out = wf.ramp_source(g, 1.0, 1.0).sum()  # 1,2,3 -> cumulative 1,3,6
+    g.run(cycles=3)
+    assert out.value() == 6.0
+
+
 def test_pygraph_reuses_a_rust_subgraph():
     # doubled_running_total is a Rust-authored sub-graph (#[pygraph]) spliced in.
     g = wf.Graph()

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -1,8 +1,9 @@
 # Python interop — user-authored Rust components, composed and extended from Python
 
 **Status:** partially landed (the plugin-SDK layer — `#[pyop]` (stateless,
-stateful, one- and two-input), `#[pygraph]`, and the object form — is built;
-`#[pyadapter]` remains). **`wingfoil-next-python`
+stateful, one- and two-input), `#[pygraph]`, source `#[pyadapter]`, and the
+object form — is built; sink/burst `#[pyadapter]` shapes remain).
+**`wingfoil-next-python`
 is the go-forward Python binding: it supersedes the legacy `wingfoil-python`
 bindings (decision 2026-07), it is not a new capability bolted beside a
 preserved legacy surface.** The erased object form and `#[pyop]` seam below are
@@ -250,7 +251,7 @@ form.
 | `#[pyop]` **proc** macro | reads an `Op` impl → `#[pyfunction]`; v1 stateless single-input concrete | ✅ done (`wingfoil-next-python-macros`) |
 | `#[pyop]` extensions | **stateful + two-input ops done** — `State` is any `Default`-seedable type (re-seeded per run); `In<'a> = (&A, &B)` emits a `module.name(stream, other)` fn over `wire_op2`. Remaining: 3+ inputs and `Cfg`-tuple arg names | 🟡 stateful + 2-input done |
 | `#[pygraph]` macro (wiring reuse) | expose a Rust `fn(&Stream<T>) -> Stream<U>` sub-graph as `module.name(stream)`, spliced into the caller's graph; interior runs at native `T`, only the edge erases. Single-input/output v1, over the `PyStream::typed_input`/`erased_output` seam | ✅ done |
-| `#[pyadapter]` macro (source/sink) | source/sink emission (needs burst/`Vec` edge erasure for channel sources) | ⬜ |
+| `#[pyadapter]` macro (source) | **source adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { fn m(&self, …) -> Stream<T> }` emits `module.m(graph, …)`, running the adapter's native wiring and erasing the output, over the `PyGraph::builder`/`erase_source` seam. Remaining: sink/transform adapters + burst (`Stream<Burst<T>>`) sources | 🟡 source done |
 | POC: call a fixed `compiled()` graph from Python | Wire `wingfoil-next` as a path dep; expose one fixed `graph!` wiring (`ticker → count → map(i*i) → accumulate`) as `compiled_squares`/`interpreted_squares` (both from a single wiring so they can't drift). Proved **compiled == interpreted output from Python** across cycle- and duration-bound runs; GIL released for the run; no `.unwrap()` in binding code. Honest limit: **one fixed, compile-time graph** — not general Python-defined-graph codegen (timing ~neutral at that ticker-bound size; a dispatch-heavy graph shows `compiled()`'s win). Consistent with the non-goal below (`compiled()`/`nested()` expose as single island nodes). Revisit against the post-refactor `compiled()` API. | ⬜ (was #506) |
 | Edge-conversion trait bounds | `PyElement <-> f64/i64/bool/String` shipped; `Trade`/user types via user impls | 🟡 scalars done |
 | Mutable-frontier engine (extend a *running* graph) | Phase 4.5 dirty-list; only needed for post-`run` mutation | 🟡 Phase 4.5 |


### PR DESCRIPTION
## Summary

Adds the third plugin-SDK macro, `#[pyadapter]`, for **source** adapters — completing the "author IO adapters in Rust, use them from Python" story alongside `#[pyop]` (ops) and `#[pygraph]` (sub-graphs).

`#[pyadapter(name = ..., source)]` on a user adapter trait implemented for `GraphBuilder` — `impl Trait for GraphBuilder { fn m(&self, args…) -> Stream<T> }` — generates a Python callable `module.m(graph, args…)` that runs the adapter's **native** wiring on the caller's graph and returns the erased output. The interior stays native `T`; only the Python-facing edge erases.

Follows #549/#551/#554/#555/#556.

## Key changes

- **Seam (`graph.rs`, `python.rs`)**
  - `PyGraph::builder()` — the `GraphBuilder` the adapter method wires onto (splicing into the same graph).
  - `PyGraph::erase_source::<T>(Stream<T>) -> PyStream` (`T: Into<PyElement>`) — the output half.
  - `Graph::object()` — exposes the inner `PyGraph` to the generated `#[pyfunction]`.
- **Macro (`wingfoil-next-python-macros`)** — `#[pyadapter]` parses the single adapter method (name, non-self params, `Stream<T>` return) and emits `fn name(graph, params…) -> Stream` forwarding to the method and erasing. The `source` marker is required in v1.

## Tests

In-module `ramp_source` example, pytest cases (source + feeding combinators), and an external-crate source `#[pyadapter]` in `plugin_seam.rs` (compile proof + `builder`/`erase_source` seam mechanics).

**41 lib + 7 `plugin_seam` Rust tests and 51 pytest cases pass**; `cargo fmt`/`clippy` clean on both crates.

## Remaining

Sink/transform `#[pyadapter]` shapes and burst (`Stream<Burst<T>>`) sources — the latter needs `Vec`-edge erasure like `collect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P)_