### PR TITLE
fix: patch seroval and postcss advisories in wingfoil-js audit

### DIFF
--- a/wingfoil-js/package.json
+++ b/wingfoil-js/package.json
@@ -76,7 +76,9 @@
       "svelte": ">=5.55.7",
       "devalue": ">=5.8.1",
       "esbuild": ">=0.25.0",
-      "@babel/core": ">=7.29.6"
+      "@babel/core": ">=7.29.6",
+      "seroval": ">=1.5.3",
+      "postcss": ">=8.5.18"
     }
   }
 }

--- a/wingfoil-js/pnpm-lock.yaml
+++ b/wingfoil-js/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   devalue: '>=5.8.1'
   esbuild: '>=0.25.0'
   '@babel/core': '>=7.29.6'
+  seroval: '>=1.5.3'
+  postcss: '>=8.5.18'
 
 importers:
 
@@ -760,8 +762,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -789,8 +791,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   rollup@4.60.2:
@@ -807,10 +809,10 @@ packages:
     resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
     engines: {node: '>=10'}
     peerDependencies:
-      seroval: ^1.0
+      seroval: '>=1.5.3'
 
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   siginfo@2.0.0:
@@ -1412,7 +1414,7 @@ snapshots:
       '@vue/shared': 3.5.33
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.10
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.33':
@@ -1606,7 +1608,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   node-releases@2.0.38: {}
 
@@ -1624,9 +1626,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.10:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1663,19 +1665,19 @@ snapshots:
 
   semver@7.8.5: {}
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
+  seroval-plugins@1.5.2(seroval@1.5.6):
     dependencies:
-      seroval: 1.5.2
+      seroval: 1.5.6
 
-  seroval@1.5.2: {}
+  seroval@1.5.6: {}
 
   siginfo@2.0.0: {}
 
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.6
+      seroval-plugins: 1.5.2(seroval@1.5.6)
 
   solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:
@@ -1781,7 +1783,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.23
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Summary

The `pnpm audit` CI job (`security-audit.yml`, `--audit-level moderate`) was failing on `main` due to three transitive **dev-dependency** advisories in `wingfoil-js`:

- `seroval <=1.5.2` — critical, [GHSA-mv8w-475r-vwqw](https://github.com/advisories/GHSA-mv8w-475r-vwqw), via `solid-js`
- `postcss <=8.5.11` — high, [GHSA-6g55-p6wh-862q](https://github.com/advisories/GHSA-6g55-p6wh-862q), via `vite`
- `postcss <=8.5.17` — high, [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849), via `vite`

Fix: pin patched versions through the existing `pnpm.overrides` block (same pattern already used for `svelte`/`devalue`/`esbuild`/`@babel/core`) and regenerate the lockfile.

- `seroval` → `>=1.5.3` (resolves to `1.5.6`)
- `postcss` → `>=8.5.18` (resolves to `8.5.23`)

Only `wingfoil-js/package.json` and `wingfoil-js/pnpm-lock.yaml` change; no source or public API is touched.

## Testing

- `pnpm audit --audit-level moderate` → **no known vulnerabilities found**
- `pnpm install --frozen-lockfile` succeeds (the command CI runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJRreDC7VKzA3fKgY5RNEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJRreDC7VKzA3fKgY5RNEZ)_