### PR TITLE
next: add /review-adapters-next skill to audit next adapters

### DIFF
--- a/.claude/commands/review-adapters-next.md
+++ b/.claude/commands/review-adapters-next.md
@@ -1,0 +1,253 @@
+Audit the wingfoil-next I/O adapters against the `/new-adapter-next` skill and
+the strict-superset parity obligation. Scope: `$ARGUMENTS` names a single
+adapter (e.g. `redis`) to review just that one; leave it blank to review **all**
+next adapters under `next/crates/wingfoil-next/src/adapters/`.
+
+This is a **read-and-report** skill — it changes no adapter code. Its four
+deliverables map to the four things a maintainer needs to know before trusting
+the next adapter surface:
+
+1. **Skill health** — is `.claude/commands/new-adapter-next.md` itself still
+   correct, internally consistent, and non-contradictory with
+   `next/CLAUDE.md`, `next/docs/port-plan.md`, and the code it points at?
+2. **Compliance** — does each adapter obey the skill's invariants and step
+   requirements?
+3. **Lessons to fold back** — did recent adapter work surface a pitfall / gate /
+   pattern the skill doesn't yet capture, per its own "Feed lessons back into
+   this skill" mandate?
+4. **Unjustified legacy deviations** — every place a next adapter differs from
+   its classic twin that is **not** documented (module-doc `# Deviations from
+   classic` block **and** the register + port-plan matrix).
+
+The output is a written report, not commits. Only touch files if the review
+concludes the *skill* or the *deviation docs* should change **and** the user
+asked you to apply fixes — otherwise report and stop.
+
+## 0. Orient (do this once, in the parent context)
+
+Read the ground truth before dispatching any per-adapter work:
+
+- `.claude/commands/new-adapter-next.md` — the skill under review. Read it end
+  to end; the audit checklist below is derived from it, but the file is the
+  authority. If it has grown rules since this review skill was last touched,
+  audit against the **file**, and note the drift in deliverable 1.
+- `next/CLAUDE.md` — the superset objective and the "skills are living
+  documents" mandate.
+- `next/docs/deviation-register.md` — the classified list of known
+  classic↔next deviations (the parity audit cross-checks against this).
+- `next/docs/port-plan.md` — Phase 4 adapter status + the capability matrix +
+  "Known parity gaps".
+- `next/docs/source-lifecycle-defer-to-start.md`, `runtime-ownership.md` — the
+  open design items the skill references (A1–A5).
+
+Then enumerate the review set:
+
+```bash
+# next adapters (single-file modules and directory modules)
+ls next/crates/wingfoil-next/src/adapters/
+# which legacy adapters have a next twin, and which don't yet
+ls -d wingfoil/src/adapters/*/
+# every documented deviation block currently in the tree
+grep -rn "Deviations from classic" next/crates/wingfoil-next/src/adapters/
+```
+
+Classify each next adapter up front — the audit differs by kind:
+
+- **Ported** (a classic twin exists under `wingfoil/src/adapters/<name>/`) →
+  full parity audit applies. Its classic module is the **parity oracle**.
+- **Next-only** (no classic twin — e.g. `lines`) → parity audit is N/A; audit
+  only conventions/invariants, and confirm naming/layering stay backport-ready.
+- **Shared helper** (`common.rs`, `mod.rs`) → not an adapter; check only that
+  the slicer cfg-gate and the `mod.rs` doc index are correct.
+
+Legacy adapters with **no** next twin yet (today: `aeron`, `fix`, `fluvio`,
+`iceoryx2`, `kdb`, `web`) are out of scope for compliance but belong in the
+port-plan coverage note (deliverable 4's tail): confirm they're still tracked
+as unported in `port-plan.md`, not silently dropped.
+
+## 1. Per-adapter audit (dispatch to subagents, fresh context each)
+
+For anything beyond a single small adapter, run the per-adapter audits as
+**parallel subagents** — one per adapter — so each reads its adapter, the
+adapter's classic twin, and the skill with a clean context, and returns a
+structured finding list. This mirrors step 15 of `new-adapter-next` ("self-review
+with a fresh context") and keeps the parent context free to synthesise.
+
+Give each subagent this checklist. It is the `new-adapter-next` invariants and
+step requirements turned into pass/fail probes — cite the skill section on every
+finding so the report is traceable, and quote the offending code with a
+`file:line`.
+
+### A. Invariants (skill "Invariants" section — the load-bearing rules)
+
+- **No locks on the graph path.** No `Mutex`/`RwLock` `.lock()` inside any
+  `Op::cycle`/`start`/`stop`/`teardown`, `for_each`/`for_each_mut`/`map`/`try_map`
+  closure, or `poll` closure. Locks are allowed **only** in wiring/factory
+  functions, background threads, and cross-thread handles. A graph→background
+  ad-hoc *whole-value* hand-off must use `arc_swap::ArcSwap`, **not** a lock
+  (the prometheus per-slot pattern). Graph-thread-local mutability uses
+  `RefCell`/`Rc<RefCell<…>>`. → flag any `.lock()` reachable from a cycle.
+- **Historical replay is deterministic.** A channel-replay source stamps every
+  record with `send_at` at **non-decreasing** timestamps ≥ run start, turns
+  index overflow into a clear error (`u32::try_from`), `close()`s at end, and
+  propagates malformed input via `send_error` (never `panic!`, never a silent
+  skip). Prefer the `replay_results` primitive over a hand-rolled
+  `channel`→`send_at`→`close` loop. Same-instant records ride one `Burst` (don't
+  pre-flatten).
+- **Time-sliced replay reuses the shared slicer.** An adapter that replays a
+  caller-parameterised time range must build on the ported
+  `adapters/common.rs` helpers (`WindowFilter`, `compute_validated_time_slices`),
+  **not** a hand-rolled window clamp. A *reusing* adapter widens the existing
+  `#[cfg(any(feature = …))]` gate on the slicer — it does not duplicate it. The
+  `WindowFilter` row-clamp is always-compiled; only the slicer is feature-gated.
+- **Live sources are realtime-only.** A live, never-closing source
+  (`*_sub`/watch/consumer) **rejects `RunMode::HistoricalFrom` at wiring** with
+  an adapter-named error and returns `Result`. Only finite timestamped sources
+  run historically. → confirm the reject exists and is stated in the module docs.
+- **Fallibility with context.** Wiring-time I/O is in a factory returning
+  `anyhow::Result`; a live socket/subscription's connect + thread spawn is
+  deferred to `start()` via `source_at_start` (the `zmq_sub` reference), so
+  wiring stays pure. Every I/O boundary carries `.context(...)` naming the
+  adapter + resource. No `.unwrap()` outside `#[cfg(test)]`/doc examples. A
+  closed receiver (`send` returns `false`) exits the producer loop quietly — not
+  an error.
+- **Credential redaction.** Any connection string / DSN / URL that can embed a
+  secret has a `redacted()` method used at **every** `connect()` error site, and
+  a no-service test asserts the raw secret never appears in the error. → for
+  every networked adapter with credentials (redis, kafka, zmq, postgres, etcd,
+  …), confirm both the method and the test exist.
+- **Layering / no prelude.** Sources are free fns taking `&GraphBuilder` first;
+  sinks are extension traits on `Stream<Burst<T>>`; compute ops are extension
+  traits; **nothing** is added to the prelude. Wiring goes through `Stream::wire`
+  / `GraphBuilder::source` only. Verb naming matches the skill's table
+  (`_sub`/`_pub`, `_read`/`_write`, `replay_*`/`tail_*`, exporter `_gauge`/…).
+
+### B. Structural requirements (skill steps 3–13)
+
+- **Feature gating (step 3).** Deps optional + feature-gated; dep versions pinned
+  to the classic adapter's (or a *documented* forward-roll for a security
+  advisory — the otlp opentelemetry-0.32 precedent, D5). `-integration-test`
+  feature for service-backed adapters; none for file/pure-compute.
+- **Module registration (step 4).** *Both* `mod.rs` edits present: the gated
+  `pub mod` (alphabetical) **and** the `//!` doc-index bullet.
+- **Module docs (step 6).** `//!` header has the Layering section, documents
+  every public item, `# Errors` on fallible factories, and — if ported — a
+  `# Deviations from classic` block.
+- **Realtime-only sinks (steps 2, 8).** An exporter/server/push sink guards on
+  `ctx.run_mode()` and **no-ops under historical replay**.
+- **Status streams (step 8a).** If present, a `*_with_status` tuple factory
+  (primary signature unchanged), transition-only emission, post-success recording.
+- **Tests (step 10).** Historical determinism (`RunMode::HistoricalFrom(ZERO)`,
+  assert values **and** tick times), unique temp paths (pid+counter), the
+  connection-refused-first order for service adapters, correct file-level `cfg`.
+- **Example (step 11)** registered with `required-features`; **CI (step 12)**
+  workflow + hub registration for service adapters; **Python (step 12)**
+  `#[pyadapter]` surface + pytest where applicable; **port-plan (step 13)**
+  row updated.
+
+### C. Parity (skill "parity obligation" + step 13) — ported adapters only
+
+Diff the next adapter against `wingfoil/src/adapters/<name>/`:
+
+- Every public capability (function, config knob, mode enum, event/entry type)
+  has a next equivalent **or** an explicitly documented deviation.
+- Every classic unit test is ported as a parity test (identical values **and**
+  tick times), or a comment names why not.
+- The classic example is ported.
+- Classic `CLAUDE.md` design decisions are carried into the module docs.
+- Error-message compatibility is kept where classic tests assert on messages.
+
+**Every gap here is a finding unless it is documented in all the places it must
+be:** the module-doc `# Deviations from classic` block, `deviation-register.md`
+(with a class 🔴/🟡/🟢/⚪/✅), and the `port-plan.md` matrix. A deviation
+documented in code but missing from the register — or vice-versa — is itself a
+finding (doc drift).
+
+Each subagent returns, per finding: `{adapter, section-of-skill, severity,
+file:line, what, why-it-matters}`, plus a one-line per-adapter verdict
+(compliant / minor / needs-work).
+
+## 2. Skill-health review (deliverable 1 — parent context)
+
+Independently of the adapters, read `new-adapter-next.md` critically:
+
+- **Internal consistency** — do any two rules contradict? (e.g. a step saying
+  "connect at wiring" where the invariants now say "defer to `start()`".)
+- **Currency vs the code** — every primitive/type/path the skill names
+  (`source_at_start`, `replay_results`, `for_each_mut`, `consume_async`,
+  `consume_async_bursts`, `ArcSwap` slots, `#[pyadapter]`, the `common.rs`
+  slicer, referenced reference files like `zmq.rs`/`csv.rs`/`lines.rs`/`augurs.rs`)
+  must still exist and mean what the skill says. Grep for each; a dangling
+  reference is a finding.
+- **Currency vs the design docs** — items the skill calls "open"/"tracked"
+  (defer-to-start A1/A2, runtime-ownership A5) should agree with the current
+  state in `deviation-register.md` and the two design docs. The register is
+  ahead of the skill in places (e.g. the `produce_async` family and
+  `postgres_write` have since deferred to `start()`); where the skill's prose
+  ("Not on `source_at_start` yet: …") has fallen behind the register, that is a
+  **lesson to fold back** (deliverable 3), not just a note.
+- **Consistency with `next/CLAUDE.md`** — branching (cut from / merge into
+  `next`), pre-commit checklist, out-of-prelude rule.
+
+## 3. Lessons-to-fold-back review (deliverable 3 — parent context)
+
+The skill's own "Feed lessons back into this skill" section makes keeping it
+current part of "done". Hunt for lessons the tree has learned that the skill
+hasn't absorbed yet:
+
+- **Mine recent adapter PRs.** `git log --oneline next -- next/crates/wingfoil-next/src/adapters/`
+  and the deviation register's "Resolved / ratified" list. Each resolved item
+  (B1 `consume_async` flush teardown, B3 `consume_async_bursts`, B2 unified
+  `<adapter>_source`, A5 graph-owned runtime, the `produce_async`/`postgres_write`
+  defer-to-start) is a candidate rule: does the skill now *tell the next author
+  to do it that way*, or does it still describe the pre-fix world?
+- **Recurring findings from §1.** If the same compliance miss shows up in two+
+  adapters, the skill probably lacks an explicit rule — propose the rule.
+- **New CI gates / sandbox caveats** encountered (the `dependency-review` gate,
+  the `cargo lint-all` aeron/CMake sandbox caveat) — confirm the skill still
+  documents them and that the documented fix still matches CI.
+
+Report each as a concrete proposed edit to `new-adapter-next.md` (section +
+wording), so folding it back is mechanical.
+
+## 4. Synthesise the report
+
+Produce a single markdown report with these sections:
+
+1. **Skill health** — contradictions, stale references, doc-drift; each with the
+   fix.
+2. **Compliance matrix** — one row per adapter: kind (ported/next-only/helper),
+   verdict, and the count of findings by severity. Then the findings, grouped by
+   adapter, most-severe first, each citing the skill section and `file:line`.
+3. **Lessons to fold back** — proposed `new-adapter-next.md` edits, each with the
+   triggering evidence (PR / register item / repeated finding).
+4. **Unjustified legacy deviations** — deviations found in §1.C that are **not**
+   fully documented (module doc **and** register **and** port-plan). A deviation
+   present in all three is *justified* and is **not** listed here (mention the
+   count of justified deviations for context). Close with the port-plan coverage
+   note: are the still-unported legacy adapters (`aeron`/`fix`/`fluvio`/
+   `iceoryx2`/`kdb`/`web`) still tracked as gaps, or has one been dropped?
+
+Rank everything by impact: a correctness/safety invariant breach (a lock on the
+graph path, a leaked credential, a live source that doesn't reject historical, a
+non-deterministic replay) outranks a missing doc bullet. Give a bottom-line
+verdict: is the next adapter surface compliant with its skill and a faithful
+superset of the legacy adapters, or not — and the top three things to fix.
+
+## 5. If asked to apply fixes
+
+By default this skill only reports. If the user asks you to *act* on the
+findings:
+
+- **Skill / doc edits** (deliverables 1 & 3, and documenting a justified-but-
+  undocumented deviation from 4) are safe to apply here — edit
+  `new-adapter-next.md`, `deviation-register.md`, or `port-plan.md`, then run
+  nothing heavier than a re-read (these are docs). Follow the branch rules in
+  `next/CLAUDE.md` (this is next work — the branch is cut from `next`).
+- **Adapter code fixes** (a real compliance breach) are *not* this skill's job —
+  each belongs on its own branch through `/new-adapter-next`'s pre-commit
+  checklist (fmt + `cargo lint` + `cargo lint-all` + tests). Hand them back as a
+  prioritised worklist, don't fold them into the review branch.
+
+Commit doc changes with a clear message and push to the designated branch; open
+a PR only if the user asks, with base `next`.


### PR DESCRIPTION
Adds `/review-adapters-next`, the audit counterpart to `/new-adapter-next`. It lives alongside it in `.claude/commands/` (the repo convention for these process recipes) and audits the wingfoil-next adapters against that skill and the strict-superset parity obligation.

## What it does

Invoke as `/review-adapters-next` for the whole adapter surface, or `/review-adapters-next <name>` for one adapter. Read-and-report by default (touches no adapter code unless asked). Per-adapter audits fan out to fresh-context subagents, mirroring `new-adapter-next`'s step-15 self-review.

Four deliverables, matching the review goals:

1. **Skill health** — is `new-adapter-next.md` internally consistent and still current vs the code (every primitive/path it names) and the design docs (`deviation-register.md`, defer-to-start / runtime-ownership)?
2. **Compliance** — per-adapter pass/fail probes derived from the skill's invariants and steps: no locks on the graph path, deterministic replay, live-source historical rejection, credential redaction, out-of-prelude layering, feature gating, both `mod.rs` edits, realtime-only sink no-op, test conventions. Each finding cites the skill section + `file:line`.
3. **Lessons to fold back** — mines recent adapter PRs and the register's Resolved/ratified list plus repeated compliance misses, and proposes concrete edits back into the skill (its own living-document mandate).
4. **Unjustified legacy deviations** — parity diff against each classic twin; anything not documented in module doc **and** register **and** port-plan matrix is flagged, plus a coverage note on still-unported legacy adapters.

## Notes

- Classifies each next adapter first (ported / next-only / shared-helper); the parity audit only applies to ported adapters (`lines` has no classic twin).
- Doc-only change: adds a single command file, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UNN6wny3AAsnb97eURSGX

---
_Generated by [Claude Code](https://claude.ai/code/session_018UNN6wny3AAsnb97eURSGX)_