### PR TITLE
next: port the log mode of the classic tracing example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7783,6 +7783,7 @@ dependencies = [
  "chrono",
  "criterion",
  "csv",
+ "env_logger 0.11.10",
  "etcd-client",
  "futures",
  "log",

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -163,6 +163,9 @@ criterion = "0.8.1"
 # The `latency_stages!` macro derives serde on the generated record, so a crate
 # invoking it (here, the latency tests) needs serde in scope.
 serde = { version = "1.0", features = ["derive"] }
+# Subscriber for the `tracing` example's `log` mode — renders the `logged` op's
+# `log`-crate records (target "wingfoil"). Mirrors the classic tracing example.
+env_logger = { workspace = true }
 
 [features]
 default = []
@@ -238,6 +241,13 @@ required-features = ["async"]
 name = "async"
 path = "examples/async/main.rs"
 required-features = ["async"]
+
+# Observability: the `logged` debug tap rendered through `env_logger`. Ports the
+# `log` mode of the classic `tracing` example (the `tracing`-subscriber and
+# engine-span `instruments` modes await next's instrumentation-feature port).
+[[example]]
+name = "tracing"
+path = "examples/tracing/main.rs"
 
 [[bench]]
 name = "tiers"

--- a/next/crates/wingfoil-next/examples/tracing/README.md
+++ b/next/crates/wingfoil-next/examples/tracing/README.md
@@ -1,0 +1,32 @@
+## Observability — the `logged` debug tap
+
+`logged(label, level)` taps a stream: it emits each value as it ticks through
+the `log` crate (`"{time} {label} {value:?}"`, target `"wingfoil"`) and passes
+the value through unchanged. Point any `log`-compatible subscriber at it to see
+the graph's activity without altering the data flow.
+
+```sh
+RUST_LOG=info cargo run -p wingfoil-next --example tracing
+```
+
+```text
+[.. INFO  wingfoil] 0.000_000 tick 1
+[.. INFO  wingfoil] 1.000_000 tick 2
+[.. INFO  wingfoil] 2.000_000 tick 3
+```
+
+### Parity note — this is a partial port of the classic `tracing` example
+
+The classic wingfoil `tracing` example demonstrates three modes:
+
+| mode | what it does | status in next |
+|------|--------------|----------------|
+| `log` | events via `env_logger` | ✅ ported (this example) |
+| `tracing` | same events routed through a `tracing-subscriber` | ⏳ not yet — needs the `tracing` feature ported to next |
+| `instruments` | tracing **spans** around `run` and each engine cycle | ⏳ not yet — needs the engine's `instrument-*` features ported to next |
+
+Next's op catalog logs through the `log` crate, and the engine has no span
+instrumentation yet, so only the `log` mode is faithful today. Passing
+`tracing` or `instruments` prints a note and falls back to `log`. The remaining
+two modes are tracked as a Phase-6 item in `docs/port-plan.md`; they land with
+the next engine's tracing / instrumentation port, not as example work.

--- a/next/crates/wingfoil-next/examples/tracing/main.rs
+++ b/next/crates/wingfoil-next/examples/tracing/main.rs
@@ -1,0 +1,78 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! # Default log output (env_logger)
+//! RUST_LOG=info cargo run -p wingfoil-next --example tracing
+//! RUST_LOG=info cargo run -p wingfoil-next --example tracing -- log
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+/// A one-per-second counter, tapped by `logged` so each tick is emitted as a
+/// `log` record (`"{time} tick {value}"`, target `"wingfoil"`, level `info`).
+/// `logged` is a pass-through, so the value stream is just the counter.
+fn build(g: &GraphBuilder) -> Stream<u64> {
+    g.ticker(Duration::from_secs(1))
+        .count()
+        .logged("tick", log::Level::Info)
+}
+
+fn main() -> anyhow::Result<()> {
+    let mode = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "log".into())
+        .to_lowercase();
+
+    match mode.as_str() {
+        "log" => env_logger::init(),
+        // The classic example also offers `tracing` (route the events through a
+        // `tracing-subscriber`) and `instruments` (engine spans around `run` and
+        // each cycle). Neither is available on wingfoil-next yet: the engine has
+        // no `tracing` / `instrument-*` features, so there are no spans to emit,
+        // and the op catalog logs through the `log` crate only. Both are tracked
+        // in `docs/port-plan.md` (Phase 6). Fall back to the `log` mode so the
+        // command still does something useful.
+        "tracing" | "instruments" => {
+            eprintln!(
+                "mode {mode:?} is not available in wingfoil-next yet — it needs the \
+                 `tracing` / `instrument-*` engine features, which have not been ported \
+                 from legacy (only the `log` mode is supported today). Running `log` instead."
+            );
+            env_logger::init();
+        }
+        other => {
+            eprintln!("unknown mode: {other:?}. Use 'log'.");
+            std::process::exit(1);
+        }
+    }
+
+    let g = GraphBuilder::new();
+    let _out = build(&g);
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `logged` is a pass-through debug tap: it emits a log record per tick but
+    /// leaves the value stream unchanged. Over 3 cycles the counter it wraps
+    /// still ticks 1, 2, 3.
+    #[test]
+    fn logged_passes_the_value_stream_through() {
+        let g = GraphBuilder::new();
+        let out = build(&g);
+        let states = out.accumulate();
+        let mut runner = g.build();
+        runner
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+            .unwrap();
+
+        assert_eq!(runner.value(&states), vec![1u64, 2, 3]);
+    }
+}

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -966,9 +966,15 @@ tests covered — not "legacy pytest passes unchanged."
   telemetry/tracing, per-adapter) to idiomatic next (fluent or `graph!`),
   keeping classic versions until Phase 7. 🟢 *landed so far*: order_book,
   breadth_first, run_mode, statistics, threading, async, feedback, and the
-  runtime-dynamism pair `dynamic` (`dynamic_group`) + `demux` (`demux_it`).
-  Remaining: `latency` / `telemetry` (adapter/cross-process), and `tracing`
-  (blocked — next has no `tracing`/`instrument` feature or `.logged()` yet).
+  runtime-dynamism pair `dynamic` (`dynamic_group`) + `demux` (`demux_it`), and
+  `tracing` (the `log` mode — the `logged` debug tap through `env_logger`).
+  Remaining: `latency` / `telemetry` (adapter/cross-process); and the `tracing`
+  example's other two modes — `tracing` (route events through a
+  `tracing-subscriber`) and `instruments` (engine spans around `run`/cycle) —
+  which are ⏳ *blocked* on porting next's `tracing` / `instrument-*` engine
+  features (the op catalog logs through `log` only, and the engine has no span
+  instrumentation yet). Tracked as a Phase-6 follow-up, landing with the
+  instrumentation port, not as example work.
 - **Benchmarks**: the four-way `tiers` bench 🟢 *landed* — each workload now
   runs a `classic` (legacy interpreted) bar beside next's
   `interpreted`/`compiled`/`nested`, so `next-interpreted ≥ classic-interpreted`


### PR DESCRIPTION
## Summary

Ports the `log` mode of the classic `tracing` example onto wingfoil-next: a one-per-second counter tapped by `logged("tick", Info)` and rendered through `env_logger`. `logged` (added in #573) emits a `log` record per tick (target `"wingfoil"`) and passes the value through unchanged, so the example doubles as a demonstration of next's observability tap.

```text
[.. INFO  wingfoil] 0.000_000 tick 1
[.. INFO  wingfoil] 1.000_000 tick 2
[.. INFO  wingfoil] 2.000_000 tick 3
```

## Partial port — this is deliberate

The classic `tracing` example has three modes; only `log` is faithfully portable to next today:

| mode | what it does | status |
|------|--------------|--------|
| `log` | events via `env_logger` | ✅ ported (this PR) |
| `tracing` | same events routed through a `tracing-subscriber` | ⏳ blocked — next has no `tracing` feature |
| `instruments` | tracing **spans** around `run` and each engine cycle | ⏳ blocked — next has no `instrument-*` engine instrumentation |

Next's op catalog logs through the `log` crate only, and the engine has no span instrumentation yet, so the other two modes cannot be faithfully reproduced. Passing `tracing` or `instruments` prints a note and falls back to `log` rather than silently doing nothing. Both blocked modes are documented in the example README and recorded as a Phase-6 follow-up in `port-plan.md` — they land with the next engine's tracing / instrumentation port, not as example work. Per the parity mandate, the gap is surfaced explicitly rather than faked or dropped.

## Changes

- `examples/tracing/main.rs` + `README.md` — the `log`-mode example, with a pass-through test (the value stream is unchanged: the wrapped counter still ticks 1, 2, 3).
- `Cargo.toml` — `env_logger` dev-dependency (workspace) + `[[example]]` entry; `Cargo.lock` updated in sync.
- `docs/port-plan.md` — example-status update noting the partial landing and the blocked modes.

## Testing

- `RUST_LOG=info cargo run -p wingfoil-next --example tracing` — output above.
- `cargo test -p wingfoil-next --example tracing` — green.
- `cargo fmt --all`, `cargo lint`, `cargo lint-all` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MatEkmguN4pYzgyMpSse3P)_