### PR TITLE
Halve the dev build's disk footprint by dropping dependency debuginfo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,12 +128,17 @@ Three things make the tree large, and they compound:
   carrying the entire dependency graph.
 
 That last one is why `[profile.dev.package."*"] debug = false` is set in the
-root `Cargo.toml`: debuginfo was over half the bulk and got copied into all ~69
-binaries. It took a single example binary from 260MB to 64MB and a
-`--all-targets` build from roughly 23GB to under 10GB. The override applies to
-dependencies only — cargo excludes workspace members from `package."*"` — so
-backtraces and debugger stepping through wingfoil code are unaffected; only
-frames inside third-party crates lose line numbers.
+root `Cargo.toml`: debuginfo was over half the bulk and got copied into every
+one of those binaries. It takes a single example binary from 260MB to 64MB, and
+a full `--all-targets` build (79 binaries) measures **9.2GB** with it — against
+roughly 17GB without, derived from the same per-artifact ratios. The override
+applies to dependencies only — cargo excludes workspace members from
+`package."*"` — so backtraces and debugger stepping through wingfoil code are
+unaffected; only frames inside third-party crates lose line numbers.
+
+`target/debug/incremental` is another 2.6GB of that 9.2GB. It pays for itself
+across edit-rebuild cycles, but `CARGO_INCREMENTAL=0` (what CI sets) reclaims it
+outright if you are only doing one-shot builds.
 
 Also note the git hooks installed by `.cargo-husky`: `pre-commit` runs
 `cargo fmt --all` and a full `cargo clippy --workspace --all-targets`, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,49 @@ cargo lint-all    # all features — catches code behind `fix`, `csv`, `iceoryx2
 cargo fmt --all -- --check
 ```
 
-`cargo lint-all` requires `protoc` on the build machine (one of its
-transitive dependencies builds proto files). On Debian/Ubuntu:
-`sudo apt-get install -y protobuf-compiler`.
+`protoc` is required on the build machine (a transitive dependency builds proto
+files). On Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`, or run
+`scripts/setup-dev.sh`. Note this is needed for a *plain* `cargo build
+--workspace`, not just `lint-all` — see the feature-unification note below.
+
+### Disk space
+
+Builds here are big enough to exhaust a dev sandbox, so it is worth knowing
+where the space goes. `scripts/disk.sh` reports it and reclaims it:
+
+```bash
+scripts/disk.sh          # what is using space
+scripts/disk.sh light    # drop examples/benches/incremental, keep deps/
+scripts/disk.sh deep     # also remove every target/ dir in the tree
+```
+
+Reach for `light` mid-session: it keeps `target/*/deps`, so the next build
+relinks instead of recompiling 700+ crates.
+
+Three things make the tree large, and they compound:
+
+- **There is no cheap build.** `wingfoil-python` enables 13 features on
+  `wingfoil`, and cargo unifies features across a `--workspace` build, so plain
+  `cargo build --workspace` already compiles nearly the whole `full` tree.
+  `cargo lint` and `cargo lint-all` differ only by aeron and iceoryx2.
+- **`lint-all` cannot reuse `lint`'s work.** A different feature set means a
+  different metadata hash, so the two pre-commit lints build two full artifact
+  sets back to back. If space is tight, `scripts/disk.sh light` between them.
+- **`--all-targets` links ~69 example and bench binaries**, each statically
+  carrying the entire dependency graph.
+
+That last one is why `[profile.dev.package."*"] debug = false` is set in the
+root `Cargo.toml`: debuginfo was over half the bulk and got copied into all ~69
+binaries. It took a single example binary from 260MB to 64MB and a
+`--all-targets` build from roughly 23GB to under 10GB. The override applies to
+dependencies only — cargo excludes workspace members from `package."*"` — so
+backtraces and debugger stepping through wingfoil code are unaffected; only
+frames inside third-party crates lose line numbers.
+
+Also note the git hooks installed by `.cargo-husky`: `pre-commit` runs
+`cargo fmt --all` and a full `cargo clippy --workspace --all-targets`, and
+`pre-push` runs `cargo build` plus `cargo test` across the workspace. Every
+commit and push rebuilds, so expect commits to take minutes, not seconds.
 
 **Toolchain gap (clippy):** CI runs clippy on the current **stable** rustc,
 which can be *newer* than the toolchain in a dev sandbox. Newer clippy adds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,19 @@ serde_json = "1.0"
 thiserror = "2.0.11"
 tracing = "0.1"
 
+# Debuginfo is over half the bulk of target/ (stripping the 40 largest rlibs of
+# a dev build takes them from 810MB to 378MB), and it is not paid for once — it
+# is copied into every statically-linked binary. This workspace has ~69 example
+# and bench targets, so a `--all-targets` build carries ~69 copies of the whole
+# dependency graph's debuginfo and lands around 23GB.
+#
+# We never single-step into a dependency, so drop their debuginfo and keep our
+# own at full fidelity: workspace members are unaffected by a `package."*"`
+# override, so backtraces and debugger stepping through wingfoil code are
+# exactly as before. Only frames inside third-party crates lose line numbers.
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 debug = true            # Include debug info for profiling (perf, hotspot)
 #opt-level = 3       # Options: 0, 1, 2, 3, "s" (size), "z" (min size), 3 is max speed

--- a/scripts/disk.sh
+++ b/scripts/disk.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Report and reclaim build-artifact disk usage.
+#
+#   scripts/disk.sh            # report only — what is using space
+#   scripts/disk.sh light      # drop the cheap-to-rebuild bulk (examples, benches,
+#                              #   incremental, extracted registry sources)
+#   scripts/disk.sh deep       # light + every target/ dir in the tree
+#
+# `light` is the one to reach for mid-session: it keeps target/*/deps, so the
+# next `cargo build` relinks rather than recompiling 700+ crates. The example
+# and bench binaries it deletes are the bulk of the tree (each one statically
+# links the whole dependency graph) and nothing but `--all-targets` needs them.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mode="${1:-report}"
+
+human() { du -sh "$@" 2>/dev/null | sort -hr; }
+avail() { df -h "$root" | awk 'NR==2 {print $4}'; }
+
+# target/ dirs anywhere in the tree: the workspace root, plus wingfoil-wasm,
+# which is excluded from the workspace and so builds into its own.
+targets() { find "$root" -type d -name target -prune 2>/dev/null; }
+
+report() {
+    echo "== available =="
+    avail
+    echo
+    echo "== target dirs =="
+    while IFS= read -r t; do human "$t"; done < <(targets)
+    echo
+    echo "== inside the workspace target =="
+    human "$root"/target/*/deps "$root"/target/*/examples \
+          "$root"/target/*/incremental "$root"/target/*/build 2>/dev/null | head -20
+    echo
+    echo "== caches outside the repo =="
+    human "${CARGO_HOME:-$HOME/.cargo}/registry/src" \
+          "${CARGO_HOME:-$HOME/.cargo}/registry/cache" \
+          "$root"/wingfoil-js/node_modules "$root"/wingfoil-python/.venv 2>/dev/null
+}
+
+light() {
+    while IFS= read -r t; do
+        # examples/ and benches/ hold the statically-linked binaries; incremental/
+        # is per-edit scratch that a clean rebuild regenerates.
+        rm -rf "$t"/*/examples "$t"/*/benches "$t"/*/incremental
+    done < <(targets)
+    # Extracted crate sources — cargo re-expands these from registry/cache on
+    # demand, so deleting them costs unpacking time, not a re-download.
+    rm -rf "${CARGO_HOME:-$HOME/.cargo}/registry/src"
+    echo "light clean done — available: $(avail)"
+}
+
+deep() {
+    light
+    while IFS= read -r t; do rm -rf "$t"; done < <(targets)
+    echo "deep clean done — available: $(avail)"
+}
+
+case "$mode" in
+    report) report ;;
+    light)  light; echo; report ;;
+    deep)   deep; echo; report ;;
+    *) echo "usage: $(basename "$0") [report|light|deep]" >&2; exit 1 ;;
+esac

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -16,7 +16,11 @@ echo "protoc not found, installing..."
 case "$(uname -s)" in
     Linux*)
         if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update
+            # A third-party PPA that has gone unsigned/403 makes `update` exit
+            # non-zero even though the archives we need refreshed fine, and
+            # `set -e` would abort before we ever try the install. Let the
+            # install itself be the thing that decides whether we have protoc.
+            sudo apt-get update || echo "apt-get update reported errors, continuing"
             sudo apt-get install -y protobuf-compiler
         elif command -v dnf >/dev/null 2>&1; then
             sudo dnf install -y protobuf-compiler


### PR DESCRIPTION
## Why

Dev sandboxes kept running out of disk. The cause is not the base image — a fresh cloud session starts at 7.1GB used with no `target/` at all, against a fixed 30GB allowance that [is not configurable](https://code.claude.com/docs/en/cloud-environments#resource-limits). It is the Rust tree, and three things compound:

- **767 crates, and no cheap build.** `wingfoil-python` enables 13 features on `wingfoil`, and cargo unifies features across a `--workspace` build, so plain `cargo build --workspace` already compiles nearly the whole `full` tree. `cargo lint` and `cargo lint-all` differ only by aeron and iceoryx2.
- **`lint-all` cannot reuse `lint`'s work.** A different feature set means a different metadata hash, so the two pre-commit lints build two full artifact sets back to back.
- **`--all-targets` links 79 example and bench binaries**, each statically carrying the entire dependency graph — *including that graph's debuginfo, once per binary*.

Measured: stripping debug sections from the 40 largest rlibs of a dev build takes them from 810MB to 378MB, so **debuginfo was over half the bulk**, and it was being duplicated ~79 times.

## What changed

```toml
[profile.dev.package."*"]
debug = false
```

Cargo excludes workspace members from a `package."*"` override, so this drops debuginfo for dependencies only. Backtraces and debugger stepping through wingfoil code are unaffected; only frames inside third-party crates lose line numbers. `[profile.release]` is deliberately untouched — its `debug = true` is there for `perf`/hotspot profiling.

Also included:

- **`scripts/disk.sh`** — `report` / `light` / `deep`. `light` is the mid-session one: it drops examples, benches, incremental and the re-expandable `registry/src` while keeping `target/*/deps`, so the next build relinks instead of recompiling 700+ crates. Worth running between `cargo lint` and `cargo lint-all`, since those cannot share artifacts.
- **`scripts/setup-dev.sh`** — no longer aborts when an unrelated third-party PPA fails to refresh. Under `set -euo pipefail` a single bad list entry made `apt-get update` non-zero and killed the script before `protoc` was ever installed.
- **`CLAUDE.md`** — a Disk space section documenting the feature-unification trap, the two-artifact-set lint cost, and the `.cargo-husky` rebuild-on-every-commit-and-push.

The `protoc` note in `CLAUDE.md` was also wrong: it said `protoc` is needed for `--features full` / `lint-all`, but feature unification means a plain `cargo build --workspace` needs it too.

## Verification

A/B on the same restricted build (two examples, identical feature set, clean `target/` both times):

| | before | after |
|---|---|---|
| `target/` | 3.5GB | 2.2GB |
| `target/debug/deps` | 2.1GB | 1.5GB |
| `target/debug/examples` | 514MB | 137MB |
| `web` example binary | 260MB | 64MB |
| `fluvio` example binary | 254MB | 64MB |

Full `cargo build --workspace --all-targets`, which now completes here:

| | |
|---|---|
| **total** | **9.2GB** (79 binaries) |
| `deps` | 4.1GB |
| `incremental` | 2.6GB |
| `examples` | 2.3GB |
| `build` | 296MB |

Scaling examples and deps by the ratios from the A/B puts the same build at roughly 17GB without the override. Both lint feature sets now fit in the 30GB budget at once, which they previously did not.

`cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` pass (run by the pre-commit hook on each commit).

## Not addressed

Two pre-existing issues found while measuring, both left alone as out of scope:

- `wingfoil-next-python`'s `plugin_seam` test fails to link under `--all-targets` with `undefined symbol: PyErr_NewExceptionWithDoc` and friends — a pyo3 `extension-module` linkage problem. CI does not catch it because clippy type-checks without linking test binaries, and the husky hooks exclude `wingfoil-python` but not `wingfoil-next-python`. Observed at this branch's base; `next` has since touched that file, so it may already be resolved.
- `wingfoil` and `wingfoil-next` both ship an example named `tracing`, colliding on `target/debug/examples/tracing`. Cargo warns this may become a hard error.

One open question for the reviewer: `[profile.release]` still carries full debuginfo for all 767 dependencies. Setting those to `line-tables-only` would save comparable space and still give `perf`/hotspot symbol names *and* source lines, but it changes a deliberate profiling choice, so I left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvwarKLiEnYJEbxHpy5ibK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvwarKLiEnYJEbxHpy5ibK)_