### PR TITLE
next: port classic dynamic-graph examples (dynamic + demux)

### DIFF
--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -316,3 +316,11 @@ path = "examples/statistics/main.rs"
 [[example]]
 name = "threading"
 path = "examples/threading/main.rs"
+
+# Runtime graph mutation: instruments added/removed on a live graph, a price
+# book kept correct across the changes via `dynamic_group`. Feature-gated on
+# `dynamic-graph`.
+[[example]]
+name = "dynamic"
+path = "examples/dynamic/main.rs"
+required-features = ["dynamic-graph"]

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -324,3 +324,10 @@ path = "examples/threading/main.rs"
 name = "dynamic"
 path = "examples/dynamic/main.rs"
 required-features = ["dynamic-graph"]
+
+# Statically-wired counterpart to `dynamic`: the same price book, but routed
+# through a fixed slot pool with `demux_it` instead of runtime graph mutation.
+[[example]]
+name = "demux"
+path = "examples/demux/main.rs"
+required-features = ["dynamic-graph"]

--- a/next/crates/wingfoil-next/examples/demux/README.md
+++ b/next/crates/wingfoil-next/examples/demux/README.md
@@ -1,0 +1,36 @@
+## Demux routing — a price book on a fixed slot pool
+
+This is the **statically-wired** counterpart to the [`dynamic`](../dynamic)
+example. Both maintain the same live price book — instruments come and go, and a
+`BTreeMap` of the latest price per live instrument is kept correct — but this
+one never mutates the graph. A fixed pool of slots is wired once, and
+[`Builder::demux_it`] routes each event to its instrument's slot at runtime,
+recycling a slot when that instrument is deleted (`DemuxEvent::Close`). Resource
+use tracks *concurrent* instruments, not all-time.
+
+Price and delete events share one `InstEvent` stream (merged with `combine`) so
+simultaneous ticks ride a single burst; `demux_it` then routes each item
+independently. The per-slot bursts are recombined, flattened, and folded into
+the book.
+
+```text
+price book: {inst1=110}
+price book: {inst1=110, inst2=220}
+price book: {inst1=110, inst2=220, inst3=330}
+price book: {inst2=220, inst3=330}
+price book: {inst3=330}
+price book: {inst3=360}
+```
+
+The book grows as `inst1`, `inst2`, `inst3` are discovered from price events,
+then shrinks as `inst1` and `inst2` are deleted — all on a fixed topology, no
+`run_dynamic`.
+
+```bash
+cargo run -p wingfoil-next --example demux --features dynamic-graph
+```
+
+This is the next twin of classic wingfoil's `demux` example. See the
+[`dynamic`](../dynamic) example for the graph-mutation approach to the same
+problem, and `tests/dynamic_graph.rs` for the full routing surface (`demux`,
+`demux_it`, `demux_map`).

--- a/next/crates/wingfoil-next/examples/demux/main.rs
+++ b/next/crates/wingfoil-next/examples/demux/main.rs
@@ -1,0 +1,177 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example demux --features dynamic-graph
+//! ```
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::interp::DemuxEvent;
+use wingfoil_next::prelude::*;
+
+type Instrument = u64;
+type Price = u64;
+type PriceBook = BTreeMap<Instrument, Price>;
+
+/// Lifecycle + price events for one instrument, carried on a single stream so
+/// simultaneous price/delete ticks travel together in one burst.
+#[derive(Clone, Debug, Default, PartialEq)]
+enum InstEvent {
+    #[default]
+    None,
+    Price(Instrument, Price),
+    Delete(Instrument),
+}
+
+/// The instrument an event refers to (the demux routing key).
+fn inst_key(event: &InstEvent) -> Instrument {
+    match event {
+        InstEvent::Price(inst, _) | InstEvent::Delete(inst) => *inst,
+        InstEvent::None => 0,
+    }
+}
+
+/// Pool of per-instrument slots. Peak concurrency here is 3 (inst1/2/3 before
+/// the deletes), so 4 leaves headroom and the overflow child never fires.
+const CAPACITY: usize = 4;
+
+/// Assemble a price book fed through a **statically-wired** demux, and return
+/// the builder plus the book stream. Unlike the `dynamic` example (which splices
+/// per-instrument sub-graphs onto a live graph), the topology here is fixed: a
+/// fixed pool of slots is wired once, and `demux_it` routes each event to its
+/// instrument's slot at runtime, recycling a slot when its instrument is
+/// deleted. No `run_dynamic`, no graph mutation.
+///
+/// The scenario is synthetic and deterministic, driven off a counter `n`:
+/// a price feed cycles instrument ids `1 → 2 → 3 → 1 → …`, and delete events
+/// retire `inst1` (cycle 4) and `inst2` (cycle 5).
+fn build() -> (GraphBuilder, Stream<PriceBook>) {
+    let g = GraphBuilder::new();
+
+    let n = g.ticker(Duration::from_secs(1)).count();
+
+    // One price per cycle for a cycling instrument, prices climbing.
+    let prices = n.map(|c: &u64| {
+        let inst = (c - 1) % 3 + 1;
+        InstEvent::Price(inst, inst * 100 + c * 10)
+    });
+    // Delete inst1 on cycle 4 and inst2 on cycle 5. `saturating_sub` keeps the
+    // discarded keys from underflowing on early cycles.
+    let deletes =
+        n.map_filter(|c: &u64| (InstEvent::Delete(c.saturating_sub(3)), *c == 4 || *c == 5));
+
+    // Merge the two event streams so a price and a delete landing on the same
+    // cycle ride one burst — `demux_it` then routes each item independently.
+    let events = g.combine(&[prices, deletes]).handle();
+
+    // Route each event to its instrument's slot; a `Delete` closes (recycles)
+    // the slot so resource use tracks *concurrent* instruments, not all-time.
+    let (slots, overflow) = g.with_builder(|b| {
+        b.demux_it(events, CAPACITY, |event: &InstEvent| {
+            let demux = match event {
+                InstEvent::Delete(_) => DemuxEvent::Close,
+                _ => DemuxEvent::None,
+            };
+            (inst_key(event), demux)
+        })
+    });
+
+    // Recombine every slot (plus overflow, which stays empty here), flatten the
+    // per-slot bursts back into one event burst, and fold into the price book.
+    let mut streams: Vec<Stream<Burst<InstEvent>>> = slots.iter().map(|&h| g.wrap(h)).collect();
+    streams.push(g.wrap(overflow));
+
+    let book = g
+        .combine(&streams)
+        .map(|rows: &Burst<Burst<InstEvent>>| {
+            rows.iter().flatten().cloned().collect::<Burst<InstEvent>>()
+        })
+        .fold(
+            PriceBook::new(),
+            |book: &mut PriceBook, events: &Burst<InstEvent>| {
+                for event in events {
+                    match event {
+                        InstEvent::Price(inst, px) => {
+                            book.insert(*inst, *px);
+                        }
+                        InstEvent::Delete(inst) => {
+                            book.remove(inst);
+                        }
+                        InstEvent::None => {}
+                    }
+                }
+            },
+        );
+
+    (g, book)
+}
+
+fn render(book: &PriceBook) -> String {
+    let body = book
+        .iter()
+        .map(|(inst, px)| format!("inst{inst}={px}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{{{body}}}")
+}
+
+fn main() -> anyhow::Result<()> {
+    let (g, book) = build();
+
+    let _printed = book.for_each(|book: &PriceBook| {
+        println!("price book: {}", render(book));
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(6))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Static demux ticks the book **every** cycle, so the sequence shows the
+    /// book both grow (instruments discovered from price events) and shrink
+    /// (slots recycled on delete):
+    ///
+    /// | cycle | events                       | book after            |
+    /// |-------|------------------------------|-----------------------|
+    /// | 1     | Price(1,110)                 | `{inst1=110}`         |
+    /// | 2     | Price(2,220)                 | `{inst1=110,inst2=220}` |
+    /// | 3     | Price(3,330)                 | `{inst1=110,inst2=220,inst3=330}` |
+    /// | 4     | Price(1,140), Delete(1)      | `{inst2=220,inst3=330}` |
+    /// | 5     | Price(2,250), Delete(2)      | `{inst3=330}`         |
+    /// | 6     | Price(3,360)                 | `{inst3=360}`         |
+    fn expected_states() -> Vec<PriceBook> {
+        let b = |pairs: &[(u64, u64)]| pairs.iter().copied().collect::<PriceBook>();
+        vec![
+            b(&[(1, 110)]),
+            b(&[(1, 110), (2, 220)]),
+            b(&[(1, 110), (2, 220), (3, 330)]),
+            b(&[(2, 220), (3, 330)]),
+            b(&[(3, 330)]),
+            b(&[(3, 360)]),
+        ]
+    }
+
+    #[test]
+    fn price_book_routes_through_demux_slots() {
+        let (g, book) = build();
+        let states = book.accumulate();
+        let mut runner = g.build();
+        runner
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(6))
+            .unwrap();
+
+        assert_eq!(runner.value(&states), expected_states(), "book states");
+        assert_eq!(
+            runner.value(&book),
+            PriceBook::from([(3, 360)]),
+            "final book after the deletes"
+        );
+    }
+}

--- a/next/crates/wingfoil-next/examples/dynamic/README.md
+++ b/next/crates/wingfoil-next/examples/dynamic/README.md
@@ -38,3 +38,6 @@ cleanly to ticker ticks) rather than `RunFor::Cycles`. See
 `tests/dynamic_graph.rs` for the full set of primitives (`dynamic_group`,
 `demux`, `demux_it`, `demux_map`, and the low-level `add_upstream` /
 `remove_node` driver hooks).
+
+For the same price book built **without** mutating the graph — a fixed slot pool
+routed by `demux_it` — see the [`demux`](../demux) example.

--- a/next/crates/wingfoil-next/examples/dynamic/README.md
+++ b/next/crates/wingfoil-next/examples/dynamic/README.md
@@ -1,0 +1,40 @@
+## Dynamic graphs — a live price book
+
+Wingfoil Next can add and remove nodes on a **running** graph, between engine
+cycles, without stopping execution. This example maintains a live price book:
+instruments are introduced and deleted at runtime, and a `BTreeMap` of the
+latest price per live instrument is kept correct across every change.
+
+The whole scenario is synthetic and deterministic — a per-cycle counter drives
+a price feed, an *add* stream, and a *del* stream — so the run is reproducible
+and the accompanying test asserts the exact book states the group emits.
+
+```text
+price book: {inst1=110}
+price book: {inst1=110, inst2=220}
+price book: {inst1=110, inst2=220, inst3=330}
+price book: {inst3=360}
+```
+
+The book grows as `inst1`, `inst2`, `inst3` are added, then collapses to just
+`inst3` once `inst1` and `inst2` are deleted — the wiring changed underneath a
+running graph.
+
+The engine primitive is [`Builder::dynamic_group`]: give it an `add` stream, a
+`del` stream, and a factory that builds a per-key sub-graph. On each `add` it
+splices the sub-graph in; on each `del` it tears it down; every cycle it folds
+each live member's current value into an aggregate you own. This is the next
+twin of classic wingfoil's `dynamic_group_stream`.
+
+```bash
+cargo run -p wingfoil-next --example dynamic --features dynamic-graph
+```
+
+Runtime graph mutation lives behind the `dynamic-graph` feature and on the
+interpreted `GraphBuilder` / `Handle` layer (not the fluent `Stream` layer),
+because it mutates topology mid-run. Because splicing a sub-graph in or out
+consumes scheduler cycles, the run is bounded by `RunFor::Duration` (which maps
+cleanly to ticker ticks) rather than `RunFor::Cycles`. See
+`tests/dynamic_graph.rs` for the full set of primitives (`dynamic_group`,
+`demux`, `demux_it`, `demux_map`, and the low-level `add_upstream` /
+`remove_node` driver hooks).

--- a/next/crates/wingfoil-next/examples/dynamic/main.rs
+++ b/next/crates/wingfoil-next/examples/dynamic/main.rs
@@ -1,0 +1,160 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil-next --example dynamic --features dynamic-graph
+//! ```
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::interp::{Extension, Handle};
+use wingfoil_next::prelude::*;
+
+type Instrument = u64;
+type Price = u64;
+type PriceBook = BTreeMap<Instrument, Price>;
+
+/// The run is bounded by wall-clock time rather than a cycle count: under
+/// `run_dynamic`, splicing a sub-graph in or out consumes scheduler cycles, so
+/// `RunFor::Cycles(n)` would *not* map cleanly to `n` ticker ticks. A
+/// [`RunFor::Duration`] bound is splice-independent — with a 1-second ticker it
+/// yields a fixed, reproducible set of ticks (here `n = 1..=7`).
+const RUN_FOR: RunFor = RunFor::Duration(Duration::from_secs(5));
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// Assemble the live price-book graph and return the builder plus the book
+/// handle. The scenario is fully synthetic and deterministic, driven off a
+/// per-cycle counter `n = 1, 2, 3, …`:
+///
+/// - a **price feed** emits one `(instrument, price)` each cycle, cycling the
+///   instrument id through `1 → 2 → 3 → 1 → …` with climbing prices;
+/// - an **add** stream introduces `inst1`, `inst2`, `inst3` on the first three
+///   cycles;
+/// - a **del** stream removes `inst1` (cycle 4) and `inst2` (cycle 5), so
+///   membership both grows and shrinks *at runtime*.
+///
+/// [`Builder::dynamic_group`] wires a per-instrument sub-graph on each `add`
+/// (filter the feed down to that instrument, project its price), tears it down
+/// on each `del`, and folds every live member's *current* price into a
+/// [`BTreeMap`] price book — all from inside the running graph, no stop/restart.
+fn build() -> (GraphBuilder, Handle<PriceBook>) {
+    let g = GraphBuilder::new();
+
+    // 1, 2, 3, … — one tick per cycle.
+    let n = g.ticker(Duration::from_secs(1)).count();
+
+    // Price feed: instrument id cycles 1 → 2 → 3 → 1 → …, price climbs so every
+    // update is visible.
+    let feed = n
+        .map(|c: &u64| {
+            let inst = (c - 1) % 3 + 1;
+            (inst, inst * 100 + c * 10)
+        })
+        .handle();
+
+    // Lifecycle streams. `map_filter` returns `(key, keep)`: on cycles where
+    // `keep` is false the value is dropped, so the group only ever sees the
+    // add/del keys we intend. `saturating_sub` keeps the discarded keys from
+    // underflowing on early cycles.
+    let add = n
+        .map_filter(|c: &u64| (*c, *c <= 3)) // add inst1@1, inst2@2, inst3@3
+        .handle();
+    let del = n
+        .map_filter(|c: &u64| (c.saturating_sub(3), *c == 4 || *c == 5)) // del inst1@4, inst2@5
+        .handle();
+
+    let book = g.with_builder(|b| {
+        b.dynamic_group(
+            add,
+            del,
+            // Factory: per-instrument sub-graph = the feed filtered to this
+            // instrument, projected to its price.
+            move |ext: &mut Extension<'_>, inst: Instrument| {
+                let mine = ext.filter_value(feed, move |(i, _): &(Instrument, Price)| *i == inst);
+                ext.map(mine, |(_, px): &(Instrument, Price)| *px)
+            },
+            PriceBook::new(),
+            |book: &mut PriceBook, inst: &Instrument, px: &Price| {
+                book.insert(*inst, *px);
+            },
+            |book: &mut PriceBook, inst: &Instrument| {
+                book.remove(inst);
+            },
+        )
+    });
+
+    (g, book)
+}
+
+fn render(book: &PriceBook) -> String {
+    let body = book
+        .iter()
+        .map(|(inst, px)| format!("inst{inst}={px}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{{{body}}}")
+}
+
+fn main() -> anyhow::Result<()> {
+    let (g, book) = build();
+
+    // Print the book each time it ticks. The group ticks its book downstream as
+    // membership grows, then once more once the deletes have settled — so the
+    // output shows the book both build up and collapse to the surviving
+    // instrument.
+    let _printed = g.wrap(book).for_each(|book: &PriceBook| {
+        println!("price book: {}", render(book));
+        Ok(())
+    });
+
+    // `dynamic_group` splices its per-instrument sub-graphs between cycles, so
+    // the run is driven with `run_dynamic`. The hook here is a no-op — all the
+    // add/remove logic lives inside the group, driven by its `add`/`del` edges.
+    let mut runner = g.build();
+    runner.run_dynamic(HISTORICAL, RUN_FOR, |_ext, _cycle| Ok(()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The sequence of book states the group ticks downstream. It emits as each
+    /// instrument is added (the book grows), then once more after the deletes
+    /// leave only `inst3` live — its price being the last one fed to it before
+    /// the run ended:
+    ///
+    /// | tick | event                    | book emitted            |
+    /// |------|--------------------------|-------------------------|
+    /// | 1    | add inst1, feed (1,110)  | `{inst1=110}`           |
+    /// | 2    | add inst2, feed (2,220)  | `{inst1=110,inst2=220}` |
+    /// | 3    | add inst3, feed (3,330)  | `{inst1=110,inst2=220,inst3=330}` |
+    /// | 4–7  | del inst1/inst2, feeds   | `{inst3=360}`           |
+    fn expected_states() -> Vec<PriceBook> {
+        let b = |pairs: &[(u64, u64)]| pairs.iter().copied().collect::<PriceBook>();
+        vec![
+            b(&[(1, 110)]),
+            b(&[(1, 110), (2, 220)]),
+            b(&[(1, 110), (2, 220), (3, 330)]),
+            b(&[(3, 360)]),
+        ]
+    }
+
+    #[test]
+    fn price_book_tracks_runtime_membership() {
+        let (g, book) = build();
+        let states = g.wrap(book).accumulate();
+        let mut runner = g.build();
+        runner
+            .run_dynamic(HISTORICAL, RUN_FOR, |_ext, _cycle| Ok(()))
+            .unwrap();
+
+        assert_eq!(runner.value(&states), expected_states(), "book states");
+        assert_eq!(
+            runner.value(book),
+            PriceBook::from([(3, 360)]),
+            "final book holds only the surviving instrument"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Ports the classic `dynamic` example family onto wingfoil-next, covering the two primary approaches to the same problem — a **live price book** where instruments are added and deleted at runtime. This is Phase 6 example-port work (`next/docs/port-plan.md`); the legacy example is the parity oracle.

Both examples are feature-gated on `dynamic-graph`, ship a README, and include a parity-style test asserting the exact per-cycle book state sequence and final value.

### `examples/dynamic` — runtime graph mutation
`Builder::dynamic_group` splices a per-instrument sub-graph in on each add, tears it down on each delete, and folds every live member's current price into a `BTreeMap` — all on a *running* graph, no stop/restart. The next twin of classic `dynamic_group_stream`.

### `examples/demux` — static slot pool
The statically-wired counterpart: the same price book, but routed through a fixed pool of slots with `demux_it` (recycling a slot on delete via `DemuxEvent::Close`) instead of mutating the graph. Runs under plain `run` and ticks the book every cycle, so the output shows the book both grow and shrink.

Both produce the same story — grow to `inst1/inst2/inst3`, then shrink to the surviving instrument.

## Notes

- **`RunFor::Cycles` vs `RunFor::Duration` under `run_dynamic`:** splicing a sub-graph in or out consumes scheduler cycles, so `RunFor::Cycles(n)` does *not* map cleanly to `n` ticker ticks (an early draft silently ran only 3 of 6 cycles, so the deletes never fired). The `dynamic` example uses a splice-independent `RunFor::Duration` bound; this is documented inline. The static `demux` example is unaffected and uses `RunFor::Cycles`.
- The classic example's third variant (`dynamic-manual`, raw `add_upstream`/`remove_node`) is intentionally not ported here — it re-demonstrates `dynamic_group` one abstraction layer down; can follow up if wanted.

## Testing

- `cargo run --example dynamic --features dynamic-graph` / `--example demux` — output matches the documented sequences.
- `cargo test -p wingfoil-next --example dynamic --features dynamic-graph` / `--example demux` — both green.
- `cargo fmt --all`, `cargo lint`, `cargo lint-all` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P)_