### PR TITLE
next-python: burst-erasure for #[pyadapter] (Stream&lt;Burst&lt;T&gt;&gt; ↔ Python list)

### DIFF
--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -819,21 +819,22 @@ add a pytest case in `crates/wingfoil-next-python/tests/test_interop.py`; the
 `ramp_source` (source) and `list_sink` (sink) demos in `src/python.rs` are the
 templates, and `tests/plugin_seam.rs` shows the same from an external crate.
 
-**Current limitation — burst adapters aren't wired yet.** `#[pyadapter]` v1
-only handles single-value `Stream<T>`. The layering conventions above make most
-real adapters **burst-based** (`Stream<Burst<T>>` sources/sinks), and burst →
-Python-`list` edge erasure is **not built yet** — so a burst adapter cannot get
-a `#[pyadapter]` binding today (this is the next plugin-SDK task). Other v1
-constraints: the method's params become `#[pyfunction]` params, so they must be
-`FromPyObject` (`i64`/`f64`/`String`/`Py<PyAny>`/… — a Rust-only handle like
-`Rc<RefCell<…>>` can't cross); and `T`/`U` edge-convert (`T: TryFrom<&PyElement>`,
-`U: Into<PyElement>`).
+`#[pyadapter]` handles **burst** adapters too — the common shape, since the
+layering conventions above make most real adapters `Stream<Burst<T>>`
+sources/sinks. A `Stream<Burst<T>>` erases to a Python **`list`** per tick
+(same-instant values grouped), and a burst sink is fed single-element bursts;
+`Burst<T>` may appear as a source's return, a sink's `Self`, or a transform's
+output. The `pair_source` demo in `src/python.rs` and `burst_double` in
+`tests/plugin_seam.rs` are the burst-source templates.
 
-So: **if your adapter is single-value**, expose it via `#[pyadapter]` and add
-the pytest case in the same PR. **If it's burst-based** (most are), note in the
-PR that the Python binding waits on burst-erasure support, rather than
-hand-rolling one. Service-backed integration bindings likewise follow once the
-binding exists.
+Constraints: the method's params become `#[pyfunction]` params, so they must be
+`FromPyObject` (`i64`/`f64`/`String`/`Py<PyAny>`/… — a Rust-only handle like
+`Rc<RefCell<…>>` can't cross); and the value type edge-converts
+(`T: TryFrom<&PyElement>` in, `U: Into<PyElement>` out).
+
+So expose your adapter via `#[pyadapter]` (source, sink, or burst) and add the
+pytest case in the same PR — service-backed integration bindings follow the
+same recipe.
 
 ## 13. Superset audit + roadmap bookkeeping
 

--- a/next/crates/wingfoil-next-python-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-python-macros/src/lib.rs
@@ -254,8 +254,11 @@ impl Parse for PyAdapterArgs {
 ///   to native `T`, runs the adapter, and erases the `U` output (a sink's
 ///   `Stream<()>` erases to Python `None`).
 ///
-/// v1 covers single-value streams; burst (`Stream<Burst<T>>`) adapters are not
-/// yet emitted.
+/// **Burst shapes** are handled too: a `Stream<Burst<T>>` erases to a Python
+/// `list` per tick (same-instant values grouped), and a burst *sink* input is
+/// fed single-element bursts. So `Stream<Burst<T>>` may appear as a source's
+/// return, a sink's `Self`, or a transform's output. Adapter method params
+/// become `#[pyfunction]` params, so they must be `FromPyObject`.
 #[proc_macro_attribute]
 pub fn pyadapter(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as PyAdapterArgs);
@@ -325,8 +328,13 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
     let py_name = &args.name;
 
     if args.is_source {
-        // Source: `impl Trait for GraphBuilder { fn m(&self, args…) -> Stream<T> }`
-        // => `module.name(graph, args…)`: run the adapter on the builder, erase T.
+        // Source: `impl Trait for GraphBuilder { fn m(&self, args…) -> Stream<T>
+        // | Stream<Burst<T>> }` => `module.name(graph, args…)`: run the adapter
+        // on the builder, erase the output (a `Burst<T>` becomes a Python list).
+        let erase = match burst_inner(&out_inner) {
+            Some(t) => quote! { __obj.erase_burst_source::<#t>(__typed) },
+            None => quote! { __obj.erase_source::<#out_inner>(__typed) },
+        };
         Ok(quote! {
             #[pyo3::pyfunction]
             fn #py_name(
@@ -335,15 +343,24 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
             ) -> ::wingfoil_next_python::Stream {
                 let __obj = graph.object();
                 let __typed = __obj.builder().#method_name(#(#param_names),*);
-                ::wingfoil_next_python::Stream::from(__obj.erase_source::<#out_inner>(__typed))
+                ::wingfoil_next_python::Stream::from(#erase)
             }
         })
     } else {
-        // Sink / transform: `impl Trait for Stream<T> { fn m(&self, args…) ->
-        // Stream<U> }` => `module.name(stream, args…)`: extract the input to
-        // native `T`, run the adapter, erase the `U` output (a sink's `Stream<()>`
-        // erases to Python `None`).
+        // Sink / transform: `impl Trait for Stream<T> | Stream<Burst<T>> { fn
+        // m(&self, args…) -> Stream<U> | Stream<Burst<U>> }` => `module.name(
+        // stream, args…)`: extract the input to native `T` (a burst self type
+        // feeds single-element bursts), run the adapter, erase the output (a
+        // sink's `Stream<()>` erases to Python `None`; a `Burst<U>` to a list).
         let in_inner = stream_inner(&imp.self_ty)?;
+        let typed_in = match burst_inner(&in_inner) {
+            Some(t) => quote! { __obj.typed_burst_input::<#t>() },
+            None => quote! { __obj.typed_input::<#in_inner>() },
+        };
+        let erase = match burst_inner(&out_inner) {
+            Some(u) => quote! { __obj.erased_burst_output::<#u>(__out) },
+            None => quote! { __obj.erased_output::<#out_inner>(__out) },
+        };
         Ok(quote! {
             #[pyo3::pyfunction]
             fn #py_name(
@@ -351,12 +368,26 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
                 #(#param_decls),*
             ) -> ::wingfoil_next_python::Stream {
                 let __obj = stream.object();
-                let __typed = __obj.typed_input::<#in_inner>();
+                let __typed = #typed_in;
                 let __out = __typed.#method_name(#(#param_names),*);
-                ::wingfoil_next_python::Stream::from(__obj.erased_output::<#out_inner>(__out))
+                ::wingfoil_next_python::Stream::from(#erase)
             }
         })
     }
+}
+
+/// If `ty` is `Burst<X>` (last path segment literally `Burst`), the `X`; else
+/// `None`. Distinguishes a burst-shaped adapter stream from a single-value one.
+fn burst_inner(ty: &Type) -> Option<Type> {
+    if let Type::Path(p) = ty
+        && let Some(seg) = p.path.segments.last()
+        && seg.ident == "Burst"
+        && let PathArguments::AngleBracketed(a) = &seg.arguments
+        && let Some(GenericArgument::Type(t)) = a.args.first()
+    {
+        return Some(t.clone());
+    }
+    None
 }
 
 /// The `T`s of a reference tuple `(&'a T, …)` — one entry per op input. `#[pyop]`

--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -130,6 +130,20 @@ impl PyGraph {
         self.wrap(typed.map(|v: &T| v.clone().into()))
     }
 
+    /// Erase a `Stream<Burst<T>>` source to a [`PyStream`] — each burst (the
+    /// same-instant group) becomes a Python `list` of its erased values. The
+    /// burst counterpart of [`erase_source`](Self::erase_source), for adapters
+    /// whose source produces the burst shape (`$name_read`/`$name_sub`).
+    pub fn erase_burst_source<T>(&self, typed: Stream<Burst<T>>) -> PyStream
+    where
+        T: Clone + Default + Into<PyElement> + 'static,
+    {
+        self.wrap(typed.map(|burst: &Burst<T>| {
+            let items: Vec<PyElement> = burst.iter().map(|v| v.clone().into()).collect();
+            PyElement::list(&items)
+        }))
+    }
+
     /// Run the graph to its bound, storing the runner so retained
     /// [`PyStream`]s can be read with [`PyStream::value`].
     ///
@@ -763,6 +777,35 @@ impl PyStream {
         U: Clone + Into<PyElement> + 'static,
     {
         self.wrap(typed.map(|u: &U| u.clone().into()))
+    }
+
+    /// Extract this erased stream to a `Stream<Burst<T>>` — the input half of
+    /// the **burst** adapter seam. Each erased value becomes a **single-element**
+    /// burst (`T: TryFrom<&PyElement>`), so a Python stream of scalars feeds a
+    /// burst-shaped sink; a conversion error aborts the run.
+    pub fn typed_burst_input<T>(&self) -> Stream<Burst<T>>
+    where
+        T: for<'a> TryFrom<&'a PyElement, Error = anyhow::Error> + Clone + Default + 'static,
+    {
+        self.stream.try_map(|e: &PyElement| {
+            let value = T::try_from(e)?;
+            let mut burst: Burst<T> = Burst::default();
+            burst.push(value);
+            Ok(burst)
+        })
+    }
+
+    /// Box a `Stream<Burst<U>>` back to the erased boundary — each burst becomes
+    /// a Python `list` of its erased values. The burst counterpart of
+    /// [`erased_output`](Self::erased_output).
+    pub fn erased_burst_output<U>(&self, typed: Stream<Burst<U>>) -> PyStream
+    where
+        U: Clone + Default + Into<PyElement> + 'static,
+    {
+        self.wrap(typed.map(|burst: &Burst<U>| {
+            let items: Vec<PyElement> = burst.iter().map(|v| v.clone().into()).collect();
+            PyElement::list(&items)
+        }))
     }
 
     /// The stream's current value after [`PyGraph::run`].

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -430,6 +430,30 @@ impl ListSinkOps for ::wingfoil_next::prelude::Stream<f64> {
     }
 }
 
+// `pair_source` — a **burst source `#[pyadapter]`**: emits a `Burst<f64>` of two
+// values per instant (grouped by `combine`), exposed as `module.pair_source(
+// graph)` yielding a Python **list** per tick. Demonstrates burst-shaped adapter
+// erasure (`Burst<T>` -> Python `list`), the shape most real adapters use.
+trait PairSourceOps {
+    fn pair_source(&self) -> ::wingfoil_next::prelude::Stream<::wingfoil_next::Burst<f64>>;
+}
+
+#[pyadapter(name = pair_source, source)]
+impl PairSourceOps for ::wingfoil_next::prelude::GraphBuilder {
+    fn pair_source(&self) -> ::wingfoil_next::prelude::Stream<::wingfoil_next::Burst<f64>> {
+        use ::wingfoil_next::prelude::{SourceOps, StreamOps};
+        let a = self
+            .ticker(Duration::from_nanos(100))
+            .count()
+            .map(|n: &u64| *n as f64);
+        let b = self
+            .ticker(Duration::from_nanos(100))
+            .count()
+            .map(|n: &u64| *n as f64 * 10.0);
+        self.combine(&[a, b])
+    }
+}
+
 /// The `wingfoil_next` Python module.
 #[pymodule]
 fn wingfoil_next(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -442,5 +466,6 @@ fn wingfoil_next(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(doubled_running_total, m)?)?;
     m.add_function(wrap_pyfunction!(ramp_source, m)?)?;
     m.add_function(wrap_pyfunction!(list_sink, m)?)?;
+    m.add_function(wrap_pyfunction!(pair_source, m)?)?;
     Ok(())
 }

--- a/next/crates/wingfoil-next-python/tests/plugin_seam.rs
+++ b/next/crates/wingfoil-next-python/tests/plugin_seam.rs
@@ -186,6 +186,44 @@ fn pyadapter_source_from_an_external_crate() {
     assert_eq!(vec![101.0, 102.0], v);
 }
 
+// A **burst** source `#[pyadapter]` from an external crate: returns
+// `Stream<Burst<f64>>`, so each tick erases to a Python list.
+trait BurstDoubleOps {
+    fn burst_double(&self) -> wingfoil_next::prelude::Stream<wingfoil_next::Burst<f64>>;
+}
+
+#[pyadapter(name = burst_double, source)]
+impl BurstDoubleOps for wingfoil_next::prelude::GraphBuilder {
+    fn burst_double(&self) -> wingfoil_next::prelude::Stream<wingfoil_next::Burst<f64>> {
+        use wingfoil_next::prelude::{SourceOps, StreamOps};
+        let a = self
+            .ticker(Duration::from_nanos(100))
+            .count()
+            .map(|n: &u64| *n as f64);
+        let b = self
+            .ticker(Duration::from_nanos(100))
+            .count()
+            .map(|n: &u64| *n as f64 + 0.5);
+        self.combine(&[a, b])
+    }
+}
+
+#[test]
+fn pyadapter_burst_source_from_an_external_crate() {
+    // The generated burst-source function exists (compile proof).
+    let _f = burst_double;
+
+    // The erase_burst_source seam maps each Burst<f64> to a Python list.
+    let g = PyGraph::new();
+    let typed = g.builder().burst_double();
+    let src = g.erase_burst_source::<f64>(typed);
+    let acc = src.accumulate();
+    g.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(2))
+        .unwrap();
+    let rows: Vec<Vec<f64>> = Python::attach(|py| acc.value().value().extract(py).unwrap());
+    assert_eq!(vec![vec![1.0, 1.5], vec![2.0, 2.5]], rows);
+}
+
 #[test]
 fn pygraph_exposes_a_subgraph_from_an_external_crate() {
     // The generated function exists: `#[pygraph]` expanded.

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -161,6 +161,15 @@ def test_pyadapter_source_and_sink_together():
     assert out == [10.0, 15.0, 20.0]
 
 
+def test_pyadapter_burst_source():
+    # pair_source is a burst-shaped source adapter: each tick is a Burst<f64> of
+    # two same-instant values, which erases to a Python list.
+    g = wf.Graph()
+    out = wf.pair_source(g).accumulate()
+    g.run(cycles=3)
+    assert out.value() == [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]]
+
+
 def test_pyadapter_source_feeds_combinators():
     g = wf.Graph()
     out = wf.ramp_source(g, 1.0, 1.0).sum()  # 1,2,3 -> cumulative 1,3,6

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -2,8 +2,8 @@
 
 **Status:** partially landed (the plugin-SDK layer — `#[pyop]` (stateless,
 stateful, one- and two-input), `#[pygraph]`, source `#[pyadapter]`, and the
-source + sink `#[pyadapter]`, and the object form — is built; burst-shaped
-`#[pyadapter]` adapters remain). **`wingfoil-next-python`
+`#[pyadapter]` (source, sink, and burst), and the object form — is built).
+**`wingfoil-next-python`
 is the go-forward Python binding: it supersedes the legacy `wingfoil-python`
 bindings (decision 2026-07), it is not a new capability bolted beside a
 preserved legacy surface.** The erased object form and `#[pyop]` seam below are
@@ -251,7 +251,7 @@ form.
 | `#[pyop]` **proc** macro | reads an `Op` impl → `#[pyfunction]`; v1 stateless single-input concrete | ✅ done (`wingfoil-next-python-macros`) |
 | `#[pyop]` extensions | **stateful + two-input ops done** — `State` is any `Default`-seedable type (re-seeded per run); `In<'a> = (&A, &B)` emits a `module.name(stream, other)` fn over `wire_op2`. Remaining: 3+ inputs and `Cfg`-tuple arg names | 🟡 stateful + 2-input done |
 | `#[pygraph]` macro (wiring reuse) | expose a Rust `fn(&Stream<T>) -> Stream<U>` sub-graph as `module.name(stream)`, spliced into the caller's graph; interior runs at native `T`, only the edge erases. Single-input/output v1, over the `PyStream::typed_input`/`erased_output` seam | ✅ done |
-| `#[pyadapter]` macro (source + sink) | **source and sink/transform adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. Over the `PyGraph::builder`/`erase_source` and `PyStream::typed_input`/`erased_output` seams; a sink's `Stream<()>` erases to Python `None`. Remaining: burst (`Stream<Burst<T>>`) adapters (needs `Vec`-erasure) | 🟡 single-value done; burst remains |
+| `#[pyadapter]` macro (source + sink + burst) | **source, sink/transform, and burst adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. `Stream<Burst<T>>` erases to a Python `list` per tick (a burst sink is fed single-element bursts). Over the `builder`/`erase_source`/`erase_burst_source` and `typed_input`/`typed_burst_input`/`erased_output`/`erased_burst_output` seams; a sink's `Stream<()>` erases to `None`. Adapter method params must be `FromPyObject` | ✅ done |
 | POC: call a fixed `compiled()` graph from Python | Wire `wingfoil-next` as a path dep; expose one fixed `graph!` wiring (`ticker → count → map(i*i) → accumulate`) as `compiled_squares`/`interpreted_squares` (both from a single wiring so they can't drift). Proved **compiled == interpreted output from Python** across cycle- and duration-bound runs; GIL released for the run; no `.unwrap()` in binding code. Honest limit: **one fixed, compile-time graph** — not general Python-defined-graph codegen (timing ~neutral at that ticker-bound size; a dispatch-heavy graph shows `compiled()`'s win). Consistent with the non-goal below (`compiled()`/`nested()` expose as single island nodes). Revisit against the post-refactor `compiled()` API. | ⬜ (was #506) |
 | Edge-conversion trait bounds | `PyElement <-> f64/i64/bool/String` shipped; `Trade`/user types via user impls | 🟡 scalars done |
 | Mutable-frontier engine (extend a *running* graph) | Phase 4.5 dirty-list; only needed for post-`run` mutation | 🟡 Phase 4.5 |


### PR DESCRIPTION
## Summary

Adds burst-shape support to `#[pyadapter]` — the common case, since the adapter layering conventions make most real adapters `Stream<Burst<T>>` sources/sinks.

> **Note:** this is a re-land. This work was originally the second commit on #564, but that PR's branch was auto-deleted on merge before the burst commit was associated with it, so #564 merged with only the sink commit. This PR re-applies the burst work cleanly on top of current `next`.

A `Stream<Burst<T>>` erases to a Python **`list`** per tick (same-instant values grouped); a burst sink is fed single-element bursts. `Burst<T>` may appear as a source's return, a sink's `Self`, or a transform's output — the macro detects it and routes through the burst seam.

## Key changes

- **Seam (`graph.rs`)** — `PyGraph::erase_burst_source`, `PyStream::typed_burst_input` + `erased_burst_output` (`Burst<T>` ↔ Python list of erased values; single-element bursts on the way in).
- **Macro** — `burst_inner()` detects `Stream<Burst<T>>`; `expand_pyadapter` routes source output / sink input / sink output through the burst seam when applicable.
- **Example** — `pair_source` (a two-value `Burst<f64>` per instant via `combine` → Python list) + pytest.
- **`plugin_seam.rs`** — external-crate burst source `#[pyadapter]` (compile proof + `erase_burst_source` seam).
- **skill + docs** — `/new-adapter-next` now says burst adapters bind directly (the common path); interop build list marks `#[pyadapter]` (source/sink/burst) done.

## Tests

**41 lib + 10 `plugin_seam` Rust tests and 54 pytest cases pass**; `cargo fmt`/`clippy` clean on both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P)_