### PR TITLE
next: mode-agnostic postgres_source dispatching on RunMode (B2 plan)

### DIFF
--- a/next/crates/wingfoil-next/src/adapters/postgres.rs
+++ b/next/crates/wingfoil-next/src/adapters/postgres.rs
@@ -17,7 +17,10 @@
 //!
 //! - **Sources** — the free builder functions [`postgres_read`] (bounded
 //!   historical replay, one query per time slice) and [`postgres_sub`] (a
-//!   realtime live tail) on a [`GraphBuilder`], emitting `Stream<Burst<T>>`.
+//!   realtime live tail) on a [`GraphBuilder`], emitting `Stream<Burst<T>>`; or
+//!   [`postgres_source`] — a single **mode-agnostic** source that dispatches to
+//!   the right one at `run()` based on the run's [`RunMode`], so the graph need
+//!   not choose real-time vs historical at wiring time.
 //! - **Sink** — the [`PostgresSinkOps`] extension trait on `Stream<Burst<T>>`,
 //!   enabled with `use wingfoil_next::adapters::postgres::PostgresSinkOps;`.
 //!
@@ -56,6 +59,20 @@
 //! stream with no historical timeline to replay, so it **rejects
 //! `RunMode::HistoricalFrom` at wiring time** (use [`postgres_read`] for
 //! historical replay) and runs under [`RunMode::RealTime`] only.
+//!
+//! # One source, either mode ([`postgres_source`])
+//!
+//! `RunMode` is a *run-time* choice — build the graph once, pick real-time vs
+//! historical at `run()`. But `postgres_read`/`postgres_sub` are mode-locked,
+//! forcing that choice into wiring (and duplicating downstream wiring across two
+//! source functions). [`postgres_source`] closes that gap: it takes a
+//! [`PostgresSourceConfig`] carrying an optional historical half and an optional
+//! live half, and dispatches on the run's [`RunMode`] at wiring —
+//! `HistoricalFrom` → [`postgres_read`], `RealTime` → [`postgres_sub`]. Supply
+//! both halves and the graph is fully mode-agnostic (flip the mode at `run()`,
+//! wiring unchanged); supply one and the other mode errors at wiring naming the
+//! missing half. The two primitives stay public for callers that only ever need
+//! one mode. See the deviation register's "B2 — agreed plan".
 //!
 //! # Sink
 //!
@@ -621,6 +638,143 @@ where
             }
         })
     })
+}
+
+// ---------------------------------------------------------------------------
+// Source: unified mode-agnostic source (dispatches read vs sub on run_mode)
+// ---------------------------------------------------------------------------
+
+/// The historical and live query specs for [`postgres_source`], each optional.
+///
+/// [`RunMode`] is a *run-time* choice, but [`postgres_read`] / [`postgres_sub`]
+/// are mode-locked — forcing that choice into *wiring*. This config carries both
+/// mechanisms so a single [`postgres_source`] call can dispatch on the run's mode
+/// at wiring: supply **both** halves for a fully mode-agnostic graph (flip the
+/// mode at `run()`, downstream wiring unchanged); supply **one** and the other
+/// mode errors at wiring naming the missing half. See the deviation register's
+/// "B2 — agreed plan: unified `<adapter>_source`".
+#[derive(Default)]
+pub struct PostgresSourceConfig {
+    historical: Option<HistoricalSpec>,
+    live: Option<LiveSpec>,
+}
+
+/// The historical half — see [`PostgresSourceConfig::historical`].
+struct HistoricalSpec {
+    period: Duration,
+    query_fn: Box<dyn FnMut((NanoTime, NanoTime), i32, usize) -> String>,
+}
+
+/// The live half — see [`PostgresSourceConfig::live`].
+struct LiveSpec {
+    channel: String,
+    start_from: NanoTime,
+    query_fn: Box<dyn FnMut(NanoTime) -> String + Send>,
+}
+
+impl PostgresSourceConfig {
+    /// An empty config — add halves with [`historical`](Self::historical) and/or
+    /// [`live`](Self::live).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configure the **historical** (bounded, time-sliced replay) half — the
+    /// [`postgres_read`] mechanism. `period` is the slice length; `query_fn` is
+    /// called once per slice with `((t0, t1), date, iteration)` and returns SQL
+    /// filtering `time >= t0 AND time < t1`, ordered by time.
+    pub fn historical(
+        mut self,
+        period: Duration,
+        query_fn: impl FnMut((NanoTime, NanoTime), i32, usize) -> String + 'static,
+    ) -> Self {
+        self.historical = Some(HistoricalSpec {
+            period,
+            query_fn: Box::new(query_fn),
+        });
+        self
+    }
+
+    /// Configure the **live** (`LISTEN`/`NOTIFY` tail) half — the [`postgres_sub`]
+    /// mechanism. `channel` is the notify channel, `start_from` the initial cursor,
+    /// and `query_fn(cursor)` returns SQL selecting rows with `time > cursor`,
+    /// ordered by time.
+    pub fn live(
+        mut self,
+        channel: impl Into<String>,
+        start_from: NanoTime,
+        query_fn: impl FnMut(NanoTime) -> String + Send + 'static,
+    ) -> Self {
+        self.live = Some(LiveSpec {
+            channel: channel.into(),
+            start_from,
+            query_fn: Box::new(query_fn),
+        });
+        self
+    }
+}
+
+/// A single **mode-agnostic** PostgreSQL source: dispatches on the run's
+/// [`RunMode`] at wiring time to the bounded historical read ([`postgres_read`])
+/// or the live `LISTEN`/`NOTIFY` tail ([`postgres_sub`]), per the
+/// [`PostgresSourceConfig`] halves.
+///
+/// - [`RunMode::HistoricalFrom`] → the historical half (requires
+///   [`PostgresSourceConfig::historical`]).
+/// - [`RunMode::RealTime`] → the live half (requires
+///   [`PostgresSourceConfig::live`]).
+///
+/// With both halves supplied the graph is fully mode-agnostic — pick real-time vs
+/// historical at `run()` with the wiring unchanged, exactly as `ticker` /
+/// `channel` already allow. [`postgres_read`] / [`postgres_sub`] remain the
+/// low-level primitives; this wires through them. See the deviation register's
+/// "B2 — agreed plan: unified `<adapter>_source`".
+///
+/// # Errors
+///
+/// Returns an error at **wiring time** if the config lacks the half the run's mode
+/// needs (the message names the missing half), or for any error the dispatched
+/// primitive surfaces at wiring (`postgres_read`'s bounded-window validation, or a
+/// connection failure with the password redacted).
+pub fn postgres_source<T>(
+    g: &GraphBuilder,
+    params: RunParams,
+    connection: impl Into<PostgresConnection>,
+    cfg: PostgresSourceConfig,
+) -> Result<Stream<Burst<T>>>
+where
+    T: PostgresDeserialize + Clone + Default + Send + 'static,
+{
+    let connection = connection.into();
+    match params.run_mode {
+        RunMode::HistoricalFrom(_) => {
+            let hist = cfg.historical.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "postgres_source: run mode is RunMode::HistoricalFrom but no historical \
+                     config was supplied — add .historical(period, query_fn), or run under \
+                     RunMode::RealTime with a .live(..) config"
+                )
+            })?;
+            postgres_read::<T>(g, params, connection, hist.period, hist.query_fn)
+        }
+        RunMode::RealTime => {
+            let live = cfg.live.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "postgres_source: run mode is RunMode::RealTime but no live config was \
+                     supplied — add .live(channel, start_from, query_fn), or run under \
+                     RunMode::HistoricalFrom with a .historical(..) config"
+                )
+            })?;
+            postgres_sub::<T, _>(
+                g,
+                params,
+                connection,
+                live.channel,
+                live.start_from,
+                live.query_fn,
+            )
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/next/crates/wingfoil-next/tests/postgres_adapter.rs
+++ b/next/crates/wingfoil-next/tests/postgres_adapter.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use wingfoil::{NanoTime, RunFor, RunMode};
 use wingfoil_next::adapters::postgres::{
     PostgresConnection, PostgresDeserialize, PostgresRowExt, PostgresSerialize, PostgresSinkOps,
-    Row, ToSql, postgres_read, postgres_sub,
+    PostgresSourceConfig, Row, ToSql, postgres_read, postgres_source, postgres_sub,
 };
 use wingfoil_next::async_source::RunParams;
 use wingfoil_next::prelude::*;
@@ -201,4 +201,93 @@ fn write_connection_refused_redacts_password() {
     let msg = format!("{err:#}");
     assert!(!msg.contains("hunter2"), "password leaked in error: {msg}");
     assert!(msg.contains("password=***"), "password not redacted: {msg}");
+}
+
+// ---- postgres_source: mode dispatch (no connection needed) ----
+
+fn realtime() -> RunParams {
+    RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Forever,
+        start_time: NanoTime::ZERO,
+    }
+}
+
+/// A `HistoricalFrom` run with only a live half configured errors at wiring,
+/// naming the missing historical half — before any connection is attempted.
+#[test]
+fn source_missing_historical_half_errors_under_historical_mode() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let cfg = PostgresSourceConfig::new().live("chan", NanoTime::ZERO, |_cursor| String::new());
+    let err = postgres_source::<TestTrade>(
+        &g,
+        historical(NanoTime::from_kdb_timestamp(0), 86400),
+        "host=127.0.0.1 dbname=db",
+        cfg,
+    )
+    .err()
+    .expect("HistoricalFrom without a historical config must be rejected");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("postgres_source"), "names the adapter: {msg}");
+    assert!(
+        msg.contains("historical"),
+        "names the missing historical half: {msg}"
+    );
+}
+
+/// A `RealTime` run with only a historical half configured errors at wiring,
+/// naming the missing live half.
+#[test]
+fn source_missing_live_half_errors_under_realtime() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let cfg = PostgresSourceConfig::new().historical(HOUR, read_query);
+    let err = postgres_source::<TestTrade>(&g, realtime(), "host=127.0.0.1 dbname=db", cfg)
+        .err()
+        .expect("RealTime without a live config must be rejected");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("postgres_source"), "names the adapter: {msg}");
+    assert!(msg.contains("live"), "names the missing live half: {msg}");
+}
+
+/// A `HistoricalFrom` run dispatches to the `postgres_read` mechanism, so it
+/// inherits that mechanism's bounded-window validation: `RunFor::Forever` (an
+/// unbounded slice set) is rejected with `postgres_read`'s message — proof the
+/// dispatch reached the historical primitive.
+#[test]
+fn source_dispatches_to_read_under_historical_mode() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let cfg = PostgresSourceConfig::new().historical(HOUR, read_query);
+    let params = RunParams {
+        run_mode: RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
+        run_for: RunFor::Forever,
+        start_time: NanoTime::from_kdb_timestamp(0),
+    };
+    let err = postgres_source::<TestTrade>(&g, params, "host=127.0.0.1 dbname=db", cfg)
+        .err()
+        .expect("Forever must be rejected by the read mechanism");
+    assert!(
+        format!("{err:#}").contains("RunFor::Forever"),
+        "dispatched to postgres_read's validation: {err:#}"
+    );
+}
+
+/// A `RealTime` run with a live half dispatches to the `postgres_sub` mechanism,
+/// which connects lazily in its producer task — so wiring succeeds (the graph is
+/// never run here). Proof the realtime dispatch reaches the live primitive.
+#[test]
+fn source_dispatches_to_sub_under_realtime() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let cfg = PostgresSourceConfig::new().live("chan", NanoTime::ZERO, |cursor: NanoTime| {
+        format!("SELECT time, sym, price, qty FROM trades WHERE time > '{cursor:?}' ORDER BY time")
+    });
+    let wired = postgres_source::<TestTrade>(&g, realtime(), "host=127.0.0.1 dbname=db", cfg);
+    assert!(
+        wired.is_ok(),
+        "RealTime with a live config wires (sub connects lazily): {:?}",
+        wired.err()
+    );
 }

--- a/next/crates/wingfoil-next/tests/postgres_integration.rs
+++ b/next/crates/wingfoil-next/tests/postgres_integration.rs
@@ -16,7 +16,8 @@ use tokio_postgres::NoTls;
 use wingfoil::{NanoTime, RunFor, RunMode};
 use wingfoil_next::adapters::postgres::{
     PostgresConnection, PostgresDeserialize, PostgresRowExt, PostgresSerialize, PostgresSinkOps,
-    Row, ToSql, postgres_notify_trigger_sql, postgres_read, postgres_sub, postgres_timestamp,
+    PostgresSourceConfig, Row, ToSql, postgres_notify_trigger_sql, postgres_read, postgres_source,
+    postgres_sub, postgres_timestamp,
 };
 use wingfoil_next::async_source::RunParams;
 use wingfoil_next::prelude::*;
@@ -175,6 +176,38 @@ fn test_read_time_sliced() -> anyhow::Result<()> {
         .map(|i| NanoTime::from_kdb_timestamp(i * HOUR_NANOS))
         .collect();
     assert_eq!(times, expected, "rows must tick at their row timestamps");
+    Ok(())
+}
+
+/// The mode-agnostic `postgres_source` dispatches a `HistoricalFrom` run to the
+/// bounded read mechanism — identical result to `postgres_read` (the primitive it
+/// wires through) for the same window.
+#[test]
+fn test_source_historical_dispatches_to_read() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Runtime::new()?;
+    let (_container, conn) = start_postgres()?;
+    seed_trades(&conn, 5)?; // rows at 00:00..04:00
+
+    let start = NanoTime::from_kdb_timestamp(0);
+    let dur = Duration::from_secs(86400);
+    let params = RunParams {
+        run_mode: RunMode::HistoricalFrom(start),
+        run_for: RunFor::Duration(dur),
+        start_time: start,
+    };
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let cfg = PostgresSourceConfig::new().historical(HOUR, read_query);
+    let acc = postgres_source::<TestTrade>(&g, params, conn, cfg)?
+        .collapse()
+        .with_time()
+        .accumulate();
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(start), RunFor::Duration(dur))?;
+    let rows = runner.value(&acc);
+
+    assert_eq!(rows.len(), 5, "source (historical) reads all 5 rows");
+    let syms: Vec<String> = rows.iter().map(|(_, t)| t.sym.clone()).collect();
+    assert_eq!(syms, vec!["SYM0", "SYM1", "SYM2", "SYM3", "SYM4"]);
     Ok(())
 }
 

--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -100,7 +100,10 @@ motivated the reject only ever required two *mechanisms*, not two public
 **Scope — where `_source` applies.**
 
 - **postgres** — the only adapter with both forms today (`postgres_read` +
-  `postgres_sub`). First target: add `postgres_source`.
+  `postgres_sub`). ✅ **Landed:** `postgres_source(cfg)` with a
+  `PostgresSourceConfig` carrying an optional historical half and an optional
+  live half, dispatching on `params.run_mode` at wiring; the two primitives stay
+  public underneath. `adapters/postgres.rs`.
 - **kafka** — candidate *once* it gains a bounded offset-range replay reader
   (the durable log makes this feasible); only `kafka_sub` exists now, so it
   stays under ruling (a) until then.


### PR DESCRIPTION
## Summary

Implements the deviation-register **"B2 — agreed plan: unified `<adapter>_source`"** (from #561) for its first target, **postgres**.

`RunMode` is a *run-time* choice — build the graph once, pick real-time vs historical at `run()`. But `postgres_read`/`postgres_sub` are mode-locked, forcing that choice into *wiring* and duplicating downstream wiring across two source functions. Mode-agnostic sources (`ticker`, `constant`, `channel`) already honour the run-time contract; this brings postgres in line.

## Changes

- **`postgres_source(g, params, conn, cfg)`** — a single source that inspects `params.run_mode` at wiring and dispatches:
  - `RunMode::HistoricalFrom` → `postgres_read` (bounded, time-sliced replay)
  - `RunMode::RealTime` → `postgres_sub` (`LISTEN`/`NOTIFY` live tail)
- **`PostgresSourceConfig`** — a small builder carrying two optional halves:
  - `.historical(period, query_fn)` — the read half
  - `.live(channel, start_from, query_fn)` — the live half
  - Supply **both** → a fully mode-agnostic graph (flip the mode at `run()`, downstream wiring unchanged). Supply **one** → works in that mode and errors at wiring in the other, naming the missing half.
- The closures are boxed, so the config isn't generic over them. `postgres_read` / `postgres_sub` stay public as the low-level primitives — `postgres_source` wires through them.

## Why boxed / feasibility

`run_mode` is already available to source builders at wiring (`params.run_mode`), so the dispatch is a wiring-time branch — the reject that motivated B2 only ever needed two *mechanisms*, not two public *functions*. Boxing the two query closures keeps `PostgresSourceConfig` non-generic, so "supply only one half" needs no phantom type for the other.

## Tests

No-DB dispatch tests (in `tests/postgres_adapter.rs`):
- `source_missing_historical_half_errors_under_historical_mode` — `HistoricalFrom` + live-only config → wiring error naming the historical half.
- `source_missing_live_half_errors_under_realtime` — `RealTime` + historical-only config → wiring error naming the live half.
- `source_dispatches_to_read_under_historical_mode` — `HistoricalFrom` inherits `postgres_read`'s bounded-window validation (`RunFor::Forever` rejected) — proof the dispatch reached the read primitive.
- `source_dispatches_to_sub_under_realtime` — `RealTime` with a live config wires (sub connects lazily) — proof the dispatch reached the live primitive.

Container-backed (in `tests/postgres_integration.rs`, runs in CI's postgres job):
- `test_source_historical_dispatches_to_read` — `postgres_source` in `HistoricalFrom` reads the same rows as `postgres_read` for the identical window.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo lint` (default) and `cargo lint-all` (all features) — clean (`-D warnings`)
- `cargo test -p wingfoil-next --features postgres` — 10 unit tests green; integration tests compile

Updates the postgres module docs (a "one source, either mode" section + the sources list) and marks the register's B2 postgres target ✅ landed. `kafka` remains a future `_source` candidate — only once it gains a bounded offset-range replay reader; today only `kafka_sub` exists, so it stays under ruling (a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QWPmR3wFSs5LVFMFm59EZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012QWPmR3wFSs5LVFMFm59EZ)_