### PR TITLE
next: restore kafka concurrent per-burst publish (B3) + register cleanup (D5)

### DIFF
--- a/next/crates/wingfoil-next/src/adapters/kafka.rs
+++ b/next/crates/wingfoil-next/src/adapters/kafka.rs
@@ -48,16 +48,16 @@
 //!    wiring time and the factory returns [`Result`]; librdkafka connects
 //!    lazily, so a bad broker surfaces on the first produced record during the
 //!    run rather than at wiring.
-//! 4. **Records are produced sequentially, not concurrently per burst.** Classic
-//!    handed every record in a burst to the producer up front and drained their
-//!    delivery futures together (`FuturesUnordered`), so per-burst latency was
-//!    one broker roundtrip. Next's [`consume_async`] drains each burst's records
-//!    through a **single** consumer task that awaits each `send` to delivery
-//!    confirmation before the next, so writes land in the exact order the graph
-//!    produced them at the cost of N sequential roundtrips per burst. The
-//!    explicit `producer.flush()` at upstream end is therefore unnecessary and
-//!    dropped: every send is awaited to its delivery ack (nothing is left
-//!    queued), and `consume_async` drains all queued writes at teardown.
+//!
+//! Records are produced **concurrently per burst** — at parity with classic: the
+//! sink rides [`consume_async_bursts`](crate::async_source::consume_async_bursts)
+//! and hands a whole burst's records to the producer up front, draining their
+//! delivery futures together via `FuturesUnordered`, so per-burst latency is
+//! ~one broker roundtrip rather than N. Order is preserved *across* bursts (the
+//! single consumer awaits each burst to completion before the next). The explicit
+//! `producer.flush()` classic did at upstream end is unnecessary here: every send
+//! is awaited to its delivery ack (nothing is left queued), and the consumer
+//! drains all queued bursts at teardown.
 //!
 //! # Consumer group and offsets
 //!
@@ -73,9 +73,11 @@
 //! # Sink
 //!
 //! [`KafkaSinkOps::kafka_pub`] produces one Kafka message per [`KafkaRecord`] in
-//! each burst. Each record names its own target topic, so a single sink can
-//! write to many topics. A delivery failure aborts the run with context (on the
-//! next cycle, per [`consume_async`]'s off-thread error propagation).
+//! each burst, all records in a burst concurrently (one broker roundtrip per
+//! burst). Each record names its own target topic, so a single sink can write to
+//! many topics. A delivery failure aborts the run with context (on the next
+//! cycle, or via the `flush` teardown for the final burst, per
+//! [`consume_async_bursts`](crate::async_source::consume_async_bursts)).
 //!
 //! # Setup
 //!
@@ -89,6 +91,8 @@
 //! ```
 
 use anyhow::{Context, Result};
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
 use rdkafka::Message;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
@@ -99,7 +103,7 @@ use std::time::Duration;
 use wingfoil::{NanoTime, RunMode};
 
 use crate::Burst;
-use crate::async_source::{RunParams, consume_async, produce_async};
+use crate::async_source::{RunParams, consume_async_bursts, produce_async};
 use crate::burst;
 use crate::fluent::{GraphBuilder, Stream, StreamOps};
 
@@ -292,9 +296,11 @@ pub trait KafkaSinkOps {
     ///
     /// The graph owns the tokio runtime (see the module docs).
     ///
-    /// Records are drained off the graph thread and produced in order, each
-    /// awaited to its delivery confirmation. A delivery failure aborts the run
-    /// with context (surfaced on the next cycle, per [`consume_async`]).
+    /// Records are drained off the graph thread one burst at a time; within a
+    /// burst all records are produced concurrently (one broker roundtrip), and
+    /// bursts are produced in order. A delivery failure aborts the run with
+    /// context (surfaced on the next cycle, or via the `flush` teardown for the
+    /// final burst, per [`consume_async_bursts`](crate::async_source::consume_async_bursts)).
     ///
     /// # Errors
     ///
@@ -317,28 +323,42 @@ impl KafkaSinkOps for Stream<Burst<KafkaRecord>> {
             .create()
             .context("kafka_pub: creating producer")?;
 
-        // `consume_async` drains each burst's records through a single consumer
-        // task (order preserved) off the graph thread; a write error propagates
-        // back into the graph on the next cycle, and the final cycle's error is
-        // surfaced by the `flush` teardown wired below. The producer is cloned
-        // per send (it is an `Arc` internally, cheap to clone and `Send`). The
-        // graph owns the runtime the consumer task runs on.
-        let (sink, flush) = consume_async(&self.graph(), None, move |record: KafkaRecord| {
-            let producer = producer.clone();
-            async move {
-                let mut fut_record = FutureRecord::to(&record.topic).payload(&record.value);
-                if let Some(ref key) = record.key {
-                    fut_record = fut_record.key(key.as_slice());
+        // `consume_async_bursts` drains one whole burst at a time through a single
+        // consumer task off the graph thread (order preserved *across* bursts); a
+        // write error propagates back into the graph on the next cycle, and the
+        // final burst's error is surfaced by the `flush` teardown wired below. The
+        // producer is cloned per burst (it is an `Arc` internally, cheap to clone
+        // and `Send`). The graph owns the runtime the consumer task runs on.
+        let (sink, flush) =
+            consume_async_bursts(&self.graph(), None, move |records: Vec<KafkaRecord>| {
+                let producer = producer.clone();
+                async move {
+                    // Build every record's delivery future up front and drive them
+                    // together via `FuturesUnordered`, so the whole burst is in
+                    // flight at once (~one broker roundtrip, matching classic)
+                    // rather than N sequential roundtrips. Order within a burst is
+                    // not observable to downstream (the sink emits `()`), so
+                    // draining out of completion order is fine.
+                    let mut inflight = FuturesUnordered::new();
+                    for record in &records {
+                        let mut fut_record = FutureRecord::to(&record.topic).payload(&record.value);
+                        if let Some(ref key) = record.key {
+                            fut_record = fut_record.key(key.as_slice());
+                        }
+                        let topic = record.topic.clone();
+                        let delivery = producer.send(fut_record, SEND_TIMEOUT);
+                        inflight.push(async move {
+                            delivery.await.map_err(|(e, _)| {
+                                anyhow::anyhow!("kafka_pub: producing to {topic} failed: {e}")
+                            })
+                        });
+                    }
+                    while let Some(result) = inflight.next().await {
+                        result?;
+                    }
+                    Ok(())
                 }
-                producer
-                    .send(fut_record, SEND_TIMEOUT)
-                    .await
-                    .map_err(|(e, _)| {
-                        anyhow::anyhow!("kafka_pub: producing to {} failed: {e}", record.topic)
-                    })?;
-                Ok(())
-            }
-        })?;
+            })?;
         Ok(self.for_each(sink).finally(flush))
     }
 }

--- a/next/crates/wingfoil-next/src/async_source.rs
+++ b/next/crates/wingfoil-next/src/async_source.rs
@@ -393,6 +393,80 @@ where
     F: FnMut(T) -> Fut + Send + 'static,
     Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
 {
+    // Payload = one value. The sink feeds the burst's values into the channel
+    // one at a time; the consumer awaits each `run(value)` before the next.
+    let (send_one, flush) = spawn_sink::<T, F, Fut>(g, buffer_size, run)?;
+    let sink = move |burst: &Burst<T>| -> anyhow::Result<()> {
+        for item in burst.iter() {
+            send_one(item.clone())?;
+        }
+        Ok(())
+    };
+    Ok((Box::new(sink), flush))
+}
+
+/// [`consume_async`], but the consumer processes a **whole burst at a time**
+/// instead of one value at a time — so a sink can act on the burst's values
+/// *concurrently* (e.g. hand them all to a producer and drain their delivery
+/// futures together) while the single consumer still preserves order *across*
+/// bursts.
+///
+/// The `run` closure receives one `Vec<T>` per burst (empty bursts are skipped,
+/// never handed to `run`). Everything else matches [`consume_async`]: the
+/// returned `(sink, flush)` pair wires the same way (`for_each(sink).finally(flush)`),
+/// back-pressure/ordering/error-surfacing are identical (here `buffer_size`
+/// bounds bursts, not values), and the final burst's error surfaces via `flush`.
+///
+/// This is the concurrent-within-burst shape kafka's producer wants (classic
+/// `kafka_pub` drained a burst's sends together via `FuturesUnordered`, one
+/// broker roundtrip per burst); the per-value [`consume_async`] would serialise
+/// them into N roundtrips.
+#[allow(clippy::type_complexity)]
+pub fn consume_async_bursts<T, F, Fut>(
+    g: &GraphBuilder,
+    buffer_size: Option<usize>,
+    run: F,
+) -> anyhow::Result<(
+    Box<dyn Fn(&Burst<T>) -> anyhow::Result<()>>,
+    Box<dyn Fn(&()) -> anyhow::Result<()>>,
+)>
+where
+    T: Clone + Default + Send + 'static,
+    F: FnMut(Vec<T>) -> Fut + Send + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    // Payload = one burst (as an owned `Vec<T>`). The whole burst is handed to
+    // `run` at once so it can process the values concurrently.
+    let (send_one, flush) = spawn_sink::<Vec<T>, F, Fut>(g, buffer_size, run)?;
+    let sink = move |burst: &Burst<T>| -> anyhow::Result<()> {
+        if !burst.is_empty() {
+            send_one(burst.iter().cloned().collect::<Vec<T>>())?;
+        }
+        Ok(())
+    };
+    Ok((Box::new(sink), flush))
+}
+
+/// The shared machinery behind [`consume_async`] and [`consume_async_bursts`]:
+/// spawn the single consumer task over a `buffer_size`-bounded channel, and hand
+/// back a `send_one` closure (feed one payload `P` to the consumer, surfacing a
+/// prior async error) plus the `flush` teardown. The two public entry points
+/// differ only in the payload type — one value vs one burst — and in how their
+/// sink closure chunks a burst into `send_one` calls.
+#[allow(clippy::type_complexity)]
+fn spawn_sink<P, F, Fut>(
+    g: &GraphBuilder,
+    buffer_size: Option<usize>,
+    run: F,
+) -> anyhow::Result<(
+    Box<dyn Fn(P) -> anyhow::Result<()>>,
+    Box<dyn Fn(&()) -> anyhow::Result<()>>,
+)>
+where
+    P: Send + 'static,
+    F: FnMut(P) -> Fut + Send + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
     // The graph owns the runtime (created lazily here on first async use, or a
     // caller override); the consumer task spawns onto it, and the sink closure /
     // flush teardown drive it with `block_on` on the graph thread.
@@ -405,11 +479,11 @@ where
     let (err_tx, err_rx) = mpsc::channel::<String>();
 
     // Bounded (back-pressure) or unbounded data channel, per `buffer_size`.
-    let (tx, mut rx) = sink_channel::<T>(buffer_size);
+    let (tx, mut rx) = sink_channel::<P>(buffer_size);
 
     let mut run = run;
     let task = handle.spawn(async move {
-        // Single consumer: await each write to completion before the next, so
+        // Single consumer: await each payload to completion before the next, so
         // writes land in the order the graph produced them.
         while let Some(item) = rx.recv().await {
             if let Err(e) = run(item).await {
@@ -434,7 +508,7 @@ where
 
     let send_handle = handle.clone();
     let send_shared = shared.clone();
-    let sink = move |burst: &Burst<T>| -> anyhow::Result<()> {
+    let send_one = move |item: P| -> anyhow::Result<()> {
         let s = send_shared.borrow();
         // Surface a prior async write error before doing more work.
         if let Ok(msg) = s.err_rx.try_recv() {
@@ -443,26 +517,24 @@ where
         let tx =
             s.tx.as_ref()
                 .expect("invariant: sink sender present during the run");
-        for item in burst.iter() {
-            if tx.send_blocking(&send_handle, item.clone()).is_err() {
-                // A closed data channel means the consumer task stopped, which
-                // only happens after a write error; surface it with context.
-                return match s.err_rx.try_recv() {
-                    Ok(msg) => Err(anyhow::anyhow!(
-                        "consume_async: background sink write failed: {msg}"
-                    )),
-                    Err(_) => Err(anyhow::anyhow!(
-                        "consume_async: background sink task ended unexpectedly"
-                    )),
-                };
-            }
+        if tx.send_blocking(&send_handle, item).is_err() {
+            // A closed data channel means the consumer task stopped, which
+            // only happens after a write error; surface it with context.
+            return match s.err_rx.try_recv() {
+                Ok(msg) => Err(anyhow::anyhow!(
+                    "consume_async: background sink write failed: {msg}"
+                )),
+                Err(_) => Err(anyhow::anyhow!(
+                    "consume_async: background sink task ended unexpectedly"
+                )),
+            };
         }
         Ok(())
     };
 
     let flush = move |_: &()| -> anyhow::Result<()> { shared.borrow_mut().flush() };
 
-    Ok((Box::new(sink), Box::new(flush)))
+    Ok((Box::new(send_one), Box::new(flush)))
 }
 
 /// Shared teardown state for a [`consume_async`] sink: the sender to close, the

--- a/next/crates/wingfoil-next/tests/consume_async.rs
+++ b/next/crates/wingfoil-next/tests/consume_async.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use wingfoil::{NanoTime, RunFor, RunMode};
-use wingfoil_next::async_source::consume_async;
+use wingfoil_next::async_source::{consume_async, consume_async_bursts};
 use wingfoil_next::prelude::*;
 
 const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
@@ -208,5 +208,49 @@ fn consume_async_drop_safety_net_still_drains_without_flush() {
         vec![10, 20, 30],
         *collected.lock().expect("sink values mutex poisoned"),
         "the Drop safety-net drains all queued writes even without an explicit flush",
+    );
+}
+
+/// `consume_async_bursts` hands the consumer a whole burst at a time (an owned
+/// `Vec<T>`), so a sink can process a burst's values concurrently, while the
+/// single consumer still preserves order *across* bursts. Two same-instant groups
+/// arrive as two distinct `Vec`s, in order — never flattened, never reordered.
+#[test]
+fn consume_async_bursts_delivers_whole_bursts_in_order() {
+    let collected = Arc::new(Mutex::new(Vec::<Vec<u64>>::new()));
+    {
+        let sink_batches = collected.clone();
+        let g = GraphBuilder::new();
+        let (sink, flush) = consume_async_bursts(&g, None, move |batch: Vec<u64>| {
+            let sink_batches = sink_batches.clone();
+            async move {
+                sink_batches
+                    .lock()
+                    .expect("sink batches mutex poisoned")
+                    .push(batch);
+                Ok(())
+            }
+        })
+        .unwrap();
+
+        // A historical channel groups same-instant `send_at` values into one
+        // burst: {1,2,3} at t=100, then {4,5} at t=200.
+        let (stream, sender) = g.channel::<u64>();
+        for v in [1u64, 2, 3] {
+            sender.send_at(v, NanoTime::new(100));
+        }
+        for v in [4u64, 5] {
+            sender.send_at(v, NanoTime::new(200));
+        }
+        sender.close();
+
+        let _sink = stream.for_each(sink).finally(flush);
+        let mut r = g.build();
+        r.run(HISTORICAL, RunFor::Forever).unwrap();
+    }
+    assert_eq!(
+        vec![vec![1, 2, 3], vec![4, 5]],
+        *collected.lock().expect("sink batches mutex poisoned"),
+        "each burst arrives as one whole Vec, grouped by instant and in order",
     );
 }

--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -126,7 +126,7 @@ motivated the reject only ever required two *mechanisms*, not two public
 | D2 | Factories return `anyhow::Result` (+ `.context`) vs classic's typed `io::Error` (e.g. `prometheus::serve`). | 🟢 | Fallible-with-context convention. |
 | D3 | postgres/redis sinks take a `consume_async` `buffer_size`. | 🟢 | Added back-pressure knob. |
 | D4 | `DemuxMap` uses a `BTreeSet` slot pool (lowest free slot, deterministic) vs classic's `HashSet`. | 🟢 | An *improvement* — aids backtest determinism (#529). |
-| D5 | **otlp pins opentelemetry 0.32; classic still on 0.28.** | 🟡 | Deliberate divergence for security (GHSA-w9wp-h8wv-79jx, #543). **Drift** — bump classic to match to restore lockstep + fix the advisory there. |
+| D5 | **otlp pins opentelemetry 0.32; classic still on 0.28.** | 🟢 | **Won't-fix — moot at cutover.** Deliberate divergence for security (GHSA-w9wp-h8wv-79jx, #543). Classic is retired wholesale at cutover, so next's 0.32 is the surviving version and the classic-side advisory disappears with the legacy tree; bumping classic to restore lockstep is not worth the churn. |
 | D6 | csv malformed-row error surfaces at replay start vs classic mid-stream. | 🟢 | Same run-failure outcome + context string; documented. |
 | D7 | `FileCache` log messages drop the classic "KDB " prefix. | 🟢 | The cache isn't kdb-specific in next. |
 
@@ -138,10 +138,9 @@ motivated the reject only ever required two *mechanisms*, not two public
    and the `zmq_sub` migration landed (#547); finish it by migrating the
    `produce_async` family + the plain `external`/`channel` feeders, then reopen
    §0.4 to make I/O sources **re-runnable** (A2) — the remaining structural win.
-2. **D5** — bump classic's opentelemetry to restore lockstep with next.
-3. **B3 / B4** — decide whether the throughput (kafka) / memory (csv) deviations
+2. **B3 / B4** — decide whether the throughput (kafka) / memory (csv) deviations
    matter for the "strict superset" claim, or are acceptable documented trade-offs.
-4. **A6** — measure the channel-sub startup latency to either explain or close it.
+3. **A6** — measure the channel-sub startup latency to either explain or close it.
 
 **Resolved / ratified since this register was written:** **A5** (graph-owned
 runtime, #548); **A1/A4 for `zmq_sub`** (deferred to `start()` via

--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -44,7 +44,7 @@ has its own decision record in
 |---|---|:--:|---|
 | B1 | ~~**`etcd_pub` blocks the graph thread** — `Handle::block_on` per burst.~~ | ✅ | **Resolved.** `consume_async` now returns a `flush` teardown (wired via `finally`) that closes the sink, joins the consumer task, and — unlike a `Drop` — surfaces the **final** write error as the run's `Err`. This is the "teardown-hook story for synchronous-error ops" B1 was blocked on: it lets `etcd_pub`'s `force:false` conditional abort a single-cycle run at teardown (exactly as classic's `AsyncConsumerNode::teardown` does), so the per-write `block_on` is gone and the PUTs run off the graph thread on the shared consumer task. The wiring-time connect + `LeaseGuard` revoke keep their (teardown-time, graph-thread) `block_on` — the ordinary `consume_async` footgun (A5a). The same `flush` upgrade also closes the "final-cycle write error swallowed" gap for kafka/postgres/redis/otlp. |
 | B2 | **Live sources reject `RunMode::HistoricalFrom` at wiring** (etcd/redis/kafka/postgres `_sub`, zmq_sub). | 🟡 | Live tails are unbounded wall-clock streams; a historical run would block-collect the whole stream and deadlock at `start`, so next rejects at wiring with a pointer to the bounded reader. **Classic parity for postgres** — classic `postgres_sub` already required `RunMode::RealTime` and bailed otherwise (`adapters/postgres/sub.rs`), so next's rejection is parity, *not* a deviation there; the "classic permitted a wall-clock historical run" gap is real only for `zmq_sub` and the etcd/redis/kafka `_sub` sources, which had no such guard. **Split ruling (agreed plan below):** (a) **ratified reject** for live-only sources with no bounded historical twin (`zmq_sub`, `etcd_sub`, both redis sources, `kafka_sub` today); (b) for adapters that *do* have a bounded historical read alongside the live tail, replace the mode-locked `_read`/`_sub` function pair with a single mode-agnostic `<adapter>_source` that dispatches on `run_mode`. → plan §B2. |
-| B3 | **`kafka_pub` produces sequentially** (single ordered `consume_async` consumer, N roundtrips/burst) vs classic's concurrent `FuturesUnordered` (one roundtrip/burst). | 🟡 | Order-preserving but a throughput deviation. `adapters/kafka.rs` deviation #4. |
+| B3 | ~~**`kafka_pub` produces sequentially** (N roundtrips/burst) vs classic's concurrent `FuturesUnordered` (one roundtrip/burst).~~ | ✅ | **Resolved.** Added `consume_async_bursts` — a variant that hands the consumer a whole burst at a time (order preserved *across* bursts, concurrency within one left to the sink). `kafka_pub` now drains a burst's sends together via `FuturesUnordered` (~one broker roundtrip/burst), at throughput parity with classic. `adapters/kafka.rs` sink docs. |
 | B4 | **csv reads the whole file up front** vs classic's lazy row streaming. | 🟡 | Unbounded-memory for a huge file under `RunFor::Forever`. `adapters/csv.rs` "consequences of using the channel source". |
 | B5 | **`postgres_read` queries all slices at wiring** onto `replay_results` vs classic's lazy `produce_async`. | 🟢🟡 | "Identical for a bounded historical run," but buffers the whole result set (memory). Same family as A1. `adapters/postgres.rs` deviation #2. |
 | B6 | **`spawn_map` historical is lock-step by graph time** (twin of classic `mapper()`). | 🟢🟡 | Values + tick times match classic. Two benign artifacts: (a) the sub-graph is expected to emit a result per input instant (a filtering/delaying sub-graph desynchronises the lock-step — classic's `graph_node` delay case likewise fails); (b) the lock-step reader spends one no-op poll cycle between instants (next's monotonic-clock re-arm), so bound runs by **duration**, not a raw cycle count. `fluent.rs::spawn_map`, `tests/spawn.rs`. |
@@ -138,8 +138,8 @@ motivated the reject only ever required two *mechanisms*, not two public
    and the `zmq_sub` migration landed (#547); finish it by migrating the
    `produce_async` family + the plain `external`/`channel` feeders, then reopen
    §0.4 to make I/O sources **re-runnable** (A2) — the remaining structural win.
-2. **B3 / B4** — decide whether the throughput (kafka) / memory (csv) deviations
-   matter for the "strict superset" claim, or are acceptable documented trade-offs.
+2. **B4** — decide whether the csv whole-file memory deviation matters for the
+   "strict superset" claim, or is an acceptable documented trade-off.
 3. **A6** — measure the channel-sub startup latency to either explain or close it.
 
 **Resolved / ratified since this register was written:** **A5** (graph-owned
@@ -149,7 +149,8 @@ final-cycle write errors, so `etcd_pub` moved off the graph thread — also clos
 the swallowed-final-error gap for kafka/postgres/redis/otlp); **B2** (split
 ruling, #557: reject ratified for live-only sources; adapters with a bounded
 historical twin move to a unified mode-dispatching `<adapter>_source` — see
-plan §B2, postgres first).
+plan §B2, postgres first); **B3** (`consume_async_bursts` restores kafka's
+concurrent per-burst publish).
 
 ## Keeping this current
 


### PR DESCRIPTION
## Summary

Two deviation-register items from the divergence review:

- **B3 (resolved)** — restore `kafka_pub`'s concurrent per-burst publish.
- **D5 (won't-fix)** — reclassify the classic-vs-next opentelemetry version drift, moot at cutover.

## B3 — kafka concurrent per-burst publish

next's `kafka_pub` rode the per-value `consume_async`, which serialised a burst's records into **N sequential broker roundtrips** (awaiting each send's delivery ack before the next). Classic handed a whole burst to the producer up front and drained the delivery futures together via `FuturesUnordered` — **~one roundtrip per burst**. Order-preserving, but a throughput regression.

- **New primitive `consume_async_bursts`** — hands the consumer a whole burst at a time (an owned `Vec<T>`) instead of one value, so a sink can process a burst's values *concurrently* while the single consumer still preserves order *across* bursts. It shares all the `consume_async` machinery (refactored into a private `spawn_sink` core), so back-pressure, error surfacing, and the `flush` teardown are identical — here `buffer_size` bounds bursts, not values.
- **`kafka_pub` migrated** to it: build every record's delivery future up front and drive them together via `FuturesUnordered`, back at throughput parity with classic. The final burst's error still surfaces via the `flush` teardown (from B1).

## D5 — opentelemetry drift won't-fix

D5 tracked classic pinning opentelemetry 0.28 while next moved to 0.32 for a security advisory (GHSA-w9wp-h8wv-79jx). Since the legacy tree is retired wholesale at cutover, next's 0.32 is the surviving version and the classic-side advisory disappears with legacy — bumping classic to restore lockstep isn't worth the churn. Reclassified 🟡 → 🟢 won't-fix and dropped from the active priority list.

## Tests

- Adds `consume_async_bursts_delivers_whole_bursts_in_order` — proves the consumer receives each burst as one whole `Vec`, grouped by instant and in order (never flattened, never reordered).
- The existing `consume_async` suite (order, back-pressure, mid-stream error, final-cycle teardown surfacing, Drop safety-net) is unchanged and still green.
- kafka's `test_pub_multiple_records_in_burst` integration test exercises the real concurrent path in CI.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo lint` (default) and `cargo lint-all` (all features) — clean (`-D warnings`)
- `cargo test -p wingfoil-next` across `async`, `kafka`, `etcd`, `redis`, `postgres`, `otlp` — all green

Removes the now-resolved kafka deviation #4 from the module docs and marks **B3 resolved** / **D5 won't-fix** in `next/docs/deviation-register.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QWPmR3wFSs5LVFMFm59EZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012QWPmR3wFSs5LVFMFm59EZ)_