### PR TITLE
Port the postgres adapter's Python bindings to wingfoil-next

### DIFF
--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -859,12 +859,19 @@ the legacy `wingfoil-python`; see `next/docs/python-interop.md`). A next adapter
 reaches Python through the `#[pyadapter]` proc macro — values erase to
 `PyElement` at the boundary, the adapter's interior stays natively typed:
 
+Write the binding as **free functions**, receiver first — not as a trait. The
+`impl Trait for GraphBuilder` form also works, but its trait exists only to give
+the macro a receiver and costs a throwaway trait plus a second copy of every
+signature; a binding never calls itself fluently from Rust. `name` must differ
+from the fn's own name (the macro emits a `#[pyfunction]` of that name beside
+it), which is why the fns below are short — the module is already `$ARGUMENTS`.
+
 - **Source** — `#[pyadapter(name = $ARGUMENTS_read, source)]` on
-  `impl <Name>SourceOps for GraphBuilder { fn $ARGUMENTS_read(&self, args…) ->
-  Stream<T> }` emits `wingfoil_next.$ARGUMENTS_read(graph, args…) -> Stream`.
+  `fn read(g: &GraphBuilder, args…) -> Result<Stream<T>>` emits
+  `wingfoil_next.$ARGUMENTS_read(graph, args…) -> Stream`.
 - **Sink** — `#[pyadapter(name = $ARGUMENTS_write)]` (no `source` marker) on
-  `impl <Name>SinkOps for Stream<T> { fn $ARGUMENTS_write(&self, args…) ->
-  Stream<()> }` emits `wingfoil_next.$ARGUMENTS_write(stream, args…)`.
+  `fn write(stream: &Stream<T>, args…) -> Result<Stream<()>>` emits
+  `wingfoil_next.$ARGUMENTS_write(stream, args…)`.
 
 The `ramp_source` (source) and `list_sink` (sink) demos in `src/python.rs` are
 the minimal templates, and `tests/plugin_seam.rs` shows the same from an
@@ -885,12 +892,18 @@ system library at build time must stay opt-in or it breaks the wheel for
 everyone.
 
 **Fallible wiring.** Real adapters validate at wiring (run window, run mode,
-config), so the method returns `Result<Stream<T>>`; `#[pyadapter]` then generates
-a `PyResult`-returning function and the error surfaces as a Python exception.
+config), so the fn returns `Result<Stream<T>>`; `#[pyadapter]` then generates a
+`PyResult`-returning function and the error surfaces as a Python exception.
 
-**Optional arguments.** Put `#[pyo3(signature = (…))]` on the adapter method
-over *your own* params — the macro forwards it and injects the generated
+**Optional arguments.** Put `#[pyo3(signature = (…))]` on the adapter fn over
+*your own* params — the macro forwards it and injects the generated
 `graph`/`stream` receiver.
+
+**Shared run-shape helpers.** `crate::adapters::common` already carries what
+every mode-aware source binding needs: `historical_params(start_nanos,
+duration_nanos)`, `realtime_params()`, `run_mode(realtime)` and
+`secs_to_nanotime(secs)`. Use them rather than rebuilding `RunParams` inline; add
+to that module when you find the next repeated conversion.
 
 **Dynamic payloads.** Where a Rust caller writes a record struct, Python has
 none — supply a dynamic stand-in. Reads decode into a plain-Rust intermediate

--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -866,10 +866,58 @@ reaches Python through the `#[pyadapter]` proc macro — values erase to
   `impl <Name>SinkOps for Stream<T> { fn $ARGUMENTS_write(&self, args…) ->
   Stream<()> }` emits `wingfoil_next.$ARGUMENTS_write(stream, args…)`.
 
-Register the generated `#[pyfunction]` in the `wingfoil_next` `#[pymodule]` and
-add a pytest case in `crates/wingfoil-next-python/tests/test_interop.py`; the
-`ramp_source` (source) and `list_sink` (sink) demos in `src/python.rs` are the
-templates, and `tests/plugin_seam.rs` shows the same from an external crate.
+The `ramp_source` (source) and `list_sink` (sink) demos in `src/python.rs` are
+the minimal templates, and `tests/plugin_seam.rs` shows the same from an
+external crate. **For a real, service-backed adapter, copy
+`crates/wingfoil-next-python/src/adapters/postgres.rs`** — the first one bound,
+and the template for everything below.
+
+**Where it goes, and how it is gated.** A real adapter binding lives in its own
+module, `crates/wingfoil-next-python/src/adapters/<name>.rs`, behind a
+`wingfoil-next-python` cargo feature of the same name that turns on the matching
+engine feature (`<name> = ["wingfoil-next/<name>", …]`) and is added to the
+`all-adapters` roll-up. Register the generated `#[pyfunction]`s in
+`python.rs`'s `register_adapters` under the same `#[cfg]`, importing them **by
+name** (`wrap_pyfunction!` needs pyo3's hidden wrapper in scope, so a
+module-qualified path does not resolve). List the feature in `pyproject.toml`'s
+`[tool.maturin] features` only if the adapter is pure Rust — one needing a
+system library at build time must stay opt-in or it breaks the wheel for
+everyone.
+
+**Fallible wiring.** Real adapters validate at wiring (run window, run mode,
+config), so the method returns `Result<Stream<T>>`; `#[pyadapter]` then generates
+a `PyResult`-returning function and the error surfaces as a Python exception.
+
+**Optional arguments.** Put `#[pyo3(signature = (…))]` on the adapter method
+over *your own* params — the macro forwards it and injects the generated
+`graph`/`stream` receiver.
+
+**Dynamic payloads.** Where a Rust caller writes a record struct, Python has
+none — supply a dynamic stand-in. Reads decode into a plain-Rust intermediate
+(no `Py<PyAny>` inside, so it can cross to the adapter's worker thread) that
+implements `From<T> for PyElement`. Writes usually need a runtime `columns`-style
+argument to interpret the Python value, which is not in scope at the
+`typed_burst_input` seam — so keep the sink's input erased
+(`impl … for Stream<Burst<PyElement>>`, using the identity
+`PyElement: TryFrom<&PyElement>`) and marshal inside the method with a
+`try_map`. Marshaling must fail **loudly**: a missing key or wrong-typed value
+aborts the run rather than writing a silent `NULL`.
+
+**Tests, in the same PR**, split like the adapter's Rust tests:
+- Rust `#[cfg(test)]` marshaling tests in the binding module (row → `dict`,
+  `dict` → typed params, the error paths, query construction) — these run in
+  `next-python-test.yml` via `cargo test -p wingfoil-next-python --features
+  all-adapters`.
+- `crates/wingfoil-next-python/tests/test_<name>.py`, in two groups: unit-level
+  wiring tests with **no** service (argument defaults, wiring-time rejections,
+  marshaling errors) that run by default, and `@pytest.mark.requires_<name>`
+  integration tests, deselected by default via the `addopts` in
+  `pyproject.toml`. Register the marker there.
+- A Python leg in `.github/workflows/<name>-next-integration.yml`: start the
+  service on its fixed port (the Rust tests use testcontainers, the Python ones
+  need a known host/port), `maturin develop`, then
+  `pytest -m requires_<name> tests/test_<name>.py -v`. Add the binding and test
+  paths to the workflow's `paths:` triggers.
 
 `#[pyadapter]` handles **burst** adapters too — the common shape, since the
 layering conventions above make most real adapters `Stream<Burst<T>>`
@@ -885,6 +933,21 @@ Constraints: the method's params become `#[pyfunction]` params, so they must be
 `FromPyObject` (`i64`/`f64`/`String`/`Py<PyAny>`/… — a Rust-only handle like
 `Rc<RefCell<…>>` can't cross); and the value type edge-converts
 (`T: TryFrom<&PyElement>` in, `U: Into<PyElement>` out).
+
+**A wiring-time `RunParams`/`RunMode` becomes an argument.** A Python `Graph`
+does not know its run mode until `run()`, so a source needing the run window (or
+the mode) at wiring — as `postgres_read` does to slice queries — takes it as
+explicit args (`start_nanos` / `duration_nanos` / `realtime`) that must match the
+eventual `graph.run(...)`. Expose the unified `<name>_source` too where the
+adapter has one: it is the mode-agnostic wiring, and Python is exactly where
+that ergonomic pays off.
+
+**Watch the GIL for real-time sources.** `PyGraph::run` releases the GIL for the
+duration of the run; without that a live-tail source's worker thread — and every
+other Python thread — is blocked until `run` returns, so the source only ever
+sees data that already existed. If you add a live-tail binding, cover it with an
+integration test that inserts **from another Python thread mid-run** — that is
+the only test shape which catches a regression here.
 
 So expose your adapter via `#[pyadapter]` (source, sink, or burst) and add the
 pytest case in the same PR — service-backed integration bindings follow the

--- a/.github/workflows/next-python-test.yml
+++ b/.github/workflows/next-python-test.yml
@@ -57,7 +57,12 @@ jobs:
         # embedded-interpreter unit and integration tests link libpython and run.
         # These do not run in the rust-test leg, which is scoped to
         # `-p wingfoil` / `-p wingfoil-next`.
-        run: cargo test -p wingfoil-next-python
+        #
+        # `all-adapters` additionally covers the per-adapter `#[pyadapter]`
+        # bindings and their marshaling tests, which are feature-gated off by
+        # default. Adapters needing a system library at build time must stay out
+        # of that roll-up (or be installed above) so this step keeps working.
+        run: cargo test -p wingfoil-next-python --features all-adapters
 
       - name: Build module and run pytest
         working-directory: next/crates/wingfoil-next-python

--- a/.github/workflows/postgres-next-integration.yml
+++ b/.github/workflows/postgres-next-integration.yml
@@ -8,6 +8,8 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/postgres**'
       - 'next/crates/wingfoil-next/src/adapters/common.rs'
       - 'next/crates/wingfoil-next/tests/postgres_integration.rs'
+      - 'next/crates/wingfoil-next-python/src/adapters/postgres.rs'
+      - 'next/crates/wingfoil-next-python/tests/test_postgres.py'
 
 env:
   CARGO_TERM_COLOR: always
@@ -51,3 +53,52 @@ jobs:
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      # --- Python bindings (wingfoil-next-python) ---
+      # The Rust tests above use testcontainers (per-test container); the Python
+      # tests expect a fixed localhost:5432, so start one explicitly.
+      - name: Start postgres container for Python tests
+        run: |
+          docker run -d \
+            --name postgres-next-py \
+            -p 5432:5432 \
+            -e POSTGRES_PASSWORD=postgres \
+            postgres:16-alpine
+          for i in $(seq 1 30); do
+            nc -z localhost 5432 && echo "postgres ready" && break
+            echo "Waiting... ($i/30)"
+            sleep 1
+          done
+          nc -z localhost 5432 || (echo "postgres never became ready" && exit 1)
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: next/crates/wingfoil-next-python/pyproject.toml
+
+      - name: Install patchelf
+        # maturin uses it to build the extension module on Linux.
+        run: sudo apt-get install -y patchelf
+
+      - name: Build the next Python bindings
+        working-directory: next/crates/wingfoil-next-python
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install maturin pytest "psycopg[binary]"
+          .venv/bin/maturin develop
+
+      - name: Run Python postgres (next) integration tests
+        working-directory: next/crates/wingfoil-next-python
+        run: .venv/bin/pytest -m requires_postgres tests/test_postgres.py -v
+        env:
+          RUST_LOG: INFO
+
+      - name: Dump postgres logs on failure
+        if: failure()
+        run: docker logs postgres-next-py
+
+      - name: Stop postgres container
+        if: always()
+        run: docker rm -f postgres-next-py || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7840,6 +7840,7 @@ name = "wingfoil-next-python"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "log",
  "pyo3",
  "wingfoil",

--- a/next/crates/wingfoil-next-python-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-python-macros/src/lib.rs
@@ -38,13 +38,13 @@
 //! (or the object form) directly.
 
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Delimiter, Group, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{
-    Error, FnArg, GenericArgument, Ident, ImplItem, ItemFn, ItemImpl, Pat, PathArguments,
-    ReturnType, Token, Type, parse_macro_input,
+    Attribute, Error, FnArg, GenericArgument, Ident, ImplItem, ItemFn, ItemImpl, Meta, Pat,
+    PathArguments, ReturnType, Token, Type, parse_macro_input, parse_quote,
 };
 
 /// Parsed `#[pyop(name = <fn>, [arg = <cfg param>])]`.
@@ -261,11 +261,26 @@ impl Parse for PyAdapterArgs {
 /// `Stream<Burst<T>>` may appear as a source's return, a sink's `Self`, or a
 /// transform's output. Adapter method params become `#[pyfunction]` params, so
 /// they must be `FromPyObject`.
+///
+/// **Fallible wiring** is supported: a method returning `Result<Stream<T>>`
+/// (any path ending in `Result`, so `anyhow::Result<..>` too) generates a
+/// `PyResult`-returning `#[pyfunction]`, mapping the wiring error to a Python
+/// exception. That is the usual shape for a real adapter, which validates its
+/// run window / run mode / config at wiring time.
 #[proc_macro_attribute]
 pub fn pyadapter(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as PyAdapterArgs);
-    let imp = parse_macro_input!(item as ItemImpl);
-    match expand_pyadapter(&args, &imp) {
+    let mut imp = parse_macro_input!(item as ItemImpl);
+    let expanded = expand_pyadapter(&args, &imp);
+    // `#[pyo3(..)]` attributes on the adapter method are *for the generated
+    // `#[pyfunction]`* (they were moved onto it above) — strip them from the
+    // re-emitted impl, where they would be an unknown attribute.
+    for item in &mut imp.items {
+        if let ImplItem::Fn(f) = item {
+            f.attrs.retain(|a| !a.path().is_ident("pyo3"));
+        }
+    }
+    match expanded {
         Ok(extra) => quote! { #imp #extra }.into(),
         Err(e) => {
             let e = e.to_compile_error();
@@ -293,6 +308,16 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
         ));
     }
     let method_name = &method.sig.ident;
+    // `#[pyo3(..)]` attributes written on the adapter method are forwarded to
+    // the generated `#[pyfunction]` — that is how an adapter declares Python
+    // defaults for its optional args, e.g.
+    // `#[pyo3(signature = (conn, query, chunk_secs = 3600, buffer_size = None))]`.
+    // They are stripped from the re-emitted impl by the caller.
+    let raw_py_attrs: Vec<&Attribute> = method
+        .attrs
+        .iter()
+        .filter(|a| a.path().is_ident("pyo3"))
+        .collect();
 
     // Non-receiver params: (name, type), forwarded to the method verbatim.
     let mut param_decls = Vec::new();
@@ -322,12 +347,42 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
         ReturnType::Default => {
             return Err(Error::new(
                 method.sig.span(),
-                "#[pyadapter] adapter method must return `Stream<T>`",
+                "#[pyadapter] adapter method must return `Stream<T>` or `Result<Stream<T>>`",
             ));
         }
     };
-    let out_inner = stream_inner(out_ty)?;
+    // A real adapter's wiring is usually **fallible** (`postgres_read` validates
+    // the run window, `postgres_sub` rejects a historical run, a sink quotes and
+    // checks its table name), so the method may return `Result<Stream<T>>`. When
+    // it does, the generated `#[pyfunction]` returns `PyResult<Stream>` and the
+    // wiring error surfaces as a Python exception instead of aborting the run;
+    // an infallible `Stream<T>` keeps the plain return.
+    let (out_ty, fallible) = match result_inner(out_ty) {
+        Some(inner) => (inner, true),
+        None => (out_ty.clone(), false),
+    };
+    let out_inner = stream_inner(&out_ty)?;
     let py_name = &args.name;
+
+    // The generated function's return type and how the adapter call is spelled:
+    // a fallible method's error maps to a Python exception at the seam.
+    let (ret_ty, unwrap) = if fallible {
+        (
+            quote! { pyo3::PyResult<::wingfoil_next_python::Stream> },
+            quote! { .map_err(::wingfoil_next_python::to_pyerr)? },
+        )
+    } else {
+        (quote! { ::wingfoil_next_python::Stream }, quote! {})
+    };
+    // `Stream::from(..)`, wrapped in `Ok(..)` when the signature is fallible.
+    let wrap_ret = |expr: TokenStream2| {
+        let built = quote! { ::wingfoil_next_python::Stream::from(#expr) };
+        if fallible {
+            quote! { Ok(#built) }
+        } else {
+            built
+        }
+    };
 
     if args.is_source {
         // Source: `impl Trait for GraphBuilder { fn m(&self, args…) -> Stream<T>
@@ -337,15 +392,24 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
             Some(t) => quote! { __obj.erase_burst_source::<#t>(__typed) },
             None => quote! { __obj.erase_source::<#out_inner>(__typed) },
         };
+        // The generated fn takes the graph as its first param, so a forwarded
+        // `signature` — written by the author over the *adapter method's* params
+        // — gains it too.
+        let py_attrs = forward_pyo3_attrs(&raw_py_attrs, &Ident::new("graph", py_name.span()));
+        let body = wrap_ret(erase);
         Ok(quote! {
             #[pyo3::pyfunction]
-            fn #py_name(
+            // An adapter's knobs plus the generated receiver routinely exceed
+            // clippy's threshold, and the author cannot annotate generated code.
+            #[allow(clippy::too_many_arguments)]
+            #(#py_attrs)*
+            pub fn #py_name(
                 graph: pyo3::PyRef<'_, ::wingfoil_next_python::Graph>,
                 #(#param_decls),*
-            ) -> ::wingfoil_next_python::Stream {
+            ) -> #ret_ty {
                 let __obj = graph.object();
-                let __typed = __obj.builder().#method_name(#(#param_names),*);
-                ::wingfoil_next_python::Stream::from(#erase)
+                let __typed = __obj.builder().#method_name(#(#param_names),*) #unwrap;
+                #body
             }
         })
     } else {
@@ -364,19 +428,93 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
             Some(u) => quote! { __obj.erased_burst_output::<#u>(__out) },
             None => quote! { __obj.erased_output::<#out_inner>(__out) },
         };
+        // As above, but the sink/transform form's leading param is the stream.
+        let py_attrs = forward_pyo3_attrs(&raw_py_attrs, &Ident::new("stream", py_name.span()));
+        let body = wrap_ret(erase);
         Ok(quote! {
             #[pyo3::pyfunction]
-            fn #py_name(
+            // An adapter's knobs plus the generated receiver routinely exceed
+            // clippy's threshold, and the author cannot annotate generated code.
+            #[allow(clippy::too_many_arguments)]
+            #(#py_attrs)*
+            pub fn #py_name(
                 stream: pyo3::PyRef<'_, ::wingfoil_next_python::Stream>,
                 #(#param_decls),*
-            ) -> ::wingfoil_next_python::Stream {
+            ) -> #ret_ty {
                 let __obj = stream.object();
                 let __typed = #typed_in;
-                let __out = __typed.#method_name(#(#param_names),*);
-                ::wingfoil_next_python::Stream::from(#erase)
+                let __out = __typed.#method_name(#(#param_names),*) #unwrap;
+                #body
             }
         })
     }
+}
+
+/// Forward the adapter method's `#[pyo3(..)]` attributes to the generated
+/// `#[pyfunction]`, prepending `receiver` to any `signature = (..)` list.
+///
+/// The author writes the signature over the *adapter method's* own params
+/// (`#[pyo3(signature = (conn_str, chunk_secs = 3600))]`); the generated function
+/// additionally takes the graph/stream as its first param, and pyo3 requires a
+/// signature to name every param. Injecting it here keeps the generated receiver
+/// out of the author's hands.
+fn forward_pyo3_attrs(attrs: &[&Attribute], receiver: &Ident) -> Vec<Attribute> {
+    attrs
+        .iter()
+        .map(|attr| {
+            let Meta::List(list) = &attr.meta else {
+                return (*attr).clone();
+            };
+            let mut out = TokenStream2::new();
+            // Track `signature` `=` `( .. )` so only that group is rewritten.
+            let (mut saw_signature, mut saw_eq) = (false, false);
+            for tt in list.tokens.clone() {
+                match &tt {
+                    TokenTree::Ident(ident) if ident == "signature" => {
+                        saw_signature = true;
+                        saw_eq = false;
+                        out.extend([tt]);
+                    }
+                    TokenTree::Punct(p) if saw_signature && p.as_char() == '=' => {
+                        saw_eq = true;
+                        out.extend([tt]);
+                    }
+                    TokenTree::Group(g)
+                        if saw_signature && saw_eq && g.delimiter() == Delimiter::Parenthesis =>
+                    {
+                        let inner = g.stream();
+                        let merged = if inner.is_empty() {
+                            quote! { #receiver }
+                        } else {
+                            quote! { #receiver, #inner }
+                        };
+                        out.extend([TokenTree::Group(Group::new(Delimiter::Parenthesis, merged))]);
+                        saw_signature = false;
+                        saw_eq = false;
+                    }
+                    _ => out.extend([tt]),
+                }
+            }
+            let path = &list.path;
+            parse_quote!(#[#path(#out)])
+        })
+        .collect()
+}
+
+/// If `ty` is `Result<X>` / `anyhow::Result<X>` / `Result<X, E>` (last path
+/// segment literally `Result`), the `X`; else `None`. Distinguishes a fallible
+/// adapter wiring fn — the common shape for real adapters, which validate their
+/// config and run mode at wiring — from an infallible one.
+fn result_inner(ty: &Type) -> Option<Type> {
+    if let Type::Path(p) = ty
+        && let Some(seg) = p.path.segments.last()
+        && seg.ident == "Result"
+        && let PathArguments::AngleBracketed(a) = &seg.arguments
+        && let Some(GenericArgument::Type(t)) = a.args.first()
+    {
+        return Some(t.clone());
+    }
+    None
 }
 
 /// If `ty` is `Burst<X>` (last path segment literally `Burst`), the `X`; else

--- a/next/crates/wingfoil-next-python-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-python-macros/src/lib.rs
@@ -43,8 +43,8 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{
-    Attribute, Error, FnArg, GenericArgument, Ident, ImplItem, ItemFn, ItemImpl, Meta, Pat,
-    PathArguments, ReturnType, Token, Type, parse_macro_input, parse_quote,
+    Attribute, Error, FnArg, GenericArgument, Ident, ImplItem, Item, ItemFn, ItemImpl, Meta, Pat,
+    PathArguments, ReturnType, Signature, Token, Type, parse_macro_input, parse_quote,
 };
 
 /// Parsed `#[pyop(name = <fn>, [arg = <cfg param>])]`.
@@ -243,24 +243,42 @@ impl Parse for PyAdapterArgs {
     }
 }
 
-/// `#[pyadapter(name = ...[, source])]` — expose a user adapter method as a
-/// Python callable, edge-converting at the boundary. Two shapes:
+/// `#[pyadapter(name = ...[, source])]` — expose adapter wiring as a Python
+/// callable, edge-converting at the boundary.
 ///
-/// - **source** (`source` marker): `impl Trait for GraphBuilder { fn m(&self,
-///   args…) -> Stream<T> }` => `module.name(graph, args…)` — runs the adapter on
-///   the caller's builder and erases the `T` output.
-/// - **sink / transform** (no marker): `impl Trait for Stream<T> { fn m(&self,
-///   args…) -> Stream<U> }` => `module.name(stream, args…)` — extracts the input
-///   to native `T`, runs the adapter, and erases the `U` output (a sink's
-///   `Stream<()>` erases to Python `None`).
+/// It goes on a **free fn** whose first param is the receiver, or on an **impl**
+/// block. Either way the `source` marker picks between the two shapes:
+///
+/// - **source** (`source` marker): receiver `&GraphBuilder`, returns
+///   `Stream<T>` => `module.name(graph, args…)` — runs the wiring on the
+///   caller's builder and erases the `T` output.
+/// - **sink / transform** (no marker): receiver `&Stream<T>`, returns
+///   `Stream<U>` => `module.name(stream, args…)` — extracts the input to native
+///   `T`, runs the wiring, and erases the `U` output (a sink's `Stream<()>`
+///   erases to Python `None`).
+///
+/// **Prefer the free-fn form when writing a binding.** The impl form's trait
+/// exists only to give the macro a receiver, which costs a throwaway trait plus
+/// a second copy of the whole signature; reach for it only when the adapter
+/// genuinely wants a fluent Rust trait too. `name` must differ from the fn's own
+/// name, since the macro emits a `#[pyfunction]` of that name beside it — so a
+/// `postgres` binding module writes `fn read(…)` with `name = postgres_read`.
+///
+/// ```ignore
+/// #[pyadapter(name = kafka_read, source)]
+/// #[pyo3(signature = (brokers, topic, buffer_size = None))]
+/// fn read(g: &GraphBuilder, brokers: String, topic: String, buffer_size: Option<usize>)
+///     -> anyhow::Result<Stream<Burst<KafkaRecord>>> { /* … */ }
+/// // => wingfoil_next.kafka_read(graph, brokers, topic, buffer_size=None)
+/// ```
 ///
 /// **Burst shapes** are handled too: a `Stream<Burst<T>>` erases to a Python
 /// `list` per tick (same-instant values grouped), and on the way *in* a Python
 /// `list`/`tuple` rebuilds a multi-value burst (any other value → a
 /// single-element burst) — so a burst source round-trips into a burst sink. So
 /// `Stream<Burst<T>>` may appear as a source's return, a sink's `Self`, or a
-/// transform's output. Adapter method params become `#[pyfunction]` params, so
-/// they must be `FromPyObject`.
+/// transform's output. Adapter params become `#[pyfunction]` params, so they
+/// must be `FromPyObject`.
 ///
 /// **Fallible wiring** is supported: a method returning `Result<Stream<T>>`
 /// (any path ending in `Result`, so `anyhow::Result<..>` too) generates a
@@ -270,26 +288,134 @@ impl Parse for PyAdapterArgs {
 #[proc_macro_attribute]
 pub fn pyadapter(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as PyAdapterArgs);
-    let mut imp = parse_macro_input!(item as ItemImpl);
-    let expanded = expand_pyadapter(&args, &imp);
-    // `#[pyo3(..)]` attributes on the adapter method are *for the generated
-    // `#[pyfunction]`* (they were moved onto it above) — strip them from the
-    // re-emitted impl, where they would be an unknown attribute.
-    for item in &mut imp.items {
-        if let ImplItem::Fn(f) = item {
-            f.attrs.retain(|a| !a.path().is_ident("pyo3"));
+    let item = parse_macro_input!(item as Item);
+    // `#[pyo3(..)]` attributes on the adapter fn are *for the generated
+    // `#[pyfunction]`* — strip them from the re-emitted item, where they would
+    // be an unknown attribute.
+    match item {
+        Item::Impl(mut imp) => {
+            let expanded = expand_pyadapter_impl(&args, &imp);
+            for it in &mut imp.items {
+                if let ImplItem::Fn(f) = it {
+                    f.attrs.retain(|a| !a.path().is_ident("pyo3"));
+                }
+            }
+            emit(quote! { #imp }, expanded)
         }
+        Item::Fn(mut func) => {
+            let expanded = expand_pyadapter_fn(&args, &func);
+            func.attrs.retain(|a| !a.path().is_ident("pyo3"));
+            // An adapter's arity is dictated by its knobs (a time-sliced reader
+            // legitimately takes ~8), so the wiring fn gets the same allow the
+            // generated one does rather than every binding repeating it.
+            func.attrs
+                .push(parse_quote!(#[allow(clippy::too_many_arguments)]));
+            emit(quote! { #func }, expanded)
+        }
+        other => Error::new(
+            other.span(),
+            "#[pyadapter] goes on a wiring `fn` (first param the receiver) or on an \
+             `impl Trait for GraphBuilder | Stream<T>`",
+        )
+        .to_compile_error()
+        .into(),
     }
+}
+
+/// Re-emit the annotated item followed by the generated `#[pyfunction]` (or the
+/// compile error, so the original item still resolves for downstream code).
+fn emit(item: TokenStream2, expanded: syn::Result<TokenStream2>) -> TokenStream {
     match expanded {
-        Ok(extra) => quote! { #imp #extra }.into(),
+        Ok(extra) => quote! { #item #extra }.into(),
         Err(e) => {
             let e = e.to_compile_error();
-            quote! { #imp #e }.into()
+            quote! { #item #e }.into()
         }
     }
 }
 
-fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
+/// How the generated `#[pyfunction]` reaches the user's wiring code.
+enum Callee {
+    /// An `impl` block's method — called *on* the receiver.
+    Method(Ident),
+    /// A free fn — the receiver is its first argument.
+    Free(Ident),
+}
+
+impl Callee {
+    /// The call expression. The two forms take the receiver differently — a
+    /// method call binds it as `self`, a free call passes it as the first
+    /// argument — so each site supplies both spellings (they differ for a sink,
+    /// where the method form uses the owned stream and the free form borrows it).
+    fn call(
+        &self,
+        method_recv: TokenStream2,
+        free_recv: TokenStream2,
+        args: &[Ident],
+    ) -> TokenStream2 {
+        match self {
+            Callee::Method(name) => quote! { #method_recv.#name(#(#args),*) },
+            Callee::Free(name) => quote! { #name(#free_recv #(, #args)*) },
+        }
+    }
+}
+
+/// The free-fn form: `fn m(recv, args…) -> Stream<U> | Result<Stream<U>>`, where
+/// `recv` is `&GraphBuilder` (source) or `&Stream<T>` (sink/transform).
+///
+/// This is the form a *binding* module wants — the `impl` form's trait exists
+/// only to give the macro a receiver, and costs a throwaway trait plus a second
+/// copy of every signature.
+fn expand_pyadapter_fn(args: &PyAdapterArgs, func: &ItemFn) -> syn::Result<TokenStream2> {
+    let fn_name = &func.sig.ident;
+    if fn_name == &args.name {
+        return Err(Error::new(
+            args.name.span(),
+            "#[pyadapter] `name` must differ from the wiring fn's own name (the macro emits a \
+             `#[pyfunction]` of that name alongside it) — e.g. `fn read` with `name = kafka_read`",
+        ));
+    }
+    let mut inputs = func.sig.inputs.iter();
+    let receiver = inputs.next().ok_or_else(|| {
+        Error::new(
+            func.sig.span(),
+            "#[pyadapter] wiring fn takes the receiver as its first param: `&GraphBuilder` for a \
+             source, `&Stream<T>` for a sink/transform",
+        )
+    })?;
+    let receiver_ty = match receiver {
+        FnArg::Typed(pt) => (*pt.ty).clone(),
+        FnArg::Receiver(r) => {
+            return Err(Error::new(
+                r.span(),
+                "#[pyadapter] wiring fn takes the receiver as a normal first param, not `self`",
+            ));
+        }
+    };
+    // Only the sink form needs the receiver's type (to build the typed input);
+    // a source's receiver is always the builder.
+    let in_ty = if args.is_source {
+        None
+    } else {
+        Some(stream_inner(&receiver_ty)?)
+    };
+    let (param_decls, param_names) = split_params(inputs)?;
+    let out_ty = return_type(&func.sig)?;
+    emit_pyadapter(
+        args,
+        &Callee::Free(fn_name.clone()),
+        in_ty,
+        out_ty,
+        &param_decls,
+        &param_names,
+        &pyo3_attrs(&func.attrs),
+    )
+}
+
+/// The `impl` form: `impl Trait for GraphBuilder | Stream<T> { fn m(&self, …) }`.
+/// Kept for adapters that genuinely want a fluent Rust trait; a binding module
+/// should prefer the free-fn form above.
+fn expand_pyadapter_impl(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
     // The single adapter method in the impl.
     let mut methods = imp.items.iter().filter_map(|it| match it {
         ImplItem::Fn(f) => Some(f),
@@ -307,22 +433,44 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
             "#[pyadapter] v1 expects exactly one adapter method in the impl",
         ));
     }
-    let method_name = &method.sig.ident;
-    // `#[pyo3(..)]` attributes written on the adapter method are forwarded to
-    // the generated `#[pyfunction]` — that is how an adapter declares Python
-    // defaults for its optional args, e.g.
-    // `#[pyo3(signature = (conn, query, chunk_secs = 3600, buffer_size = None))]`.
-    // They are stripped from the re-emitted impl by the caller.
-    let raw_py_attrs: Vec<&Attribute> = method
-        .attrs
+    let in_ty = if args.is_source {
+        None
+    } else {
+        Some(stream_inner(&imp.self_ty)?)
+    };
+    let (param_decls, param_names) = split_params(method.sig.inputs.iter())?;
+    let out_ty = return_type(&method.sig)?;
+    emit_pyadapter(
+        args,
+        &Callee::Method(method.sig.ident.clone()),
+        in_ty,
+        out_ty,
+        &param_decls,
+        &param_names,
+        &pyo3_attrs(&method.attrs),
+    )
+}
+
+/// The `#[pyo3(..)]` attributes written on the adapter fn — forwarded to the
+/// generated `#[pyfunction]`. That is how an adapter declares Python defaults,
+/// e.g. `#[pyo3(signature = (conn, chunk_secs = 3600, buffer_size = None))]`.
+fn pyo3_attrs(attrs: &[Attribute]) -> Vec<Attribute> {
+    attrs
         .iter()
         .filter(|a| a.path().is_ident("pyo3"))
-        .collect();
+        .cloned()
+        .collect()
+}
 
-    // Non-receiver params: (name, type), forwarded to the method verbatim.
-    let mut param_decls = Vec::new();
-    let mut param_names = Vec::new();
-    for arg in &method.sig.inputs {
+/// Split an adapter fn's non-receiver params into `(decls, names)`, forwarded to
+/// the generated `#[pyfunction]` verbatim. A `self` receiver is skipped (the
+/// `impl` form); the free-fn form has already consumed its first param.
+type Params = (Vec<TokenStream2>, Vec<Ident>);
+
+fn split_params<'a>(inputs: impl Iterator<Item = &'a FnArg>) -> syn::Result<Params> {
+    let mut decls = Vec::new();
+    let mut names = Vec::new();
+    for arg in inputs {
         match arg {
             FnArg::Receiver(_) => {}
             FnArg::Typed(pt) => {
@@ -331,41 +479,55 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
                     _ => {
                         return Err(Error::new(
                             pt.pat.span(),
-                            "#[pyadapter] method params must be simple identifiers",
+                            "#[pyadapter] adapter params must be simple identifiers",
                         ));
                     }
                 };
                 let ty = &pt.ty;
-                param_decls.push(quote! { #name: #ty });
-                param_names.push(name);
+                decls.push(quote! { #name: #ty });
+                names.push(name);
             }
         }
     }
+    Ok((decls, names))
+}
 
-    let out_ty = match &method.sig.output {
-        ReturnType::Type(_, ty) => &**ty,
-        ReturnType::Default => {
-            return Err(Error::new(
-                method.sig.span(),
-                "#[pyadapter] adapter method must return `Stream<T>` or `Result<Stream<T>>`",
-            ));
-        }
-    };
+/// The adapter fn's declared return type.
+fn return_type(sig: &Signature) -> syn::Result<Type> {
+    match &sig.output {
+        ReturnType::Type(_, ty) => Ok((**ty).clone()),
+        ReturnType::Default => Err(Error::new(
+            sig.span(),
+            "#[pyadapter] adapter fn must return `Stream<T>` or `Result<Stream<T>>`",
+        )),
+    }
+}
+
+/// Emit the `#[pyfunction]` — shared by both forms, which differ only in how
+/// they reach the user's wiring ([`Callee`]) and where the sink's input type
+/// comes from.
+fn emit_pyadapter(
+    args: &PyAdapterArgs,
+    callee: &Callee,
+    in_ty: Option<Type>,
+    out_ty: Type,
+    param_decls: &[TokenStream2],
+    param_names: &[Ident],
+    raw_py_attrs: &[Attribute],
+) -> syn::Result<TokenStream2> {
     // A real adapter's wiring is usually **fallible** (`postgres_read` validates
     // the run window, `postgres_sub` rejects a historical run, a sink quotes and
-    // checks its table name), so the method may return `Result<Stream<T>>`. When
-    // it does, the generated `#[pyfunction]` returns `PyResult<Stream>` and the
-    // wiring error surfaces as a Python exception instead of aborting the run;
-    // an infallible `Stream<T>` keeps the plain return.
-    let (out_ty, fallible) = match result_inner(out_ty) {
+    // checks its table name), so it may return `Result<Stream<T>>`. When it does,
+    // the generated `#[pyfunction]` returns `PyResult<Stream>` and the wiring
+    // error surfaces as a Python exception instead of aborting the run; an
+    // infallible `Stream<T>` keeps the plain return.
+    let (out_ty, fallible) = match result_inner(&out_ty) {
         Some(inner) => (inner, true),
-        None => (out_ty.clone(), false),
+        None => (out_ty, false),
     };
     let out_inner = stream_inner(&out_ty)?;
     let py_name = &args.name;
 
-    // The generated function's return type and how the adapter call is spelled:
-    // a fallible method's error maps to a Python exception at the seam.
     let (ret_ty, unwrap) = if fallible {
         (
             quote! { pyo3::PyResult<::wingfoil_next_python::Stream> },
@@ -383,43 +545,53 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
             built
         }
     };
+    // The generated fn takes the graph/stream as its first param, so a forwarded
+    // `signature` — written by the author over their *own* params — gains it too.
+    let receiver_name = Ident::new(
+        if args.is_source { "graph" } else { "stream" },
+        py_name.span(),
+    );
+    let py_attrs = forward_pyo3_attrs(raw_py_attrs, &receiver_name);
+    // An adapter's knobs plus the generated receiver routinely exceed clippy's
+    // argument threshold, and the author cannot annotate generated code.
+    let preamble = quote! {
+        #[pyo3::pyfunction]
+        #[allow(clippy::too_many_arguments)]
+        #(#py_attrs)*
+    };
 
     if args.is_source {
-        // Source: `impl Trait for GraphBuilder { fn m(&self, args…) -> Stream<T>
-        // | Stream<Burst<T>> }` => `module.name(graph, args…)`: run the adapter
-        // on the builder, erase the output (a `Burst<T>` becomes a Python list).
+        // Source: `(&GraphBuilder, args…) -> Stream<T> | Stream<Burst<T>>` =>
+        // `module.name(graph, args…)`: run the adapter on the caller's builder,
+        // erase the output (a `Burst<T>` becomes a Python list).
         let erase = match burst_inner(&out_inner) {
             Some(t) => quote! { __obj.erase_burst_source::<#t>(__typed) },
             None => quote! { __obj.erase_source::<#out_inner>(__typed) },
         };
-        // The generated fn takes the graph as its first param, so a forwarded
-        // `signature` — written by the author over the *adapter method's* params
-        // — gains it too.
-        let py_attrs = forward_pyo3_attrs(&raw_py_attrs, &Ident::new("graph", py_name.span()));
+        let call = callee.call(
+            quote! { __obj.builder() },
+            quote! { __obj.builder() },
+            param_names,
+        );
         let body = wrap_ret(erase);
         Ok(quote! {
-            #[pyo3::pyfunction]
-            // An adapter's knobs plus the generated receiver routinely exceed
-            // clippy's threshold, and the author cannot annotate generated code.
-            #[allow(clippy::too_many_arguments)]
-            #(#py_attrs)*
+            #preamble
             pub fn #py_name(
                 graph: pyo3::PyRef<'_, ::wingfoil_next_python::Graph>,
                 #(#param_decls),*
             ) -> #ret_ty {
                 let __obj = graph.object();
-                let __typed = __obj.builder().#method_name(#(#param_names),*) #unwrap;
+                let __typed = #call #unwrap;
                 #body
             }
         })
     } else {
-        // Sink / transform: `impl Trait for Stream<T> | Stream<Burst<T>> { fn
-        // m(&self, args…) -> Stream<U> | Stream<Burst<U>> }` => `module.name(
-        // stream, args…)`: extract the input to native `T` (a burst self type
-        // rebuilds a burst from each Python list/tuple, else a single-element
-        // burst), run the adapter, erase the output (a sink's `Stream<()>` erases
-        // to Python `None`; a `Burst<U>` to a list).
-        let in_inner = stream_inner(&imp.self_ty)?;
+        // Sink / transform: `(&Stream<T>, args…) -> Stream<U> | Stream<Burst<U>>`
+        // => `module.name(stream, args…)`: extract the input to native `T` (a
+        // burst receiver rebuilds a burst from each Python list/tuple, else a
+        // single-element burst), run the adapter, erase the output (a sink's
+        // `Stream<()>` erases to Python `None`; a `Burst<U>` to a list).
+        let in_inner = in_ty.expect("invariant: the sink form always resolves an input type");
         let typed_in = match burst_inner(&in_inner) {
             Some(t) => quote! { __obj.typed_burst_input::<#t>() },
             None => quote! { __obj.typed_input::<#in_inner>() },
@@ -428,22 +600,17 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
             Some(u) => quote! { __obj.erased_burst_output::<#u>(__out) },
             None => quote! { __obj.erased_output::<#out_inner>(__out) },
         };
-        // As above, but the sink/transform form's leading param is the stream.
-        let py_attrs = forward_pyo3_attrs(&raw_py_attrs, &Ident::new("stream", py_name.span()));
+        let call = callee.call(quote! { __typed }, quote! { &__typed }, param_names);
         let body = wrap_ret(erase);
         Ok(quote! {
-            #[pyo3::pyfunction]
-            // An adapter's knobs plus the generated receiver routinely exceed
-            // clippy's threshold, and the author cannot annotate generated code.
-            #[allow(clippy::too_many_arguments)]
-            #(#py_attrs)*
+            #preamble
             pub fn #py_name(
                 stream: pyo3::PyRef<'_, ::wingfoil_next_python::Stream>,
                 #(#param_decls),*
             ) -> #ret_ty {
                 let __obj = stream.object();
                 let __typed = #typed_in;
-                let __out = __typed.#method_name(#(#param_names),*) #unwrap;
+                let __out = #call #unwrap;
                 #body
             }
         })
@@ -458,12 +625,12 @@ fn expand_pyadapter(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<TokenSt
 /// additionally takes the graph/stream as its first param, and pyo3 requires a
 /// signature to name every param. Injecting it here keeps the generated receiver
 /// out of the author's hands.
-fn forward_pyo3_attrs(attrs: &[&Attribute], receiver: &Ident) -> Vec<Attribute> {
+fn forward_pyo3_attrs(attrs: &[Attribute], receiver: &Ident) -> Vec<Attribute> {
     attrs
         .iter()
         .map(|attr| {
             let Meta::List(list) = &attr.meta else {
-                return (*attr).clone();
+                return attr.clone();
             };
             let mut out = TokenStream2::new();
             // Track `signature` `=` `( .. )` so only that group is rewritten.

--- a/next/crates/wingfoil-next-python/Cargo.toml
+++ b/next/crates/wingfoil-next-python/Cargo.toml
@@ -22,6 +22,17 @@ workspace = true
 # at load time instead.
 extension-module = ["pyo3/extension-module"]
 
+# Per-adapter Python bindings, each gated on the matching `wingfoil-next`
+# adapter feature so a wheel only carries the adapters it was built with.
+# `all-adapters` is the convenience roll-up the maturin build and CI use.
+#
+# PostgreSQL: `postgres_read` / `postgres_sub` / `postgres_source` sources, the
+# `postgres_write` sink, and the `postgres_notify_trigger_sql` helper. `chrono`
+# is needed here (not just transitively) because the row decoder names
+# `NaiveDateTime` to read `timestamp` / `timestamptz` columns.
+postgres = ["wingfoil-next/postgres", "dep:chrono"]
+all-adapters = ["postgres"]
+
 [dependencies]
 # The erased boundary value. pyo3 stays without `extension-module` here so the
 # rlib links libpython normally; the eventual `#[pymodule]` glue crate turns
@@ -37,6 +48,10 @@ wingfoil = { path = "../../../wingfoil" }
 # `log::Level` — the `logged` debug tap's level argument. Workspace-pinned so it
 # matches the `log` the `wingfoil-next` fluent signature names.
 log = { workspace = true }
+# `NaiveDateTime` / `DateTime<Utc>` — the types the postgres row decoder reads
+# `timestamp` / `timestamptz` columns as. Workspace-pinned so it matches the
+# `with-chrono-0_4` tokio-postgres the engine's postgres adapter builds against.
+chrono = { workspace = true, optional = true }
 
 [dev-dependencies]
 # `auto-initialize` starts an embedded interpreter so the boundary type and the

--- a/next/crates/wingfoil-next-python/README.md
+++ b/next/crates/wingfoil-next-python/README.md
@@ -18,6 +18,36 @@ assert out.value() == 6  # 3rd tick -> 3 * 2
 cross the boundary as native Python objects and are boxed into the erased
 `PyElement` only at the edges.
 
+## I/O adapters
+
+The `wingfoil_next::adapters::*` adapters are exposed as module-level functions
+(`src/adapters/`), each behind a cargo feature of the same name — a wheel only
+carries the adapters it was built with. **postgres** is bound today:
+
+```python
+g = wf.Graph()
+
+# Historical, time-sliced replay. Each tick is a list of {column: value} dicts.
+rows = wf.postgres_read(
+    g, CONN_STR, "SELECT time, sym, price FROM trades", "time",
+    start_nanos=START, duration_nanos=ONE_DAY, chunk_secs=86400,
+)
+g.run(start_nanos=START, duration_nanos=ONE_DAY)
+
+# Streaming insert sink — declare the target columns in table order.
+wf.postgres_write(stream, CONN_STR, "trades",
+                  [("sym", "text"), ("price", "float")])
+```
+
+Also `postgres_sub` (a real-time `LISTEN`/`NOTIFY` live tail), `postgres_source`
+(one wiring call for either run mode) and `postgres_notify_trigger_sql`. See the
+module docs in `src/adapters/postgres.rs` for the argument semantics and how the
+surface differs from the legacy `wingfoil-python` bindings.
+
+A source that needs the run window at wiring takes it as arguments
+(`start_nanos` / `duration_nanos` / `realtime`), which must match the eventual
+`graph.run(...)` — a Python `Graph` does not know its run mode until then.
+
 ## Build / test
 
 ```bash
@@ -26,6 +56,16 @@ maturin build --out dist          # build the wheel
 pip install --force-reinstall dist/*.whl
 pytest                            # Python round-trip tests
 
-# the Rust object form and boundary type have their own unit tests:
-cargo test -p wingfoil-next-python
+# the Rust object form and boundary type have their own unit tests
+# (`--features all-adapters` also covers the per-adapter marshaling tests):
+cargo test -p wingfoil-next-python --features all-adapters
+```
+
+Adapter integration tests are marked (`@pytest.mark.requires_postgres`) and
+deselected by default, so a plain `pytest` is never silently green against a
+service that is not up. Opt in explicitly with a service running:
+
+```bash
+docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine
+pytest -m requires_postgres tests/test_postgres.py
 ```

--- a/next/crates/wingfoil-next-python/pyproject.toml
+++ b/next/crates/wingfoil-next-python/pyproject.toml
@@ -21,9 +21,24 @@ dev = ["maturin>=1.4,<2.0", "pytest>=7"]
 [tool.maturin]
 # `extension-module` resolves Python symbols at load time (no libpython link in
 # the wheel). Importing `wingfoil_next` gives the Graph / Stream classes.
-features = ["extension-module"]
+#
+# Adapter features are listed one by one rather than via the `all-adapters`
+# roll-up, so each new adapter binding is a considered decision: an adapter that
+# is pure Rust (postgres, on tokio-postgres) can ship in the default wheel,
+# whereas one needing a system library at build time must stay opt-in
+# (`maturin develop -F kdb`) or it breaks the build for everyone.
+features = ["extension-module", "postgres"]
 module-name = "wingfoil_next"
 include = ["Cargo.toml"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Integration tests are deselected by default so the regular `pytest` run is
+# never silently green against a service that is not actually up. Each
+# integration workflow opts in explicitly, e.g. `pytest -m requires_postgres`.
+# Running a marker selection without the backing service fails loudly with a
+# real ConnectionRefused/import error — not a skip.
+markers = [
+    "requires_postgres: needs PostgreSQL on localhost:5432",
+]
+addopts = "-m 'not requires_postgres'"

--- a/next/crates/wingfoil-next-python/src/adapters/common.rs
+++ b/next/crates/wingfoil-next-python/src/adapters/common.rs
@@ -1,0 +1,100 @@
+//! Shared helpers for the adapter bindings — the run-shape plumbing every
+//! source binding needs.
+//!
+//! A Rust caller picks the run mode at `run()`, but several adapters need it (or
+//! the whole run window) at **wiring** time: a time-sliced reader slices its
+//! queries up front, and a live-tail source rejects a historical run. A Python
+//! `Graph` does not know its run mode until `run()` either, so those bindings
+//! take the run shape as arguments and rebuild it here — which is the same three
+//! conversions in every one of them.
+
+use anyhow::{Result, bail};
+use std::time::Duration;
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::async_source::RunParams;
+
+/// The [`RunParams`] a **historical** source is wired for, from the Python
+/// `start_nanos` / `duration_nanos` arguments.
+///
+/// `RunFor::Duration` is the only bound a time-sliced reader can slice (it needs
+/// a concrete end time), so this always builds one. The values must match the
+/// eventual `graph.run(start_nanos=…, duration_nanos=…)`; a reader validates the
+/// window at wiring, so a mismatched or empty one is rejected there.
+pub fn historical_params(start_nanos: u64, duration_nanos: u64) -> RunParams {
+    let start = NanoTime::from(start_nanos);
+    RunParams {
+        run_mode: RunMode::HistoricalFrom(start),
+        run_for: RunFor::Duration(Duration::from_nanos(duration_nanos)),
+        start_time: start,
+    }
+}
+
+/// The [`RunParams`] a **real-time** source is wired for. Unbounded: a live
+/// source's bound comes from the actual `run()`, not from wiring.
+pub fn realtime_params() -> RunParams {
+    RunParams {
+        run_mode: RunMode::RealTime,
+        run_for: RunFor::Forever,
+        start_time: NanoTime::ZERO,
+    }
+}
+
+/// The [`RunMode`] a source is being wired for, from the Python `realtime` flag.
+///
+/// The historical arm carries `ZERO`: a source taking only a mode (rather than
+/// full params) uses it to *reject* the wrong mode, never to read the instant.
+pub fn run_mode(realtime: bool) -> RunMode {
+    if realtime {
+        RunMode::RealTime
+    } else {
+        RunMode::HistoricalFrom(NanoTime::ZERO)
+    }
+}
+
+/// Unix seconds -> [`NanoTime`], for the cursor/offset arguments adapters take
+/// as a Python `float`. Rejects a negative or non-finite input rather than
+/// wrapping it into a nonsense instant.
+pub fn secs_to_nanotime(secs: f64) -> Result<NanoTime> {
+    if !secs.is_finite() || secs < 0.0 {
+        bail!("expected a finite, non-negative Unix-seconds value, got {secs}");
+    }
+    Ok(NanoTime::new((secs * 1e9) as u64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn historical_params_span_the_requested_window() {
+        let params = historical_params(1_000, 500);
+        assert!(matches!(
+            params.run_mode,
+            RunMode::HistoricalFrom(t) if t == NanoTime::from(1_000_u64)
+        ));
+        assert!(matches!(params.run_for, RunFor::Duration(d) if d.as_nanos() == 500));
+        assert_eq!(NanoTime::from(1_000_u64), params.start_time);
+    }
+
+    #[test]
+    fn realtime_params_are_unbounded() {
+        let params = realtime_params();
+        assert!(matches!(params.run_mode, RunMode::RealTime));
+        assert!(matches!(params.run_for, RunFor::Forever));
+    }
+
+    #[test]
+    fn run_mode_maps_the_realtime_flag() {
+        assert!(matches!(run_mode(true), RunMode::RealTime));
+        assert!(matches!(run_mode(false), RunMode::HistoricalFrom(_)));
+    }
+
+    #[test]
+    fn secs_to_nanotime_rejects_nonsense() {
+        assert!(secs_to_nanotime(-1.0).is_err());
+        assert!(secs_to_nanotime(f64::NAN).is_err());
+        assert!(secs_to_nanotime(f64::INFINITY).is_err());
+        assert_eq!(NanoTime::new(1_500_000_000), secs_to_nanotime(1.5).unwrap());
+        assert_eq!(NanoTime::ZERO, secs_to_nanotime(0.0).unwrap());
+    }
+}

--- a/next/crates/wingfoil-next-python/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next-python/src/adapters/mod.rs
@@ -12,5 +12,9 @@
 //! `list`), while the adapter's interior stays the concrete Rust record type,
 //! exactly as [`crate::graph`] describes.
 
+// Compiled whenever any adapter binding is, since that is its only consumer.
+#[cfg(feature = "postgres")]
+pub mod common;
+
 #[cfg(feature = "postgres")]
 pub mod postgres;

--- a/next/crates/wingfoil-next-python/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next-python/src/adapters/mod.rs
@@ -1,0 +1,16 @@
+//! Per-adapter Python bindings — the `#[pyadapter]` exposure of the
+//! `wingfoil_next::adapters::*` I/O adapters.
+//!
+//! Each adapter lives behind a cargo feature of the same name, which turns on
+//! the matching `wingfoil-next` adapter feature, so a wheel only carries the
+//! adapters it was built with (`maturin develop -F postgres`). The generated
+//! `#[pyfunction]`s are registered in the `wingfoil_next` `#[pymodule]` under
+//! the same `#[cfg]`.
+//!
+//! The binding is a thin, *dynamic* skin over the natively-typed Rust adapter:
+//! only the Python-facing edge erases (a row becomes a `dict`, a burst a
+//! `list`), while the adapter's interior stays the concrete Rust record type,
+//! exactly as [`crate::graph`] describes.
+
+#[cfg(feature = "postgres")]
+pub mod postgres;

--- a/next/crates/wingfoil-next-python/src/adapters/postgres.rs
+++ b/next/crates/wingfoil-next-python/src/adapters/postgres.rs
@@ -1,0 +1,881 @@
+//! Python bindings for the wingfoil-next **PostgreSQL** adapter
+//! ([`wingfoil_next::adapters::postgres`]).
+//!
+//! Four graph entry points plus one helper, all `#[pyadapter]`-generated:
+//!
+//! | Python                          | Rust                | shape |
+//! |---------------------------------|---------------------|-------|
+//! | `postgres_read(graph, …)`       | [`pg_read`]         | historical, time-sliced replay |
+//! | `postgres_sub(graph, …)`        | [`pg_sub`]          | real-time `LISTEN`/`NOTIFY` live tail |
+//! | `postgres_source(graph, …)`     | [`pg_source`]       | mode-agnostic — dispatches on the run mode |
+//! | `postgres_write(stream, …)`     | [`PostgresSinkOps`] | streaming insert sink |
+//! | `postgres_notify_trigger_sql()` | —                   | the trigger DDL `postgres_sub` needs |
+//!
+//! # The dynamic edge
+//!
+//! A Rust caller writes a record `struct` and implements
+//! [`PostgresDeserialize`] / [`PostgresSerialize`] on it. Python has no such
+//! struct, so these bindings supply two *dynamic* record types instead:
+//!
+//! - **reads** decode into [`PyPgRow`] — column name/value pairs resolved from
+//!   the row's own type metadata — which erases to a Python **`dict`**;
+//! - **writes** take the caller's declared `columns` (name + SQL type, in table
+//!   order) and marshal each Python `dict` into a typed `PyPgWriteRow`.
+//!
+//! Both intermediates are plain Rust data (no `Py<PyAny>` inside), which is what
+//! lets them cross to the adapter's own worker thread — the reason for the
+//! [`PyPgValue`] / `PgParam` indirection rather than passing Python objects
+//! straight through.
+//!
+//! Every source is burst-shaped (`Stream<Burst<PyPgRow>>`), so each tick yields
+//! a Python **`list` of row dicts** — the same-instant group, losslessly.
+//!
+//! # Deviations from the legacy `wingfoil-python` bindings
+//!
+//! 1. **`postgres_read` yields a list per tick, not a single dict.** Legacy
+//!    `collapse()`d the burst and kept only the last row of any timestamp, which
+//!    silently dropped rows sharing a timestamp (its own docstring warned about
+//!    it). Bursts erase to lists uniformly here, so the read is lossless and
+//!    matches `postgres_sub`'s shape. Call `[0]` for the single-row case.
+//! 2. **The run window is an argument.** The Rust `postgres_read` takes the
+//!    run's `[start, end)` at *wiring* time (slicing is a pure, fail-fast
+//!    check), and a Python `Graph` does not know its run mode until `run()` — so
+//!    `start_nanos` / `duration_nanos` are passed explicitly and must match the
+//!    eventual `graph.run(...)`.
+//! 3. **New capabilities**: `postgres_source` (one wiring call, either run mode)
+//!    and the `buffer_size` back-pressure bound, neither of which legacy had.
+
+use std::time::Duration;
+
+use anyhow::{Result, anyhow, bail};
+use chrono::NaiveDateTime;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyDict};
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::adapters::postgres::{
+    PostgresConnection, PostgresDeserialize, PostgresRowExt, PostgresSerialize, PostgresSinkOps,
+    PostgresSourceConfig, Row, ToSql, Type, postgres_notify_trigger_sql as pg_notify_trigger_sql,
+    postgres_read as pg_read, postgres_source as pg_source, postgres_sub as pg_sub,
+    postgres_timestamp, quote_ident,
+};
+use wingfoil_next::async_source::RunParams;
+use wingfoil_next::prelude::{Burst, GraphBuilder, Stream, StreamOps};
+
+use crate::{PyElement, pyadapter};
+
+// ---------------------------------------------------------------------------
+// Reading: a row -> a Python dict.
+// ---------------------------------------------------------------------------
+
+/// One decoded column value on its way from PostgreSQL to Python.
+///
+/// Deliberately *not* a `Py<PyAny>`: rows are decoded on the adapter's async
+/// worker and handed to the graph across a channel, so the intermediate must be
+/// plain `Send` Rust data. The Python object is built later, on the graph
+/// thread, by [`PyPgValue::to_py`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum PyPgValue {
+    /// SQL `NULL` — Python `None`.
+    #[default]
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Bytes(Vec<u8>),
+    /// A `timestamp`/`timestamptz` rendered with [`postgres_timestamp`]
+    /// formatting, so it round-trips into a query predicate verbatim.
+    Timestamp(String),
+}
+
+impl PyPgValue {
+    /// Build the Python object for this value.
+    fn to_py(&self, py: Python<'_>) -> Py<PyAny> {
+        /// Box a scalar. Primitive `IntoPyObject` conversions are infallible,
+        /// so the `expect` is an unreachable invariant. `to_owned()` covers the
+        /// borrowed results (`bool` interns `True`/`False`).
+        macro_rules! boxed {
+            ($v:expr) => {
+                $v.into_pyobject(py)
+                    .map(|b| b.to_owned().into_any().unbind())
+                    .expect("invariant: scalar -> PyObject conversion is infallible")
+            };
+        }
+        match self {
+            PyPgValue::Null => py.None(),
+            PyPgValue::Bool(v) => boxed!(*v),
+            PyPgValue::Int(v) => boxed!(*v),
+            PyPgValue::Float(v) => boxed!(*v),
+            PyPgValue::Text(v) => boxed!(v.as_str()),
+            PyPgValue::Bytes(v) => PyBytes::new(py, v).into_any().unbind(),
+            PyPgValue::Timestamp(v) => boxed!(v.as_str()),
+        }
+    }
+}
+
+/// A deserialized PostgreSQL row as column name/value pairs — the dynamic
+/// stand-in for the record `struct` a Rust caller would write. Erases to a
+/// Python `dict`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct PyPgRow {
+    columns: Vec<(String, PyPgValue)>,
+}
+
+impl PyPgRow {
+    /// The decoded columns, in the order the query selected them.
+    pub fn columns(&self) -> &[(String, PyPgValue)] {
+        &self.columns
+    }
+}
+
+/// Decode one column, dispatching on its **declared** SQL type.
+///
+/// The type comes from the row metadata (no per-cell trial and error), and an
+/// unsupported column type is an **error** — not a silent `None` — so a schema
+/// mismatch (a `numeric`, `uuid` or `json` column, say) aborts on the first row
+/// instead of producing rows full of nulls indistinguishable from SQL `NULL`.
+fn column_value(row: &Row, idx: usize) -> Result<PyPgValue> {
+    let ty = row.columns()[idx].type_();
+    let value = if *ty == Type::BOOL {
+        row.try_get::<_, Option<bool>>(idx)?
+            .map_or(PyPgValue::Null, PyPgValue::Bool)
+    } else if *ty == Type::INT2 {
+        row.try_get::<_, Option<i16>>(idx)?
+            .map_or(PyPgValue::Null, |i| PyPgValue::Int(i as i64))
+    } else if *ty == Type::INT4 {
+        row.try_get::<_, Option<i32>>(idx)?
+            .map_or(PyPgValue::Null, |i| PyPgValue::Int(i as i64))
+    } else if *ty == Type::INT8 {
+        row.try_get::<_, Option<i64>>(idx)?
+            .map_or(PyPgValue::Null, PyPgValue::Int)
+    } else if *ty == Type::FLOAT4 {
+        row.try_get::<_, Option<f32>>(idx)?
+            .map_or(PyPgValue::Null, |f| PyPgValue::Float(f as f64))
+    } else if *ty == Type::FLOAT8 {
+        row.try_get::<_, Option<f64>>(idx)?
+            .map_or(PyPgValue::Null, PyPgValue::Float)
+    } else if *ty == Type::TEXT || *ty == Type::VARCHAR || *ty == Type::BPCHAR || *ty == Type::NAME
+    {
+        row.try_get::<_, Option<String>>(idx)?
+            .map_or(PyPgValue::Null, PyPgValue::Text)
+    } else if *ty == Type::TIMESTAMP {
+        row.try_get::<_, Option<NaiveDateTime>>(idx)?
+            .map_or(PyPgValue::Null, |t| {
+                PyPgValue::Timestamp(postgres_timestamp(t.into()))
+            })
+    } else if *ty == Type::TIMESTAMPTZ {
+        row.try_get::<_, Option<chrono::DateTime<chrono::Utc>>>(idx)?
+            .map_or(PyPgValue::Null, |t| {
+                PyPgValue::Timestamp(postgres_timestamp(t.naive_utc().into()))
+            })
+    } else if *ty == Type::BYTEA {
+        row.try_get::<_, Option<Vec<u8>>>(idx)?
+            .map_or(PyPgValue::Null, PyPgValue::Bytes)
+    } else {
+        bail!(
+            "postgres_read: unsupported column type `{ty}` for column `{}`; supported: \
+             bool, int2/int4/int8, float4/float8, text/varchar, timestamp/timestamptz, bytea",
+            row.columns()[idx].name()
+        );
+    };
+    Ok(value)
+}
+
+impl PostgresDeserialize for PyPgRow {
+    fn from_row(row: &Row) -> Result<(NanoTime, Self)> {
+        // Convention (as classic): the query selects its timestamp column first.
+        let time = row.get_nanotime(0)?;
+        let columns = row
+            .columns()
+            .iter()
+            .enumerate()
+            .map(|(i, col)| Ok((col.name().to_string(), column_value(row, i)?)))
+            .collect::<Result<Vec<_>>>()?;
+        Ok((time, PyPgRow { columns }))
+    }
+}
+
+impl From<PyPgRow> for PyElement {
+    fn from(row: PyPgRow) -> Self {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            for (name, value) in &row.columns {
+                dict.set_item(name, value.to_py(py))
+                    .expect("invariant: inserting a str key into a fresh PyDict cannot fail");
+            }
+            PyElement::new(dict.into_any().unbind())
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Query construction — the base query wrapped as a filtered subquery.
+// ---------------------------------------------------------------------------
+
+/// Strip a trailing `;` so `SELECT …;` survives the subquery wrap.
+fn normalise_query(query: &str) -> String {
+    query.trim().trim_end_matches(';').trim_end().to_string()
+}
+
+/// The historical slice query: `time >= t0 AND time < t1`, ordered by time —
+/// the contract [`pg_read`] requires of its `query_fn`.
+fn window_query(
+    query: &str,
+    time_col: &str,
+) -> impl FnMut((NanoTime, NanoTime), i32, usize) -> String + Send + 'static {
+    let query = normalise_query(query);
+    let tc = quote_ident(time_col);
+    move |(t0, t1), _date, _iter| {
+        format!(
+            "SELECT sub.* FROM ({query}) AS sub \
+             WHERE sub.{tc} >= '{t0}' AND sub.{tc} < '{t1}' ORDER BY sub.{tc}",
+            t0 = postgres_timestamp(t0),
+            t1 = postgres_timestamp(t1),
+        )
+    }
+}
+
+/// The live-tail cursor query: `time > cursor`, ordered by time — the contract
+/// [`pg_sub`] requires of its `query_fn`.
+fn cursor_query(query: &str, time_col: &str) -> impl FnMut(NanoTime) -> String + Send + 'static {
+    let query = normalise_query(query);
+    let tc = quote_ident(time_col);
+    move |cursor| {
+        format!(
+            "SELECT sub.* FROM ({query}) AS sub WHERE sub.{tc} > '{c}' ORDER BY sub.{tc}",
+            c = postgres_timestamp(cursor),
+        )
+    }
+}
+
+/// The `RunParams` a historical read is wired for. `RunFor::Duration` is the
+/// only bound [`pg_read`] can slice (it needs a concrete end time), so the
+/// binding always builds one.
+fn historical_params(start_nanos: u64, duration_nanos: u64) -> RunParams {
+    let start = NanoTime::from(start_nanos);
+    RunParams {
+        run_mode: RunMode::HistoricalFrom(start),
+        run_for: RunFor::Duration(Duration::from_nanos(duration_nanos)),
+        start_time: start,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sources.
+// ---------------------------------------------------------------------------
+
+/// The `postgres_read` source, as a `GraphBuilder` extension.
+trait PostgresReadOps {
+    #[allow(clippy::too_many_arguments)]
+    fn postgres_read(
+        &self,
+        conn_str: String,
+        query: String,
+        time_col: String,
+        start_nanos: u64,
+        duration_nanos: u64,
+        chunk_secs: u64,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<Burst<PyPgRow>>>;
+}
+
+/// Read a time-partitioned PostgreSQL table as a bounded historical replay.
+///
+/// `query` is wrapped as a subquery and filtered per time slice on `time_col`;
+/// **it must select `time_col` as its first column** so the row's on-graph
+/// timestamp can be extracted. Each tick yields a `list` of `{column: value}`
+/// dicts — the rows sharing that timestamp.
+///
+/// `start_nanos` / `duration_nanos` describe the run this source is wired for
+/// and must match the eventual `graph.run(start_nanos=…, duration_nanos=…)`;
+/// the window is validated and sliced at wiring, so a bad one raises here.
+/// `time_col` is identifier-quoted, so it must match the stored column name
+/// exactly (lower-case unless created quoted). A trailing `;` is stripped. An
+/// unsupported column type fails the run on the first row rather than reading as
+/// `None`. `buffer_size` bounds the replay's look-ahead (`None` = unbounded).
+#[pyadapter(name = postgres_read, source)]
+impl PostgresReadOps for GraphBuilder {
+    #[pyo3(signature = (
+        conn_str, query, time_col, start_nanos, duration_nanos,
+        chunk_secs = 3600, buffer_size = None,
+    ))]
+    fn postgres_read(
+        &self,
+        conn_str: String,
+        query: String,
+        time_col: String,
+        start_nanos: u64,
+        duration_nanos: u64,
+        chunk_secs: u64,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<Burst<PyPgRow>>> {
+        pg_read::<PyPgRow>(
+            self,
+            historical_params(start_nanos, duration_nanos),
+            PostgresConnection::new(conn_str),
+            Duration::from_secs(chunk_secs),
+            window_query(&query, &time_col),
+            buffer_size,
+        )
+    }
+}
+
+/// The `postgres_sub` live tail, as a `GraphBuilder` extension.
+trait PostgresSubOps {
+    fn postgres_sub(
+        &self,
+        conn_str: String,
+        query: String,
+        time_col: String,
+        channel: String,
+        start_secs: f64,
+        realtime: bool,
+    ) -> Result<Stream<Burst<PyPgRow>>>;
+}
+
+/// Live-tail a PostgreSQL table in real time using `LISTEN`/`NOTIFY`.
+///
+/// `query` is wrapped as a subquery and re-run past a time cursor whenever a
+/// notification arrives on `channel` (notifications are a wake-up signal only —
+/// rows always come from the query). **The query must select `time_col` as its
+/// first column.** Each tick yields a `list` of `{column: value}` dicts.
+///
+/// Install the notify trigger on the table first —
+/// `postgres_notify_trigger_sql` returns the SQL. `start_secs` is the initial
+/// cursor in Unix seconds (`0.0` = replay every existing row as a catch-up, then
+/// tail). The time column must be **strictly increasing** across inserts: the
+/// cursor query is `time > cursor`, so a row stamped at or before the cursor
+/// (including one tying the current max) is dropped.
+///
+/// `realtime` declares the run mode this source is wired for and must match the
+/// eventual `graph.run(realtime=…)`. The live tail has no historical timeline to
+/// replay, so `realtime=False` raises here — use `postgres_read` instead.
+#[pyadapter(name = postgres_sub, source)]
+impl PostgresSubOps for GraphBuilder {
+    #[pyo3(signature = (conn_str, query, time_col, channel, start_secs = 0.0, realtime = true))]
+    fn postgres_sub(
+        &self,
+        conn_str: String,
+        query: String,
+        time_col: String,
+        channel: String,
+        start_secs: f64,
+        realtime: bool,
+    ) -> Result<Stream<Burst<PyPgRow>>> {
+        pg_sub::<PyPgRow, _>(
+            self,
+            run_mode(realtime),
+            PostgresConnection::new(conn_str),
+            channel,
+            secs_to_nanotime(start_secs)?,
+            cursor_query(&query, &time_col),
+        )
+    }
+}
+
+/// The mode-agnostic `postgres_source`, as a `GraphBuilder` extension.
+trait PostgresSourceOps {
+    #[allow(clippy::too_many_arguments)]
+    fn postgres_source(
+        &self,
+        conn_str: String,
+        query: String,
+        time_col: String,
+        channel: String,
+        realtime: bool,
+        start_nanos: u64,
+        duration_nanos: u64,
+        start_secs: f64,
+        chunk_secs: u64,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<Burst<PyPgRow>>>;
+}
+
+/// One PostgreSQL source for **either** run mode: wire once, choose real-time vs
+/// historical at `run()`.
+///
+/// `realtime=False` dispatches to the `postgres_read` mechanism (using
+/// `start_nanos` / `duration_nanos` / `chunk_secs` / `buffer_size`);
+/// `realtime=True` dispatches to the `postgres_sub` live tail (using `channel` /
+/// `start_secs`). Both halves are configured from the same `query` + `time_col`,
+/// so the downstream wiring is identical either way — flip `realtime` (and the
+/// matching `graph.run(realtime=…)`) and nothing else changes.
+///
+/// This has no legacy `wingfoil-python` equivalent; it is the Python exposure of
+/// next's unified `<adapter>_source`.
+#[pyadapter(name = postgres_source, source)]
+impl PostgresSourceOps for GraphBuilder {
+    #[pyo3(signature = (
+        conn_str, query, time_col, channel, realtime,
+        start_nanos = 0, duration_nanos = 0, start_secs = 0.0,
+        chunk_secs = 3600, buffer_size = None,
+    ))]
+    fn postgres_source(
+        &self,
+        conn_str: String,
+        query: String,
+        time_col: String,
+        channel: String,
+        realtime: bool,
+        start_nanos: u64,
+        duration_nanos: u64,
+        start_secs: f64,
+        chunk_secs: u64,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<Burst<PyPgRow>>> {
+        let params = if realtime {
+            RunParams {
+                run_mode: RunMode::RealTime,
+                run_for: RunFor::Forever,
+                start_time: NanoTime::ZERO,
+            }
+        } else {
+            historical_params(start_nanos, duration_nanos)
+        };
+        let cfg = PostgresSourceConfig::new()
+            .historical(
+                Duration::from_secs(chunk_secs),
+                window_query(&query, &time_col),
+                buffer_size,
+            )
+            .live(
+                channel,
+                secs_to_nanotime(start_secs)?,
+                cursor_query(&query, &time_col),
+            );
+        pg_source::<PyPgRow>(self, params, PostgresConnection::new(conn_str), cfg)
+    }
+}
+
+/// The run mode a source is being wired for, from the Python `realtime` flag.
+/// The historical arm carries `ZERO`: the live-tail sources only ever test
+/// *which* variant it is (to reject a historical run), never the instant.
+fn run_mode(realtime: bool) -> RunMode {
+    if realtime {
+        RunMode::RealTime
+    } else {
+        RunMode::HistoricalFrom(NanoTime::ZERO)
+    }
+}
+
+/// Unix seconds -> [`NanoTime`]. Rejects a negative or non-finite input rather
+/// than wrapping it into a nonsense cursor.
+fn secs_to_nanotime(secs: f64) -> Result<NanoTime> {
+    if !secs.is_finite() || secs < 0.0 {
+        bail!("expected a finite, non-negative Unix-seconds value, got {secs}");
+    }
+    Ok(NanoTime::new((secs * 1e9) as u64))
+}
+
+// ---------------------------------------------------------------------------
+// Writing: a Python dict -> typed SQL parameters.
+// ---------------------------------------------------------------------------
+
+/// An owned, typed parameter produced from a Python value.
+///
+/// `None` inside a variant is a **typed** SQL `NULL`, so a nullable column binds
+/// with the right parameter type whatever the column's SQL type.
+#[derive(Debug, Clone, PartialEq)]
+enum PgParam {
+    Bool(Option<bool>),
+    Int4(Option<i32>),
+    Int8(Option<i64>),
+    Float4(Option<f32>),
+    Float8(Option<f64>),
+    Text(Option<String>),
+    Bytes(Option<Vec<u8>>),
+}
+
+impl PgParam {
+    fn boxed(&self) -> Box<dyn ToSql + Sync + Send> {
+        match self {
+            PgParam::Bool(v) => Box::new(*v),
+            PgParam::Int4(v) => Box::new(*v),
+            PgParam::Int8(v) => Box::new(*v),
+            PgParam::Float4(v) => Box::new(*v),
+            PgParam::Float8(v) => Box::new(*v),
+            PgParam::Text(v) => Box::new(v.clone()),
+            PgParam::Bytes(v) => Box::new(v.clone()),
+        }
+    }
+}
+
+/// One row to insert: the declared columns' values in table order (after time).
+#[derive(Debug, Clone, Default, PartialEq)]
+struct PyPgWriteRow {
+    values: Vec<PgParam>,
+}
+
+impl PostgresSerialize for PyPgWriteRow {
+    fn to_params(&self) -> Vec<Box<dyn ToSql + Sync + Send>> {
+        self.values.iter().map(PgParam::boxed).collect()
+    }
+}
+
+/// Extract the declared `columns` from a Python dict into an ordered write row.
+///
+/// Fails loudly: a missing key, an unsupported declared type, or a wrong-typed
+/// value aborts the run — never a silently-inserted `NULL`. Pass an explicit
+/// Python `None` to write SQL `NULL`.
+fn dict_to_write_row(
+    dict: &Bound<'_, PyDict>,
+    columns: &[(String, String)],
+) -> Result<PyPgWriteRow> {
+    let values =
+        columns
+            .iter()
+            .map(|(name, ty)| {
+                let value = dict
+                    .get_item(name)
+                    .map_err(|e| anyhow!("postgres_write: reading key '{name}': {e}"))?
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "postgres_write: missing column '{name}' in dict \
+                         (pass an explicit None to write SQL NULL)"
+                        )
+                    })?;
+                // `Some(T)` from the Python value, or `None` for Python `None`.
+                macro_rules! extract {
+                    ($t:ty) => {
+                        if value.is_none() {
+                            None
+                        } else {
+                            Some(value.extract::<$t>().map_err(|e| {
+                                anyhow!("postgres_write: column '{name}' ({ty}): {e}")
+                            })?)
+                        }
+                    };
+                }
+                Ok(match ty.as_str() {
+                    "bool" => PgParam::Bool(extract!(bool)),
+                    "int" | "int4" | "integer" => PgParam::Int4(extract!(i32)),
+                    "long" | "int8" | "bigint" => PgParam::Int8(extract!(i64)),
+                    "float4" | "real" => PgParam::Float4(extract!(f32)),
+                    "float" | "float8" | "double" => PgParam::Float8(extract!(f64)),
+                    "text" | "str" => PgParam::Text(extract!(String)),
+                    "bytes" | "bytea" => PgParam::Bytes(extract!(Vec<u8>)),
+                    other => bail!(
+                        "postgres_write: unsupported column type '{other}' for column '{name}'; \
+                     supported: bool, int/int4/integer, long/int8/bigint, float4/real, \
+                     float/float8/double, text/str, bytes/bytea"
+                    ),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+    Ok(PyPgWriteRow { values })
+}
+
+/// Marshal one erased stream value — a Python `dict` — into a write row.
+fn element_to_write_row(elem: &PyElement, columns: &[(String, String)]) -> Result<PyPgWriteRow> {
+    if elem.is_none() {
+        bail!("postgres_write: stream value is empty (the upstream produced no value)");
+    }
+    Python::attach(|py| {
+        let obj = elem.object().bind(py);
+        let dict = obj.cast::<PyDict>().map_err(|_| {
+            anyhow!(
+                "postgres_write: stream value must be a dict of the declared columns \
+                 (or a list of such dicts), got {}",
+                obj.get_type()
+            )
+        })?;
+        dict_to_write_row(dict, columns)
+    })
+}
+
+/// The `postgres_write` sink, as an extension on the **erased** burst stream.
+///
+/// The input stays `PyElement` rather than a concrete record type because the
+/// row shape is only known from the caller's `columns` argument — which is in
+/// scope here, inside the adapter, and not at the `typed_burst_input` seam. The
+/// marshaling happens in this method's `try_map`; everything downstream of it is
+/// natively typed.
+trait PostgresWriteOps {
+    fn postgres_write(
+        &self,
+        conn_str: String,
+        table: String,
+        columns: Vec<(String, String)>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>>;
+}
+
+/// Write this stream to a PostgreSQL table.
+///
+/// Each tick's value is either a single `dict` of the declared columns, or a
+/// `list`/`tuple` of such dicts for several rows at one timestamp. The graph
+/// timestamp is prepended, so the target table's columns must line up as
+/// `(timestamp, <columns in the declared order>)`.
+///
+/// `columns` is a list of `(name, sql_type)` pairs in table order; the accepted
+/// types are `bool`, `int`/`int4`/`integer`, `long`/`int8`/`bigint`,
+/// `float4`/`real`, `float`/`float8`/`double`, `text`/`str` and `bytes`/`bytea`.
+/// A missing key, an unsupported type, or a wrong-typed value aborts the run
+/// rather than inserting a silent `NULL` — pass an explicit `None` for SQL
+/// `NULL`. The connection is opened lazily on the first write, so a connection
+/// failure also aborts the run rather than raising at wiring. `buffer_size`
+/// bounds the unwritten backlog (`None` = unbounded). Returns a terminal stream
+/// whose value is `None`.
+#[pyadapter(name = postgres_write)]
+impl PostgresWriteOps for Stream<Burst<PyElement>> {
+    #[pyo3(signature = (conn_str, table, columns, buffer_size = None))]
+    fn postgres_write(
+        &self,
+        conn_str: String,
+        table: String,
+        columns: Vec<(String, String)>,
+        buffer_size: Option<usize>,
+    ) -> Result<Stream<()>> {
+        let rows: Stream<Burst<PyPgWriteRow>> = self.try_map(move |burst: &Burst<PyElement>| {
+            burst
+                .iter()
+                .map(|elem| element_to_write_row(elem, &columns))
+                .collect::<Result<Burst<PyPgWriteRow>>>()
+        });
+        PostgresSinkOps::postgres_write(
+            &rows,
+            PostgresConnection::new(conn_str),
+            &table,
+            buffer_size,
+        )
+    }
+}
+
+/// SQL installing an `AFTER INSERT` trigger that fires `pg_notify(channel, '')`.
+///
+/// Run it against the database (with psycopg, say) to wire a table up for
+/// `postgres_sub`. Idempotent.
+#[pyfunction]
+#[pyo3(name = "postgres_notify_trigger_sql")]
+pub fn postgres_notify_trigger_sql(table: String, channel: String) -> String {
+    pg_notify_trigger_sql(&table, &channel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::types::PyList;
+
+    /// `columns` as the Python binding receives them.
+    fn columns() -> Vec<(String, String)> {
+        [("sym", "text"), ("price", "float"), ("qty", "long")]
+            .into_iter()
+            .map(|(n, t)| (n.to_string(), t.to_string()))
+            .collect()
+    }
+
+    fn dict_element(py: Python<'_>, items: &[(&str, Py<PyAny>)]) -> PyElement {
+        let dict = PyDict::new(py);
+        for (k, v) in items {
+            dict.set_item(k, v).unwrap();
+        }
+        PyElement::new(dict.into_any().unbind())
+    }
+
+    #[test]
+    fn row_erases_to_a_dict() {
+        let row = PyPgRow {
+            columns: vec![
+                ("sym".into(), PyPgValue::Text("AAPL".into())),
+                ("price".into(), PyPgValue::Float(1.5)),
+                ("qty".into(), PyPgValue::Int(7)),
+                ("flag".into(), PyPgValue::Bool(true)),
+                ("blob".into(), PyPgValue::Bytes(vec![1, 2])),
+                ("missing".into(), PyPgValue::Null),
+            ],
+        };
+        let element = PyElement::from(row);
+        Python::attach(|py| {
+            let dict = element.object().bind(py).cast::<PyDict>().unwrap().clone();
+            assert_eq!(
+                "AAPL",
+                dict.get_item("sym")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<String>()
+                    .unwrap()
+            );
+            assert_eq!(
+                1.5,
+                dict.get_item("price")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<f64>()
+                    .unwrap()
+            );
+            assert_eq!(
+                7,
+                dict.get_item("qty")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<i64>()
+                    .unwrap()
+            );
+            assert!(
+                dict.get_item("flag")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<bool>()
+                    .unwrap()
+            );
+            assert_eq!(
+                vec![1_u8, 2],
+                dict.get_item("blob")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<Vec<u8>>()
+                    .unwrap()
+            );
+            assert!(dict.get_item("missing").unwrap().unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn dict_marshals_to_declared_column_order() {
+        Python::attach(|py| {
+            // Deliberately out of table order: the declared `columns` decide.
+            let element = dict_element(
+                py,
+                &[
+                    ("qty", 7_i64.into_pyobject(py).unwrap().into_any().unbind()),
+                    ("sym", "AAPL".into_pyobject(py).unwrap().into_any().unbind()),
+                    (
+                        "price",
+                        1.5_f64.into_pyobject(py).unwrap().into_any().unbind(),
+                    ),
+                ],
+            );
+            let row = element_to_write_row(&element, &columns()).unwrap();
+            assert_eq!(
+                vec![
+                    PgParam::Text(Some("AAPL".into())),
+                    PgParam::Float8(Some(1.5)),
+                    PgParam::Int8(Some(7)),
+                ],
+                row.values
+            );
+        });
+    }
+
+    #[test]
+    fn explicit_none_is_a_typed_null() {
+        Python::attach(|py| {
+            let element = dict_element(
+                py,
+                &[("sym", py.None()), ("price", py.None()), ("qty", py.None())],
+            );
+            let row = element_to_write_row(&element, &columns()).unwrap();
+            assert_eq!(
+                vec![
+                    PgParam::Text(None),
+                    PgParam::Float8(None),
+                    PgParam::Int8(None)
+                ],
+                row.values
+            );
+        });
+    }
+
+    #[test]
+    fn missing_column_errors_rather_than_writing_null() {
+        Python::attach(|py| {
+            let element = dict_element(
+                py,
+                &[("sym", "AAPL".into_pyobject(py).unwrap().into_any().unbind())],
+            );
+            let err = element_to_write_row(&element, &columns()).unwrap_err();
+            assert!(
+                err.to_string().contains("missing column 'price'"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn wrong_typed_value_errors() {
+        Python::attach(|py| {
+            let element = dict_element(
+                py,
+                &[
+                    ("sym", "AAPL".into_pyobject(py).unwrap().into_any().unbind()),
+                    (
+                        "price",
+                        "not-a-number"
+                            .into_pyobject(py)
+                            .unwrap()
+                            .into_any()
+                            .unbind(),
+                    ),
+                    ("qty", 7_i64.into_pyobject(py).unwrap().into_any().unbind()),
+                ],
+            );
+            let err = element_to_write_row(&element, &columns()).unwrap_err();
+            assert!(
+                err.to_string().contains("column 'price'"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn unsupported_declared_type_errors() {
+        Python::attach(|py| {
+            let element = dict_element(
+                py,
+                &[("id", "x".into_pyobject(py).unwrap().into_any().unbind())],
+            );
+            let cols = vec![("id".to_string(), "uuid".to_string())];
+            let err = element_to_write_row(&element, &cols).unwrap_err();
+            assert!(
+                err.to_string().contains("unsupported column type 'uuid'"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn non_dict_value_errors() {
+        Python::attach(|py| {
+            let element = PyElement::new(PyList::empty(py).into_any().unbind());
+            let err = element_to_write_row(&element, &columns()).unwrap_err();
+            assert!(
+                err.to_string().contains("must be a dict"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn empty_element_errors() {
+        let err = element_to_write_row(&PyElement::none(), &columns()).unwrap_err();
+        assert!(err.to_string().contains("empty"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn query_is_wrapped_and_filtered_on_the_quoted_time_column() {
+        let mut q = window_query("SELECT time, sym FROM trades;", "time");
+        let sql = q((NanoTime::ZERO, NanoTime::new(1_000_000_000)), 0, 0);
+        // The trailing `;` is stripped so the subquery wrap stays valid.
+        assert!(
+            sql.contains("FROM (SELECT time, sym FROM trades) AS sub"),
+            "{sql}"
+        );
+        assert!(sql.contains(r#"WHERE sub."time" >="#), "{sql}");
+        assert!(sql.contains(r#"ORDER BY sub."time""#), "{sql}");
+    }
+
+    #[test]
+    fn cursor_query_filters_strictly_past_the_cursor() {
+        let mut q = cursor_query("SELECT time, sym FROM trades", "time");
+        let sql = q(NanoTime::new(1_000_000_000));
+        assert!(sql.contains(r#"WHERE sub."time" >"#), "{sql}");
+        assert!(!sql.contains(">="), "cursor must be strict: {sql}");
+    }
+
+    #[test]
+    fn start_secs_rejects_nonsense() {
+        assert!(secs_to_nanotime(-1.0).is_err());
+        assert!(secs_to_nanotime(f64::NAN).is_err());
+        assert_eq!(NanoTime::new(1_500_000_000), secs_to_nanotime(1.5).unwrap());
+    }
+}

--- a/next/crates/wingfoil-next-python/src/adapters/postgres.rs
+++ b/next/crates/wingfoil-next-python/src/adapters/postgres.rs
@@ -51,16 +51,16 @@ use anyhow::{Result, anyhow, bail};
 use chrono::NaiveDateTime;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
-use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil::NanoTime;
 use wingfoil_next::adapters::postgres::{
     PostgresConnection, PostgresDeserialize, PostgresRowExt, PostgresSerialize, PostgresSinkOps,
     PostgresSourceConfig, Row, ToSql, Type, postgres_notify_trigger_sql as pg_notify_trigger_sql,
     postgres_read as pg_read, postgres_source as pg_source, postgres_sub as pg_sub,
     postgres_timestamp, quote_ident,
 };
-use wingfoil_next::async_source::RunParams;
 use wingfoil_next::prelude::{Burst, GraphBuilder, Stream, StreamOps};
 
+use crate::adapters::common::{historical_params, realtime_params, run_mode, secs_to_nanotime};
 use crate::{PyElement, pyadapter};
 
 // ---------------------------------------------------------------------------
@@ -248,36 +248,9 @@ fn cursor_query(query: &str, time_col: &str) -> impl FnMut(NanoTime) -> String +
     }
 }
 
-/// The `RunParams` a historical read is wired for. `RunFor::Duration` is the
-/// only bound [`pg_read`] can slice (it needs a concrete end time), so the
-/// binding always builds one.
-fn historical_params(start_nanos: u64, duration_nanos: u64) -> RunParams {
-    let start = NanoTime::from(start_nanos);
-    RunParams {
-        run_mode: RunMode::HistoricalFrom(start),
-        run_for: RunFor::Duration(Duration::from_nanos(duration_nanos)),
-        start_time: start,
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Sources.
 // ---------------------------------------------------------------------------
-
-/// The `postgres_read` source, as a `GraphBuilder` extension.
-trait PostgresReadOps {
-    #[allow(clippy::too_many_arguments)]
-    fn postgres_read(
-        &self,
-        conn_str: String,
-        query: String,
-        time_col: String,
-        start_nanos: u64,
-        duration_nanos: u64,
-        chunk_secs: u64,
-        buffer_size: Option<usize>,
-    ) -> Result<Stream<Burst<PyPgRow>>>;
-}
 
 /// Read a time-partitioned PostgreSQL table as a bounded historical replay.
 ///
@@ -294,43 +267,28 @@ trait PostgresReadOps {
 /// unsupported column type fails the run on the first row rather than reading as
 /// `None`. `buffer_size` bounds the replay's look-ahead (`None` = unbounded).
 #[pyadapter(name = postgres_read, source)]
-impl PostgresReadOps for GraphBuilder {
-    #[pyo3(signature = (
-        conn_str, query, time_col, start_nanos, duration_nanos,
-        chunk_secs = 3600, buffer_size = None,
-    ))]
-    fn postgres_read(
-        &self,
-        conn_str: String,
-        query: String,
-        time_col: String,
-        start_nanos: u64,
-        duration_nanos: u64,
-        chunk_secs: u64,
-        buffer_size: Option<usize>,
-    ) -> Result<Stream<Burst<PyPgRow>>> {
-        pg_read::<PyPgRow>(
-            self,
-            historical_params(start_nanos, duration_nanos),
-            PostgresConnection::new(conn_str),
-            Duration::from_secs(chunk_secs),
-            window_query(&query, &time_col),
-            buffer_size,
-        )
-    }
-}
-
-/// The `postgres_sub` live tail, as a `GraphBuilder` extension.
-trait PostgresSubOps {
-    fn postgres_sub(
-        &self,
-        conn_str: String,
-        query: String,
-        time_col: String,
-        channel: String,
-        start_secs: f64,
-        realtime: bool,
-    ) -> Result<Stream<Burst<PyPgRow>>>;
+#[pyo3(signature = (
+    conn_str, query, time_col, start_nanos, duration_nanos,
+    chunk_secs = 3600, buffer_size = None,
+))]
+fn read(
+    g: &GraphBuilder,
+    conn_str: String,
+    query: String,
+    time_col: String,
+    start_nanos: u64,
+    duration_nanos: u64,
+    chunk_secs: u64,
+    buffer_size: Option<usize>,
+) -> Result<Stream<Burst<PyPgRow>>> {
+    pg_read::<PyPgRow>(
+        g,
+        historical_params(start_nanos, duration_nanos),
+        PostgresConnection::new(conn_str),
+        Duration::from_secs(chunk_secs),
+        window_query(&query, &time_col),
+        buffer_size,
+    )
 }
 
 /// Live-tail a PostgreSQL table in real time using `LISTEN`/`NOTIFY`.
@@ -351,44 +309,24 @@ trait PostgresSubOps {
 /// eventual `graph.run(realtime=…)`. The live tail has no historical timeline to
 /// replay, so `realtime=False` raises here — use `postgres_read` instead.
 #[pyadapter(name = postgres_sub, source)]
-impl PostgresSubOps for GraphBuilder {
-    #[pyo3(signature = (conn_str, query, time_col, channel, start_secs = 0.0, realtime = true))]
-    fn postgres_sub(
-        &self,
-        conn_str: String,
-        query: String,
-        time_col: String,
-        channel: String,
-        start_secs: f64,
-        realtime: bool,
-    ) -> Result<Stream<Burst<PyPgRow>>> {
-        pg_sub::<PyPgRow, _>(
-            self,
-            run_mode(realtime),
-            PostgresConnection::new(conn_str),
-            channel,
-            secs_to_nanotime(start_secs)?,
-            cursor_query(&query, &time_col),
-        )
-    }
-}
-
-/// The mode-agnostic `postgres_source`, as a `GraphBuilder` extension.
-trait PostgresSourceOps {
-    #[allow(clippy::too_many_arguments)]
-    fn postgres_source(
-        &self,
-        conn_str: String,
-        query: String,
-        time_col: String,
-        channel: String,
-        realtime: bool,
-        start_nanos: u64,
-        duration_nanos: u64,
-        start_secs: f64,
-        chunk_secs: u64,
-        buffer_size: Option<usize>,
-    ) -> Result<Stream<Burst<PyPgRow>>>;
+#[pyo3(signature = (conn_str, query, time_col, channel, start_secs = 0.0, realtime = true))]
+fn sub(
+    g: &GraphBuilder,
+    conn_str: String,
+    query: String,
+    time_col: String,
+    channel: String,
+    start_secs: f64,
+    realtime: bool,
+) -> Result<Stream<Burst<PyPgRow>>> {
+    pg_sub::<PyPgRow, _>(
+        g,
+        run_mode(realtime),
+        PostgresConnection::new(conn_str),
+        channel,
+        secs_to_nanotime(start_secs)?,
+        cursor_query(&query, &time_col),
+    )
 }
 
 /// One PostgreSQL source for **either** run mode: wire once, choose real-time vs
@@ -404,67 +342,41 @@ trait PostgresSourceOps {
 /// This has no legacy `wingfoil-python` equivalent; it is the Python exposure of
 /// next's unified `<adapter>_source`.
 #[pyadapter(name = postgres_source, source)]
-impl PostgresSourceOps for GraphBuilder {
-    #[pyo3(signature = (
-        conn_str, query, time_col, channel, realtime,
-        start_nanos = 0, duration_nanos = 0, start_secs = 0.0,
-        chunk_secs = 3600, buffer_size = None,
-    ))]
-    fn postgres_source(
-        &self,
-        conn_str: String,
-        query: String,
-        time_col: String,
-        channel: String,
-        realtime: bool,
-        start_nanos: u64,
-        duration_nanos: u64,
-        start_secs: f64,
-        chunk_secs: u64,
-        buffer_size: Option<usize>,
-    ) -> Result<Stream<Burst<PyPgRow>>> {
-        let params = if realtime {
-            RunParams {
-                run_mode: RunMode::RealTime,
-                run_for: RunFor::Forever,
-                start_time: NanoTime::ZERO,
-            }
-        } else {
-            historical_params(start_nanos, duration_nanos)
-        };
-        let cfg = PostgresSourceConfig::new()
-            .historical(
-                Duration::from_secs(chunk_secs),
-                window_query(&query, &time_col),
-                buffer_size,
-            )
-            .live(
-                channel,
-                secs_to_nanotime(start_secs)?,
-                cursor_query(&query, &time_col),
-            );
-        pg_source::<PyPgRow>(self, params, PostgresConnection::new(conn_str), cfg)
-    }
-}
-
-/// The run mode a source is being wired for, from the Python `realtime` flag.
-/// The historical arm carries `ZERO`: the live-tail sources only ever test
-/// *which* variant it is (to reject a historical run), never the instant.
-fn run_mode(realtime: bool) -> RunMode {
-    if realtime {
-        RunMode::RealTime
+#[pyo3(signature = (
+    conn_str, query, time_col, channel, realtime,
+    start_nanos = 0, duration_nanos = 0, start_secs = 0.0,
+    chunk_secs = 3600, buffer_size = None,
+))]
+fn source(
+    g: &GraphBuilder,
+    conn_str: String,
+    query: String,
+    time_col: String,
+    channel: String,
+    realtime: bool,
+    start_nanos: u64,
+    duration_nanos: u64,
+    start_secs: f64,
+    chunk_secs: u64,
+    buffer_size: Option<usize>,
+) -> Result<Stream<Burst<PyPgRow>>> {
+    let params = if realtime {
+        realtime_params()
     } else {
-        RunMode::HistoricalFrom(NanoTime::ZERO)
-    }
-}
-
-/// Unix seconds -> [`NanoTime`]. Rejects a negative or non-finite input rather
-/// than wrapping it into a nonsense cursor.
-fn secs_to_nanotime(secs: f64) -> Result<NanoTime> {
-    if !secs.is_finite() || secs < 0.0 {
-        bail!("expected a finite, non-negative Unix-seconds value, got {secs}");
-    }
-    Ok(NanoTime::new((secs * 1e9) as u64))
+        historical_params(start_nanos, duration_nanos)
+    };
+    let cfg = PostgresSourceConfig::new()
+        .historical(
+            Duration::from_secs(chunk_secs),
+            window_query(&query, &time_col),
+            buffer_size,
+        )
+        .live(
+            channel,
+            secs_to_nanotime(start_secs)?,
+            cursor_query(&query, &time_col),
+        );
+    pg_source::<PyPgRow>(g, params, PostgresConnection::new(conn_str), cfg)
 }
 
 // ---------------------------------------------------------------------------
@@ -583,23 +495,6 @@ fn element_to_write_row(elem: &PyElement, columns: &[(String, String)]) -> Resul
     })
 }
 
-/// The `postgres_write` sink, as an extension on the **erased** burst stream.
-///
-/// The input stays `PyElement` rather than a concrete record type because the
-/// row shape is only known from the caller's `columns` argument — which is in
-/// scope here, inside the adapter, and not at the `typed_burst_input` seam. The
-/// marshaling happens in this method's `try_map`; everything downstream of it is
-/// natively typed.
-trait PostgresWriteOps {
-    fn postgres_write(
-        &self,
-        conn_str: String,
-        table: String,
-        columns: Vec<(String, String)>,
-        buffer_size: Option<usize>,
-    ) -> Result<Stream<()>>;
-}
-
 /// Write this stream to a PostgreSQL table.
 ///
 /// Each tick's value is either a single `dict` of the declared columns, or a
@@ -616,29 +511,33 @@ trait PostgresWriteOps {
 /// failure also aborts the run rather than raising at wiring. `buffer_size`
 /// bounds the unwritten backlog (`None` = unbounded). Returns a terminal stream
 /// whose value is `None`.
+///
+/// The input stays **erased** (`Burst<PyElement>`) rather than a concrete record
+/// type because the row shape is only known from `columns` — which is in scope
+/// here, inside the adapter, and not at the `typed_burst_input` seam. The
+/// marshaling happens in the `try_map` below; everything downstream of it is
+/// natively typed.
 #[pyadapter(name = postgres_write)]
-impl PostgresWriteOps for Stream<Burst<PyElement>> {
-    #[pyo3(signature = (conn_str, table, columns, buffer_size = None))]
-    fn postgres_write(
-        &self,
-        conn_str: String,
-        table: String,
-        columns: Vec<(String, String)>,
-        buffer_size: Option<usize>,
-    ) -> Result<Stream<()>> {
-        let rows: Stream<Burst<PyPgWriteRow>> = self.try_map(move |burst: &Burst<PyElement>| {
-            burst
-                .iter()
-                .map(|elem| element_to_write_row(elem, &columns))
-                .collect::<Result<Burst<PyPgWriteRow>>>()
-        });
-        PostgresSinkOps::postgres_write(
-            &rows,
-            PostgresConnection::new(conn_str),
-            &table,
-            buffer_size,
-        )
-    }
+#[pyo3(signature = (conn_str, table, columns, buffer_size = None))]
+fn write(
+    stream: &Stream<Burst<PyElement>>,
+    conn_str: String,
+    table: String,
+    columns: Vec<(String, String)>,
+    buffer_size: Option<usize>,
+) -> Result<Stream<()>> {
+    let rows: Stream<Burst<PyPgWriteRow>> = stream.try_map(move |burst: &Burst<PyElement>| {
+        burst
+            .iter()
+            .map(|elem| element_to_write_row(elem, &columns))
+            .collect::<Result<Burst<PyPgWriteRow>>>()
+    });
+    PostgresSinkOps::postgres_write(
+        &rows,
+        PostgresConnection::new(conn_str),
+        &table,
+        buffer_size,
+    )
 }
 
 /// SQL installing an `AFTER INSERT` trigger that fires `pg_notify(channel, '')`.
@@ -870,12 +769,5 @@ mod tests {
         let sql = q(NanoTime::new(1_000_000_000));
         assert!(sql.contains(r#"WHERE sub."time" >"#), "{sql}");
         assert!(!sql.contains(">="), "cursor must be strict: {sql}");
-    }
-
-    #[test]
-    fn start_secs_rejects_nonsense() {
-        assert!(secs_to_nanotime(-1.0).is_err());
-        assert!(secs_to_nanotime(f64::NAN).is_err());
-        assert_eq!(NanoTime::new(1_500_000_000), secs_to_nanotime(1.5).unwrap());
     }
 }

--- a/next/crates/wingfoil-next-python/src/element.rs
+++ b/next/crates/wingfoil-next-python/src/element.rs
@@ -244,6 +244,23 @@ macro_rules! try_into_scalar {
 }
 try_into_scalar!(f64, i64, bool, String);
 
+/// The **identity** edge conversion: extracting a `PyElement` from a
+/// `PyElement` is a clone.
+///
+/// This is what lets an adapter whose payload is inherently *dynamic* — a
+/// PostgreSQL row written from an arbitrary Python `dict`, say — stay on the
+/// erased type at the seam and do its own marshaling inside the adapter (where
+/// the column spec is in scope), while still going through the standard
+/// `#[pyadapter]` `typed_input` / `typed_burst_input` path. Without it such an
+/// adapter would need a hand-written `#[pyfunction]`.
+impl TryFrom<&PyElement> for PyElement {
+    type Error = anyhow::Error;
+
+    fn try_from(el: &PyElement) -> Result<Self> {
+        Ok(el.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -40,6 +40,25 @@ use crate::PyElement;
 /// [`PyStream`] wired from it so `value()` works on whichever you kept.
 type RunnerSlot = Rc<RefCell<Option<Runner>>>;
 
+/// A raw pointer marked `Send` purely to satisfy the bound on
+/// [`Python::detach`], which requires a `Send` closure even though it runs that
+/// closure in place on the calling thread. See the safety note in
+/// [`PyGraph::run`], the only user.
+struct SendPtr<T>(*const T);
+
+impl<T> SendPtr<T> {
+    /// The wrapped pointer. An accessor rather than a field read because
+    /// edition-2024 closures capture disjoint *fields*: reading `.0` directly
+    /// would capture the bare (non-`Send`) pointer instead of this wrapper.
+    fn get(&self) -> *const T {
+        self.0
+    }
+}
+
+// SAFETY: the pointer is never dereferenced on, or sent to, another thread —
+// `detach` releases the GIL around an in-place call. See `PyGraph::run`.
+unsafe impl<T> Send for SendPtr<T> {}
+
 /// Box a `(time, value)` pair into a Python `(nanos, value)` tuple element —
 /// the edge conversion shared by `with_time` and `collect` (nanoseconds as an
 /// int).
@@ -153,14 +172,38 @@ impl PyGraph {
     /// to its wiring-time state so runs are independent (engine reset hook). A
     /// graph with single-run sources (`external`/`poll`/`channel`) errors on the
     /// second run, surfaced from the engine.
+    ///
+    /// **The GIL is released for the duration of the run** (re-acquired per
+    /// Python callback via `Python::attach`). Without that, a real-time adapter
+    /// source could not deliver — its worker thread, and every other Python
+    /// thread, would be blocked until `run` returned, so a live tail would only
+    /// ever see rows that already existed when it started. This mirrors legacy
+    /// `wingfoil-python`, whose `run` releases the GIL for the same reason.
     pub fn run(&self, run_mode: RunMode, run_for: RunFor) -> Result<()> {
-        let mut slot = self.runner.borrow_mut();
-        if slot.is_none() {
-            *slot = Some(self.builder.build());
+        // Build outside the detached section: construction touches no Python.
+        {
+            let mut slot = self.runner.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(self.builder.build());
+            }
         }
-        slot.as_mut()
-            .expect("runner set above")
-            .run(run_mode, run_for)
+        let runner = SendPtr(Rc::as_ptr(&self.runner));
+        Python::attach(|py| {
+            py.detach(move || {
+                // SAFETY: `detach` runs its closure **in place on this thread** —
+                // it only releases the GIL for the closure's duration, it does
+                // not move the work elsewhere. Its `Send` bound is therefore
+                // conservative, and the pointee is kept alive for the whole call
+                // by `self`, which outlives it. Nothing else can reach the slot:
+                // `PyGraph` is `Rc`-based and its pyclass is `unsendable`, so it
+                // is pinned to this thread.
+                let slot = unsafe { &*runner.get() };
+                slot.borrow_mut()
+                    .as_mut()
+                    .expect("invariant: runner built above")
+                    .run(run_mode, run_for)
+            })
+        })
     }
 
     /// Wire a **Python-defined custom node** — a Python object acting as a graph

--- a/next/crates/wingfoil-next-python/src/lib.rs
+++ b/next/crates/wingfoil-next-python/src/lib.rs
@@ -23,6 +23,7 @@
 // downstream crates — also resolves when the macro is used inside this crate.
 extern crate self as wingfoil_next_python;
 
+pub mod adapters;
 pub mod element;
 pub mod graph;
 #[macro_use]
@@ -31,7 +32,7 @@ mod python;
 
 pub use element::PyElement;
 pub use graph::{PyGraph, PyStream};
-pub use python::{Graph, Stream};
+pub use python::{Graph, Stream, to_pyerr};
 
 /// Derive a Python-callable function from an `Op` impl. See
 /// [`wingfoil_next_python_macros`] — placed on `impl Op for MyOp`, it generates

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -23,7 +23,14 @@ use wingfoil::{NanoTime, RunFor, RunMode};
 use crate::graph::{PyGraph, PyStream};
 use crate::{Activation, Ctx, Op, PyElement, Tick, pyadapter, pygraph, pyop};
 
-fn to_pyerr(err: anyhow::Error) -> PyErr {
+/// Map an `anyhow::Error` to a Python exception, preserving the whole context
+/// chain (`{:#}`).
+///
+/// Public because `#[pyadapter]`-generated code names it: an adapter whose
+/// wiring is fallible (`Result<Stream<T>>`) turns that error into a Python
+/// exception at the seam, in this crate and in third-party op/adapter crates
+/// alike.
+pub fn to_pyerr(err: anyhow::Error) -> PyErr {
     PyRuntimeError::new_err(format!("{err:#}"))
 }
 
@@ -526,5 +533,30 @@ fn wingfoil_next(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(list_sink, m)?)?;
     m.add_function(wrap_pyfunction!(pair_source, m)?)?;
     m.add_function(wrap_pyfunction!(burst_list_sink, m)?)?;
+    register_adapters(m)?;
+    Ok(())
+}
+
+/// Register the per-adapter bindings the wheel was built with. Each adapter is
+/// behind its own cargo feature (see `crate::adapters`), so a wheel built
+/// without it simply has no such attribute.
+fn register_adapters(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    #[cfg(feature = "postgres")]
+    {
+        // Imported by name (rather than called through the module path) because
+        // `wrap_pyfunction!` resolves the hidden wrapper pyo3 defines alongside
+        // each `#[pyfunction]`, which needs the name in scope.
+        use crate::adapters::postgres::{
+            postgres_notify_trigger_sql, postgres_read, postgres_source, postgres_sub,
+            postgres_write,
+        };
+        m.add_function(wrap_pyfunction!(postgres_read, m)?)?;
+        m.add_function(wrap_pyfunction!(postgres_sub, m)?)?;
+        m.add_function(wrap_pyfunction!(postgres_source, m)?)?;
+        m.add_function(wrap_pyfunction!(postgres_write, m)?)?;
+        m.add_function(wrap_pyfunction!(postgres_notify_trigger_sql, m)?)?;
+    }
+    // `m` is unused when no adapter feature is on.
+    let _ = m;
     Ok(())
 }

--- a/next/crates/wingfoil-next-python/tests/plugin_seam.rs
+++ b/next/crates/wingfoil-next-python/tests/plugin_seam.rs
@@ -430,3 +430,84 @@ fn fallible_pyadapter_wiring_succeeds_and_fails_as_written() {
         "{err:#}"
     );
 }
+
+// The **free-fn** `#[pyadapter]` form — the shape a binding module wants. The
+// receiver is the first param (`&GraphBuilder` for a source, `&Stream<T>` for a
+// sink), so there is no throwaway trait and no second copy of the signature.
+// `name` differs from the fn's own name because the macro emits a
+// `#[pyfunction]` of that name alongside it.
+#[pyadapter(name = free_ramp, source)]
+#[pyo3(signature = (start, step = 1.0))]
+fn ramp(g: &wingfoil_next::prelude::GraphBuilder, start: f64, step: f64) -> Stream<f64> {
+    use wingfoil_next::prelude::{SourceOps, StreamOps};
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(move |n: &u64| start + step * ((*n - 1) as f64))
+}
+
+#[pyadapter(name = free_checked_ramp, source)]
+fn checked_ramp_fn(
+    g: &wingfoil_next::prelude::GraphBuilder,
+    start: f64,
+    step: f64,
+) -> anyhow::Result<Stream<f64>> {
+    if step <= 0.0 {
+        anyhow::bail!("free_checked_ramp: step must be positive, got {step}");
+    }
+    Ok(ramp(g, start, step))
+}
+
+#[pyadapter(name = free_push_sink)]
+#[pyo3(signature = (target, scale = 1.0))]
+fn push_sink(stream: &Stream<f64>, target: Py<PyAny>, scale: f64) -> anyhow::Result<Stream<()>> {
+    use wingfoil_next::prelude::StreamOps;
+    Ok(stream.for_each(move |v: &f64| {
+        Python::attach(|py| {
+            target
+                .bind(py)
+                .call_method1("append", (*v * scale,))
+                .map_err(|err| anyhow::anyhow!("free_push_sink append raised: {err}"))?;
+            Ok(())
+        })
+    }))
+}
+
+#[test]
+fn free_fn_pyadapter_generates_source_and_sink_functions() {
+    // Compile proof: infallible source, fallible source, and fallible sink all
+    // generate their `#[pyfunction]` from a plain fn in an external crate.
+    let _a = free_ramp;
+    let _b = free_checked_ramp;
+    let _c = free_push_sink;
+}
+
+#[test]
+fn free_fn_pyadapter_wires_end_to_end() {
+    let g = PyGraph::new();
+
+    // The wiring fns stay ordinary Rust fns, callable directly — the macro adds
+    // the Python entry point beside them rather than consuming them.
+    let typed = checked_ramp_fn(g.builder(), 10.0, 5.0).expect("positive step wires");
+    let (target, unit) = Python::attach(|py| {
+        let list = pyo3::types::PyList::empty(py).into_any().unbind();
+        let sink = push_sink(&typed, list.clone_ref(py), 2.0).expect("sink wires");
+        (list, sink)
+    });
+    let _erased = g.erase_source::<()>(unit);
+
+    g.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+
+    let got: Vec<f64> = Python::attach(|py| target.extract(py).unwrap());
+    assert_eq!(vec![20.0, 30.0, 40.0], got);
+
+    // And the fallible free-fn form rejects its bad config at wiring.
+    let err = match checked_ramp_fn(g.builder(), 10.0, 0.0) {
+        Ok(_) => panic!("a non-positive step must be rejected at wiring"),
+        Err(err) => err,
+    };
+    assert!(
+        format!("{err:#}").contains("step must be positive"),
+        "{err:#}"
+    );
+}

--- a/next/crates/wingfoil-next-python/tests/plugin_seam.rs
+++ b/next/crates/wingfoil-next-python/tests/plugin_seam.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use pyo3::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::Stream;
 use wingfoil_next_python::{
     Activation, Ctx, Op, PyElement, PyGraph, Tick, pyadapter, pygraph, pyop,
 };
@@ -344,4 +345,88 @@ fn custom_op_error_aborts_run() {
         .unwrap_err();
     assert!(format!("{err:#}").contains("odd value"));
     let _ = checked;
+}
+
+// A **fallible** source `#[pyadapter]` with **Python defaults** — the shape
+// every real IO adapter has: its wiring validates config and can fail, and most
+// of its knobs are optional. `Result<Stream<T>>` makes the generated
+// `#[pyfunction]` return `PyResult`, and the `#[pyo3(signature = ..)]` written
+// over the *adapter method's* params is forwarded to it with the generated
+// `graph` receiver injected.
+trait CheckedRampOps {
+    fn checked_ramp(&self, start: f64, step: f64) -> anyhow::Result<Stream<f64>>;
+}
+
+#[pyadapter(name = checked_ramp, source)]
+impl CheckedRampOps for wingfoil_next::prelude::GraphBuilder {
+    #[pyo3(signature = (start, step = 1.0))]
+    fn checked_ramp(&self, start: f64, step: f64) -> anyhow::Result<Stream<f64>> {
+        use wingfoil_next::prelude::{SourceOps, StreamOps};
+        if step <= 0.0 {
+            anyhow::bail!("checked_ramp: step must be positive, got {step}");
+        }
+        Ok(self
+            .ticker(Duration::from_nanos(100))
+            .count()
+            .map(move |n: &u64| start + step * ((*n - 1) as f64)))
+    }
+}
+
+// The fallible **sink** shape, likewise: a wiring-time check plus an optional arg.
+trait CheckedSinkOps {
+    fn checked_sink(&self, target: Py<PyAny>, limit: Option<usize>) -> anyhow::Result<Stream<()>>;
+}
+
+#[pyadapter(name = checked_sink)]
+impl CheckedSinkOps for Stream<f64> {
+    #[pyo3(signature = (target, limit = None))]
+    fn checked_sink(&self, target: Py<PyAny>, limit: Option<usize>) -> anyhow::Result<Stream<()>> {
+        use wingfoil_next::prelude::StreamOps;
+        if limit == Some(0) {
+            anyhow::bail!("checked_sink: limit must be non-zero");
+        }
+        Ok(self.for_each(move |v: &f64| {
+            Python::attach(|py| {
+                target
+                    .bind(py)
+                    .call_method1("append", (*v,))
+                    .map_err(|err| anyhow::anyhow!("checked_sink append raised: {err}"))?;
+                Ok(())
+            })
+        }))
+    }
+}
+
+#[test]
+fn fallible_pyadapter_generates_pyresult_functions() {
+    // Compile proof: both generated functions exist for `Result`-returning
+    // adapter methods carrying a forwarded `#[pyo3(signature = ..)]`.
+    let _source = checked_ramp;
+    let _sink = checked_sink;
+}
+
+#[test]
+fn fallible_pyadapter_wiring_succeeds_and_fails_as_written() {
+    let g = PyGraph::new();
+    // The happy path wires and runs like any other source.
+    let ok = g
+        .builder()
+        .checked_ramp(10.0, 5.0)
+        .expect("positive step wires");
+    let erased = g.erase_source::<f64>(ok);
+    g.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+    let v: f64 = (&erased.value()).try_into().unwrap();
+    assert_eq!(20.0, v);
+
+    // The rejected config is a *wiring* error — what the generated
+    // `#[pyfunction]` turns into a Python exception.
+    let err = match g.builder().checked_ramp(10.0, 0.0) {
+        Ok(_) => panic!("a non-positive step must be rejected at wiring"),
+        Err(err) => err,
+    };
+    assert!(
+        format!("{err:#}").contains("step must be positive"),
+        "{err:#}"
+    );
 }

--- a/next/crates/wingfoil-next-python/tests/test_postgres.py
+++ b/next/crates/wingfoil-next-python/tests/test_postgres.py
@@ -1,0 +1,407 @@
+"""Tests for the wingfoil-next PostgreSQL Python bindings.
+
+Two groups:
+
+- Unit-level wiring / marshaling tests (no marker): run by default, with no live
+  service. They exercise the ``#[pyadapter]`` glue — argument defaults, the
+  wiring-time validation a fallible adapter surfaces as an exception, and the
+  dict-to-parameter marshaling — without touching the network.
+- Integration tests (``@pytest.mark.requires_postgres``): deselected by default.
+  The postgres-next integration workflow opts in with ``-m requires_postgres``;
+  without PostgreSQL on localhost:5432 they fail loudly rather than skipping.
+
+Local setup:
+    docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine
+"""
+
+import pytest
+
+import wingfoil_next as wf
+
+CONN_STR = "host=localhost port=5432 user=postgres password=postgres dbname=postgres"
+# Loopback port 1 is reserved and never hosts a service: connect is rejected.
+UNREACHABLE = "host=127.0.0.1 port=1 user=postgres dbname=postgres connect_timeout=1"
+
+QUERY = "SELECT time, sym, price, qty FROM py_pg_trades"
+TABLE = "py_pg_trades"
+COLUMNS = [("sym", "text"), ("price", "float"), ("qty", "long")]
+
+SECOND_NANOS = 1_000_000_000
+DAY_NANOS = 86_400 * SECOND_NANOS
+# 2000-01-01 00:00:00 UTC in nanoseconds — the historical start used for reads.
+KDB_EPOCH_NANOS = 946_684_800 * SECOND_NANOS
+
+
+# ---- Unit-level coverage (no live PostgreSQL) ----
+
+
+def test_module_exposes_the_postgres_surface():
+    for name in (
+        "postgres_read",
+        "postgres_sub",
+        "postgres_source",
+        "postgres_write",
+        "postgres_notify_trigger_sql",
+    ):
+        assert callable(getattr(wf, name)), name
+
+
+def test_read_constructs_a_stream():
+    g = wf.Graph()
+    stream = wf.postgres_read(
+        g, UNREACHABLE, QUERY, "time", KDB_EPOCH_NANOS, DAY_NANOS, chunk_secs=86400
+    )
+    assert isinstance(stream, wf.Stream)
+
+
+def test_read_optional_args_have_defaults():
+    """`chunk_secs` / `buffer_size` are optional — the forwarded pyo3 signature."""
+    g = wf.Graph()
+    assert isinstance(
+        wf.postgres_read(g, UNREACHABLE, QUERY, "time", KDB_EPOCH_NANOS, DAY_NANOS),
+        wf.Stream,
+    )
+
+
+def test_read_rejects_an_unbounded_window_at_wiring():
+    """A fallible adapter's wiring error surfaces as a Python exception."""
+    g = wf.Graph()
+    with pytest.raises(RuntimeError) as excinfo:
+        wf.postgres_read(g, UNREACHABLE, QUERY, "time", 0, DAY_NANOS)
+    assert "start_time" in str(excinfo.value)
+
+
+def test_read_rejects_a_zero_chunk_size_at_wiring():
+    g = wf.Graph()
+    with pytest.raises(RuntimeError):
+        wf.postgres_read(
+            g, UNREACHABLE, QUERY, "time", KDB_EPOCH_NANOS, DAY_NANOS, chunk_secs=0
+        )
+
+
+def test_sub_constructs_a_stream():
+    g = wf.Graph()
+    stream = wf.postgres_sub(g, UNREACHABLE, QUERY, "time", "py_pg_feed")
+    assert isinstance(stream, wf.Stream)
+
+
+def test_sub_rejects_historical_mode_at_wiring():
+    g = wf.Graph()
+    with pytest.raises(RuntimeError) as excinfo:
+        wf.postgres_sub(g, UNREACHABLE, QUERY, "time", "py_pg_feed", realtime=False)
+    assert "HistoricalFrom" in str(excinfo.value)
+
+
+def test_source_dispatches_on_the_declared_run_mode():
+    """One wiring call, either mode — next's unified `<adapter>_source`."""
+    g = wf.Graph()
+    historical = wf.postgres_source(
+        g,
+        UNREACHABLE,
+        QUERY,
+        "time",
+        "py_pg_feed",
+        False,
+        start_nanos=KDB_EPOCH_NANOS,
+        duration_nanos=DAY_NANOS,
+    )
+    live = wf.postgres_source(g, UNREACHABLE, QUERY, "time", "py_pg_feed", True)
+    assert isinstance(historical, wf.Stream)
+    assert isinstance(live, wf.Stream)
+
+
+def test_source_historical_still_validates_its_window():
+    g = wf.Graph()
+    with pytest.raises(RuntimeError):
+        wf.postgres_source(g, UNREACHABLE, QUERY, "time", "py_pg_feed", False)
+
+
+def test_write_constructs_a_terminal_stream():
+    g = wf.Graph()
+    sink = wf.postgres_write(
+        g.constant({"sym": "A", "price": 1.0, "qty": 2}), UNREACHABLE, TABLE, COLUMNS
+    )
+    assert isinstance(sink, wf.Stream)
+
+
+def _run_write(value, columns=COLUMNS):
+    """Wire and run a one-tick write of `value`, returning the raised error."""
+    g = wf.Graph()
+    wf.postgres_write(g.constant(value), UNREACHABLE, TABLE, columns)
+    with pytest.raises(RuntimeError) as excinfo:
+        g.run(cycles=1, start_nanos=KDB_EPOCH_NANOS)
+    return str(excinfo.value)
+
+
+def test_write_missing_key_errors():
+    assert "missing column 'price'" in _run_write({"sym": "A", "qty": 2})
+
+
+def test_write_wrong_value_type_errors():
+    assert "column 'price'" in _run_write({"sym": "A", "price": "nope", "qty": 2})
+
+
+def test_write_unsupported_declared_type_errors():
+    message = _run_write({"id": "x"}, columns=[("id", "uuid")])
+    assert "unsupported column type 'uuid'" in message
+
+
+def test_write_non_dict_value_errors():
+    assert "must be a dict" in _run_write(42.0)
+
+
+def test_notify_trigger_sql_shape():
+    sql = wf.postgres_notify_trigger_sql(TABLE, "py_pg_feed")
+    assert "pg_notify('py_pg_feed', '')" in sql
+    assert f'AFTER INSERT ON "{TABLE}"' in sql
+
+
+# ---- Integration tests (require PostgreSQL on localhost:5432) ----
+
+
+def _reset_table(sql_rows=()):
+    """Create a fresh `py_pg_trades` table and optionally seed rows (needs psycopg)."""
+    import psycopg
+
+    with psycopg.connect(CONN_STR, autocommit=True) as conn:
+        conn.execute(f"DROP TABLE IF EXISTS {TABLE}")
+        conn.execute(
+            f"CREATE TABLE {TABLE} (time timestamp, sym text, price float8, qty int8)"
+        )
+        for ts, sym, price, qty in sql_rows:
+            conn.execute(
+                f"INSERT INTO {TABLE} VALUES (%s, %s, %s, %s)", (ts, sym, price, qty)
+            )
+
+
+@pytest.mark.requires_postgres
+def test_read_returns_lists_of_row_dicts():
+    _reset_table(
+        [
+            ("2000-01-01 00:00:01", "AAPL", 100.0, 10),
+            ("2000-01-01 00:00:02", "GOOG", 200.0, 20),
+            ("2000-01-01 00:00:03", "MSFT", 300.0, 30),
+        ]
+    )
+
+    g = wf.Graph()
+    out = wf.postgres_read(
+        g, CONN_STR, QUERY, "time", KDB_EPOCH_NANOS, DAY_NANOS, chunk_secs=86400
+    ).accumulate()
+    g.run(start_nanos=KDB_EPOCH_NANOS, duration_nanos=DAY_NANOS)
+
+    ticks = out.value()
+    # Each tick is a *list* of the rows sharing that timestamp — lossless, unlike
+    # legacy's collapse-to-one-dict.
+    assert [[row["sym"] for row in tick] for tick in ticks] == [
+        ["AAPL"],
+        ["GOOG"],
+        ["MSFT"],
+    ]
+    assert ticks[0][0]["qty"] == 10
+    assert ticks[1][0]["price"] == 200.0
+
+
+@pytest.mark.requires_postgres
+def test_read_ticks_at_the_row_timestamps():
+    """The row's time column becomes the on-graph tick time."""
+    _reset_table(
+        [
+            ("2000-01-01 00:00:01", "AAPL", 100.0, 10),
+            ("2000-01-01 00:00:02", "GOOG", 200.0, 20),
+        ]
+    )
+
+    g = wf.Graph()
+    out = wf.postgres_read(
+        g, CONN_STR, QUERY, "time", KDB_EPOCH_NANOS, DAY_NANOS, chunk_secs=86400
+    ).collect()
+    g.run(start_nanos=KDB_EPOCH_NANOS, duration_nanos=DAY_NANOS)
+
+    times = [nanos for nanos, _ in out.value()]
+    assert times == [KDB_EPOCH_NANOS + SECOND_NANOS, KDB_EPOCH_NANOS + 2 * SECOND_NANOS]
+
+
+@pytest.mark.requires_postgres
+def test_write_round_trip():
+    import psycopg
+
+    _reset_table()
+
+    g = wf.Graph()
+    # The table's qty column is int8, so the declared type is "long".
+    wf.postgres_write(
+        g.constant({"sym": "TEST", "price": 42.0, "qty": 100}),
+        CONN_STR,
+        TABLE,
+        COLUMNS,
+    )
+    g.run(cycles=1, start_nanos=KDB_EPOCH_NANOS)
+
+    with psycopg.connect(CONN_STR) as conn:
+        row = conn.execute(f"SELECT sym, price, qty FROM {TABLE}").fetchone()
+    assert row[0] == "TEST"
+    assert row[1] == pytest.approx(42.0)
+    assert row[2] == 100
+
+
+@pytest.mark.requires_postgres
+def test_write_a_list_of_dicts_inserts_every_row():
+    """A Python list on one tick is a multi-row burst — all of it is written."""
+    import psycopg
+
+    _reset_table()
+
+    g = wf.Graph()
+    wf.postgres_write(
+        g.constant(
+            [
+                {"sym": "AAA", "price": 1.0, "qty": 1},
+                {"sym": "BBB", "price": 2.0, "qty": 2},
+            ]
+        ),
+        CONN_STR,
+        TABLE,
+        COLUMNS,
+    )
+    g.run(cycles=1, start_nanos=KDB_EPOCH_NANOS)
+
+    with psycopg.connect(CONN_STR) as conn:
+        rows = conn.execute(f"SELECT sym, qty FROM {TABLE} ORDER BY sym").fetchall()
+    assert rows == [("AAA", 1), ("BBB", 2)]
+
+
+@pytest.mark.requires_postgres
+def test_write_int4_and_null_round_trip():
+    """`int` binds as int4 (plain `integer` columns work); None writes SQL NULL."""
+    import psycopg
+
+    with psycopg.connect(CONN_STR, autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS py_pg_int4")
+        conn.execute("CREATE TABLE py_pg_int4 (time timestamp, qty integer, note text)")
+
+    g = wf.Graph()
+    wf.postgres_write(
+        g.constant({"qty": 7, "note": None}),
+        CONN_STR,
+        "py_pg_int4",
+        [("qty", "int"), ("note", "text")],
+    )
+    g.run(cycles=1, start_nanos=KDB_EPOCH_NANOS)
+
+    with psycopg.connect(CONN_STR) as conn:
+        row = conn.execute("SELECT qty, note FROM py_pg_int4").fetchone()
+    assert row[0] == 7
+    assert row[1] is None
+
+    # Read back through the adapter: int4 dispatch + SQL NULL -> Python None.
+    g = wf.Graph()
+    out = wf.postgres_read(
+        g,
+        CONN_STR,
+        "SELECT time, qty, note FROM py_pg_int4",
+        "time",
+        KDB_EPOCH_NANOS,
+        DAY_NANOS,
+        chunk_secs=86400,
+    ).accumulate()
+    g.run(start_nanos=KDB_EPOCH_NANOS, duration_nanos=DAY_NANOS)
+
+    ticks = out.value()
+    assert len(ticks) == 1
+    assert ticks[0][0]["qty"] == 7
+    assert ticks[0][0]["note"] is None
+
+
+@pytest.mark.requires_postgres
+def test_read_unsupported_column_type_aborts_the_run():
+    """A `numeric` column fails on the first row rather than reading as None."""
+    import psycopg
+
+    with psycopg.connect(CONN_STR, autocommit=True) as conn:
+        conn.execute("DROP TABLE IF EXISTS py_pg_numeric")
+        conn.execute("CREATE TABLE py_pg_numeric (time timestamp, amount numeric)")
+        conn.execute(
+            "INSERT INTO py_pg_numeric VALUES ('2000-01-01 00:00:01', 1.25)",
+        )
+
+    g = wf.Graph()
+    wf.postgres_read(
+        g,
+        CONN_STR,
+        "SELECT time, amount FROM py_pg_numeric",
+        "time",
+        KDB_EPOCH_NANOS,
+        DAY_NANOS,
+        chunk_secs=86400,
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        g.run(start_nanos=KDB_EPOCH_NANOS, duration_nanos=DAY_NANOS)
+    assert "unsupported column type" in str(excinfo.value)
+
+
+@pytest.mark.requires_postgres
+def test_sub_catch_up_then_live_inserts():
+    """Seeded rows arrive via catch-up; mid-run inserts arrive via NOTIFY."""
+    import gc
+    import threading
+    import time as time_mod
+
+    import psycopg
+
+    # `Graph` is an unsendable pyclass, so dropping one on a foreign thread
+    # raises. `run` below releases the GIL, which lets the inserter thread
+    # trigger a cyclic GC — and collect any *earlier* test's unreferenced Graph
+    # there. Sweep them now so the collection happens on this thread.
+    gc.collect()
+
+    _reset_table([("2000-01-01 00:00:00", "SEED0", 1.0, 10)])
+    with psycopg.connect(CONN_STR, autocommit=True) as conn:
+        conn.execute(wf.postgres_notify_trigger_sql(TABLE, "py_pg_feed"))
+
+    def insert_later():
+        time_mod.sleep(0.5)
+        with psycopg.connect(CONN_STR, autocommit=True) as conn:
+            conn.execute(
+                f"INSERT INTO {TABLE} VALUES ('2000-01-01 00:00:01', 'LIVE1', 2.0, 20)"
+            )
+            conn.execute(
+                f"INSERT INTO {TABLE} VALUES ('2000-01-01 00:00:02', 'LIVE2', 3.0, 30)"
+            )
+
+    inserter = threading.Thread(target=insert_later)
+    inserter.start()
+    try:
+        g = wf.Graph()
+        # cursor in the past -> the catch-up query picks up SEED0
+        out = wf.postgres_sub(g, CONN_STR, QUERY, "time", "py_pg_feed").accumulate()
+        g.run(realtime=True, duration_nanos=3 * SECOND_NANOS)
+    finally:
+        inserter.join()
+
+    # Each tick is a list of row dicts (several rows can share one real-time
+    # cycle); flatten before asserting.
+    syms = [row["sym"] for tick in out.value() for row in tick]
+    assert syms == ["SEED0", "LIVE1", "LIVE2"]
+
+
+@pytest.mark.requires_postgres
+def test_source_reads_historically_with_the_same_wiring():
+    """`postgres_source(realtime=False)` is the read path, wiring unchanged."""
+    _reset_table([("2000-01-01 00:00:01", "AAPL", 100.0, 10)])
+
+    g = wf.Graph()
+    out = wf.postgres_source(
+        g,
+        CONN_STR,
+        QUERY,
+        "time",
+        "py_pg_feed",
+        False,
+        start_nanos=KDB_EPOCH_NANOS,
+        duration_nanos=DAY_NANOS,
+        chunk_secs=86400,
+    ).accumulate()
+    g.run(start_nanos=KDB_EPOCH_NANOS, duration_nanos=DAY_NANOS)
+
+    assert [row["sym"] for tick in out.value() for row in tick] == ["AAPL"]

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -1199,7 +1199,12 @@ tests covered — not "legacy pytest passes unchanged."
   `#[pyo3(signature = …)]`** so optional args get Python defaults, and
   `PyGraph::run` now **releases the GIL** for the run — without which no
   real-time adapter source can deliver, since its worker (and every other Python
-  thread) stays blocked until `run` returns. Remaining: the other adapters.
+  thread) stays blocked until `run` returns. It also grew a **free-fn form**
+  (receiver as the first param) so a binding needs no throwaway trait and no
+  duplicated signature, and the shared run-shape helpers live in
+  `crate::adapters::common` (`historical_params` / `realtime_params` /
+  `run_mode` / `secs_to_nanotime`) for the mode-aware sources that follow.
+  Remaining: the other adapters.
 - **`wingfoil_next::compat` (`Signal<T>`)** stays a *Rust-side* classic-idiom
   ergonomic (free `ticker`/`constant`, `stream.run`/`peek_value`; `tests/
   compat.rs`) — it is **not** the Python-binding path (that is the object-form

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -1185,6 +1185,21 @@ tests covered — not "legacy pytest passes unchanged."
   the legacy combinator surface (`fold`/`sample`/`count`/`limit`/`difference`/
   `with_time`/`collect`/`buffer`/`window`/`not`, a `sum`/`mean` statistics
   bridge), then the per-adapter Python bindings as each Rust adapter lands.
+- **Per-adapter Python bindings** 🟡 *postgres landed*: the `#[pyadapter]`
+  exposure of the real `adapters::*` I/O adapters, each behind a
+  `wingfoil-next-python` cargo feature of the same name (`crate::adapters::*`,
+  registered in the `#[pymodule]` under the same `#[cfg]`). **postgres** is the
+  first and the template: `postgres_read` / `postgres_sub` / `postgres_source` /
+  `postgres_write` / `postgres_notify_trigger_sql`, with a dynamic row↔`dict`
+  edge and declared-column write marshaling, unit-level marshaling tests, and a
+  service-backed pytest leg in `postgres-next-integration.yml`. Landing it
+  closed three gaps in the seam itself, now available to every adapter that
+  follows: `#[pyadapter]` accepts **fallible** wiring (`Result<Stream<T>>` → a
+  `PyResult` fn, so a wiring rejection raises a Python exception), it **forwards
+  `#[pyo3(signature = …)]`** so optional args get Python defaults, and
+  `PyGraph::run` now **releases the GIL** for the run — without which no
+  real-time adapter source can deliver, since its worker (and every other Python
+  thread) stays blocked until `run` returns. Remaining: the other adapters.
 - **`wingfoil_next::compat` (`Signal<T>`)** stays a *Rust-side* classic-idiom
   ergonomic (free `ticker`/`constant`, `stream.run`/`peek_value`; `tests/
   compat.rs`) — it is **not** the Python-binding path (that is the object-form

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -173,7 +173,21 @@ impl MySocketSourceOps for GraphBuilder {
 // => PyGraphBuilder.my_socket_source(addr) -> PyStream   (Trade edge-erased to PyElement)
 ```
 
-A **real** adapter needs two things beyond that shape, both supported:
+That trait form still works, but a **binding** should use the free-fn form: the
+trait exists only to give the macro a receiver, and costs a throwaway trait plus
+a second copy of every signature. Put the receiver first instead —
+`&GraphBuilder` for a source, `&Stream<T>` for a sink — and give the Python name
+separately (it must differ from the fn's own name, which the macro emits beside
+it):
+
+```rust
+#[pyadapter(name = kafka_read, source)]
+fn read(g: &GraphBuilder, brokers: String, topic: String)
+    -> anyhow::Result<Stream<Burst<KafkaRecord>>> { /* ... */ }
+// => wingfoil_next.kafka_read(graph, brokers, topic)
+```
+
+A **real** adapter needs two more things, both supported:
 
 - **Fallible wiring.** Returning `Result<Stream<T>>` (any `…::Result`) makes the
   generated function return `PyResult`, so a wiring-time rejection — a bad run
@@ -278,7 +292,7 @@ form.
 | `#[pyop]` **proc** macro | reads an `Op` impl → `#[pyfunction]`; v1 stateless single-input concrete | ✅ done (`wingfoil-next-python-macros`) |
 | `#[pyop]` extensions | **stateful + two-input ops done** — `State` is any `Default`-seedable type (re-seeded per run); `In<'a> = (&A, &B)` emits a `module.name(stream, other)` fn over `wire_op2`. Remaining: 3+ inputs and `Cfg`-tuple arg names | 🟡 stateful + 2-input done |
 | `#[pygraph]` macro (wiring reuse) | expose a Rust `fn(&Stream<T>) -> Stream<U>` sub-graph as `module.name(stream)`, spliced into the caller's graph; interior runs at native `T`, only the edge erases. Single-input/output v1, over the `PyStream::typed_input`/`erased_output` seam | ✅ done |
-| `#[pyadapter]` macro (source + sink + burst) | **source, sink/transform, and burst adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. `Stream<Burst<T>>` erases to a Python `list` per tick, and on the way in a Python `list`/`tuple` rebuilds a multi-value burst (else a single-element burst) — so a burst source round-trips into a burst sink. Over the `builder`/`erase_source`/`erase_burst_source` and `typed_input`/`typed_burst_input`/`erased_output`/`erased_burst_output` seams; a sink's `Stream<()>` erases to `None`. Adapter method params must be `FromPyObject`. **Fallible wiring** (`Result<Stream<T>>` → a `PyResult` fn, wiring errors raised as Python exceptions) and **forwarded `#[pyo3(signature = …)]`** (Python defaults for optional args, with the generated receiver injected) landed with the first real adapter binding | ✅ done |
+| `#[pyadapter]` macro (source + sink + burst) | **source, sink/transform, and burst adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. `Stream<Burst<T>>` erases to a Python `list` per tick, and on the way in a Python `list`/`tuple` rebuilds a multi-value burst (else a single-element burst) — so a burst source round-trips into a burst sink. Over the `builder`/`erase_source`/`erase_burst_source` and `typed_input`/`typed_burst_input`/`erased_output`/`erased_burst_output` seams; a sink's `Stream<()>` erases to `None`. Adapter method params must be `FromPyObject`. **Fallible wiring** (`Result<Stream<T>>` → a `PyResult` fn, wiring errors raised as Python exceptions) and **forwarded `#[pyo3(signature = …)]`** (Python defaults for optional args, with the generated receiver injected), and the **free-fn form** (receiver as the first param — no throwaway trait, no duplicated signature; the impl form remains for adapters wanting a fluent Rust trait) landed with the first real adapter binding | ✅ done |
 | Per-adapter Python bindings (`crate::adapters::*`) | The `#[pyadapter]` exposure of the real `wingfoil_next::adapters::*` I/O adapters, each behind a cargo feature of the same name and registered in the `#[pymodule]` under the same `#[cfg]`. **postgres done**: `postgres_read` / `postgres_sub` / `postgres_source` / `postgres_write` / `postgres_notify_trigger_sql`, with a dynamic row↔`dict` edge (`PyPgRow`) and declared-column write marshaling; unit-level marshaling tests plus a service-backed pytest leg in `postgres-next-integration.yml`. Remaining: the other adapters as they are bound | 🟡 postgres done |
 | POC: call a fixed `compiled()` graph from Python | Wire `wingfoil-next` as a path dep; expose one fixed `graph!` wiring (`ticker → count → map(i*i) → accumulate`) as `compiled_squares`/`interpreted_squares` (both from a single wiring so they can't drift). Proved **compiled == interpreted output from Python** across cycle- and duration-bound runs; GIL released for the run; no `.unwrap()` in binding code. Honest limit: **one fixed, compile-time graph** — not general Python-defined-graph codegen (timing ~neutral at that ticker-bound size; a dispatch-heavy graph shows `compiled()`'s win). Consistent with the non-goal below (`compiled()`/`nested()` expose as single island nodes). Revisit against the post-refactor `compiled()` API. | ⬜ (was #506) |
 | Edge-conversion trait bounds | `PyElement <-> f64/i64/bool/String` shipped; `Trade`/user types via user impls | 🟡 scalars done |

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -173,6 +173,33 @@ impl MySocketSourceOps for GraphBuilder {
 // => PyGraphBuilder.my_socket_source(addr) -> PyStream   (Trade edge-erased to PyElement)
 ```
 
+A **real** adapter needs two things beyond that shape, both supported:
+
+- **Fallible wiring.** Returning `Result<Stream<T>>` (any `…::Result`) makes the
+  generated function return `PyResult`, so a wiring-time rejection — a bad run
+  window, an unsupported run mode, a malformed config — raises a Python
+  exception instead of aborting a later run.
+- **Optional arguments.** A `#[pyo3(signature = (…))]` on the adapter method is
+  forwarded to the generated `#[pyfunction]`, with the generated `graph`/`stream`
+  receiver injected, so the author writes the signature over their own params
+  only.
+
+```rust
+#[pyadapter(name = postgres_read, source)]
+impl PostgresReadOps for GraphBuilder {
+    #[pyo3(signature = (conn_str, query, time_col, start_nanos, duration_nanos,
+                        chunk_secs = 3600, buffer_size = None))]
+    fn postgres_read(&self, /* … */) -> anyhow::Result<Stream<Burst<PyPgRow>>> { /* … */ }
+}
+```
+
+When the payload shape is only known from a *runtime argument* — a row written
+from an arbitrary Python `dict`, whose columns the caller declares — the adapter
+can stay on the erased type (`Stream<Burst<PyElement>>`) and marshal inside the
+method, where that argument is in scope. `PyElement: TryFrom<&PyElement>` (the
+identity conversion) is what lets such an adapter still go through the standard
+`typed_burst_input` seam rather than a hand-written `#[pyfunction]`.
+
 ### `#[pygraph]` — expose user wiring logic
 
 Write the wiring as a function over the shared builder; `#[pygraph]` exposes it
@@ -251,7 +278,8 @@ form.
 | `#[pyop]` **proc** macro | reads an `Op` impl → `#[pyfunction]`; v1 stateless single-input concrete | ✅ done (`wingfoil-next-python-macros`) |
 | `#[pyop]` extensions | **stateful + two-input ops done** — `State` is any `Default`-seedable type (re-seeded per run); `In<'a> = (&A, &B)` emits a `module.name(stream, other)` fn over `wire_op2`. Remaining: 3+ inputs and `Cfg`-tuple arg names | 🟡 stateful + 2-input done |
 | `#[pygraph]` macro (wiring reuse) | expose a Rust `fn(&Stream<T>) -> Stream<U>` sub-graph as `module.name(stream)`, spliced into the caller's graph; interior runs at native `T`, only the edge erases. Single-input/output v1, over the `PyStream::typed_input`/`erased_output` seam | ✅ done |
-| `#[pyadapter]` macro (source + sink + burst) | **source, sink/transform, and burst adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. `Stream<Burst<T>>` erases to a Python `list` per tick, and on the way in a Python `list`/`tuple` rebuilds a multi-value burst (else a single-element burst) — so a burst source round-trips into a burst sink. Over the `builder`/`erase_source`/`erase_burst_source` and `typed_input`/`typed_burst_input`/`erased_output`/`erased_burst_output` seams; a sink's `Stream<()>` erases to `None`. Adapter method params must be `FromPyObject` | ✅ done |
+| `#[pyadapter]` macro (source + sink + burst) | **source, sink/transform, and burst adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. `Stream<Burst<T>>` erases to a Python `list` per tick, and on the way in a Python `list`/`tuple` rebuilds a multi-value burst (else a single-element burst) — so a burst source round-trips into a burst sink. Over the `builder`/`erase_source`/`erase_burst_source` and `typed_input`/`typed_burst_input`/`erased_output`/`erased_burst_output` seams; a sink's `Stream<()>` erases to `None`. Adapter method params must be `FromPyObject`. **Fallible wiring** (`Result<Stream<T>>` → a `PyResult` fn, wiring errors raised as Python exceptions) and **forwarded `#[pyo3(signature = …)]`** (Python defaults for optional args, with the generated receiver injected) landed with the first real adapter binding | ✅ done |
+| Per-adapter Python bindings (`crate::adapters::*`) | The `#[pyadapter]` exposure of the real `wingfoil_next::adapters::*` I/O adapters, each behind a cargo feature of the same name and registered in the `#[pymodule]` under the same `#[cfg]`. **postgres done**: `postgres_read` / `postgres_sub` / `postgres_source` / `postgres_write` / `postgres_notify_trigger_sql`, with a dynamic row↔`dict` edge (`PyPgRow`) and declared-column write marshaling; unit-level marshaling tests plus a service-backed pytest leg in `postgres-next-integration.yml`. Remaining: the other adapters as they are bound | 🟡 postgres done |
 | POC: call a fixed `compiled()` graph from Python | Wire `wingfoil-next` as a path dep; expose one fixed `graph!` wiring (`ticker → count → map(i*i) → accumulate`) as `compiled_squares`/`interpreted_squares` (both from a single wiring so they can't drift). Proved **compiled == interpreted output from Python** across cycle- and duration-bound runs; GIL released for the run; no `.unwrap()` in binding code. Honest limit: **one fixed, compile-time graph** — not general Python-defined-graph codegen (timing ~neutral at that ticker-bound size; a dispatch-heavy graph shows `compiled()`'s win). Consistent with the non-goal below (`compiled()`/`nested()` expose as single island nodes). Revisit against the post-refactor `compiled()` API. | ⬜ (was #506) |
 | Edge-conversion trait bounds | `PyElement <-> f64/i64/bool/String` shipped; `Trade`/user types via user impls | 🟡 scalars done |
 | Mutable-frontier engine (extend a *running* graph) | Phase 4.5 dirty-list; only needed for post-`run` mutation | 🟡 Phase 4.5 |


### PR DESCRIPTION
`wingfoil-next-python` had the `#[pyadapter]` seam but only synthetic demos (`ramp_source`, `list_sink`, `pair_source`, `burst_list_sink`) — no real adapter was bound. Phase 6 of `port-plan.md` lists "the per-adapter Python bindings as each Rust adapter lands" as open work.

This lands **postgres** — the meatiest of the legacy bindings, and the one that exercises every seam at once (historical burst source, real-time burst source, burst sink, plus a plain helper) — as the first one and the template for the rest. A second commit then cuts the boilerplate that binding exposed, so the seven adapters after it are cheaper.

## The bindings

`next/crates/wingfoil-next-python/src/adapters/postgres.rs`, behind a `postgres` cargo feature that turns on the engine's, registered in the `#[pymodule]` under the same `#[cfg]`:

| Python | Rust | shape |
|---|---|---|
| `postgres_read(graph, …)` | `postgres_read` | historical, time-sliced replay |
| `postgres_sub(graph, …)` | `postgres_sub` | real-time `LISTEN`/`NOTIFY` live tail |
| `postgres_source(graph, …)` | `postgres_source` | mode-agnostic — no legacy equivalent |
| `postgres_write(stream, …)` | `PostgresSinkOps` | streaming insert sink |
| `postgres_notify_trigger_sql()` | — | the trigger DDL `postgres_sub` needs |

Python has no record struct, so the payload edge is dynamic: reads decode into a plain-Rust `PyPgRow` (no `Py<PyAny>` inside, so it can cross to the adapter's worker thread) which erases to a `dict`; writes marshal each `dict` into typed params from the caller's declared `columns`, failing loudly rather than inserting a silent `NULL`.

## Commit 1 — three fixes in the seam

Landing a *real* adapter surfaced three gaps, all now available to every adapter that follows:

1. **`#[pyadapter]` accepts fallible wiring** — `Result<Stream<T>>` generates a `PyResult`-returning function, so a wiring-time rejection (bad run window, unsupported run mode, malformed config) raises a Python exception. Every real adapter validates at wiring; the macro only took infallible `Stream<T>`.
2. **It forwards `#[pyo3(signature = …)]`** from the adapter fn, injecting the generated `graph`/`stream` receiver, so optional args get Python defaults without the author touching the receiver.
3. **`PyGraph::run` now releases the GIL** for the run, as legacy `wingfoil-python`'s `run` does. Without it a live-tail source's worker thread — and every other Python thread — is blocked until `run` returns, so `postgres_sub` only ever saw rows that existed before it started. The live-tail integration test caught this; `python-interop.md` already claimed the behaviour.

Also adds the identity `PyElement: TryFrom<&PyElement>`, which lets an adapter whose payload shape comes from a *runtime* argument keep its input erased and marshal inside the adapter (where that argument is in scope) while still going through the standard `typed_burst_input` seam.

## Commit 2 — cutting the per-adapter boilerplate

Two reductions, both in the seam rather than in postgres:

**Free-function `#[pyadapter]`.** The macro only took an `impl Trait for GraphBuilder | Stream<T>`, so every binding declared a throwaway trait whose only job was to give the macro a receiver — and wrote the whole signature *twice*, once in the trait and once in the impl (`postgres_source` has eleven params, sixteen lines each). It now also accepts a plain fn with the receiver first:

```rust
#[pyadapter(name = postgres_read, source)]
#[pyo3(signature = (conn_str, query, chunk_secs = 3600, buffer_size = None))]
fn read(g: &GraphBuilder, …) -> Result<Stream<Burst<PyPgRow>>> { … }
```

`name` must differ from the fn's own name, matching `#[pygraph]`'s existing rule — which is why a binding's fns are short, the module being named for the adapter already. The impl form still works for an adapter that genuinely wants a fluent Rust trait, and **both forms now share one emitter**, so the source/sink, burst/plain, fallible/infallible and signature-forwarding behaviour cannot drift between them. The macro also puts the `too_many_arguments` allow on the wiring fn, since an adapter's arity is dictated by its knobs.

**`adapters/common.rs`.** The run-shape conversions every mode-aware source binding needs — `historical_params`, `realtime_params`, `run_mode`, `secs_to_nanotime` — were private to postgres. They're the same three conversions in every binding (a Python `Graph` doesn't know its run mode until `run()`, so mode-at-wiring adapters take it as arguments), so they move out with their own tests.

Applied to postgres: **four traits gone, code down from 437 to 355 lines**, ~30 of those relocated to `common.rs` where the next adapter reuses them. The Python surface is unchanged — all 8 integration tests still pass against a live database.

**Deliberately not folded in:** the record↔dict conversion (`PyElement::dict` + a derive), which is where the remaining per-adapter cost lives — the next engine adapters carry fixed record structs (`KafkaRecord`, `EtcdEntry`, `FluvioRecord`, `RedisEntry`) each needing ~25 lines of hand-rolled dict conversion. Held until one broker adapter is bound so it's shaped by two real users rather than fitted to postgres, which is the atypical one.

## Deviations from the legacy bindings

Documented in the module header:

1. **`postgres_read` yields a list of row dicts per tick, not a single dict.** Legacy `collapse()`d the burst and kept only the last row of any timestamp — silently dropping rows sharing a timestamp (its own docstring warned about it). Bursts erase to lists uniformly here, so the read is lossless and matches `postgres_sub`'s shape.
2. **The run window is an explicit argument.** The Rust `postgres_read` takes the run's `[start, end)` at wiring (slicing is a pure, fail-fast check), and a Python `Graph` does not know its run mode until `run()` — so `start_nanos`/`duration_nanos` are passed and must match the eventual `graph.run(...)`.
3. **New capabilities**: `postgres_source` (one wiring call, either run mode) and the `buffer_size` back-pressure bound, neither of which legacy had.

## Tests

- **11 Rust marshaling tests** in the binding module — row → `dict`, `dict` → typed params, declared-column ordering, typed NULLs, and the error paths (missing key, wrong type, unsupported declared type, non-dict value, empty element), plus query construction. **4 more** in `common.rs`.
- **15 unit-level pytest cases** with no service: argument defaults, wiring-time rejections, marshaling errors.
- **8 `requires_postgres` integration cases**, run against a live PostgreSQL 16 — read, write, list-of-dicts multi-row bursts, int4/NULL round-trip, tick timestamps, unsupported-column-type abort, the mode-agnostic source, and the NOTIFY live tail with a mid-run insert **from another Python thread** (the shape that guards the GIL fix).
- **4 cross-crate seam tests** in `plugin_seam.rs` for the fallible, defaulted and free-fn `#[pyadapter]` shapes.

## CI and docs

- `next-python-test.yml` runs `cargo test -p wingfoil-next-python --features all-adapters`.
- `postgres-next-integration.yml` gains a Python leg (fixed-port container → `maturin develop` → `pytest -m requires_postgres`), plus the binding/test paths as triggers.
- The `/new-adapter-next` skill's Python section now carries the real-adapter recipe — the free-fn form as the default, feature gating and registration, fallible wiring, optional args, the shared `common.rs` helpers, dynamic payloads, the wiring-time `RunParams` rule, and the GIL rule with the test shape that guards it. `port-plan.md` Phase 6 and `python-interop.md` updated.

## Verification

`cargo fmt --all -- --check`, `cargo lint`, `cargo lint-all`, `cargo test -p wingfoil-next-python --features all-adapters`, `cargo test -p wingfoil-next --features postgres`, and both pytest groups — all green after both commits.

**One caveat for reviewers:** `cargo test -p wingfoil-next --all-features` did not complete in my sandbox — the container ran out of disk (`target/` reached 29G). I ran `cargo test -p wingfoil-next --features postgres` instead (green), and `cargo lint-all` compiles every workspace test target under all features. This diff touches only `wingfoil-next-python`, the macros crate, docs and CI, so the engine suite should be unaffected — but CI will be its first full run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TaKx6yNvtvSHBKhur5wJE