### PR TITLE
next-python: add runnable examples (quick-start, custom node, dataframe, plugin SDK)

### DIFF
--- a/next/crates/wingfoil-next-python/examples/README.md
+++ b/next/crates/wingfoil-next-python/examples/README.md
@@ -1,0 +1,20 @@
+# wingfoil-next Python examples
+
+Runnable demonstrations of the `wingfoil_next` binding. Build the extension
+module first, then run any example:
+
+```sh
+cd next/crates/wingfoil-next-python
+maturin develop            # builds + installs the `wingfoil_next` module
+python examples/quick_start.py
+```
+
+| Example | Shows |
+|---|---|
+| `quick_start.py`   | build a graph, chain combinators, run, read a value |
+| `custom_stream.py` | a Python object as a graph node (`Graph.custom_node`) |
+| `dataframe.py`     | collect a stream into a pandas DataFrame (needs `pandas`) |
+| `plugin_sdk.py`    | compose Rust-authored ops / sub-graphs / adapters from Python |
+
+All four are smoke-tested in `tests/test_examples.py`, so they stay working as
+the binding evolves.

--- a/next/crates/wingfoil-next-python/examples/custom_stream.py
+++ b/next/crates/wingfoil-next-python/examples/custom_stream.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Custom node — a Python object acting as a graph node.
+
+`Graph.custom_node(upstreams, obj)` wires a Python object into the graph as a
+first-class node. The object implements the node protocol:
+  - cycle(values) -> bool : given the upstreams' current values, did it tick?
+  - peek() -> value       : its output value when it ticked.
+"""
+
+import wingfoil_next as wf
+
+
+class RunningMax:
+    """Emits the running maximum of its single upstream."""
+
+    def __init__(self):
+        self.hi = None
+
+    def cycle(self, values):
+        (v,) = values
+        self.hi = v if self.hi is None else max(self.hi, v)
+        return True
+
+    def peek(self):
+        return self.hi
+
+
+g = wf.Graph()
+
+# A bouncy input: (n * 7) % 5  ->  2, 4, 1, 3, 0, 2
+source = g.counter(period_nanos=100).map(lambda n: (n * 7) % 5)
+
+running_max = g.custom_node([source], RunningMax()).inspect(
+    lambda v: print("max so far:", v)
+)
+
+g.run(cycles=6)
+print("final max:", running_max.value())

--- a/next/crates/wingfoil-next-python/examples/dataframe.py
+++ b/next/crates/wingfoil-next-python/examples/dataframe.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""DataFrame — collect a stream into a pandas DataFrame.
+
+`stream.dataframe()` accumulates each value with its engine time and, on the
+last cycle, produces a pandas DataFrame (columns `time`, `value`) as the
+stream's final value. Requires pandas (`pip install pandas`).
+"""
+
+import wingfoil_next as wf
+
+g = wf.Graph()
+
+df = g.counter(period_nanos=100).map(lambda n: n * n).dataframe()  # squares
+g.run(cycles=5)
+
+print(df.value())

--- a/next/crates/wingfoil-next-python/examples/plugin_sdk.py
+++ b/next/crates/wingfoil-next-python/examples/plugin_sdk.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Plugin SDK — compose Rust-authored components from Python.
+
+wingfoil-next lets you author ops, sub-graphs, and IO adapters in Rust and call
+them from Python (the #[pyop] / #[pygraph] / #[pyadapter] macros). This module
+ships a few demo components; here we wire them together with built-in
+combinators — compiled-speed interiors, dynamic composition from Python.
+"""
+
+import wingfoil_next as wf
+
+g = wf.Graph()
+
+# ramp_source: a Rust *source adapter* (#[pyadapter]) -> 10, 12, 14, ...
+ramp = wf.ramp_source(g, 10.0, 2.0)
+
+# square: a Rust *op* (#[pyop]);  doubled_running_total: a Rust *sub-graph*
+# (#[pygraph], double then cumulative-sum). Both fan out from `ramp`.
+squared = wf.square(ramp)                 # 100, 144, 196, ...
+totals = wf.doubled_running_total(ramp)   # 20, 44, 72, ...
+
+# list_sink: a Rust *sink adapter* draining a stream into a Python list.
+collected = []
+wf.list_sink(squared, collected)
+
+g.run(cycles=3)
+print("squared (via Rust sink):", collected)
+print("doubled running total  :", totals.value())

--- a/next/crates/wingfoil-next-python/examples/quick_start.py
+++ b/next/crates/wingfoil-next-python/examples/quick_start.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Quick start — build a small wingfoil-next graph and run it.
+
+A `Graph` holds the wiring; sources (`counter`, `constant`, `values`) and
+combinators (`map`, `filter`, `distinct`, …) build streams on it; `run` drives
+it and each stream's `value()` reads back its final value.
+
+Build the module first, then run:
+    cd next/crates/wingfoil-next-python && maturin develop
+    python examples/quick_start.py
+"""
+
+import wingfoil_next as wf
+
+g = wf.Graph()
+
+greetings = (
+    g.counter(period_nanos=100)  # ticks 1, 2, 3, … every 100ns
+    .map(lambda n: f"hello world {n}")
+    .inspect(print)  # side-effect tap: print each value as it flows
+)
+
+# Historical run (deterministic, no wall clock) for three ticks.
+g.run(cycles=3)
+
+print("final value:", greetings.value())

--- a/next/crates/wingfoil-next-python/tests/test_examples.py
+++ b/next/crates/wingfoil-next-python/tests/test_examples.py
@@ -1,0 +1,22 @@
+"""Smoke-test the runnable examples: each must execute without raising.
+
+Keeps `examples/*.py` working as the binding evolves. The examples print to
+stdout (that's their point); we only assert they run clean.
+"""
+
+import pathlib
+import runpy
+
+import pytest
+
+EXAMPLES = pathlib.Path(__file__).resolve().parent.parent / "examples"
+
+
+@pytest.mark.parametrize("name", ["quick_start", "custom_stream", "plugin_sdk"])
+def test_example_runs(name):
+    runpy.run_path(str(EXAMPLES / f"{name}.py"), run_name="__main__")
+
+
+def test_dataframe_example_runs():
+    pytest.importorskip("pandas")
+    runpy.run_path(str(EXAMPLES / "dataframe.py"), run_name="__main__")


### PR DESCRIPTION
## Summary

The `wingfoil_next` binding had no examples. Adds four idiomatic, runnable `.py` examples under `crates/wingfoil-next-python/examples/`, plus a README and a smoke-test so they stay working.

## Examples

| Example | Shows |
|---|---|
| `quick_start.py` | build a `Graph`, chain combinators, run, read a value |
| `custom_stream.py` | a Python object as a graph node (`Graph.custom_node`, `cycle(values)`/`peek` protocol) — a running maximum |
| `dataframe.py` | collect a stream into a pandas `DataFrame` |
| `plugin_sdk.py` | the headline — compose Rust-authored components from Python: `ramp_source` (`#[pyadapter]`), `square` (`#[pyop]`), `doubled_running_total` (`#[pygraph]`), `list_sink` (sink adapter), mixed with built-in combinators |

`examples/README.md` documents the `maturin develop`-then-run flow and what each shows.

## Keeping them alive

`tests/test_examples.py` smoke-tests all four via `runpy` (the pandas one guarded by `importorskip`), so they run in the existing pytest gate and don't rot as the binding evolves.

## Tests

**60 pytest cases pass** (56 interop + 4 example smoke-tests). No Rust changed (pure `.py` additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P)_