### PR TITLE
feat: add drop_small_change operator

### DIFF
--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -8,6 +8,7 @@ use ::wingfoil::{Element, IntoStream, NodeOperators, Stream, StreamOperators};
 use pyo3::conversion::IntoPyObject;
 use pyo3::prelude::*;
 
+use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::proxy_stream::*;
@@ -273,6 +274,39 @@ impl PyStream {
     /// only propagates its source if it changed (uses PartialEq on PyElement)
     fn distinct(&self) -> PyStream {
         PyStream(self.0.distinct())
+    }
+
+    /// Only propagates ticks where is_small(current, previous) returns False.
+    /// The first tick always propagates.
+    fn drop_small_change(&self, is_small: Py<PyAny>) -> PyStream {
+        let last_emitted = Rc::new(RefCell::new(None::<PyElement>));
+        let evaluated = self.0.try_map({
+            let last_emitted = Rc::clone(&last_emitted);
+            move |current: PyElement| {
+                let previous = last_emitted.borrow().clone();
+                let should_suppress = match previous {
+                    None => false,
+                    Some(previous) => Python::attach(|py| {
+                        let result = is_small
+                            .call1(py, (current.value(), previous.value()))
+                            .map_err(py_callback_error)?;
+                        result.extract::<bool>(py).map_err(|e| {
+                            py_callback_error(e)
+                                .context("drop_small_change predicate must return a bool")
+                        })
+                    })?,
+                };
+
+                if should_suppress {
+                    Ok(None)
+                } else {
+                    *last_emitted.borrow_mut() = Some(current.clone());
+                    Ok(Some(current))
+                }
+            }
+        });
+
+        PyStream(evaluated.filter_map(|value| value))
     }
 
     /// drops source contingent on supplied predicate (Python callable)

--- a/wingfoil-python/tests/test_streams.py
+++ b/wingfoil-python/tests/test_streams.py
@@ -36,6 +36,29 @@ class TestBasicOperators(unittest.TestCase):
         stream.run(realtime=False, cycles=5)
         self.assertEqual(stream.peek_value(), [0, 1, 2])
 
+    def test_drop_small_change(self):
+        predicate_calls = []
+        prices = [100.000, 100.005, 100.020, 100.025]
+
+        def is_small(current, previous):
+            predicate_calls.append((current, previous))
+            return abs(current - previous) < 0.01
+
+        stream = (
+            ticker(0.1)
+                .count()
+                .map(lambda count: prices[count - 1])
+                .drop_small_change(is_small)
+                .collect()
+        )
+        stream.run(realtime=False, cycles=4)
+
+        self.assertEqual(stream.peek_value(), [100.000, 100.020])
+        self.assertEqual(
+            predicate_calls,
+            [(100.005, 100.000), (100.020, 100.000), (100.025, 100.020)],
+        )
+
     def test_inspect(self):
         inspected_values = []
         stream = (
@@ -316,6 +339,24 @@ class TestCallbackExceptionPropagation(unittest.TestCase):
         stream = ticker(0.1).count().filter(lambda x: "not a bool").collect()
         with self.assertRaises(Exception):
             stream.run(realtime=False, cycles=1)
+
+    def test_drop_small_change_callback_exception_propagates(self):
+        def explode(_current, _previous):
+            raise ValueError("drop_small_change predicate blew up")
+
+        stream = ticker(0.1).count().drop_small_change(explode).collect()
+        with self.assertRaises(ValueError):
+            stream.run(realtime=False, cycles=2)
+
+    def test_drop_small_change_non_bool_return_raises(self):
+        stream = (
+            ticker(0.1)
+                .count()
+                .drop_small_change(lambda _current, _previous: "not a bool")
+                .collect()
+        )
+        with self.assertRaises(Exception):
+            stream.run(realtime=False, cycles=2)
 
     def test_for_each_callback_exception_propagates(self):
         def explode(_value, _t):

--- a/wingfoil/src/nodes/drop_small_change.rs
+++ b/wingfoil/src/nodes/drop_small_change.rs
@@ -1,0 +1,91 @@
+use crate::types::*;
+use derive_new::new;
+use std::rc::Rc;
+
+/// Suppresses source ticks while the change from the last emitted value is
+/// considered small. Used by
+/// [`drop_small_change`](crate::nodes::StreamOperators::drop_small_change).
+#[derive(new)]
+pub(crate) struct DropSmallChangeStream<T: Element> {
+    source: Rc<dyn Stream<T>>,
+    is_small: Box<dyn Fn(&T, &T) -> bool>,
+    #[new(default)]
+    value: T,
+    #[new(default)]
+    last_emitted: Option<T>,
+}
+
+#[node(active = [source], output = value: T)]
+impl<T: Element> MutableNode for DropSmallChangeStream<T> {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        let current = self.source.peek_value();
+        let should_emit = match &self.last_emitted {
+            None => true,
+            Some(previous) => !(self.is_small)(&current, previous),
+        };
+
+        if should_emit {
+            self.last_emitted = Some(current.clone());
+            self.value = current;
+        }
+
+        Ok(should_emit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::graph::*;
+    use crate::nodes::*;
+
+    #[test]
+    fn first_tick_always_propagates() {
+        let collected = ticker(Duration::from_nanos(100))
+            .count()
+            .drop_small_change(|_, _| true)
+            .collect();
+
+        collected
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+            .unwrap();
+
+        let values: Vec<u64> = collected.peek_value().iter().map(|v| v.value).collect();
+        assert_eq!(values, vec![1]);
+    }
+
+    #[test]
+    fn compares_f64_changes_to_last_emitted_value() {
+        let collected = ticker(Duration::from_nanos(100))
+            .count()
+            .map(|count| match count {
+                1 => 100.000_f64,
+                2 => 100.005,
+                3 => 100.020,
+                _ => 100.025,
+            })
+            .drop_small_change(|current, previous| (current - previous).abs() < 0.01)
+            .collect();
+
+        collected
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(4))
+            .unwrap();
+
+        let values: Vec<f64> = collected.peek_value().iter().map(|v| v.value).collect();
+        assert_eq!(values, vec![100.000, 100.020]);
+    }
+
+    #[test]
+    fn propagates_every_tick_when_predicate_returns_false() {
+        let collected = ticker(Duration::from_nanos(100))
+            .count()
+            .drop_small_change(|_, _| false)
+            .collect();
+
+        collected
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(4))
+            .unwrap();
+
+        let values: Vec<u64> = collected.peek_value().iter().map(|v| v.value).collect();
+        assert_eq!(values, vec![1, 2, 3, 4]);
+    }
+}

--- a/wingfoil/src/nodes/mod.rs
+++ b/wingfoil/src/nodes/mod.rs
@@ -17,6 +17,7 @@ mod delay_with_reset;
 mod demux;
 mod difference;
 mod distinct;
+mod drop_small_change;
 #[cfg(feature = "dynamic-graph")]
 pub mod dynamic_group;
 mod feedback;
@@ -75,6 +76,7 @@ use delay::*;
 use delay_with_reset::*;
 use difference::*;
 use distinct::*;
+use drop_small_change::*;
 use filter::*;
 use finally::*;
 use fold::*;
@@ -475,6 +477,29 @@ pub trait StreamOperators<T: Element> {
     fn distinct(self: &Rc<Self>) -> Rc<dyn Stream<T>>
     where
         T: PartialEq;
+    /// Only propagates source ticks when the change from the last emitted
+    /// value is considered significant.
+    ///
+    /// `is_small(current, previous)` should return `true` to suppress the
+    /// current tick. The first upstream tick always propagates.
+    ///
+    /// # Example
+    /// ```
+    /// use std::time::Duration;
+    /// use wingfoil::{NodeOperators, StreamOperators, ticker};
+    ///
+    /// let prices = ticker(Duration::from_millis(1))
+    ///     .count()
+    ///     .map(|value| value as f64);
+    /// let significant = prices.drop_small_change(|current, previous| {
+    ///     (current - previous).abs() < 0.01
+    /// });
+    /// ```
+    #[must_use]
+    fn drop_small_change(
+        self: &Rc<Self>,
+        is_small: impl Fn(&T, &T) -> bool + 'static,
+    ) -> Rc<dyn Stream<T>>;
     /// drops source contingent on supplied stream
     #[must_use]
     fn filter(self: &Rc<Self>, condition: Rc<dyn Stream<bool>>) -> Rc<dyn Stream<T>>;
@@ -704,6 +729,13 @@ where
         T: PartialEq,
     {
         DistinctStream::new(self.clone()).into_stream()
+    }
+
+    fn drop_small_change(
+        self: &Rc<Self>,
+        is_small: impl Fn(&T, &T) -> bool + 'static,
+    ) -> Rc<dyn Stream<T>> {
+        DropSmallChangeStream::new(self.clone(), Box::new(is_small)).into_stream()
     }
 
     fn filter(self: &Rc<Self>, condition: Rc<dyn Stream<bool>>) -> Rc<dyn Stream<T>> {


### PR DESCRIPTION
## Summary

- Add `StreamOperators::drop_small_change` for suppressing changes considered insignificant by a caller-provided predicate.
- Compare each current value against the last emitted value, rather than the last observed value.
- Always propagate the first upstream tick.
- Expose the operator through the Python bindings with Python exception propagation.
- Add Rust and Python tests covering threshold behavior, callback arguments, and error handling.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p wingfoil --lib -- -D warnings`
- `cargo test -p wingfoil drop_small_change`
- `cargo test -p wingfoil --doc`

Closes #126