### PR TITLE
Add Python bindings for the statistics adapter

### DIFF
--- a/wingfoil-python/README.md
+++ b/wingfoil-python/README.md
@@ -23,6 +23,7 @@ model, operators, and production-ready I/O adapters from Python.
 - [Quick Start](#-quick-start)
 - [Core Concepts](#-core-concepts)
 - [Stream Operators](#-stream-operators)
+  - [Statistics](#statistics)
 - [Composing Streams: `Graph`, `bimap`, `CustomStream`](#-composing-streams-graph-bimap-customstream)
 - [Backtesting with Historical Mode](#-backtesting-with-historical-mode)
 - [Pandas Integration](#-pandas-integration)
@@ -154,12 +155,62 @@ All methods are available on `Stream` instances. Examples assume
 | Operator | Description |
 | --- | --- |
 | `.count()` | Emit tick count: 1, 2, 3, ... |
-| `.sum()` | Running sum (values must be numeric). |
-| `.average()` | Running mean (values must be numeric). |
+| `.average()` | Running mean — shorthand for `.mean()` (see [Statistics](#statistics)). |
 | `.buffer(n)` | Tumbling window of size `n`. |
 | `.collect()` | Accumulate every value into a `list` emitted each cycle. |
 | `.with_time()` | Pair each value with graph-time as `(seconds, value)`. |
 | `.dataframe()` | Collect `[(time, value), ...]` for pandas (see below). |
+
+### Statistics
+
+Streaming statistics for numeric streams. Each operator emits a `float` per
+tick and is maintained incrementally, so a rolling mean over a million-sample
+window costs the same per tick as one over ten.
+
+| Operator | Description |
+| --- | --- |
+| `.mean(window, weighting)` | Mean over `window`. |
+| `.variance(window, weighting)` | Variance — sample (ddof = 1) when count weighted, population when time weighted. |
+| `.std(window, weighting)` | Standard deviation — the square root of `.variance()`. |
+| `.sum(window)` | Sum over `window`. |
+| `.min(window)` / `.max(window)` | Extremes over `window`. |
+| `.median(window, weighting)` | Median over `window`. |
+| `.ewma(span)` | Exponentially weighted moving average. |
+
+`window` says *which* samples an operator sees, `weighting` says *how* they
+count:
+
+| `window` | Meaning |
+| --- | --- |
+| omitted / `None` / `Window.unbounded()` | Every sample so far (cumulative). |
+| `Window.count(n)` or plain `n` | The most recent `n` samples. |
+| `Window.seconds(s)` | Every sample from the last `s` of graph time. |
+
+| `weighting` | Meaning |
+| --- | --- |
+| omitted / `Weighting.Count` / `"count"` | Every sample counts equally. |
+| `Weighting.Time` / `"time"` | Each sample is weighted by how long it was in effect. |
+
+A bare `float` is not accepted as a `window`: `.mean(10)` (ten samples) and
+`.mean(10.0)` (ten seconds?) would mean very different things, so a time window
+must say so with `Window.seconds(...)`.
+
+`.ewma()` takes an `EwmaSpan` instead: `EwmaSpan.per_tick(alpha)` applies a
+fixed smoothing factor once per tick (a plain `float` is shorthand for this),
+while `EwmaSpan.half_life(seconds)` decays by elapsed graph time, independent of
+tick rate.
+
+```python
+from wingfoil import EwmaSpan, Weighting, Window, ticker
+
+prices = ticker(0.1).count().map(float)
+
+rolling_mean = prices.mean(20)                             # last 20 samples
+twap         = prices.mean(Window.seconds(5.0), "time")    # 5s, time weighted
+band         = prices.std(Window.count(20))                # rolling volatility
+smoothed     = prices.ewma(EwmaSpan.half_life(2.0))        # 2s half-life
+spread       = prices.max(20).logged("high")
+```
 
 ### Observing and sinking
 

--- a/wingfoil-python/docs/api.rst
+++ b/wingfoil-python/docs/api.rst
@@ -21,9 +21,17 @@ Quick index
 **Stream operators (methods on** :class:`Stream` **)**:
 
 ``map``, ``filter``, ``distinct``, ``difference``, ``delay``, ``not``,
-``limit``, ``sample``, ``count``, ``sum``, ``average``, ``buffer``,
+``limit``, ``sample``, ``count``, ``average``, ``buffer``,
 ``collect``, ``with_time``, ``dataframe``, ``inspect``, ``logged``,
 ``for_each``, ``finally``, ``peek_value``, ``run``.
+
+**Statistics operators (methods on** :class:`Stream` **)**:
+
+``mean``, ``variance``, ``std``, ``sum``, ``min``, ``max``, ``median``,
+``ewma`` — each takes a :class:`Window` (or a plain ``int`` for a count
+window, or ``None`` for cumulative); the moment operators additionally take a
+:class:`Weighting` (or ``"count"`` / ``"time"``), and ``ewma`` takes an
+:class:`EwmaSpan` (or a plain ``float`` for a per-tick smoothing factor).
 
 **Pandas helpers**: :func:`to_dataframe`, :func:`build_dataframe`.
 

--- a/wingfoil-python/python/wingfoil/__init__.py
+++ b/wingfoil-python/python/wingfoil/__init__.py
@@ -69,6 +69,12 @@ fix_accept = _ext.py_fix_accept
 # User-friendly aliases for OTLP
 # (otlp_push is exposed as a stream method, no top-level sub function needed)
 
+# Statistics operator arguments (stream.mean/variance/std/sum/min/max/median/ewma)
+Window = _ext.Window
+Weighting = _ext.Weighting
+EwmaSpan = _ext.EwmaSpan
+__all__.extend(["Window", "Weighting", "EwmaSpan"])
+
 # User-friendly aliases for Prometheus
 PrometheusExporter = _ext.PrometheusExporter
 __all__.append("PrometheusExporter")

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -17,6 +17,7 @@ mod py_otlp;
 mod py_postgres;
 mod py_prometheus;
 mod py_redis;
+mod py_statistics;
 mod py_stream;
 mod py_web;
 mod py_zmq;
@@ -232,6 +233,9 @@ fn _wingfoil(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<py_iceoryx2::PyIceoryx2Mode>()?;
     #[cfg(feature = "aeron")]
     module.add_class::<py_aeron::PyAeronMode>()?;
+    module.add_class::<py_statistics::PyWindow>()?;
+    module.add_class::<py_statistics::PyWeighting>()?;
+    module.add_class::<py_statistics::PyEwmaSpan>()?;
     module.add_class::<py_prometheus::PyPrometheusExporter>()?;
     module.add_class::<py_latency::PyLatency>()?;
     module.add_class::<py_latency::PyTracedBytes>()?;

--- a/wingfoil-python/src/py_augurs.rs
+++ b/wingfoil-python/src/py_augurs.rs
@@ -24,21 +24,10 @@ use wingfoil::adapters::augurs::{
 use wingfoil::{Stream, StreamOperators};
 
 use crate::py_element::PyElement;
-
-/// Map a `PyElement` stream to an `f64` stream, failing the graph run with a
-/// contextual error on a value that is not a float. This mirrors
-/// [`PyStream::extract`] used by `.average()` / `.sum()`; substituting `NaN`
-/// instead would silently poison the model window and abort the run later with
-/// an augurs-internal message that never points back at the offending value.
-fn as_floats(stream: &Rc<dyn Stream<PyElement>>, op: &'static str) -> Rc<dyn Stream<f64>> {
-    stream.try_map(move |elem: PyElement| {
-        Python::attach(|py| {
-            elem.as_ref().extract::<f64>(py).map_err(|e| {
-                anyhow::Error::new(e).context(format!("{op}: expected a float input value"))
-            })
-        })
-    })
-}
+// Shared with the statistics bindings: substituting `NaN` for a non-float
+// instead would silently poison the model window and abort the run later with
+// an augurs-internal message that never points back at the offending value.
+use crate::py_stream::as_floats;
 
 /// Map a `PyElement` stream to a `Vec<f64>` (per-series readings) stream,
 /// failing the graph run with a contextual error on a value that is not a

--- a/wingfoil-python/src/py_statistics.rs
+++ b/wingfoil-python/src/py_statistics.rs
@@ -1,0 +1,319 @@
+//! Python bindings for the statistics adapter.
+//!
+//! The statistics adapter is pure Rust with no external service, so — like
+//! augurs — every binding is a stream transform exposed as a method on
+//! [`PyStream`](crate::py_stream::PyStream) rather than a source function.
+//! Each consumes a stream of numbers and emits a stream of floats:
+//!
+//! - `.mean(window, weighting)` / `.variance(...)` / `.std(...)`
+//! - `.sum(window)` / `.min(window)` / `.max(window)` / `.median(window, weighting)`
+//! - `.ewma(span)`
+//!
+//! The Rust API takes a [`Window`] and a [`Weighting`] by value; Python gets
+//! the same two knobs through the [`Window`](PyWindow) and
+//! [`Weighting`](PyWeighting) classes, with `int` and `str` shorthands so the
+//! common cases stay terse:
+//!
+//! ```python
+//! from wingfoil import Window, Weighting, EwmaSpan
+//!
+//! prices.mean()                                  # cumulative, count weighted
+//! prices.mean(10)                                # last 10 samples
+//! prices.mean(Window.seconds(5.0), "time")       # 5s of graph time, time weighted
+//! prices.ewma(EwmaSpan.half_life(30.0))
+//! ```
+//!
+//! A bare `float` is deliberately *not* accepted as a window: `mean(10)` and
+//! `mean(10.0)` would mean wildly different things (ten samples vs ten
+//! seconds), so a time window must say so via `Window.seconds(...)`.
+
+use std::rc::Rc;
+use std::time::Duration;
+
+use pyo3::prelude::*;
+use wingfoil::Stream;
+use wingfoil::adapters::statistics::{EwmaSpan, StatisticsOperators, Weighting, Window};
+
+use crate::py_element::PyElement;
+use crate::py_stream::as_floats;
+
+/// How samples are weighted when aggregating a stream.
+#[pyclass(eq, eq_int, name = "Weighting", from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PyWeighting {
+    /// Every sample counts equally — the ordinary arithmetic statistic.
+    Count,
+    /// Each sample is weighted by how long it was in effect (elapsed graph
+    /// time since the previous sample).
+    Time,
+}
+
+impl From<PyWeighting> for Weighting {
+    fn from(w: PyWeighting) -> Self {
+        match w {
+            PyWeighting::Count => Weighting::Count,
+            PyWeighting::Time => Weighting::Time,
+        }
+    }
+}
+
+/// The extent an operator aggregates over.
+///
+/// Build one with `Window.count(n)`, `Window.seconds(secs)` or
+/// `Window.unbounded()`. Operators also accept a plain `int` as shorthand for
+/// `Window.count(n)`, and `None` for `Window.unbounded()`.
+#[pyclass(name = "Window", frozen, eq, from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PyWindow(Window);
+
+#[pymethods]
+impl PyWindow {
+    /// The most recent `n` samples (clamped to at least one).
+    #[staticmethod]
+    fn count(n: usize) -> Self {
+        Self(Window::Count(n))
+    }
+
+    /// All samples seen in the last `seconds` of graph time.
+    #[staticmethod]
+    fn seconds(seconds: f64) -> PyResult<Self> {
+        Ok(Self(Window::Time(duration_from_secs(
+            "Window.seconds",
+            seconds,
+        )?)))
+    }
+
+    /// Every sample seen so far — a cumulative (expanding) window.
+    #[staticmethod]
+    fn unbounded() -> Self {
+        Self(Window::Unbounded)
+    }
+
+    fn __repr__(&self) -> String {
+        match self.0 {
+            Window::Count(n) => format!("Window.count({n})"),
+            Window::Time(d) => format!("Window.seconds({})", d.as_secs_f64()),
+            Window::Unbounded => "Window.unbounded()".to_string(),
+        }
+    }
+}
+
+/// How an [`ewma`](crate::py_stream::PyStream::ewma) decays older observations.
+///
+/// Build one with `EwmaSpan.per_tick(alpha)` or `EwmaSpan.half_life(seconds)`.
+/// `ewma` also accepts a plain `float` as shorthand for
+/// `EwmaSpan.per_tick(alpha)`.
+#[pyclass(name = "EwmaSpan", frozen, eq, from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PyEwmaSpan(EwmaSpan);
+
+#[pymethods]
+impl PyEwmaSpan {
+    /// Fixed smoothing factor applied once per tick
+    /// (`ewma_t = alpha * x_t + (1 - alpha) * ewma_{t-1}`).
+    #[staticmethod]
+    fn per_tick(alpha: f64) -> PyResult<Self> {
+        // The Rust operator only `debug_assert!`s this, so a release build
+        // would silently produce a diverging (or frozen) average. Reject it at
+        // the boundary instead.
+        if !(0.0..=1.0).contains(&alpha) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "ewma: per_tick alpha must be between 0 and 1, got {alpha}"
+            )));
+        }
+        Ok(Self(EwmaSpan::PerTick(alpha)))
+    }
+
+    /// Time decay: a sample's weight halves every `seconds` of elapsed graph
+    /// time, independent of tick rate.
+    #[staticmethod]
+    fn half_life(seconds: f64) -> PyResult<Self> {
+        let half_life = duration_from_secs("EwmaSpan.half_life", seconds)?;
+        if half_life.is_zero() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "EwmaSpan.half_life: seconds must be greater than 0",
+            ));
+        }
+        Ok(Self(EwmaSpan::HalfLife(half_life)))
+    }
+
+    fn __repr__(&self) -> String {
+        match self.0 {
+            EwmaSpan::PerTick(alpha) => format!("EwmaSpan.per_tick({alpha})"),
+            EwmaSpan::HalfLife(d) => format!("EwmaSpan.half_life({})", d.as_secs_f64()),
+        }
+    }
+}
+
+/// Convert a seconds `float` to a [`Duration`], rejecting the negative and
+/// non-finite values that [`Duration::from_secs_f64`] would panic on.
+fn duration_from_secs(op: &str, seconds: f64) -> PyResult<Duration> {
+    if !seconds.is_finite() || seconds < 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "{op}: seconds must be a finite, non-negative number, got {seconds}"
+        )));
+    }
+    Ok(Duration::from_secs_f64(seconds))
+}
+
+/// Resolve the `window` argument shared by every statistics operator.
+///
+/// Accepts a [`Window`](PyWindow), a plain `int` (shorthand for a count
+/// window), or `None` (an unbounded/cumulative window).
+fn window_from_py(op: &str, window: Option<&Bound<'_, PyAny>>) -> PyResult<Window> {
+    let Some(window) = window else {
+        return Ok(Window::Unbounded);
+    };
+    if window.is_none() {
+        return Ok(Window::Unbounded);
+    }
+    if let Ok(window) = window.extract::<PyWindow>() {
+        return Ok(window.0);
+    }
+    // `extract::<usize>` goes through `__index__`, so a `float` lands in the
+    // error below rather than being silently truncated to a count window.
+    if let Ok(n) = window.extract::<usize>() {
+        return Ok(Window::Count(n));
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "{op}: window must be a Window, an int (sample count), or None (unbounded) — \
+         pass Window.seconds(...) for a time window"
+    )))
+}
+
+/// Resolve the `weighting` argument of the moment operators.
+///
+/// Accepts a [`Weighting`](PyWeighting), the string `"count"` or `"time"`, or
+/// `None` (count weighting).
+fn weighting_from_py(op: &str, weighting: Option<&Bound<'_, PyAny>>) -> PyResult<Weighting> {
+    let Some(weighting) = weighting else {
+        return Ok(Weighting::Count);
+    };
+    if weighting.is_none() {
+        return Ok(Weighting::Count);
+    }
+    if let Ok(weighting) = weighting.extract::<PyWeighting>() {
+        return Ok(weighting.into());
+    }
+    if let Ok(name) = weighting.extract::<String>() {
+        return match name.to_ascii_lowercase().as_str() {
+            "count" => Ok(Weighting::Count),
+            "time" => Ok(Weighting::Time),
+            other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "{op}: unknown weighting '{other}' (expected 'count' or 'time')"
+            ))),
+        };
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(format!(
+        "{op}: weighting must be a Weighting, 'count', 'time', or None"
+    )))
+}
+
+/// Resolve the `span` argument of [`py_ewma_inner`].
+///
+/// Accepts an [`EwmaSpan`](PyEwmaSpan) or a plain `float` (shorthand for a
+/// per-tick smoothing factor).
+fn span_from_py(span: &Bound<'_, PyAny>) -> PyResult<EwmaSpan> {
+    if let Ok(span) = span.extract::<PyEwmaSpan>() {
+        return Ok(span.0);
+    }
+    if let Ok(alpha) = span.extract::<f64>() {
+        return Ok(PyEwmaSpan::per_tick(alpha)?.0);
+    }
+    Err(pyo3::exceptions::PyTypeError::new_err(
+        "ewma: span must be an EwmaSpan or a float (per-tick alpha)",
+    ))
+}
+
+/// A moment operator selected by the `.mean()` / `.variance()` / `.std()`
+/// stream methods, which differ only in which trait method they call.
+#[derive(Clone, Copy)]
+pub enum PyMoment {
+    Mean,
+    Variance,
+    Std,
+}
+
+impl PyMoment {
+    fn name(self) -> &'static str {
+        match self {
+            PyMoment::Mean => "mean",
+            PyMoment::Variance => "variance",
+            PyMoment::Std => "std",
+        }
+    }
+}
+
+/// Inner implementation for the `.mean()` / `.variance()` / `.std()` stream
+/// methods.
+pub fn py_moment_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    moment: PyMoment,
+    window: Option<&Bound<'_, PyAny>>,
+    weighting: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Rc<dyn Stream<f64>>> {
+    let op = moment.name();
+    let window = window_from_py(op, window)?;
+    let weighting = weighting_from_py(op, weighting)?;
+    let floats = as_floats(stream, op);
+    Ok(match moment {
+        PyMoment::Mean => floats.mean(window, weighting),
+        PyMoment::Variance => floats.variance(window, weighting),
+        PyMoment::Std => floats.std(window, weighting),
+    })
+}
+
+/// An unweighted window operator selected by the `.sum()` / `.min()` /
+/// `.max()` stream methods.
+#[derive(Clone, Copy)]
+pub enum PyAggregate {
+    Sum,
+    Min,
+    Max,
+}
+
+impl PyAggregate {
+    fn name(self) -> &'static str {
+        match self {
+            PyAggregate::Sum => "sum",
+            PyAggregate::Min => "min",
+            PyAggregate::Max => "max",
+        }
+    }
+}
+
+/// Inner implementation for the `.sum()` / `.min()` / `.max()` stream methods.
+pub fn py_aggregate_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    aggregate: PyAggregate,
+    window: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Rc<dyn Stream<f64>>> {
+    let op = aggregate.name();
+    let window = window_from_py(op, window)?;
+    let floats = as_floats(stream, op);
+    Ok(match aggregate {
+        PyAggregate::Sum => floats.sum(window),
+        PyAggregate::Min => floats.min(window),
+        PyAggregate::Max => floats.max(window),
+    })
+}
+
+/// Inner implementation for the `.median()` stream method.
+pub fn py_median_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    window: Option<&Bound<'_, PyAny>>,
+    weighting: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Rc<dyn Stream<f64>>> {
+    let window = window_from_py("median", window)?;
+    let weighting = weighting_from_py("median", weighting)?;
+    Ok(as_floats(stream, "median").median(window, weighting))
+}
+
+/// Inner implementation for the `.ewma()` stream method.
+pub fn py_ewma_inner(
+    stream: &Rc<dyn Stream<PyElement>>,
+    span: &Bound<'_, PyAny>,
+) -> PyResult<Rc<dyn Stream<f64>>> {
+    let span = span_from_py(span)?;
+    Ok(as_floats(stream, "ewma").ewma(span))
+}

--- a/wingfoil-python/src/py_stream.rs
+++ b/wingfoil-python/src/py_stream.rs
@@ -54,6 +54,26 @@ impl PyStream {
     }
 }
 
+/// Map a `PyElement` stream to an `f64` stream, failing the graph run with a
+/// contextual error naming `op` on a value that is not a float.
+///
+/// This is [`PyStream::extract`] with a caller-supplied label: the numeric
+/// adapters (statistics, augurs) take an arbitrary Python stream, so the error
+/// has to point back at the operator that demanded a number rather than report
+/// a bare conversion failure.
+pub(crate) fn as_floats(
+    stream: &Rc<dyn Stream<PyElement>>,
+    op: &'static str,
+) -> Rc<dyn Stream<f64>> {
+    stream.try_map(move |elem: PyElement| {
+        Python::attach(|py| {
+            elem.as_ref().extract::<f64>(py).map_err(|e| {
+                anyhow::Error::new(e).context(format!("{op}: expected a float input value"))
+            })
+        })
+    })
+}
+
 /// Convert a native Rust value into a `Py<PyAny>`.
 ///
 /// Only ever called with concrete types (`f64`, `u64`, `Vec<Py<PyAny>>`) whose
@@ -203,6 +223,7 @@ impl PyStream {
         PyStream(strm)
     }
 
+    /// Cumulative arithmetic mean — shorthand for `.mean()`.
     fn average(&self) -> PyStream {
         self.extract::<f64>()
             .mean(Window::Unbounded, Weighting::Count)
@@ -364,9 +385,133 @@ impl PyStream {
         })
     }
 
-    /// sum the stream (extracts f64 values before summing)
-    fn sum(&self) -> PyStream {
-        self.extract::<f64>().sum(Window::Unbounded).as_py_stream()
+    /// Mean of this stream of numbers over `window`.
+    ///
+    /// Args:
+    ///     window: `Window.count(n)`, `Window.seconds(s)`, `Window.unbounded()`,
+    ///         a plain `int` (shorthand for a count window), or `None`
+    ///         (cumulative — the default).
+    ///     weighting: `Weighting.Count` / `"count"` (default) for the ordinary
+    ///         arithmetic mean, or `Weighting.Time` / `"time"` to weight each
+    ///         sample by how long it was in effect.
+    ///
+    /// Returns:
+    ///     A Stream of floats.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn mean(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_moment_inner(
+            &self.0,
+            crate::py_statistics::PyMoment::Mean,
+            window,
+            weighting,
+        )?
+        .as_py_stream())
+    }
+
+    /// Variance of this stream of numbers over `window`.
+    ///
+    /// `Weighting.Count` gives the sample variance (ddof = 1); `Weighting.Time`
+    /// gives the time-weighted population variance. Yields `0.0` until enough
+    /// data is present. See `mean` for the argument forms.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn variance(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_moment_inner(
+            &self.0,
+            crate::py_statistics::PyMoment::Variance,
+            window,
+            weighting,
+        )?
+        .as_py_stream())
+    }
+
+    /// Standard deviation over `window` — the square root of `variance` under
+    /// the same weighting. See `mean` for the argument forms.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn std(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_moment_inner(
+            &self.0,
+            crate::py_statistics::PyMoment::Std,
+            window,
+            weighting,
+        )?
+        .as_py_stream())
+    }
+
+    /// Sum of this stream of numbers over `window` (cumulative by default).
+    /// See `mean` for the accepted `window` forms.
+    #[pyo3(signature = (window=None))]
+    fn sum(&self, window: Option<&Bound<'_, PyAny>>) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_aggregate_inner(
+            &self.0,
+            crate::py_statistics::PyAggregate::Sum,
+            window,
+        )?
+        .as_py_stream())
+    }
+
+    /// Minimum of this stream of numbers over `window` (cumulative by default).
+    /// See `mean` for the accepted `window` forms.
+    #[pyo3(signature = (window=None))]
+    fn min(&self, window: Option<&Bound<'_, PyAny>>) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_aggregate_inner(
+            &self.0,
+            crate::py_statistics::PyAggregate::Min,
+            window,
+        )?
+        .as_py_stream())
+    }
+
+    /// Maximum of this stream of numbers over `window` (cumulative by default).
+    /// See `mean` for the accepted `window` forms.
+    #[pyo3(signature = (window=None))]
+    fn max(&self, window: Option<&Bound<'_, PyAny>>) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_aggregate_inner(
+            &self.0,
+            crate::py_statistics::PyAggregate::Max,
+            window,
+        )?
+        .as_py_stream())
+    }
+
+    /// Median of this stream of numbers over `window`.
+    ///
+    /// `Weighting.Time` gives the time-weighted median (the value at which
+    /// cumulative in-effect time crosses one half). Over an unbounded window
+    /// this retains every sample, so memory grows with the stream. See `mean`
+    /// for the argument forms.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn median(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_median_inner(&self.0, window, weighting)?.as_py_stream())
+    }
+
+    /// Exponentially weighted moving average of this stream of numbers.
+    ///
+    /// Args:
+    ///     span: `EwmaSpan.per_tick(alpha)` for a fixed smoothing factor
+    ///         applied once per tick, `EwmaSpan.half_life(seconds)` to decay by
+    ///         elapsed graph time, or a plain `float` (shorthand for
+    ///         `per_tick`). The first sample seeds the average.
+    ///
+    /// Returns:
+    ///     A Stream of floats.
+    fn ewma(&self, span: &Bound<'_, PyAny>) -> PyResult<PyStream> {
+        Ok(crate::py_statistics::py_ewma_inner(&self.0, span)?.as_py_stream())
     }
 
     fn count(&self) -> PyStream {

--- a/wingfoil-python/tests/test_statistics.py
+++ b/wingfoil-python/tests/test_statistics.py
@@ -1,0 +1,249 @@
+"""Tests for the statistics Python bindings.
+
+The statistics adapter is pure Rust with no external service, so — like augurs —
+these tests run by default; there is no `requires_*` marker to gate. They pin
+the pyo3 argument-marshaling glue (`Window` / `Weighting` / `EwmaSpan` and their
+`int` / `str` / `float` shorthands) against deterministic historical-mode runs.
+
+Every helper builds a *fresh* stream: node state (counters, rolling windows)
+survives a run, so reusing one stream across runs would make later expectations
+depend on earlier tests.
+"""
+
+import math
+import unittest
+
+from wingfoil import EwmaSpan, Weighting, Window, ticker
+
+
+def _counts():
+    """A fresh stream of floats 1.0, 2.0, 3.0, ... one per second of graph time."""
+    return ticker(1.0).count().map(float)
+
+
+def _run(stream, cycles):
+    """Run `stream` in historical mode and return every value it emitted."""
+    captured = stream.collect()
+    captured.run(realtime=False, cycles=cycles)
+    return captured.peek_value()
+
+
+class TestMean(unittest.TestCase):
+    def test_cumulative_default(self):
+        # No window argument is the cumulative (unbounded) window.
+        self.assertEqual([1.0, 1.5, 2.0, 2.5, 3.0], _run(_counts().mean(), 5))
+
+    def test_explicit_unbounded_matches_default(self):
+        self.assertEqual(
+            _run(_counts().mean(), 5), _run(_counts().mean(Window.unbounded()), 5)
+        )
+
+    def test_count_window(self):
+        # Rolling mean of the last three samples.
+        self.assertEqual([1.0, 1.5, 2.0, 3.0, 4.0, 5.0], _run(_counts().mean(3), 6))
+
+    def test_int_shorthand_matches_window_count(self):
+        self.assertEqual(
+            _run(_counts().mean(Window.count(3)), 6), _run(_counts().mean(3), 6)
+        )
+
+    def test_time_window(self):
+        # Ticks land on whole seconds, and a sample exactly `seconds` old is
+        # still in the window, so a 3s window holds four samples once warm.
+        self.assertEqual(
+            [1.0, 1.5, 2.0, 2.5, 3.5, 4.5], _run(_counts().mean(Window.seconds(3.0)), 6)
+        )
+
+    def test_time_weighting_differs_from_count(self):
+        # Each sample is weighted by how long it was in effect, so the newest
+        # sample (in effect for zero time so far) carries no weight yet.
+        self.assertEqual(
+            [1.0, 1.0, 1.5, 2.0, 2.5],
+            _run(_counts().mean(Window.unbounded(), Weighting.Time), 5),
+        )
+
+    def test_weighting_accepts_strings(self):
+        for name, weighting in (("count", Weighting.Count), ("time", Weighting.Time)):
+            with self.subTest(weighting=name):
+                self.assertEqual(
+                    _run(_counts().mean(None, weighting), 5),
+                    _run(_counts().mean(None, name), 5),
+                )
+
+    def test_average_is_cumulative_mean(self):
+        self.assertEqual(_run(_counts().mean(), 5), _run(_counts().average(), 5))
+
+
+class TestVarianceAndStd(unittest.TestCase):
+    def test_cumulative_sample_variance(self):
+        # ddof = 1, so the first tick yields 0.0 rather than a division by zero.
+        expected = [0.0, 0.5, 1.0, 5.0 / 3.0, 2.5]
+        for got, want in zip(_run(_counts().variance(), 5), expected):
+            self.assertAlmostEqual(want, got)
+
+    def test_std_is_sqrt_of_variance(self):
+        variances = _run(_counts().variance(4), 8)
+        stds = _run(_counts().std(4), 8)
+        self.assertEqual(len(variances), len(stds))
+        for variance, std in zip(variances, stds):
+            self.assertAlmostEqual(math.sqrt(variance), std)
+
+    def test_std_time_weighted_is_non_negative(self):
+        # The time-weighted form is the population variance (no ddof), which is
+        # a different number from the count-weighted one but never negative.
+        stds = _run(_counts().std(Window.unbounded(), "time"), 6)
+        self.assertTrue(all(std >= 0.0 for std in stds))
+        self.assertGreater(stds[-1], 0.0)
+
+
+class TestSumMinMax(unittest.TestCase):
+    def test_sum_no_args_is_cumulative(self):
+        # The pre-existing zero-argument `.sum()` keeps working unchanged.
+        self.assertEqual([1.0, 3.0, 6.0, 10.0, 15.0], _run(_counts().sum(), 5))
+
+    def test_sum_count_window(self):
+        self.assertEqual([1.0, 3.0, 6.0, 9.0, 12.0, 15.0], _run(_counts().sum(3), 6))
+
+    def test_sum_time_window(self):
+        self.assertEqual(
+            [1.0, 3.0, 6.0, 10.0, 14.0, 18.0],
+            _run(_counts().sum(Window.seconds(3.0)), 6),
+        )
+
+    def test_cumulative_min_and_max(self):
+        self.assertEqual([1.0] * 5, _run(_counts().min(), 5))
+        self.assertEqual([1.0, 2.0, 3.0, 4.0, 5.0], _run(_counts().max(), 5))
+
+    def test_rolling_min_and_max(self):
+        self.assertEqual([1.0, 1.0, 1.0, 2.0, 3.0, 4.0], _run(_counts().min(3), 6))
+        self.assertEqual([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], _run(_counts().max(3), 6))
+
+    def test_time_windowed_min(self):
+        self.assertEqual(
+            [1.0, 1.0, 1.0, 1.0, 2.0, 3.0], _run(_counts().min(Window.seconds(3.0)), 6)
+        )
+
+
+class TestMedian(unittest.TestCase):
+    def test_count_window_even_and_odd(self):
+        # Even window sizes interpolate between the two middle samples.
+        self.assertEqual([1.0, 1.5, 2.0, 2.5, 3.5, 4.5], _run(_counts().median(4), 6))
+        self.assertEqual([1.0, 1.5, 2.0, 3.0, 4.0, 5.0], _run(_counts().median(3), 6))
+
+    def test_unbounded(self):
+        self.assertEqual([1.0, 1.5, 2.0, 2.5, 3.0], _run(_counts().median(), 5))
+
+    def test_time_weighted_differs(self):
+        count_weighted = _run(_counts().median(5, Weighting.Count), 6)
+        time_weighted = _run(_counts().median(5, Weighting.Time), 6)
+        self.assertEqual(len(count_weighted), len(time_weighted))
+        self.assertNotEqual(count_weighted, time_weighted)
+
+
+class TestEwma(unittest.TestCase):
+    def test_per_tick_float_shorthand(self):
+        # The first sample seeds the average; thereafter
+        # ewma = alpha * x + (1 - alpha) * previous.
+        self.assertEqual([1.0, 1.5, 2.25, 3.125, 4.0625], _run(_counts().ewma(0.5), 5))
+
+    def test_float_shorthand_matches_per_tick(self):
+        self.assertEqual(
+            _run(_counts().ewma(EwmaSpan.per_tick(0.5)), 5), _run(_counts().ewma(0.5), 5)
+        )
+
+    def test_alpha_one_is_passthrough(self):
+        self.assertEqual([1.0, 2.0, 3.0, 4.0, 5.0], _run(_counts().ewma(1.0), 5))
+
+    def test_half_life_seeds_then_lags(self):
+        values = _run(_counts().ewma(EwmaSpan.half_life(2.0)), 5)
+        self.assertEqual(1.0, values[0])
+        # A decayed average trails a rising input but keeps rising with it.
+        for i in range(1, len(values)):
+            self.assertGreater(values[i], values[i - 1])
+            self.assertLess(values[i], float(i + 1))
+
+
+class TestArgumentTypes(unittest.TestCase):
+    """`Window` / `Weighting` / `EwmaSpan` behave as ordinary Python values."""
+
+    def test_window_repr(self):
+        self.assertEqual("Window.count(3)", repr(Window.count(3)))
+        self.assertEqual("Window.seconds(2.5)", repr(Window.seconds(2.5)))
+        self.assertEqual("Window.unbounded()", repr(Window.unbounded()))
+
+    def test_window_equality(self):
+        self.assertEqual(Window.count(3), Window.count(3))
+        self.assertNotEqual(Window.count(3), Window.count(4))
+        self.assertNotEqual(Window.count(3), Window.unbounded())
+
+    def test_ewma_span_repr_and_equality(self):
+        self.assertEqual("EwmaSpan.per_tick(0.25)", repr(EwmaSpan.per_tick(0.25)))
+        self.assertEqual(EwmaSpan.half_life(2.0), EwmaSpan.half_life(2.0))
+        self.assertNotEqual(EwmaSpan.per_tick(0.25), EwmaSpan.half_life(2.0))
+
+    def test_weighting_equality(self):
+        self.assertEqual(Weighting.Count, Weighting.Count)
+        self.assertNotEqual(Weighting.Count, Weighting.Time)
+
+
+class TestValidation(unittest.TestCase):
+    """Invalid arguments are rejected loudly rather than silently coerced."""
+
+    def test_float_window_raises(self):
+        # `mean(10)` (ten samples) and `mean(10.0)` (ten seconds?) would mean
+        # wildly different things, so a bare float is rejected in favour of
+        # Window.seconds(...).
+        for op in ("mean", "variance", "std", "sum", "min", "max", "median"):
+            with self.subTest(op=op):
+                with self.assertRaises(TypeError):
+                    getattr(_counts(), op)(3.0)
+
+    def test_unknown_window_type_raises(self):
+        with self.assertRaises(TypeError):
+            _counts().mean("everything")
+
+    def test_unknown_weighting_raises(self):
+        with self.assertRaises(ValueError):
+            _counts().mean(None, "exponential")
+
+    def test_non_string_weighting_raises(self):
+        with self.assertRaises(TypeError):
+            _counts().mean(None, 1.5)
+
+    def test_negative_and_non_finite_seconds_raise(self):
+        for bad in (-1.0, float("nan"), float("inf")):
+            with self.subTest(seconds=bad):
+                with self.assertRaises(ValueError):
+                    Window.seconds(bad)
+                with self.assertRaises(ValueError):
+                    EwmaSpan.half_life(bad)
+
+    def test_zero_half_life_raises(self):
+        with self.assertRaises(ValueError):
+            EwmaSpan.half_life(0.0)
+
+    def test_out_of_range_alpha_raises(self):
+        # Rust only `debug_assert!`s this, so a release build would otherwise
+        # produce a silently diverging average.
+        for bad in (-0.1, 1.1, float("nan")):
+            with self.subTest(alpha=bad):
+                with self.assertRaises(ValueError):
+                    EwmaSpan.per_tick(bad)
+                with self.assertRaises(ValueError):
+                    _counts().ewma(bad)
+
+    def test_non_ewma_span_raises(self):
+        with self.assertRaises(TypeError):
+            _counts().ewma("fast")
+
+    def test_non_float_input_fails_fast(self):
+        # A non-numeric value is a hard error, not a silently substituted NaN
+        # that would poison every downstream aggregate.
+        bad = ticker(1.0).count().map(lambda n: "not a float")
+        captured = bad.mean(3).collect()
+        with self.assertRaises(Exception):
+            captured.run(realtime=False, cycles=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The statistics adapter was the last wingfoil adapter with no Python
bindings: Python could reach it only through `.average()` and `.sum()`,
both hardcoded to a cumulative, count-weighted window. Everything else the
adapter offers — rolling and time windows, time weighting, variance, std,
min, max, median and EWMA — was Rust-only.

Adds `py_statistics.rs` exposing the full operator set as `PyStream`
methods (`mean`, `variance`, `std`, `sum`, `min`, `max`, `median`, `ewma`)
plus the `Window`, `Weighting` and `EwmaSpan` argument types.

The Rust `Window`/`Weighting`/`EwmaSpan` enums come across as pyclasses so
the Python API mirrors the fluent Rust one, with shorthands for the common
cases: an `int` window means `Window.count(n)`, `None` (or omitting it)
means unbounded, `"count"`/`"time"` name a weighting, and a bare `float`
span means `EwmaSpan.per_tick(alpha)`. A bare `float` is deliberately
rejected as a window — `mean(10)` and `mean(10.0)` would otherwise silently
mean ten samples versus ten seconds.

Arguments Rust only `debug_assert!`s or would panic on (an EWMA alpha
outside [0, 1], a negative or non-finite duration) are validated at the
binding boundary and raise `ValueError`/`TypeError` instead.

`.sum()` keeps its zero-argument behaviour and `.average()` is unchanged,
so existing pipelines are unaffected. The float-extraction helper that
augurs already had is hoisted into `py_stream.rs` and shared, rather than
duplicated a second time.

Contributes to #106.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XzzirFVp6u5LAqkq3LoCxH