### PR TITLE
Fix the flaky kafka consume helper (0-of-2 records read back)

### DIFF
--- a/next/crates/wingfoil-next/tests/kafka_integration.rs
+++ b/next/crates/wingfoil-next/tests/kafka_integration.rs
@@ -134,7 +134,7 @@ fn consume_messages(
             .map_err(|e| anyhow::anyhow!("subscribe failed: {e}"))?;
 
         let mut results = Vec::new();
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
         loop {
             if results.len() >= max || tokio::time::Instant::now() >= deadline {
                 break;
@@ -147,7 +147,16 @@ fn consume_messages(
                     ));
                 }
                 Ok(Err(e)) => return Err(anyhow::anyhow!("consume error: {e}")),
-                Err(_) => break, // timeout
+                // A `recv()` timeout is NOT end-of-topic — it is the normal
+                // shape of a fresh consumer group's first poll, which has to
+                // find the group coordinator, join, and take its partition
+                // assignment before any fetch can return. On a loaded CI runner
+                // that routinely exceeds one 2 s slice. Keep polling until the
+                // overall deadline instead of giving up on the first slow slice;
+                // returning early here reports an empty topic when the records
+                // are in fact present, which is what made
+                // `test_pub_multiple_records_in_burst` flaky.
+                Err(_) => continue,
             }
         }
         Ok(results)
@@ -309,8 +318,17 @@ fn test_pub_multiple_records_in_burst() -> anyhow::Result<()> {
     }
 
     let messages = consume_messages(&brokers, topic, "multi-verify-group", 2)?;
-    assert_eq!(messages.len(), 2);
     let values: Vec<Vec<u8>> = messages.iter().map(|(_, v)| v.clone()).collect();
+    // Report what actually arrived: 0 of 2 points at the consumer side (no
+    // assignment within the deadline), whereas 1 of 2 would point at the
+    // producer dropping part of the burst — very different bugs.
+    assert_eq!(
+        messages.len(),
+        2,
+        "expected both burst records, got {}: {:?}",
+        messages.len(),
+        values
+    );
     assert!(values.contains(&b"v1".to_vec()));
     assert!(values.contains(&b"v2".to_vec()));
     Ok(())

--- a/wingfoil/src/adapters/kafka/integration_tests.rs
+++ b/wingfoil/src/adapters/kafka/integration_tests.rs
@@ -131,7 +131,7 @@ fn consume_messages(
             .map_err(|e| anyhow::anyhow!("subscribe failed: {e}"))?;
 
         let mut results = Vec::new();
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
         loop {
             if results.len() >= max || tokio::time::Instant::now() >= deadline {
                 break;
@@ -144,7 +144,15 @@ fn consume_messages(
                     ));
                 }
                 Ok(Err(e)) => return Err(anyhow::anyhow!("consume error: {e}")),
-                Err(_) => break, // timeout
+                // A `recv()` timeout is NOT end-of-topic — it is the normal
+                // shape of a fresh consumer group's first poll, which has to
+                // find the group coordinator, join, and take its partition
+                // assignment before any fetch can return. On a loaded CI runner
+                // that routinely exceeds one 2 s slice. Keep polling until the
+                // overall deadline instead of giving up on the first slow slice;
+                // returning early here reports an empty topic when the records
+                // are in fact present. Kept in step with the wingfoil-next twin.
+                Err(_) => continue,
             }
         }
         Ok(results)


### PR DESCRIPTION
`test_pub_multiple_records_in_burst` has been failing in CI reading back 0 of 2 records, which reddens **Build, Test, & Lint** on `next` and therefore on every PR opened against it (it was the sole remaining failure on #598 when that merged).

```
---- test_pub_multiple_records_in_burst stdout ----
panicked at next/crates/wingfoil-next/tests/kafka_integration.rs:312:5:
assertion `left == right` failed
  left: 0
 right: 2
```

## Diagnosis

The records were produced correctly — the bug is in the test helper, not the adapter.

`kafka_pub` builds every record's delivery future and drives them all to completion through `FuturesUnordered`, propagating the first error; the `flush` teardown (wired via `finally`) then closes the sink and joins the consumer task, surfacing the final burst's error as the run's `Err`. The test's `run(...)` returned `Ok`, so the broker had acknowledged both records before the assertion ran.

The fault is in `consume_messages`:

```rust
match tokio::time::timeout(Duration::from_secs(2), consumer.recv()).await {
    …
    Err(_) => break, // timeout   ← treats a slow poll as end-of-topic
}
```

A `recv()` timeout there is *not* end-of-topic. It is the ordinary shape of a fresh consumer group's **first** poll, which has to locate the group coordinator, join the group, and take its partition assignment before any fetch can return. On a loaded CI runner that routinely exceeds a single 2 s slice — so the helper abandoned the loop and returned an empty vec while both records sat in the topic.

That also explains the *shape* of the failure. Getting **0** of 2 rather than **1** of 2 is the signature of a consumer that never received its assignment; a producer dropping part of a burst would have left one record behind.

## Fix

- Keep polling until the overall deadline rather than bailing on the first slow slice (`Err(_) => continue`), and raise that deadline from 10 s to 20 s for headroom.
- Report the arrival count in the multi-record assertion. `0 of 2` and `1 of 2` indicate completely different bugs, and the bare `assert_eq!` distinguished neither — this is why the original failure gave nothing to work with.

Both sibling tests were equally exposed; `test_pub_round_trip` merely won the race. So this clears a latent flake across every caller of the helper, not only the test that happened to fail.

## Both trees

Classic's `wingfoil/src/adapters/kafka/integration_tests.rs::consume_messages` is byte-identical and carries the same bug, so it takes the same fix — keeping the two trees in step per the port's parity objective. The classic side is a test-harness change only; no adapter code is touched in either tree.

## Checks

`cargo fmt --all -- --check` and `cargo lint-all` pass. Both gated test targets compile (`-p wingfoil-next --features kafka-integration-test --test kafka_integration`, and classic's `-p wingfoil --features kafka-integration-test`).

**Not verified locally:** Docker is unavailable in this sandbox, so I could not run the container-backed suite or reproduce the original failure — the diagnosis is from reading the helper against the adapter's delivery path and the failure's 0-of-2 shape. CI is the real check here. If the test still fails after this, the improved assertion message will say whether it is 0 or 1 of 2, which distinguishes a remaining consumer-side problem from a producer-side one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKhf2tiM8nwtSBzC1St3ga

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKhf2tiM8nwtSBzC1St3ga)_