### PR TITLE
Complete the non-adapter Python interop surface

### DIFF
--- a/next/crates/wingfoil-next-python-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-python-macros/src/lib.rs
@@ -159,14 +159,28 @@ impl Parse for PyGraphArgs {
 }
 
 /// `#[pygraph(name = ...)]` — expose a Rust-authored sub-graph wiring function
-/// (`fn(&Stream<T>) -> Stream<U>`) as a Python callable `module.name(stream)`
-/// that splices the sub-graph's nodes into the caller's builder and returns the
-/// erased output. `T`/`U` edge-convert at the boundary (`T: TryFrom<&PyElement>`,
-/// `U: Into<PyElement>`); the interior runs at native types.
+/// as a Python callable that splices the sub-graph's nodes into the caller's
+/// builder and returns the erased output(s). Inputs and outputs edge-convert at
+/// the boundary (`T: TryFrom<&PyElement>`, `U: Into<PyElement>`); the interior
+/// runs at native types.
+///
+/// The wiring fn is `fn([&GraphBuilder,] &Stream<T>…) -> Stream<U> | (Stream<U>…)`:
+///
+/// - **N inputs** — each becomes a Python stream parameter, named by the same
+///   convention `#[pyop]` uses (`stream`, then `other` at arity two, else
+///   `second`/`third`/…), so they can be passed by keyword.
+/// - **N outputs** — a tuple return becomes a Python tuple of streams, each
+///   erased independently and each chainable.
+/// - **An optional leading `&GraphBuilder`** — for wiring that creates nodes of
+///   its own rather than only extending its inputs. The generated callable then
+///   takes the graph first. This is what makes a `graph!`-generated
+///   **`nested()` compiled island** expressible: its signature is exactly
+///   `(&GraphBuilder, &Stream<In>…) -> Stream<Out>`, so an island needs no
+///   island-specific macro. With the builder and no stream inputs, the
+///   sub-graph is a *source* and its outputs erase via `erase_source`.
 ///
 /// The `name` must differ from the wiring function's own name (the macro emits a
-/// `#[pyfunction]` of that name alongside the untouched function). Single-input,
-/// single-output in v1.
+/// `#[pyfunction]` of that name alongside the untouched function).
 #[proc_macro_attribute]
 pub fn pygraph(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as PyGraphArgs);
@@ -201,6 +215,24 @@ fn stream_inner(ty: &Type) -> syn::Result<Type> {
     ))
 }
 
+/// Is this the wiring fn's optional leading `&GraphBuilder` parameter?
+///
+/// A sub-graph needs the builder when it creates nodes of its own rather than
+/// only extending its inputs — most importantly a `graph!`-generated
+/// `nested()` **compiled island**, whose signature is
+/// `(&GraphBuilder, &Stream<In>…) -> Stream<Out>`.
+fn is_graph_builder(ty: &Type) -> bool {
+    let bare = match ty {
+        Type::Reference(r) => &*r.elem,
+        other => other,
+    };
+    matches!(bare, Type::Path(p) if p
+        .path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "GraphBuilder"))
+}
+
 fn expand_pygraph(args: &PyGraphArgs, func: &ItemFn) -> syn::Result<TokenStream2> {
     let fn_name = &func.sig.ident;
     let py_name = &args.name;
@@ -211,42 +243,146 @@ fn expand_pygraph(args: &PyGraphArgs, func: &ItemFn) -> syn::Result<TokenStream2
              `#[pyfunction]` of that name)",
         ));
     }
-    if func.sig.inputs.len() != 1 {
+
+    let mut params = func.sig.inputs.iter();
+    let mut peeked = params.clone();
+    // An optional leading `&GraphBuilder`; the rest are the stream inputs.
+    let takes_builder = matches!(peeked.next(), Some(FnArg::Typed(pt)) if is_graph_builder(&pt.ty));
+    if takes_builder {
+        params.next();
+    }
+    let in_tys = params
+        .map(|arg| match arg {
+            FnArg::Typed(pt) => stream_inner(&pt.ty),
+            FnArg::Receiver(r) => Err(Error::new(
+                r.span(),
+                "#[pygraph] goes on a free wiring fn, not a method",
+            )),
+        })
+        .collect::<syn::Result<Vec<_>>>()?;
+    if in_tys.is_empty() && !takes_builder {
         return Err(Error::new(
             func.sig.span(),
-            "#[pygraph] supports a single-input wiring fn (`fn(&Stream<T>) -> Stream<U>`) in v1",
+            "#[pygraph] wiring fn takes `&Stream<T>` inputs, a leading `&GraphBuilder`, or both",
         ));
     }
-    let in_ty = match func.sig.inputs.first() {
-        Some(FnArg::Typed(pt)) => &*pt.ty,
-        _ => {
-            return Err(Error::new(
-                func.sig.span(),
-                "#[pygraph] wiring fn takes a `&Stream<T>` argument",
-            ));
-        }
-    };
-    let t_ty = stream_inner(in_ty)?;
+
     let out_ty = match &func.sig.output {
-        ReturnType::Type(_, ty) => &**ty,
+        ReturnType::Type(_, ty) => (**ty).clone(),
         ReturnType::Default => {
             return Err(Error::new(
                 func.sig.span(),
-                "#[pygraph] wiring fn must return `Stream<U>`",
+                "#[pygraph] wiring fn must return `Stream<U>` or a tuple of streams",
             ));
         }
     };
-    let u_ty = stream_inner(out_ty)?;
+    // One output, or a tuple of them — a sub-graph routinely produces several.
+    let (out_tys, single_output) = match &out_ty {
+        Type::Tuple(t) if !t.elems.is_empty() => (
+            t.elems
+                .iter()
+                .map(stream_inner)
+                .collect::<syn::Result<Vec<_>>>()?,
+            false,
+        ),
+        other => (vec![stream_inner(other)?], true),
+    };
+
+    let receivers: Vec<Ident> = receiver_names(in_tys.len())
+        .iter()
+        .map(|s| Ident::new(s, py_name.span()))
+        .collect();
+    let receiver_params = receivers.iter().map(|r| {
+        quote! { #r: pyo3::PyRef<'_, ::wingfoil_next_python::Stream> }
+    });
+    let graph_param = takes_builder.then(|| {
+        quote! { graph: pyo3::PyRef<'_, ::wingfoil_next_python::Graph>, }
+    });
+
+    // Everything is spliced onto one graph, so any node on it can host the
+    // conversions. With stream inputs the first is the anchor; with none (a
+    // builder-only *source* sub-graph) the graph itself is, and its outputs
+    // erase through `erase_source` rather than `erased_output`.
+    let (anchor, erase): (TokenStream2, Vec<TokenStream2>) = if let Some(first) = receivers.first()
+    {
+        (
+            quote! { #first.object() },
+            out_tys
+                .iter()
+                .enumerate()
+                .map(|(i, u)| {
+                    let out = Ident::new(&format!("__out{i}"), py_name.span());
+                    quote! { __anchor.erased_output::<#u>(#out) }
+                })
+                .collect(),
+        )
+    } else {
+        (
+            quote! { graph.object() },
+            out_tys
+                .iter()
+                .enumerate()
+                .map(|(i, u)| {
+                    let out = Ident::new(&format!("__out{i}"), py_name.span());
+                    quote! { __anchor.erase_source::<#u>(#out) }
+                })
+                .collect(),
+        )
+    };
+
+    let typed_binds = receivers
+        .iter()
+        .zip(&in_tys)
+        .enumerate()
+        .map(|(i, (r, t))| {
+            let typed = Ident::new(&format!("__typed{i}"), py_name.span());
+            quote! { let #typed = #r.object().typed_input::<#t>(); }
+        });
+    let call_args = (0..in_tys.len()).map(|i| {
+        let typed = Ident::new(&format!("__typed{i}"), py_name.span());
+        quote! { &#typed }
+    });
+    // The builder always comes from the graph parameter (emitted whenever the
+    // wiring fn takes it) — not from `__anchor`, which is a `PyStream` when
+    // there are stream inputs and carries no builder.
+    let builder_arg = takes_builder.then(|| quote! { graph.object().builder(), });
+
+    let out_idents: Vec<Ident> = (0..out_tys.len())
+        .map(|i| Ident::new(&format!("__out{i}"), py_name.span()))
+        .collect();
+    let bind_outs = if single_output {
+        let out0 = &out_idents[0];
+        quote! { let #out0 = #fn_name(#builder_arg #(#call_args),*); }
+    } else {
+        quote! { let (#(#out_idents),*) = #fn_name(#builder_arg #(#call_args),*); }
+    };
+    let (ret_ty, ret_expr) = if single_output {
+        let e = &erase[0];
+        (
+            quote! { ::wingfoil_next_python::Stream },
+            quote! { ::wingfoil_next_python::Stream::from(#e) },
+        )
+    } else {
+        let tys = out_tys
+            .iter()
+            .map(|_| quote! { ::wingfoil_next_python::Stream });
+        (
+            quote! { ( #(#tys),* ) },
+            quote! { ( #(::wingfoil_next_python::Stream::from(#erase)),* ) },
+        )
+    };
 
     Ok(quote! {
         #[pyo3::pyfunction]
-        fn #py_name(
-            stream: pyo3::PyRef<'_, ::wingfoil_next_python::Stream>,
-        ) -> ::wingfoil_next_python::Stream {
-            let __obj = stream.object();
-            let __typed = __obj.typed_input::<#t_ty>();
-            let __out = #fn_name(&__typed);
-            ::wingfoil_next_python::Stream::from(__obj.erased_output::<#u_ty>(__out))
+        #[allow(clippy::too_many_arguments)]
+        pub fn #py_name(
+            #graph_param
+            #(#receiver_params),*
+        ) -> #ret_ty {
+            let __anchor = #anchor;
+            #(#typed_binds)*
+            #bind_outs
+            #ret_expr
         }
     })
 }
@@ -744,17 +880,25 @@ fn burst_inner(ty: &Type) -> Option<Type> {
 
 /// The `T`s of a reference tuple `(&'a T, …)` — one entry per op input. `#[pyop]`
 /// supports one- or two-input ops.
-/// The generated function's stream parameters, by input arity.
+/// The generated function's stream parameter names, by input arity — shared by
+/// `#[pyop]` and `#[pygraph]` so one convention covers both.
 ///
 /// `other` (rather than `second`) at arity two is the name that shipped with the
-/// two-input form; keeping it avoids breaking a caller who passes it by keyword.
-fn receiver_names(n: usize) -> &'static [&'static str] {
-    match n {
-        1 => &["stream"],
-        2 => &["stream", "other"],
-        3 => &["stream", "second", "third"],
-        _ => &["stream", "second", "third", "fourth"],
+/// two-input `#[pyop]`; keeping it avoids breaking a caller who passes it by
+/// keyword.
+fn receiver_names(n: usize) -> Vec<String> {
+    const ORDINALS: [&str; 5] = ["second", "third", "fourth", "fifth", "sixth"];
+    if n == 2 {
+        return vec!["stream".to_string(), "other".to_string()];
     }
+    std::iter::once("stream".to_string())
+        .chain((1..n).map(|i| {
+            ORDINALS
+                .get(i - 1)
+                .map(|s| (*s).to_string())
+                .unwrap_or_else(|| format!("input{i}"))
+        }))
+        .collect()
 }
 
 /// The generated function's config parameter list and the value handed to the

--- a/next/crates/wingfoil-next-python/src/element.rs
+++ b/next/crates/wingfoil-next-python/src/element.rs
@@ -8,7 +8,7 @@
 use anyhow::{Context, Result};
 use pyo3::BoundObject;
 use pyo3::prelude::*;
-use pyo3::types::PyAny;
+use pyo3::types::{PyAny, PyBytes};
 
 /// An erased Python value flowing on a wingfoil-next edge.
 ///
@@ -201,7 +201,29 @@ macro_rules! from_scalar {
         }
     )*};
 }
-from_scalar!(f64, i64, bool);
+from_scalar!(
+    f32, f64, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, bool,
+);
+
+/// `Vec<u8>` erases to Python **`bytes`**, not a list of ints — the shape a
+/// binary payload wants (pyo3's blanket `Vec<T>` conversion would give a
+/// `list[int]`, which is both wrong-typed and far slower for a message body).
+impl From<Vec<u8>> for PyElement {
+    fn from(value: Vec<u8>) -> Self {
+        Python::attach(|py| PyElement(Some(PyBytes::new(py, &value).into_any().unbind())))
+    }
+}
+
+/// `Option<T>` erases with `None` as Python `None`, so a nullable field crosses
+/// the boundary without the adapter hand-rolling the empty case.
+impl<T: Into<PyElement>> From<Option<T>> for PyElement {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(v) => v.into(),
+            None => PyElement::none(),
+        }
+    }
+}
 
 /// The unit type erases to Python `None` — so a **sink** adapter that produces a
 /// `Stream<()>` (a terminal, no meaningful value) can cross the boundary like
@@ -242,7 +264,42 @@ macro_rules! try_into_scalar {
         }
     )*};
 }
-try_into_scalar!(f64, i64, bool, String);
+try_into_scalar!(
+    f32, f64, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, bool, String,
+);
+
+/// The inverse of the `bytes` edge. Accepts `bytes`/`bytearray` (and, via
+/// pyo3's extraction, a sequence of ints) so a Python caller can hand back
+/// whichever it has.
+impl TryFrom<&PyElement> for Vec<u8> {
+    type Error = anyhow::Error;
+
+    fn try_from(el: &PyElement) -> Result<Self> {
+        let obj =
+            el.0.as_ref()
+                .context("cannot extract Vec<u8> from an empty PyElement")?;
+        Python::attach(|py| {
+            obj.extract::<Vec<u8>>(py)
+                .context("PyElement is not bytes-like")
+        })
+    }
+}
+
+/// The inverse of the `Option<T>` edge: Python `None` (or an empty element)
+/// reads back as `None`, anything else as `Some`.
+impl<T> TryFrom<&PyElement> for Option<T>
+where
+    T: for<'a> TryFrom<&'a PyElement, Error = anyhow::Error>,
+{
+    type Error = anyhow::Error;
+
+    fn try_from(el: &PyElement) -> Result<Self> {
+        if el.is_none() {
+            return Ok(None);
+        }
+        T::try_from(el).map(Some)
+    }
+}
 
 /// The **identity** edge conversion: extracting a `PyElement` from a
 /// `PyElement` is a clone.
@@ -316,5 +373,75 @@ mod tests {
 
         let out: f64 = (&runner.value(&doubled)).try_into().unwrap();
         assert_eq!(42.0, out);
+    }
+
+    #[test]
+    fn integer_widths_round_trip() {
+        // Every width goes out and comes back; the narrow ones matter because a
+        // record field is rarely an i64.
+        assert_eq!(7_u8, u8::try_from(&PyElement::from(7_u8)).unwrap());
+        assert_eq!(7_u16, u16::try_from(&PyElement::from(7_u16)).unwrap());
+        assert_eq!(7_u32, u32::try_from(&PyElement::from(7_u32)).unwrap());
+        assert_eq!(7_u64, u64::try_from(&PyElement::from(7_u64)).unwrap());
+        assert_eq!(7_usize, usize::try_from(&PyElement::from(7_usize)).unwrap());
+        assert_eq!(-7_i8, i8::try_from(&PyElement::from(-7_i8)).unwrap());
+        assert_eq!(-7_i16, i16::try_from(&PyElement::from(-7_i16)).unwrap());
+        assert_eq!(-7_i32, i32::try_from(&PyElement::from(-7_i32)).unwrap());
+        assert_eq!(
+            -7_isize,
+            isize::try_from(&PyElement::from(-7_isize)).unwrap()
+        );
+    }
+
+    #[test]
+    fn f32_round_trips() {
+        assert_eq!(1.5_f32, f32::try_from(&PyElement::from(1.5_f32)).unwrap());
+    }
+
+    #[test]
+    fn a_negative_value_does_not_silently_become_unsigned() {
+        let element = PyElement::from(-1_i64);
+        assert!(
+            u32::try_from(&element).is_err(),
+            "a negative must not wrap into an unsigned width"
+        );
+    }
+
+    #[test]
+    fn bytes_erase_to_python_bytes_not_a_list() {
+        let element = PyElement::from(vec![1_u8, 2, 255]);
+        Python::attach(|py| {
+            let obj = element.object().bind(py);
+            assert!(
+                obj.is_instance_of::<PyBytes>(),
+                "Vec<u8> must erase to bytes, got {obj:?}"
+            );
+        });
+        assert_eq!(vec![1_u8, 2, 255], Vec::<u8>::try_from(&element).unwrap());
+    }
+
+    #[test]
+    fn empty_bytes_round_trip() {
+        let element = PyElement::from(Vec::<u8>::new());
+        assert_eq!(Vec::<u8>::new(), Vec::<u8>::try_from(&element).unwrap());
+    }
+
+    #[test]
+    fn option_maps_none_to_python_none() {
+        let empty = PyElement::from(None::<f64>);
+        assert!(empty.is_none());
+        assert_eq!(None, Option::<f64>::try_from(&empty).unwrap());
+
+        let full = PyElement::from(Some(2.5_f64));
+        assert!(!full.is_none());
+        assert_eq!(Some(2.5), Option::<f64>::try_from(&full).unwrap());
+    }
+
+    #[test]
+    fn option_propagates_a_wrong_typed_inner() {
+        // Present but not extractable is an error, not a silent None — that
+        // distinction is the whole point of the nullable edge.
+        let text = PyElement::from("not a number");
+        assert!(Option::<f64>::try_from(&text).is_err());
     }
 }

--- a/next/crates/wingfoil-next-python/src/island.rs
+++ b/next/crates/wingfoil-next-python/src/island.rs
@@ -1,0 +1,48 @@
+//! A **compiled island** exposed to Python — the one execution path that is not
+//! interpreted.
+//!
+//! `graph!` expands a single wiring into `interpreted()` / `compiled()` /
+//! `nested()`. The island form is `nested()`: the whole sub-graph collapses to
+//! one node in the outer graph, and its interior is monomorphized straight-line
+//! code — the same code `compiled()` emits — instead of a dyn call per node.
+//!
+//! `nested()`'s signature is `(&GraphBuilder, &Stream<In>…) -> Stream<Out>`,
+//! which is exactly a `#[pygraph]` wiring fn that takes the builder. So exposing
+//! an island needs no island-specific machinery: Python wires *around* it
+//! dynamically while the interior runs compiled — the "compiled interiors,
+//! dynamic wiring" shape, rather than the whole graph being one or the other.
+//!
+//! This lives in its own module because `graph!` requires the fluent `Stream`
+//! and `GraphBuilder` unqualified, and `python.rs` shadows `Stream` with the
+//! pyclass of the same name.
+
+use wingfoil_next::prelude::*;
+
+use crate::pygraph;
+
+wingfoil_next::graph! {
+    fn hot_interior(_g: &GraphBuilder, input: &Stream<f64>) -> Stream<f64> {
+        let doubled = input.map(|x: &f64| x * 2.0);
+        let shifted = doubled.map(|x: &f64| x + 1.0);
+        let squared = shifted.map(|x: &f64| x * x);
+        squared
+    }
+}
+
+/// The island as a Python callable: `compiled_island(graph, stream)`.
+#[pygraph(name = compiled_island)]
+fn build_compiled_island(g: &GraphBuilder, input: &Stream<f64>) -> Stream<f64> {
+    hot_interior::nested(g, input)
+}
+
+/// The same wiring through the plain fluent layer, so a test can assert the
+/// island produces identical values and tick times. Kept beside the `graph!`
+/// above rather than derived from it — if the two ever disagree, that is the
+/// island's semantics drifting, which is exactly what the parity test is for.
+#[pygraph(name = interpreted_twin)]
+fn build_interpreted_twin(input: &Stream<f64>) -> Stream<f64> {
+    input
+        .map(|x: &f64| x * 2.0)
+        .map(|x: &f64| x + 1.0)
+        .map(|x: &f64| x * x)
+}

--- a/next/crates/wingfoil-next-python/src/lib.rs
+++ b/next/crates/wingfoil-next-python/src/lib.rs
@@ -26,6 +26,7 @@ extern crate self as wingfoil_next_python;
 pub mod adapters;
 pub mod element;
 pub mod graph;
+pub mod island;
 #[macro_use]
 mod macros;
 mod python;

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -479,6 +479,23 @@ fn build_doubled_running_total(
     input.map(|x: &f64| x * 2.0).cumulative_sum()
 }
 
+// `spread_and_mid` — a **multi-input, multi-output `#[pygraph]`**: two streams
+// in, two out. The tuple return erases element-wise, so Python receives a tuple
+// of streams and can wire onward from each.
+#[pygraph(name = spread_and_mid)]
+fn build_spread_and_mid(
+    bid: &::wingfoil_next::prelude::Stream<f64>,
+    ask: &::wingfoil_next::prelude::Stream<f64>,
+) -> (
+    ::wingfoil_next::prelude::Stream<f64>,
+    ::wingfoil_next::prelude::Stream<f64>,
+) {
+    use ::wingfoil_next::prelude::StreamOps;
+    let spread = bid.join(ask, |b: &f64, a: &f64| a - b);
+    let mid = bid.join(ask, |b: &f64, a: &f64| (a + b) / 2.0);
+    (spread, mid)
+}
+
 // `ramp_source` — a **source `#[pyadapter]`**: a user-style adapter trait
 // implemented on `GraphBuilder`, exposed as `module.ramp_source(graph, start,
 // step)`. This synthetic source (no real IO) emits `start, start+step, …` as
@@ -605,6 +622,9 @@ fn _wingfoil(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(blend4, m)?)?;
     m.add_function(wrap_pyfunction!(clamped_scale, m)?)?;
     m.add_function(wrap_pyfunction!(doubled_running_total, m)?)?;
+    m.add_function(wrap_pyfunction!(spread_and_mid, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::island::compiled_island, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::island::interpreted_twin, m)?)?;
     m.add_function(wrap_pyfunction!(ramp_source, m)?)?;
     m.add_function(wrap_pyfunction!(list_sink, m)?)?;
     m.add_function(wrap_pyfunction!(pair_source, m)?)?;

--- a/next/crates/wingfoil-next-python/tests/plugin_seam.rs
+++ b/next/crates/wingfoil-next-python/tests/plugin_seam.rs
@@ -659,3 +659,193 @@ fn wire_op4_seam_runs_four_inputs_from_an_external_crate() {
     let got: Vec<f64> = Python::attach(|py| acc.value().value().extract(py).unwrap());
     assert_eq!(vec![10.0, 20.0, 30.0], got);
 }
+
+// A **user struct at the boundary**, defined in this (third-party) crate. The
+// build-list's "user types via user impls" claim rests on the orphan rules
+// allowing both directions from a downstream crate: `From<Trade> for PyElement`
+// is legal because `Trade` is local, and `TryFrom<&PyElement> for Trade` because
+// the self type is. If this file compiles, a plugin crate can put its own record
+// type on a Python-facing edge.
+#[derive(Clone, Debug, Default, PartialEq)]
+struct Trade {
+    symbol: String,
+    price: f64,
+    size: u32,
+}
+
+impl From<Trade> for PyElement {
+    fn from(trade: Trade) -> Self {
+        Python::attach(|py| {
+            let dict = pyo3::types::PyDict::new(py);
+            // A wiring-time conversion cannot fail usefully here, so a failure
+            // to build the dict is a bug in this impl, not user input.
+            dict.set_item("symbol", trade.symbol)
+                .and_then(|()| dict.set_item("price", trade.price))
+                .and_then(|()| dict.set_item("size", trade.size))
+                .expect("invariant: inserting owned scalars into a fresh dict cannot fail");
+            PyElement::new(dict.into_any().unbind())
+        })
+    }
+}
+
+impl TryFrom<&PyElement> for Trade {
+    type Error = anyhow::Error;
+
+    fn try_from(element: &PyElement) -> anyhow::Result<Self> {
+        Python::attach(|py| {
+            let obj = element.object().bind(py);
+            let get = |key: &str| {
+                obj.get_item(key)
+                    .map_err(|err| anyhow::anyhow!("trade is missing `{key}`: {err}"))
+            };
+            Ok(Trade {
+                symbol: get("symbol")?.extract()?,
+                price: get("price")?.extract()?,
+                size: get("size")?.extract()?,
+            })
+        })
+    }
+}
+
+#[test]
+fn a_user_struct_round_trips_across_the_boundary() {
+    let trade = Trade {
+        symbol: "ETHUSD".into(),
+        price: 42.5,
+        size: 7,
+    };
+    let element = PyElement::from(trade.clone());
+    assert_eq!(trade, Trade::try_from(&element).unwrap());
+}
+
+#[test]
+fn a_user_struct_flows_through_a_typed_op() {
+    // The edge erases, the op runs at native `Trade`: notional = price * size.
+    let g = PyGraph::new();
+    let source = g
+        .counter(Duration::from_nanos(100))
+        .map(Python::attach(|py| {
+            py.eval(
+                pyo3::ffi::c_str!("lambda n: {'symbol': 'ETHUSD', 'price': float(n), 'size': 2}"),
+                None,
+                None,
+            )
+            .expect("lambda compiles")
+            .unbind()
+        }));
+
+    let notional = source.wire_op1::<Trade, _, _, f64, _, _>(
+        "notional",
+        Activation::NONE,
+        (),
+        || (),
+        |_c, _s, trade: &Trade, _ctx| Ok(Tick::Value(trade.price * f64::from(trade.size))),
+    );
+    let acc = notional.accumulate();
+
+    g.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+    let got: Vec<f64> = Python::attach(|py| acc.value().value().extract(py).unwrap());
+    assert_eq!(vec![2.0, 4.0, 6.0], got);
+}
+
+#[test]
+fn a_malformed_user_struct_aborts_the_run_with_context() {
+    let g = PyGraph::new();
+    let source = g
+        .counter(Duration::from_nanos(100))
+        .map(Python::attach(|py| {
+            py.eval(pyo3::ffi::c_str!("lambda n: {'symbol': 'X'}"), None, None)
+                .expect("lambda compiles")
+                .unbind()
+        }));
+    let _ = source.wire_op1::<Trade, _, _, f64, _, _>(
+        "notional",
+        Activation::NONE,
+        (),
+        || (),
+        |_c, _s, trade: &Trade, _ctx| Ok(Tick::Value(trade.price)),
+    );
+
+    let err = g
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+        .expect_err("a trade missing `price` must abort the run");
+    assert!(
+        format!("{err:#}").contains("missing `price`"),
+        "want the field name in the error, got: {err:#}"
+    );
+}
+
+// A **multi-input, multi-output** `#[pygraph]` from an external crate: two
+// streams in, a tuple of two out. Proves the tuple return erases element-wise
+// cross-crate.
+#[pygraph(name = min_max_pair)]
+fn build_min_max_pair(a: &Stream<f64>, b: &Stream<f64>) -> (Stream<f64>, Stream<f64>) {
+    use wingfoil_next::prelude::StreamOps;
+    let lo = a.join(b, |x: &f64, y: &f64| x.min(*y));
+    let hi = a.join(b, |x: &f64, y: &f64| x.max(*y));
+    (lo, hi)
+}
+
+// A **builder-taking** `#[pygraph]`: the wiring fn creates nodes of its own
+// rather than only extending its input, so it needs `&GraphBuilder` — the same
+// shape a `graph!` island's `nested()` has. The generated fn takes the graph as
+// its first Python argument.
+#[pygraph(name = against_own_ticker)]
+fn build_against_own_ticker(
+    g: &wingfoil_next::prelude::GraphBuilder,
+    input: &Stream<f64>,
+) -> Stream<f64> {
+    use wingfoil_next::prelude::{SourceOps, StreamOps};
+    let own = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map(|n: &u64| *n as f64);
+    input.join(&own, |a: &f64, b: &f64| a + b)
+}
+
+// A **source** `#[pygraph]`: builder only, no stream inputs. Its output erases
+// through `erase_source` rather than `erased_output`.
+#[pygraph(name = own_ramp)]
+fn build_own_ramp(g: &wingfoil_next::prelude::GraphBuilder) -> Stream<f64> {
+    use wingfoil_next::prelude::{SourceOps, StreamOps};
+    g.ticker(Duration::from_nanos(100))
+        .count()
+        .map(|n: &u64| *n as f64 * 3.0)
+}
+
+#[test]
+fn pygraph_shapes_expand_in_an_external_crate() {
+    let _a = min_max_pair;
+    let _b = against_own_ticker;
+    let _c = own_ramp;
+}
+
+#[test]
+fn pygraph_multi_output_erases_each_element() {
+    let g = PyGraph::new();
+    let counter = g.counter(Duration::from_nanos(100));
+    let other = counter.map(Python::attach(|py| {
+        py.eval(pyo3::ffi::c_str!("lambda n: 5.0 - n"), None, None)
+            .expect("lambda compiles")
+            .unbind()
+    }));
+
+    let (lo, hi) = Python::attach(|py| {
+        let l = pyo3::Py::new(py, wingfoil_next_python::Stream::from(counter.clone()))
+            .expect("stream pyclass");
+        let r = pyo3::Py::new(py, wingfoil_next_python::Stream::from(other.clone()))
+            .expect("stream pyclass");
+        let pair = min_max_pair(l.borrow(py), r.borrow(py));
+        (pair.0.object().clone(), pair.1.object().clone())
+    });
+    let (lo_acc, hi_acc) = (lo.accumulate(), hi.accumulate());
+
+    g.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+    let got_lo: Vec<f64> = Python::attach(|py| lo_acc.value().value().extract(py).unwrap());
+    let got_hi: Vec<f64> = Python::attach(|py| hi_acc.value().value().extract(py).unwrap());
+    // counter 1,2,3 against 4,3,2 -> min 1,2,2 / max 4,3,3
+    assert_eq!(vec![1.0, 2.0, 2.0], got_lo);
+    assert_eq!(vec![4.0, 3.0, 3.0], got_hi);
+}

--- a/next/crates/wingfoil-next-python/tests/test_interop.py
+++ b/next/crates/wingfoil-next-python/tests/test_interop.py
@@ -616,3 +616,53 @@ def test_bimap_exception_aborts_run():
     a.bimap(b, boom)
     with pytest.raises(RuntimeError, match="Python bimap callable raised"):
         g.run(cycles=1)
+
+
+def test_pygraph_multi_input_multi_output():
+    """Two streams in, a tuple of two streams out — each wired onward."""
+    g = wf.Graph()
+    bid = g.counter(period_nanos=100).map(lambda n: float(n))
+    ask = g.counter(period_nanos=100).map(lambda n: float(n) + 4.0)
+    spread, mid = wf.spread_and_mid(bid, ask)
+    spreads = spread.collect()
+    mids = mid.collect()
+    g.run(cycles=3)
+    assert [(0, 4.0), (100, 4.0), (200, 4.0)] == spreads.value()
+    assert [(0, 3.0), (100, 4.0), (200, 5.0)] == mids.value()
+
+
+def test_pygraph_outputs_chain_like_any_stream():
+    g = wf.Graph()
+    bid = g.counter(period_nanos=100).map(lambda n: float(n))
+    ask = g.counter(period_nanos=100).map(lambda n: float(n) + 4.0)
+    _, mid = wf.spread_and_mid(bid, ask)
+    out = mid.map(lambda v: v * 2).collect()
+    g.run(cycles=2)
+    assert [(0, 6.0), (100, 8.0)] == out.value()
+
+
+def test_compiled_island_matches_its_interpreted_twin():
+    """The island's interior is monomorphized straight-line code; Python wires
+    around it. It must produce identical values *and* tick times."""
+    g = wf.Graph()
+    source = g.counter(period_nanos=100).map(lambda n: float(n))
+    island = wf.compiled_island(g, source).collect()
+    twin = wf.interpreted_twin(source).collect()
+    g.run(cycles=4)
+    # (2n + 1)^2 -> 9, 25, 49, 81
+    assert [(0, 9.0), (100, 25.0), (200, 49.0), (300, 81.0)] == island.value()
+    assert twin.value() == island.value()
+
+
+def test_compiled_island_composes_with_dynamic_python_wiring():
+    """The point of the island: a compiled interior with Python on both sides."""
+    g = wf.Graph()
+    source = g.counter(period_nanos=100).map(lambda n: float(n))
+    out = (
+        wf.compiled_island(g, source.map(lambda v: v + 1.0))
+        .map(lambda v: v / 2.0)
+        .collect()
+    )
+    g.run(cycles=2)
+    # n+1 -> (2(n+1)+1)^2 -> /2
+    assert [(0, 12.5), (100, 24.5)] == out.value()

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -1,8 +1,12 @@
 # Python interop — user-authored Rust components, composed and extended from Python
 
-**Status:** partially landed (the plugin-SDK layer — `#[pyop]` (stateless,
-stateful, one- and two-input), `#[pygraph]`, source `#[pyadapter]`, and the
-`#[pyadapter]` (source, sink, and burst), and the object form — is built).
+**Status:** the plugin-SDK layer is **built** — the object form, `#[pyop]`
+(one to four inputs, stateless or stateful, tuple configs), `#[pygraph]` (any
+arity, optional builder, including compiled islands), `#[pyadapter]` (source,
+sink, burst, fallible, defaults), the edge conversions, and Python-defined
+nodes in both the composition and subclass forms. What remains is breadth, not
+mechanism: the per-adapter bindings (postgres done, seven to go) and the
+Phase 4.5 mutable frontier for extending a *running* graph.
 **`wingfoil-next-python`
 is the go-forward Python binding: it supersedes the legacy `wingfoil-python`
 bindings (decision 2026-07), it is not a new capability bolted beside a
@@ -221,42 +225,51 @@ as a Python callable that **splices its nodes into the caller's builder** and
 returns erased handles — so Python can wire onward from its outputs.
 
 ```rust
-#[pygraph(name = "vwap_pipeline")]
-pub fn vwap_pipeline(g: &mut GraphBuilder, trades: Handle<Trade>) -> Handle<f64> {
-    let px  = g.register_op1(trades, /* price */ ..);
-    let vol = g.register_op1(trades, /* size  */ ..);
-    // ... six-node vwap sub-graph ...
-    vwap
+#[pygraph(name = vwap_pipeline)]
+fn build_vwap(trades: &Stream<Trade>) -> Stream<f64> {
+    // ... six-node vwap sub-graph, all at native `Trade`/`f64` ...
 }
-// => wingfoil.vwap_pipeline(trades: PyStream) -> PyStream, nodes spliced into the live builder
+// => wingfoil_next.vwap_pipeline(trades) -> Stream, nodes spliced into the live builder
 ```
+
+Any arity works: N `&Stream<T>` inputs, and a tuple return becomes a Python
+tuple of streams. A leading `&GraphBuilder` — for wiring that creates nodes of
+its own rather than only extending its inputs — makes the generated callable
+take the graph first, `vwap_pipeline(graph, trades)`. With the builder and *no*
+stream inputs, the sub-graph is a source. As with `#[pygraph]`'s other rule,
+`name` must differ from the wiring fn's own name.
 
 ## Worked example — all three, composed and extended from Python
 
 ```python
-import wingfoil as wf
-from my_plugin import my_socket_source, vwap_pipeline   # user's Rust cdylib
+import wingfoil_next as wf
+from my_plugin import my_socket_source, vwap_pipeline, zscore   # user's Rust cdylib
 
-g = wf.GraphBuilder()
+g = wf.Graph()
 
-# 1. user Rust IO adapter (source)
-trades = g.my_socket_source("tcp://feed:9000")
+# 1. user Rust IO adapter (source) — #[pyadapter(source)]
+trades = my_socket_source(g, "tcp://feed:9000")
 
-# 2. user Rust wiring logic, reused — nodes spliced into g
+# 2. user Rust wiring logic, reused — #[pygraph], nodes spliced into g
 vwap = vwap_pipeline(trades)
 
-# 3. user Rust op, reused
-z = vwap.zscore(window=100)
+# 3. user Rust op, reused — #[pyop]
+z = zscore(vwap, window=100)
 
-# 4. EXTEND in Python: mix built-ins + a Python closure + another user op
+# 4. EXTEND in Python: mix built-ins with a Python closure
 signal = (z
           .filter(z.map(lambda v: abs(v) > 3.0))   # built-in filter + Python map
-          .throttle("1s")                          # built-in
+          .throttle(interval_nanos=1_000_000_000)  # built-in
           .distinct())                             # built-in
 
 signal.print()
 g.run(realtime=True)
 ```
+
+Note the shapes pyo3 forces: a user op or adapter is a **free function**
+(`zscore(vwap, …)`, not `vwap.zscore(…)`) because `#[pymethods]` cannot be added
+to a foreign pyclass; and a source takes the graph explicitly, since Python has
+no ambient graph.
 
 Every node above — user adapter, user sub-graph, user op, built-ins, and a raw
 Python lambda — is a peer in one erased interpreted graph. That is the whole
@@ -268,7 +281,10 @@ The Python lane lives on the **interpreted** engine, so the `compiled()` /
 `nested()` LLVM-fusion path is off the table *for the Python-spliced portion* —
 you cannot splice a Python node into a monomorphized graph. But a user can
 author a hot sub-graph as a **`nested()` compiled island** and expose *that
-island as a single erased node* Python wires around:
+island as a single erased node* Python wires around. **This is built**: an
+island's `nested()` is `(&GraphBuilder, &Stream<In>…) -> Stream<Out>`, which is
+exactly a builder-taking `#[pygraph]` wiring fn, so it needed no island-specific
+macro — see `src/island.rs`:
 
 ```
 compiled-speed interior (Rust, nested island)  ──►  dynamic wiring (Python)
@@ -276,8 +292,7 @@ compiled-speed interior (Rust, nested island)  ──►  dynamic wiring (Python
 
 So the envelope is strictly better than legacy: legacy was `PyElement` dynamic
 dispatch on every node; here the expensive interiors run at compiled speed and
-only the wiring seams are dynamic. `#[pygraph(nested)]` would emit the island
-form.
+only the wiring seams are dynamic.
 
 ## What's missing (build list)
 
@@ -291,11 +306,11 @@ form.
 | `pyop_fn!` seam + declarative macro | `PyStream::wire_op1` + `pyop_fn!` for stateless single-input ops | ✅ done (`macros.rs`) |
 | `#[pyop]` **proc** macro | reads an `Op` impl → `#[pyfunction]`; v1 stateless single-input concrete | ✅ done (`wingfoil-next-python-macros`) |
 | `#[pyop]` extensions | **done** — `State` is any `Default`-seedable type (re-seeded per run); `In<'a> = (&A, &B)` emits `module.name(stream, other)` over `wire_op2`, `(&A, &B, &C)` emits `module.name(stream, second, third)` over `wire_op3` / `Builder::register_op3` (the general form of the `Join3`-specialised `trimap`), and `(&A, …, &D)` over `wire_op4` / `register_op4`; stream parameters are named, so they take keywords. A tuple `Cfg` destructures into one named Python parameter per element via `arg = (p1, p2, …)`. The emitter is arity-generic — arity 5+ needs only a `register_op<n>`/`wire_op<n>` pair plus a parameter name. Note this ceiling is on *Rust-authored* ops (heterogeneous static input types, no variadic generics); a Python-defined node via `Graph.custom_node` takes any number of erased upstreams | ✅ done |
-| `#[pygraph]` macro (wiring reuse) | expose a Rust `fn(&Stream<T>) -> Stream<U>` sub-graph as `module.name(stream)`, spliced into the caller's graph; interior runs at native `T`, only the edge erases. Single-input/output v1, over the `PyStream::typed_input`/`erased_output` seam | ✅ done |
+| `#[pygraph]` macro (wiring reuse) | expose a Rust-authored sub-graph as a Python callable, spliced into the caller's graph; interior runs at native types, only the edges erase. **Any arity**: N `&Stream<T>` inputs, and a single `Stream<U>` or a tuple of them out (Python gets a tuple of streams). An optional leading `&GraphBuilder` — for wiring that creates nodes of its own — makes the generated fn take the graph first; builder-only (no stream inputs) is a *source* sub-graph, erasing via `erase_source`. Over the `typed_input`/`erased_output` seams | ✅ done |
 | `#[pyadapter]` macro (source + sink + burst) | **source, sink/transform, and burst adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. `Stream<Burst<T>>` erases to a Python `list` per tick, and on the way in a Python `list`/`tuple` rebuilds a multi-value burst (else a single-element burst) — so a burst source round-trips into a burst sink. Over the `builder`/`erase_source`/`erase_burst_source` and `typed_input`/`typed_burst_input`/`erased_output`/`erased_burst_output` seams; a sink's `Stream<()>` erases to `None`. Adapter method params must be `FromPyObject`. **Fallible wiring** (`Result<Stream<T>>` → a `PyResult` fn, wiring errors raised as Python exceptions) and **forwarded `#[pyo3(signature = …)]`** (Python defaults for optional args, with the generated receiver injected), and the **free-fn form** (receiver as the first param — no throwaway trait, no duplicated signature; the impl form remains for adapters wanting a fluent Rust trait) landed with the first real adapter binding | ✅ done |
 | Per-adapter Python bindings (`crate::adapters::*`) | The `#[pyadapter]` exposure of the real `wingfoil_next::adapters::*` I/O adapters, each behind a cargo feature of the same name and registered in the `#[pymodule]` under the same `#[cfg]`. **postgres done**: `postgres_read` / `postgres_sub` / `postgres_source` / `postgres_write` / `postgres_notify_trigger_sql`, with a dynamic row↔`dict` edge (`PyPgRow`) and declared-column write marshaling; unit-level marshaling tests plus a service-backed pytest leg in `postgres-next-integration.yml`. Remaining: the other adapters as they are bound | 🟡 postgres done |
-| POC: call a fixed `compiled()` graph from Python | Wire `wingfoil-next` as a path dep; expose one fixed `graph!` wiring (`ticker → count → map(i*i) → accumulate`) as `compiled_squares`/`interpreted_squares` (both from a single wiring so they can't drift). Proved **compiled == interpreted output from Python** across cycle- and duration-bound runs; GIL released for the run; no `.unwrap()` in binding code. Honest limit: **one fixed, compile-time graph** — not general Python-defined-graph codegen (timing ~neutral at that ticker-bound size; a dispatch-heavy graph shows `compiled()`'s win). Consistent with the non-goal below (`compiled()`/`nested()` expose as single island nodes). Revisit against the post-refactor `compiled()` API. | ⬜ (was #506) |
-| Edge-conversion trait bounds | `PyElement <-> f64/i64/bool/String` shipped; `Trade`/user types via user impls | 🟡 scalars done |
+| Compiled graph reachable from Python | **done, and better than the original POC** — rather than one hard-coded `compiled()` graph, a `graph!`-generated **`nested()` island** is exposed through `#[pygraph]`: its signature is `(&GraphBuilder, &Stream<In>…) -> Stream<Out>`, i.e. exactly a builder-taking `#[pygraph]` wiring fn, so no island-specific machinery was needed. The interior is monomorphized straight-line code; Python wires around it dynamically. A pytest asserts the island's values *and* tick times match its interpreted twin, and that it composes with Python `map` on both sides. Still true: `compiled()`/`nested()` are not Python-*splittable* — an island is one opaque node | ✅ done |
+| Edge-conversion trait bounds | **done** — every integer width (`i8`…`isize`, `u8`…`usize`), `f32`/`f64`, `bool`, `String`/`&str`, `()`→`None`, `Vec<u8>`→**`bytes`** (not a list of ints), and `Option<T>`→`None`/value with the inner conversion propagating a wrong-typed value as an error rather than a silent `None`. A user record type crosses via its own `From`/`TryFrom` impls — legal from a downstream crate under the orphan rules, proven by a `Trade` struct defined in the external seam-test crate | ✅ done |
 | Mutable-frontier engine (extend a *running* graph) | Phase 4.5 dirty-list; only needed for post-`run` mutation | 🟡 Phase 4.5 |
 
 ## Constraints / non-goals
@@ -318,7 +333,8 @@ form.
 2. `#[pyop]` first (smallest, highest-leverage; unlocks user ops).
 3. `#[pygraph]` (wiring reuse — the "extend in Python" headline).
 4. `#[pyadapter]` (sources/sinks; leans on the threaded-source plumbing).
-5. `#[pygraph(nested)]` compiled-island form once the above is proven.
+5. ✅ the compiled-island form — which fell out of giving `#[pygraph]` a
+   `&GraphBuilder` parameter, rather than needing a `nested` marker of its own.
 
 One PR per macro; each carries a round-trip test (author in Rust → compose and
 extend in Python → assert values + tick times against the same graph authored


### PR DESCRIPTION
Closes the three remaining build-list items that aren't per-adapter bindings: **edge conversions**, **`#[pygraph]`'s arity limits**, and **reaching a compiled graph from Python**.

## Edge conversions

The boundary carried `f64`/`i64`/`bool`/`String` only, so a record field of any other shape needed a hand-written conversion. Now every integer width (`i8`…`isize`, `u8`…`usize`), `f32`, and two shapes that are more than just extra scalars:

- **`Vec<u8>` erases to Python `bytes`**, not a `list[int]`. pyo3's blanket `Vec<T>` conversion gives the latter, which is both wrong-typed for a message body and far slower.
- **`Option<T>`** maps `None` to Python `None` and otherwise defers to the inner conversion — and a *present but wrong-typed* value is an **error, not a silent `None`**. That distinction is what makes a nullable edge trustworthy, and it has its own test.

A user record type crosses via its own `From`/`TryFrom` impls. That was always the claim; it's now proven rather than asserted, by a `Trade` struct defined in the **external** seam-test crate — which is also the check that the orphan rules permit both directions from a downstream crate.

## `#[pygraph]` at any arity

It took exactly one input and one output. Now N `&Stream<T>` inputs, and either a `Stream<U>` or a tuple of them out — Python receives a tuple of streams, each independently erased and chainable. Stream parameters are named by the same convention `#[pyop]` uses, so one rule covers both macros.

## A compiled graph, reachable from Python

The open row (was #506) asked for a POC exposing one fixed `compiled()` graph. What landed is better and smaller.

A `graph!`-generated `nested()` island has the signature `(&GraphBuilder, &Stream<In>…) -> Stream<Out>` — which is **exactly a `#[pygraph]` wiring fn that takes the builder**. So giving `#[pygraph]` an optional leading `&GraphBuilder` made islands expressible with *no island-specific machinery*: the `#[pygraph(nested)]` marker the design doc anticipated turned out to be unnecessary, and the same parameter serves any wiring that creates nodes of its own. With the builder and no stream inputs, a sub-graph is a **source**, erasing via `erase_source`.

```python
out = wf.compiled_island(g, source.map(lambda v: v + 1.0)).map(lambda v: v / 2.0)
```

Compiled interior, Python wiring on both sides — the shape the design doc promised. A pytest asserts the island's values **and tick times** match an interpreted twin.

The island lives in its own module because `graph!` needs the fluent `Stream` unqualified and `python.rs` shadows it with the pyclass of the same name.

## Tests

- **7 element unit tests** — widths, bytes-not-a-list, empty bytes, nullable round-trip, and the two failure modes (a negative not wrapping into an unsigned width; a wrong-typed inner not becoming `None`).
- **6 cross-crate seam tests** — a user struct round-tripping, flowing through a typed op, and aborting with its field name when malformed; multi-output, builder-taking and source-shaped `#[pygraph]`s.
- **5 pytest cases** — multi-input/output, chaining off a tuple output, island-vs-twin parity, island composed with Python wiring.

## Docs

Build list, compiled-islands section and sequencing list updated. I also corrected the aspirational snippets that predated the implementation: they showed `import wingfoil`, ops as *methods* (which pyo3 forbids on a foreign pyclass — as the same document explains two sections earlier), a `PyGraphBuilder` class that shipped as `Graph`, and a `#[pygraph]` signature over `Handle<T>` that never existed.

## Not included

Per-adapter bindings (left deliberately), and the Phase 4.5 mutable frontier for extending a *running* graph — engine work rather than Python-lane work.

## Verification

`cargo fmt --all -- --check`, `cargo lint`, `cargo lint-all`, `cargo test -p wingfoil-next-python --features all-adapters` (85 tests), and the full pytest suite (100 passed).

One thing worth knowing: the island's `graph!` closures needed explicit `|x: &f64|` annotations. Unannotated, they build fine under `--features all-adapters` but blow the trait-inference recursion limit under `cargo lint`'s feature set, once nalgebra is in scope via augurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TaKx6yNvtvSHBKhur5wJE

---
_Generated by [Claude Code](https://claude.ai/code/session_018TaKx6yNvtvSHBKhur5wJE)_