### PR TITLE
next: close two csv/zmq adapter parity gaps

### DIFF
--- a/next/crates/wingfoil-next/src/adapters/csv.rs
+++ b/next/crates/wingfoil-next/src/adapters/csv.rs
@@ -36,13 +36,27 @@
 //! into one burst (use `.collapse_accumulate()` when the source is strictly
 //! ascending and you want a flat `Vec<T>`).
 //!
-//! Two consequences of using the channel source (deviations from classic):
-//! record timestamps must be **non-decreasing**
-//! (the historical receiver rejects out-of-order sends), and a row that fails
-//! to deserialize is propagated as a [`Message::Error`](crate::channel::Message)
-//! so it still aborts the run — the same observable outcome as classic (the run
-//! fails with a "failed to deserialize row" context), just surfaced at the
-//! start of the replay rather than mid-stream.
+//! # Deviations from classic
+//!
+//! - **Whole-file read / non-decreasing timestamps.** The channel source reads
+//!   and deserializes the whole file up front and queues each record via
+//!   `send_at`, so record timestamps must be **non-decreasing** (the historical
+//!   receiver rejects out-of-order sends). Classic's `TryIteratorStream` pulls
+//!   rows lazily per tick and imposes no such ordering constraint at the source.
+//! - **Malformed-row timing.** A row that fails to deserialize is propagated as
+//!   a [`Message::Error`](crate::channel::Message) so it still aborts the run —
+//!   the same observable outcome as classic (the run fails with a "failed to
+//!   deserialize row" context), just surfaced at the start of the replay rather
+//!   than mid-stream.
+//! - **Eager header write.** [`csv_write`](CsvSinkOps::csv_write) opens the file
+//!   and writes the CSV header at wiring time (before `for_each_mut`), whereas
+//!   classic defers the header to the first tick via a `headers_written` flag in
+//!   `CsvWriterNode` (see `wingfoil/src/adapters/csv/write.rs`). Observable
+//!   difference for a named-struct record: a graph that wires `csv_write` but
+//!   produces zero rows leaves a header-only file in next, but an empty file in
+//!   classic (whose `cycle` never runs, so the header is never written). For a
+//!   positional-tuple record no header is written in either, so there is no
+//!   difference.
 //!
 //! # Sink
 //!

--- a/next/crates/wingfoil-next/tests/csv_adapter.rs
+++ b/next/crates/wingfoil-next/tests/csv_adapter.rs
@@ -8,6 +8,7 @@
 #![cfg(feature = "csv")]
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use wingfoil::{NanoTime, RunFor, RunMode};
 use wingfoil_next::adapters::csv::{CsvSinkOps, csv_read};
@@ -20,10 +21,15 @@ fn get_time(r: &Record) -> NanoTime {
     r.0
 }
 
-/// Stage a CSV fixture in a uniquely-named temp file (unique per test so
-/// parallel runs don't collide).
+/// Stage a CSV fixture in a uniquely-named temp file. Uniqueness keys on the
+/// pid *and* a process-wide `AtomicU64` counter (mirroring `tests/lines_adapter.rs`)
+/// as well as the call-site `name`, so parallel runs — and any future test that
+/// reuses a `name` — never collide.
 fn write_tmp(name: &str, contents: &str) -> PathBuf {
-    let path = std::env::temp_dir().join(format!("wf_next_csv_{}_{name}", std::process::id()));
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path =
+        std::env::temp_dir().join(format!("wf_next_csv_{}_{}_{name}", std::process::id(), n));
     std::fs::write(&path, contents).expect("write temp fixture");
     path
 }

--- a/next/crates/wingfoil-next/tests/zmq_integration.rs
+++ b/next/crates/wingfoil-next/tests/zmq_integration.rs
@@ -138,6 +138,44 @@ fn first_message_not_dropped() {
 }
 
 #[test]
+fn first_message_not_dropped_no_delay() {
+    // Faithful port of classic's `zmq_first_message_not_dropped_no_delay` — the
+    // sibling of `first_message_not_dropped` with NO artificial startup delay on
+    // the publisher. Publisher and subscriber share ONE graph (so they start
+    // together) and the publisher begins ticking immediately, isolating the
+    // publisher's buffer-until-accept slow-joiner path: it buffers outgoing
+    // messages until the first subscriber connects (up to `BUFFER_TIMEOUT`, plus
+    // the post-accept subscription-propagation window), so counter value 1 must
+    // never be lost even without a settle delay to have the subscription live
+    // before the first message. Run generously (2 s) as CI-load headroom for
+    // next's `channel`-based subscriber to connect within the buffering window.
+    let port = 5716;
+    let address = format!("tcp://127.0.0.1:{port}");
+    let period = Duration::from_millis(50);
+
+    let g = GraphBuilder::new();
+    let _sink = g
+        .ticker(period)
+        .count()
+        .map(|n: &u64| format!("{n}").into_bytes())
+        .zmq_pub(port, ());
+    let (data, _status) = zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, &address).unwrap();
+    let received = data.collapse_accumulate();
+
+    let mut runner = g.build();
+    runner
+        .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))
+        .unwrap();
+    let values: Vec<u64> = runner
+        .value(&received)
+        .into_iter()
+        .map(|b| String::from_utf8(b).expect("utf8").parse().expect("u64"))
+        .collect();
+    assert!(!values.is_empty(), "no values received");
+    assert_eq!(values[0], 1, "first message dropped: got {values:?}");
+}
+
+#[test]
 fn reports_connected_status() {
     // The subscriber's socket monitor surfaces a `Connected` transition on the
     // status stream — parity of classic `zmq_reports_connected_status`.


### PR DESCRIPTION
## What

Two small parity/doc gaps in the wingfoil-next adapters, surfaced by the `/review-adapters-next` audit.

**csv**
- Moved the module-doc deviations under the literal `//! # Deviations from classic` heading. They previously lived under a prose heading ("consequences of using the channel source"), so the deviation-register's regeneration grep (`git grep "Deviations from classic"`) silently missed csv — a doc-drift trap.
- Documented a real (previously undocumented) behavioural deviation: next writes the CSV header eagerly at wiring, whereas classic defers it to the first tick via a `headers_written` flag — so a graph that wires `csv_write` but emits zero rows leaves a header-only file in next vs an empty file in classic. Behaviour unchanged; only documented.
- Test hygiene: `write_tmp` now keys uniqueness on pid + an `AtomicU64` counter (mirroring `tests/lines_adapter.rs`) so a future test reusing a name can't collide under parallel runs.

**zmq**
- Ported classic's `zmq_first_message_not_dropped_no_delay` — the no-startup-delay sibling of the already-ported `first_message_not_dropped` — which isolates the publisher's buffer-until-accept slow-joiner path.

## Why

Both were "port every classic test / document every deviation" gaps against the parity obligation. The csv heading fix also protects the register's regeneration from silently dropping csv.

## Verification

- `cargo fmt --all` ✓
- `cargo clippy -p wingfoil-next --all-features --all-targets -- -D warnings` ✓ (scoped clippy substituted for `cargo lint-all`; aeron's C lib can't build in the sandbox, full lint runs in CI)
- `cargo test -p wingfoil-next --features csv` ✓ (csv_adapter 7/7)
- `cargo test -p wingfoil-next --features zmq-integration-test -- --test-threads=1` ✓ (all 6 zmq_integration tests incl. the new one — the sandbox has libzmq + working sockets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgNR15yBH6V5gbnWenHmEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgNR15yBH6V5gbnWenHmEA)_