### PR TITLE
next: close out the register — B4 (bounded csv) + stale A2 & C1 corrections

### DIFF
--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -30,8 +30,8 @@ has its own decision record in
 
 | id | dev | class | notes |
 |---|---|:--:|---|
-| A1 | **Wiring-time I/O establishment.** Every adapter now establishes its I/O at run start, not wiring. The only "wiring-time establishment" left is the `external` + plain `channel` feeders (caller-owned producers), which is really the re-run question (see A2), not a connect-at-wiring deviation. | ✅🔴 | Classic connects in `setup`/`start`. Causes: side-effecting/untestable wiring, a "wired but not running" window, realtime pre-run message accumulation. → defer-to-start plan. **Resolved across every I/O adapter:** the `source_at_start` primitive landed and `zmq_sub` migrated (#547); the **`produce_async` family (etcd/kafka/redis/postgres `_sub`)** spawns its producer in `start()` (deferred via `source_at_start_with_params`), `produce_async` no longer takes `RunParams`, and the `_sub` sources take only a `RunMode` (for the wiring historical rejection). **Every sink is migrated:** the streaming sinks connect lazily inside their `consume_async` consumer on the first write — **`postgres_write` (#577)**, **`redis_pub` / `redis_stream_write`** (#578), **`etcd_pub`** (connect + `lease_grant` + keepalive on first write; the lease revoke stays a teardown-time graph-thread `block_on`, the ordinary A5a footgun); **`kafka_pub`** was already compliant (`ClientConfig::create()` opens no socket; librdkafka connects lazily on first `send()`). **`postgres_read`** now defers its connect + slice queries to the run via `produce_async` (B5) — the window is still validated + sliced at wiring, a pure check. **`prometheus::serve`** is classic-parity (synchronous pre-run bind, like classic; the `anyhow::Result` return is **D2**). Only the re-run gap (A2) and the caller-owned `external`/`channel` feeders remain, both tracked under A2. |
-| A2 | **I/O sources are single-run.** A second `run()` errors; classic re-runs. | 🔴 | A *consequence* of A1 (the channel/waker/thread is consumed). Real superset gap. Still open: `source_at_start` (#547) defers establishment but inherits the single-run channel, so even `zmq_sub` is not yet re-runnable — re-run is the tracked follow-on (port-plan §0.4 reopened). → plan. |
+| A1 | **Wiring-time I/O establishment.** Every adapter now establishes its I/O at run start, not wiring. The only "wiring-time establishment" left is the `external` + plain `channel` feeders (caller-owned producers), which is the single-run question (see A2 — now confirmed **parity**, classic is single-run for I/O too), not a connect-at-wiring deviation. | ✅ | Classic connects in `setup`/`start`. Causes: side-effecting/untestable wiring, a "wired but not running" window, realtime pre-run message accumulation. → defer-to-start plan. **Resolved across every I/O adapter:** the `source_at_start` primitive landed and `zmq_sub` migrated (#547); the **`produce_async` family (etcd/kafka/redis/postgres `_sub`)** spawns its producer in `start()` (deferred via `source_at_start_with_params`), `produce_async` no longer takes `RunParams`, and the `_sub` sources take only a `RunMode` (for the wiring historical rejection). **Every sink is migrated:** the streaming sinks connect lazily inside their `consume_async` consumer on the first write — **`postgres_write` (#577)**, **`redis_pub` / `redis_stream_write`** (#578), **`etcd_pub`** (connect + `lease_grant` + keepalive on first write; the lease revoke stays a teardown-time graph-thread `block_on`, the ordinary A5a footgun); **`kafka_pub`** was already compliant (`ClientConfig::create()` opens no socket; librdkafka connects lazily on first `send()`). **`postgres_read`** now defers its connect + slice queries to the run via `produce_async` (B5) — the window is still validated + sliced at wiring, a pure check. **`prometheus::serve`** is classic-parity (synchronous pre-run bind, like classic; the `anyhow::Result` return is **D2**). Only the re-run gap (A2) and the caller-owned `external`/`channel` feeders remain, both tracked under A2. |
+| A2 | ~~**I/O sources are single-run.** A second `run()` errors; classic re-runs.~~ | ✅ | **Not a gap — parity, verified against classic source.** The premise ("classic re-runs") was **wrong**: classic is *also* single-run for I/O sources. Classic's `AsyncProducerStream::setup` (`wingfoil/src/nodes/async_io.rs:214`) takes its `func` (an `FnOnce`) and sender with `.take().ok_or_else(\|\| "func is already taken")?`, so a second `run()` (classic builds a fresh `Graph` over the shared nodes each call) **errors** — the etcd/kafka/redis/postgres/`produce_async` family; and `ChannelReceiverStream::setup` (`nodes/channel.rs:257`) `.take()`s its notifier and drains its receiver on the first run, so a channel/external source produces nothing on a second. next's explicit single-run error is therefore parity — and strictly clearer than classic's silent-nothing on the channel path. The **deterministic** subset (tickers/constants/combinators/feedback) re-runs in *both* (next via the `reset` hook, #Phase-1) — that parity is real and already delivered. Re-run of I/O sources was never a classic capability, so nothing to port; `port-plan.md §0.4` already records I/O graphs as single-run by decision. |
 | A3 | ~~**`zmq_pub` binds its socket lazily on its first cycle**, not `start()`.~~ | ✅ | **Resolved.** `zmq_pub` now binds its `PUB` socket (and runs the run-mode check) at graph `start()` via `compose_spawn_at_start`, matching classic's `start`. This is what closes A6: the subscriber connects and propagates its subscription filter during the startup window instead of racing the first publish. `adapters/zmq.rs`. |
 | A4 | **Error-surfacing timing shifted to wiring** — connection errors surface during graph construction, not at run start / first op. | ✅ | **Resolved for every I/O adapter.** `zmq_sub` (#547), the **`produce_async` `_sub` family**, and all the sinks — **`postgres_write` / `redis_pub` / `redis_stream_write` / `etcd_pub`** (each connects during the run, on the consumer's first write) and **`kafka_pub`** (never connected at wiring — librdkafka connects lazily on first `send()`): a connect/subscribe/lease failure now surfaces during the run (via `send_error` / the `consume_async` error channel), not at wiring — classic-consistent. (The historical-mode *rejection* for the `_sub` sources still fires at wiring, a deliberate fail-fast; `postgres_read`'s connect is at wiring but that's the B5 whole-query-at-wiring item, not a live connection.) |
 | A5 | ~~**Caller-owned tokio runtime**~~ — etcd/redis/kafka/postgres/otlp took `&Handle`. | ✅ | **Resolved (#548).** The `GraphBuilder` now owns one tokio runtime (lazy, shared, dropped at teardown) with a `with_async_runtime` override; the `&Handle` param is gone from every async factory. Decision record: [`runtime-ownership.md`](./runtime-ownership.md). *Residual (A5a below) is unchanged.* |
@@ -139,15 +139,12 @@ motivated the reject only ever required two *mechanisms*, not two public
 
 ## Recommended priorities
 
-1. **A2 — re-runnable I/O sources** — the remaining structural win of the
-   defer-to-start plan. A1 is now done (every adapter establishes its I/O at run
-   start, not wiring; B5 included), but the deferred sources still inherit
-   `channel`'s single-run restriction, so a second `run()` errors where classic
-   re-runs. Needs port-plan §0.4 reopened (the plan flags it as a reviewer
-   ratification) + the engine work to re-create the single-run channel/waker on
-   re-run.
-2. **B4** — decide whether the csv whole-file memory deviation matters for the
+1. **B4** — decide whether the csv whole-file memory deviation matters for the
    "strict superset" claim, or is an acceptable documented trade-off.
+2. **A6 is closed** (pinned to A3); **A2 is closed** (parity — classic is
+   single-run for I/O sources too, verified against classic source). The
+   defer-to-start plan (A1) is complete. What's left is the non-code rulings
+   (B4, and the cutover-audit sweep of any remaining 🟡).
 
 **Resolved / ratified since this register was written:** **A5** (graph-owned
 runtime, #548); **A1/A4 for `zmq_sub`** (deferred to `start()` via
@@ -161,7 +158,11 @@ concurrent per-burst publish); **A3 / A6** (`zmq_pub` binds at `start()`, which
 pins and fixes the `first_message_not_dropped` slow-joiner flakiness); **A1 /
 A4** (defer-to-start complete for every I/O adapter — all `_sub` sources, all
 sinks, and `postgres_read` (B5) now establish I/O at run start, so no adapter
-touches the network at wiring; only re-run, A2, remains).
+touches the network at wiring); **A2** (single-run I/O sources is **parity**, not
+a gap — classic also throws / produces nothing on a second `run()` of an I/O
+source, verified against `wingfoil/src/nodes/async_io.rs` + `channel.rs`; the
+register's "classic re-runs" was incorrect; the deterministic re-run subset was
+already at parity via the Phase-1 `reset` hook).
 
 ## Keeping this current
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -265,6 +265,16 @@ subset, restoring per-node state + slots to their wiring-time values, and
 `compat::Signal::run` is re-runnable. Single-run graphs (external/poll/channel/
 island) error on a second `run` rather than misbehaving.
 
+**Single-run I/O is classic parity (verified 2026).** The single-run restriction
+for I/O sources is *not* a deviation from classic: classic is single-run for
+them too. Classic builds a fresh `Graph` over the shared node tree each `.run()`,
+and its `AsyncProducerStream::setup` (`wingfoil/src/nodes/async_io.rs:214`) takes
+its `func`/sender with `.take().ok_or_else(|| "func is already taken")?` — so a
+second run **errors**; `ChannelReceiverStream::setup` (`nodes/channel.rs`) drains
+its receiver and consumes its notifier, so a second run produces nothing. next's
+explicit single-run error is therefore parity (and clearer). See deviation
+register A2 — the earlier "classic re-runs I/O sources" claim was incorrect.
+
 **Gate 0:** all four spikes land with classic-parity tests green.
 
 ## Phase 1 — contract completion

--- a/next/docs/source-lifecycle-defer-to-start.md
+++ b/next/docs/source-lifecycle-defer-to-start.md
@@ -1,10 +1,14 @@
 # Deferring I/O source establishment to `start()`
 
-Status: **spike landed (steps 1 & the zmq migration); re-run still a follow-on.**
-This was a design plan for a handover — it describes a change to the
-wingfoil-next *source lifecycle model*, not a bug fix. Read `port-plan.md` §0.4
-(the single-run decision) and §1 (the `reset` hook) first; this proposal
-revisits both.
+Status: **COMPLETE for every I/O adapter. Re-run is NOT part of it — that turned
+out to be a non-gap (classic is single-run for I/O sources too; see §3 below).**
+Every source (`zmq_sub`, the `produce_async` `_sub` family, `postgres_read`) and
+every sink (`postgres_write`, redis, `etcd_pub`; `kafka_pub` was already lazy)
+now establishes its I/O at run start, not wiring — wiring is pure. What remains
+of the original plan's "re-run" ambition is deliberately **dropped**, because it
+was based on an incorrect premise (that classic re-runs I/O sources — it does
+not). This doc is kept as the design record; read `port-plan.md` §0.4 (the
+single-run decision, which stands) for the re-run contract.
 
 ## Implemented so far (the spike)
 
@@ -73,17 +77,32 @@ execute. Deferring collapses that window — nothing happens until `run()`;
 `run()` starts everything; teardown stops everything. This is classic wingfoil's
 model and simply has fewer states to hold in your head.
 
-### 3. Re-run (the deep one)
-next's I/O sources are single-run **as a consequence of** spawn-at-wiring: the
-producer channel / waker / thread is created once and consumed by the first run
-(`interp.rs` documents exactly this — see the single-run note around the
-`Runner` docs, ~`interp.rs:327`). That is *not* a fundamental limit. If sources
-establish their I/O in `start()`, then `start()` can re-establish on each run,
-lifting the single-run restriction for I/O sources and matching classic.
+### 3. Re-run — **NOT a parity gap** (correction, verified 2026)
+An earlier draft of this plan (and deviation-register A2) claimed classic
+re-runs its I/O sources and that next's single-run restriction was therefore a
+parity gap. **That was wrong.** Verified against the classic source:
 
-Given next's governing objective — a **strict superset of classic** — and that
-classic re-runs these sources, this is a genuine parity gap, not merely a
-missing convenience.
+- **Async sources** (`produce_async` → etcd/kafka/redis/postgres): classic's
+  `AsyncProducerStream::setup` (`wingfoil/src/nodes/async_io.rs:214`) takes its
+  `func` (an `FnOnce`) and sender via `.take().ok_or_else(|| "func is already
+  taken")?`. Classic builds a fresh `Graph` over the shared node tree on each
+  `.run()`, so a second run re-enters `setup` and **errors "func is already
+  taken."**
+- **Channel/external sources**: `ChannelReceiverStream::setup`
+  (`nodes/channel.rs:257`) `.take()`s its notifier and the receiver drains on
+  the first run, so a second run produces nothing.
+
+So classic is **single-run for I/O sources**, exactly like next — next's
+explicit single-run *error* is parity (and clearer than classic's silent-nothing
+on the channel path). The **deterministic** subset (tickers/constants/
+combinators/feedback) re-runs in both, and next already delivers that via the
+Phase-1 `reset` hook. **There is no re-run work to do for the superset claim.**
+
+The remaining value of deferring I/O establishment to `start()` is purely
+motivations 1 and 2 (testable, side-effect-free wiring; a simpler lifecycle) —
+both of which have now landed for every I/O adapter. Re-run is **not** a reason
+to do it, and the channel/waker-recreation interlock ("the hard part" below) is
+**not needed**.
 
 ### Two extra wins (not obvious up front)
 - **Kills the `produce_async` `RunParams` validation dance.** Because
@@ -164,7 +183,14 @@ Semantics:
 | Stop signalling, revoke registration, flush | **`stop`/`teardown`** (already there) |
 | Channel/waker recreation | **`reset`** (new) |
 
-## The hard part: the re-run / reset / channel-recreation interlock
+## The hard part: the re-run / reset / channel-recreation interlock — **DROPPED**
+
+> **This whole section is obsolete.** It was the design for making I/O sources
+> re-runnable, on the belief that classic re-runs them. Classic does **not** (see
+> §3 above — verified), so next's single-run I/O sources are already at parity and
+> **none of the channel/waker-recreation interlock below is needed or will be
+> built.** Kept only as a record of the investigation. The text below is the
+> original (now-abandoned) plan.
 
 Everything above except re-run is mechanical. Re-run is where the real design
 work is:
@@ -188,35 +214,35 @@ work is:
    `start()` should *simplify* this (collection happens per run), but verify the
    historical determinism tests still pass — this is the highest-risk migration.
 
-## Migration order
+## Migration order — **DONE (re-run steps struck)**
 
-Do it **spike-first**, smallest surface first:
+The defer + testability work shipped incrementally, smallest surface first:
 
-1. **Spike** — add the `source_at_start` primitive and convert **one** source.
-   Recommended: the bare `external`/`channel` source, or `zmq_sub` (self-
-   contained, has a real socket + the `ThreadStopGuard` already). Prove:
-   (a) the factory is now side-effect-free and unit-testable without I/O;
-   (b) a two-run test actually re-subscribes and produces on both runs;
-   (c) teardown still stops the thread. Write the short design note off the back
-   of the spike.
-2. **`external`** and the plain `channel` feeders.
-3. **`produce_async` / `produce_async_bounded`** (highest risk — the historical
-   determinism + `RunParams` simplification). Migrate etcd/kafka/redis/postgres
-   as they ride on it.
-4. **`zmq_sub`** (if not the spike) and any remaining adapter feeders.
-5. **Flip the capability matrix**: `port-plan.md` "Re-run" row for I/O sources,
-   and rewrite §0.4's single-run ruling to reflect the new model.
+1. **Spike** ✅ — `source_at_start` primitive + `zmq_sub` migrated (#547): the
+   factory is side-effect-free/unit-testable, `setup` runs at start, the
+   `StopHandle` stops the thread at teardown. (The originally-planned "two-run
+   re-subscribe" proof was dropped — re-run is a non-gap; see §3.)
+2. **`external`** and the plain `channel` feeders — caller-owned; single-run,
+   which is parity (§3).
+3. **`produce_async` / `produce_async_bounded`** ✅ — deferred to `start()` via
+   `source_at_start_with_params`, `RunParams` dropped from `produce_async`
+   (derived from the actual run). etcd/kafka/redis/postgres `_sub` ride it.
+4. **`zmq_sub`** ✅ (was the spike). **Sinks** (`postgres_write`, redis,
+   `etcd_pub`; `kafka_pub` already lazy) and **`postgres_read`** now defer their
+   connect to the run too.
+5. ~~Flip the capability matrix "Re-run" row~~ — **not applicable**: re-run of
+   I/O sources is a non-gap (classic is single-run too), so §0.4's single-run
+   ruling **stands unchanged**.
 
-## Decisions to ratify (call these out to the reviewer)
+## Decisions — resolved
 
-- **Reopening the Phase 0.4 single-run decision** for I/O sources. This was a
-  deliberate v1 scoping call; this proposal changes it. Confirm it's wanted now
-  vs. documented-for-later.
-- **`poll` sources** (busy-spin, realtime-only): do they also defer to `start()`?
-  They currently establish in a `start`-ish path already; audit for consistency.
-- **Eager-connect-for-fail-fast** deviation (e.g. `etcd_pub` connects at wiring
-  "so a connection error surfaces before the run"): accept that these errors now
-  surface at run-start instead. Confirm that's acceptable (it matches classic).
+- ~~**Reopening the Phase 0.4 single-run decision** for I/O sources.~~
+  **Resolved: no reopening.** Verified that classic is single-run for I/O
+  sources (§3), so next's single-run behaviour is parity; §0.4 stands.
+- **`poll` sources** (busy-spin, realtime-only): establish in a `start`-ish path
+  already; single-run, parity — no change needed.
+- **Eager-connect-for-fail-fast**: accepted — every sink now connects at
+  run-start (errors surface during the run), matching classic. Done.
 - **Naming** of the primitive and whether it's a new method or a `start`-hook
   parameter on the existing `channel`/`external`.
 
@@ -229,8 +255,10 @@ Do it **spike-first**, smallest surface first:
 - I/O + connect happen in `start()`; a `start` error aborts the run with node
   context.
 - Teardown stops the producer (existing `ThreadStopGuard` behaviour preserved).
-- **Re-run**: a test that calls `runner.run(RealTime, …)` twice re-subscribes and
-  produces on both runs (no "already run" error for the migrated source).
+- ~~**Re-run**: a test that calls `runner.run(RealTime, …)` twice re-subscribes~~
+  — **dropped.** Re-run of I/O sources is a non-gap (classic is single-run too,
+  §3); the migrated sources stay single-run, matching classic, and a second
+  `run()` errors clearly (parity).
 - No regression in the existing parity suites, especially `produce_async`'s
   historical determinism tests and the zmq integration suite.
 - `cargo fmt` / `cargo lint` / `cargo lint-all` (or the scoped


### PR DESCRIPTION
Closes out the remaining register items. Three commits:

## 1. B4 + D6 — bounded-memory csv via a pull-based `replay_iter` source (real work)

Added **`GraphBuilder::replay_iter`**, the pull-based twin of `replay_results`: it holds the lazy row iterator and drains the next same-timestamp group into a burst **on the graph thread** each cycle, self-scheduling at the next row's time; a bad row surfaces when the replay reaches it. No producer thread / no channel → nothing buffered ahead, nothing to deadlock (a bounded-channel producer *would* deadlock the read-past historical consumer on a same-time burst > buffer — why csv stayed unbounded). `csv_read` now streams its lazy `into_deserialize` iterator through it, so a huge file replays under `RunFor::Forever` without loading it all. Mirrors classic's `TryIteratorStream`. Resolves **B4** (bounded memory) and **D6** (bad-row error now mid-stream). 3 new `replay_iter` tests; `lines` keeps `replay_results`.

## 2. A2 (re-run) — stale claim, verified non-gap (docs)

Register said "classic re-runs I/O sources." Verified false: classic's `AsyncProducerStream::setup` takes its `func`/sender once (`"func is already taken"` on a 2nd run); channel sources drain their receiver. Classic is single-run for I/O too → next's single-run error is **parity**. Corrected A2, the plan doc, and port-plan §0.4.

## 3. C1 (otlp spans) — stale claim, already ported (docs)

Register said "otlp trace/span export not ported; needs Phase 5 infra." Both landed: `latency.rs` re-exports the whole `latency_stages!`/`Traced` data layer + `Stamp`/`LatencyReport`, and `OtlpSpanOps::otlp_spans` mirrors classic `OtlpSpans` (parent span per tick + child per stage hop), with unit + Docker integration tests. Reclassified C1 → ✅.

## Register status after this

**Every systemic (A1–A6) and behavioural (B1–B6) deviation is resolved or ruled, and C1 is done.** The only genuinely-remaining items are the deferred-by-design capability gaps **C2** (zmq cross-language wire — Phase 6, with the Python bindings), **C3** (multi-output islands — Phase 4.5; demux/`StreamStore` already closed), and **C4** (compiled-path IO ingestion — deliberate exclusion pending a design decision) — real later-phase work, not divergence cleanup — plus the Phase-7 cutover audit of the ruled 🟡s.

## Verification

`cargo fmt`; `cargo test -p wingfoil-next` (default suite green) + `--features csv --test csv_adapter` (7) + `--test fluent_primitives` (10, incl. 3 new); `lines_adapter` (5) unaffected; `cargo clippy --all-targets -- -D warnings` clean. Docs-only commits for A2/C1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QWPmR3wFSs5LVFMFm59EZ