### PR TITLE
next: redact credentials from redis connection error context

### DIFF
--- a/next/crates/wingfoil-next/src/adapters/redis.rs
+++ b/next/crates/wingfoil-next/src/adapters/redis.rs
@@ -123,6 +123,41 @@ impl RedisConnection {
     pub fn new(url: impl Into<String>) -> Self {
         Self { url: url.into() }
     }
+
+    /// Render the URL with any `user:pass@` / `:pass@` userinfo masked, for safe
+    /// inclusion in error messages and logs.
+    ///
+    /// Redis URLs carry credentials in the authority's userinfo
+    /// (`redis://user:pass@host:6379/0`, `rediss://:pass@host`), so the whole
+    /// userinfo component is replaced with `***:***` while the scheme, host,
+    /// port, and path are preserved. A URL without userinfo is returned
+    /// unchanged. Used at every `Client::open` / connect error site so the raw
+    /// URL's password never reaches a log or an aborted-run error (parity with
+    /// the postgres adapter's `PostgresConnection::redacted`, classic PR #433).
+    #[must_use]
+    pub fn redacted(&self) -> String {
+        redact_redis_url(&self.url)
+    }
+}
+
+/// Mask any `user:pass@` / `:pass@` userinfo in a Redis URL, preserving the
+/// scheme, host, port, and path. See [`RedisConnection::redacted`].
+fn redact_redis_url(url: &str) -> String {
+    // Split `scheme://` from the authority (+ optional `/path`).
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return url.to_string();
+    };
+    // The authority ends at the first `/` (the db path) if present. The host
+    // never contains `@`, so the last `@` in the authority delimits userinfo
+    // (robust to an `@` inside the password).
+    let (authority, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, ""),
+    };
+    match authority.rsplit_once('@') {
+        Some((_userinfo, host_port)) => format!("{scheme}://***:***@{host_port}{path}"),
+        None => url.to_string(),
+    }
 }
 
 impl From<&str> for RedisConnection {
@@ -153,7 +188,7 @@ impl From<&String> for RedisConnection {
 async fn get_or_connect(
     client: &redis::Client,
     cell: &tokio::sync::Mutex<Option<redis::aio::MultiplexedConnection>>,
-    url: &str,
+    redacted_url: &str,
     who: &str,
 ) -> Result<redis::aio::MultiplexedConnection> {
     let mut guard = cell.lock().await;
@@ -163,7 +198,7 @@ async fn get_or_connect(
             let c = client
                 .get_multiplexed_async_connection()
                 .await
-                .with_context(|| format!("{who}: connecting to {url:?}"))?;
+                .with_context(|| format!("{who}: connecting to {redacted_url}"))?;
             *guard = Some(c.clone());
             Ok(c)
         }
@@ -308,11 +343,11 @@ pub fn redis_sub(
     let channel = channel.into();
     produce_async(g, move |_p: RunParams| async move {
         let client = redis::Client::open(conn.url.as_str())
-            .with_context(|| format!("redis_sub: opening client for {:?}", conn.url))?;
+            .with_context(|| format!("redis_sub: opening client for {}", conn.redacted()))?;
         let mut pubsub = client
             .get_async_pubsub()
             .await
-            .with_context(|| format!("redis_sub: connecting to {:?}", conn.url))?;
+            .with_context(|| format!("redis_sub: connecting to {}", conn.redacted()))?;
         pubsub
             .subscribe(channel.as_str())
             .await
@@ -373,12 +408,13 @@ pub fn redis_stream_read(
     let conn = conn.into();
     let key = key.into();
     produce_async(g, move |_p: RunParams| async move {
-        let client = redis::Client::open(conn.url.as_str())
-            .with_context(|| format!("redis_stream_read: opening client for {:?}", conn.url))?;
+        let client = redis::Client::open(conn.url.as_str()).with_context(|| {
+            format!("redis_stream_read: opening client for {}", conn.redacted())
+        })?;
         let mut connection = client
             .get_multiplexed_async_connection()
             .await
-            .with_context(|| format!("redis_stream_read: connecting to {:?}", conn.url))?;
+            .with_context(|| format!("redis_stream_read: connecting to {}", conn.redacted()))?;
 
         // 1. Snapshot all existing entries and capture the last ID.
         let snapshot: StreamRangeReply = connection
@@ -478,17 +514,18 @@ impl RedisSinkOps for Stream<Burst<RedisEntry>> {
         // stays at wiring. The socket opens lazily on the first write (below), so
         // wiring does no I/O and a connect failure aborts the run, not wiring.
         let client = redis::Client::open(conn.url.as_str())
-            .with_context(|| format!("redis_pub: opening client for {:?}", conn.url))?;
-        let url = conn.url.clone();
+            .with_context(|| format!("redis_pub: opening client for {}", conn.redacted()))?;
+        let redacted = conn.redacted();
         let conn_cell: Arc<tokio::sync::Mutex<Option<redis::aio::MultiplexedConnection>>> =
             Arc::new(tokio::sync::Mutex::new(None));
 
         let (sink, flush) = consume_async(&g, buffer_size, move |entry: RedisEntry| {
             let client = client.clone();
             let conn_cell = Arc::clone(&conn_cell);
-            let url = url.clone();
+            let redacted = redacted.clone();
             async move {
-                let mut connection = get_or_connect(&client, &conn_cell, &url, "redis_pub").await?;
+                let mut connection =
+                    get_or_connect(&client, &conn_cell, &redacted, "redis_pub").await?;
                 redis::cmd("PUBLISH")
                     .arg(entry.channel.as_str())
                     .arg(entry.payload.as_slice())
@@ -555,19 +592,20 @@ impl RedisStreamSinkOps for Stream<Burst<RedisStreamRecord>> {
         // `Client::open` only parses the URL (no socket) — a config error, so it
         // stays at wiring. The socket opens lazily on the first write (below), so
         // wiring does no I/O and a connect failure aborts the run, not wiring.
-        let client = redis::Client::open(conn.url.as_str())
-            .with_context(|| format!("redis_stream_write: opening client for {:?}", conn.url))?;
-        let url = conn.url.clone();
+        let client = redis::Client::open(conn.url.as_str()).with_context(|| {
+            format!("redis_stream_write: opening client for {}", conn.redacted())
+        })?;
+        let redacted = conn.redacted();
         let conn_cell: Arc<tokio::sync::Mutex<Option<redis::aio::MultiplexedConnection>>> =
             Arc::new(tokio::sync::Mutex::new(None));
 
         let (sink, flush) = consume_async(&g, buffer_size, move |record: RedisStreamRecord| {
             let client = client.clone();
             let conn_cell = Arc::clone(&conn_cell);
-            let url = url.clone();
+            let redacted = redacted.clone();
             async move {
                 let mut connection =
-                    get_or_connect(&client, &conn_cell, &url, "redis_stream_write").await?;
+                    get_or_connect(&client, &conn_cell, &redacted, "redis_stream_write").await?;
                 let mut cmd = redis::cmd("XADD");
                 cmd.arg(record.key.as_str()).arg("*");
                 for (field, value) in &record.fields {
@@ -641,5 +679,36 @@ mod tests {
             RedisConnection::from("redis://h:6379".to_string()).url,
             "redis://h:6379"
         );
+    }
+
+    #[test]
+    fn test_redacted_masks_user_and_password() {
+        let conn = RedisConnection::new("redis://user:sup3rs3cr3t@127.0.0.1:6379/0");
+        let out = conn.redacted();
+        assert!(!out.contains("sup3rs3cr3t"), "password leaked: {out}");
+        assert_eq!(out, "redis://***:***@127.0.0.1:6379/0");
+    }
+
+    #[test]
+    fn test_redacted_masks_password_only_userinfo() {
+        // `redis://:pass@host` — no username, just a password.
+        let conn = RedisConnection::new("redis://:hunter2@host:6379");
+        let out = conn.redacted();
+        assert!(!out.contains("hunter2"), "password leaked: {out}");
+        assert_eq!(out, "redis://***:***@host:6379");
+    }
+
+    #[test]
+    fn test_redacted_masks_rediss_scheme() {
+        let conn = RedisConnection::new("rediss://user:s3cr3t@host:6380/1");
+        let out = conn.redacted();
+        assert!(!out.contains("s3cr3t"), "password leaked: {out}");
+        assert_eq!(out, "rediss://***:***@host:6380/1");
+    }
+
+    #[test]
+    fn test_redacted_noop_without_userinfo() {
+        let conn = RedisConnection::new("redis://127.0.0.1:6379/0");
+        assert_eq!(conn.redacted(), "redis://127.0.0.1:6379/0");
     }
 }

--- a/next/crates/wingfoil-next/tests/redis_adapter.rs
+++ b/next/crates/wingfoil-next/tests/redis_adapter.rs
@@ -132,6 +132,35 @@ fn pub_connection_refused_surfaces_an_error() {
     );
 }
 
+/// A connection URL can embed a password (`redis://user:pass@host`). When the
+/// deferred connect fails at run time, the error context must **redact** that
+/// password — it must never reach a log or the aborted-run error (parity with
+/// the postgres adapter; a leak regression versus classic that this restores).
+#[test]
+fn pub_connection_refused_redacts_password() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let source = g.constant(burst![RedisEntry {
+        channel: "ch".to_string(),
+        payload: b"v".to_vec(),
+    }]);
+    let conn = RedisConnection::new("redis://user:sup3rs3cr3t@127.0.0.1:59999/0");
+
+    let _sink = source
+        .redis_pub(conn, None)
+        .expect("wiring must succeed (connect is deferred to the run)");
+    let err = g
+        .build()
+        .run(RunMode::RealTime, RunFor::Cycles(1))
+        .expect_err("an unreachable Redis endpoint must abort the run");
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("sup3rs3cr3t"),
+        "password leaked in error: {msg}"
+    );
+    assert!(msg.contains("***:***"), "userinfo not redacted: {msg}");
+}
+
 /// The stream sink connects lazily the same way.
 #[test]
 fn stream_write_connection_refused_surfaces_an_error() {


### PR DESCRIPTION
## What

The `redis` next adapter interpolated the raw connection URL into error context at every `Client::open`/connect site. A Redis URL can embed credentials (`redis://user:pass@host`), so the password leaked into logs and the run-abort error.

This adds `RedisConnection::redacted()` (mirroring `PostgresConnection::redacted()`), which masks any `user:pass@` / `:pass@` userinfo as `***:***` while preserving scheme/host/port/path (and handles `rediss://`), and routes **every** error-path interpolation through it. The stored URL and the actual `Client::open` connect call are untouched — only the error-display path changes.

## Why

This is a **regression versus classic wingfoil**, which never interpolated the URL into its error text, and a violation of the adapter security invariant in `/new-adapter-next` that names redis explicitly ("Never leak credentials into error context … reproduce it for any networked adapter with credentials: redis, kafka, …"). postgres reproduced the redaction fix in the same phase; redis did not. Surfaced by the `/review-adapters-next` audit as the one real code/security finding.

## Changes

- `adapters/redis.rs`: `RedisConnection::redacted()` + `redact_redis_url()` helper; all connect error sites in `get_or_connect`, `redis_sub`, `redis_stream_read`, `redis_pub`, `redis_stream_write` now emit `conn.redacted()` instead of the raw URL. Four unit tests for the masking (user+pass, password-only userinfo, `rediss://`, no-userinfo passthrough).
- `tests/redis_adapter.rs`: no-service test `pub_connection_refused_redacts_password` asserts the aborted-run error contains `***:***` and not the secret.

## Verification

- `cargo fmt --all` ✓
- `cargo clippy -p wingfoil-next --all-features --all-targets -- -D warnings` ✓ (scoped clippy substituted for `cargo lint-all` because the sandbox can't build aeron's C lib; the full workspace lint runs in CI)
- `cargo test -p wingfoil-next --features redis` ✓ (redis_adapter 7 passed, lib `adapters::redis` 8 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgNR15yBH6V5gbnWenHmEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgNR15yBH6V5gbnWenHmEA)_