### PR TITLE
Attach the GIL once per burst, and extract the Python-binding skill

### DIFF
--- a/.claude/commands/bind-adapter-next.md
+++ b/.claude/commands/bind-adapter-next.md
@@ -1,0 +1,322 @@
+Add the **Python bindings** for the already-ported wingfoil-next I/O adapter
+named `$ARGUMENTS`, in `next/crates/wingfoil-next-python/src/adapters/`.
+
+This is the *binding* task, not the port. It assumes
+`next/crates/wingfoil-next/src/adapters/$ARGUMENTS*` already exists and passes
+its own tests — if it does not, run `/new-adapter-next $ARGUMENTS` first and
+come back. (`/new-adapter-next` links here for its Python step, so a brand-new
+adapter ends up running both.)
+
+`wingfoil-next-python` is the **go-forward** Python binding: it supersedes the
+legacy `wingfoil-python`, it is not a facade over it (decision 2026-07, see
+`next/docs/python-interop.md` and Phase 6 of `next/docs/port-plan.md`). At
+cutover `import wingfoil` becomes `import wingfoil_next`.
+
+## Read first
+
+- **`next/crates/wingfoil-next-python/src/adapters/postgres.rs`** — the first
+  real adapter bound and the template for every one after it. Read it before
+  writing code; most of what follows is a generalisation of what it does.
+- `next/crates/wingfoil-next-python/src/adapters/common.rs` — the shared
+  run-shape helpers.
+- `next/crates/wingfoil-next-python/src/python.rs` — `ramp_source` /
+  `list_sink` / `pair_source` / `burst_list_sink`, the four minimal
+  `#[pyadapter]` demos (plain + burst, source + sink).
+- `next/crates/wingfoil-next-python/tests/plugin_seam.rs` — the same seams
+  exercised from an *external* crate.
+- `next/docs/python-interop.md` — why the boundary is shaped this way.
+
+## The parity obligation
+
+Legacy `wingfoil-python/src/py_$ARGUMENTS.rs` is your **parity oracle**, the
+same way the classic adapter is for the Rust port. Before writing anything,
+inventory it:
+
+- every `#[pyfunction]`, `#[pyclass]`, and `*_inner` helper it exposes;
+- every argument, including defaults and the types they accept;
+- the pytest cases in `wingfoil-python/tests/` that cover it.
+
+Every one needs a next equivalent **or** an explicit deviation note in the
+binding module's `//!` header. Do not silently drop a legacy entry point. Where
+next's Rust adapter has capability legacy never had — a unified
+`$ARGUMENTS_source`, a `buffer_size` bound — expose it too and say so in the
+docs; the superset objective runs through the bindings as well.
+
+Cross-cutting classic↔next differences go in `next/docs/deviation-register.md`.
+
+## Feed lessons back into this skill
+
+Like `/new-adapter-next`, this file is a **living document**. The first binding
+(postgres) grew three capabilities in the `#[pyadapter]` macro itself and the
+whole of `adapters/common.rs`. When a binding surfaces something not captured
+here — a repeated conversion, a boundary pitfall, a CI gate — fold it back in,
+ideally in the same PR.
+
+## 1. Branch
+
+Cut from `next`, never `main` (see `next/CLAUDE.md`):
+
+```bash
+git checkout next && git pull origin next && git checkout -b bind-$ARGUMENTS-python
+```
+
+The PR targets base `next`.
+
+## 2. Feature gate — `next/crates/wingfoil-next-python/Cargo.toml`
+
+Each binding lives behind a `wingfoil-next-python` cargo feature of the **same
+name** as the adapter, which turns on the matching engine feature:
+
+```toml
+$ARGUMENTS = ["wingfoil-next/$ARGUMENTS"]           # + any dep: it names directly
+all-adapters = ["postgres", "$ARGUMENTS", ...]
+```
+
+Add a comment saying what the feature exposes, as the `postgres` entry does.
+
+Name a dependency directly (`dep:chrono`) only if your *binding* code names its
+types — postgres does, because the row decoder mentions `NaiveDateTime`.
+Transitive availability through the engine feature is not enough.
+
+Two roll-ups to keep straight:
+
+- **`all-adapters`** is what `next-python-test.yml` builds
+  (`cargo test -p wingfoil-next-python --features all-adapters`), and that job
+  installs only `protobuf-compiler` and `patchelf`. An adapter needing a system
+  library at build time (clang, CMake, a vendored C lib) **must not** join
+  `all-adapters` without also adding the install step to that workflow. Say
+  which you did in the PR.
+- **`[tool.maturin] features` in `pyproject.toml`** is what ships in the default
+  wheel. Features are listed one by one there on purpose — adding one is a
+  considered decision. Pure-Rust adapters can ship by default; anything needing
+  a system library stays opt-in (`maturin develop -F $ARGUMENTS`) or it breaks
+  the wheel build for everyone.
+
+## 3. Module registration
+
+`src/adapters/mod.rs` — gate the module and note it in the header:
+
+```rust
+#[cfg(feature = "$ARGUMENTS")]
+pub mod $ARGUMENTS;
+```
+
+`common` is gated on *any* adapter being on, so extend its `#[cfg]` when you add
+the first adapter after postgres:
+
+```rust
+#[cfg(any(feature = "postgres", feature = "$ARGUMENTS"))]
+pub mod common;
+```
+
+`src/python.rs` — register the generated `#[pyfunction]`s in
+`register_adapters` under the **same** `#[cfg]`, importing them **by name**:
+
+```rust
+#[cfg(feature = "$ARGUMENTS")]
+{
+    use crate::adapters::$ARGUMENTS::{$ARGUMENTS_read, $ARGUMENTS_write};
+    m.add_function(wrap_pyfunction!($ARGUMENTS_read, m)?)?;
+    m.add_function(wrap_pyfunction!($ARGUMENTS_write, m)?)?;
+}
+```
+
+`wrap_pyfunction!` needs pyo3's hidden wrapper in scope, so a module-qualified
+path (`crate::adapters::foo::bar`) does **not** resolve. Import by name.
+
+## 4. Write the bindings — `src/adapters/$ARGUMENTS.rs`
+
+### Use the free-fn form, receiver first
+
+```rust
+#[pyadapter(name = $ARGUMENTS_read, source)]
+fn read(g: &GraphBuilder, addr: String) -> Result<Stream<Burst<Record>>> { … }
+//  => wingfoil_next.$ARGUMENTS_read(graph, addr) -> Stream
+
+#[pyadapter(name = $ARGUMENTS_write)]
+fn write(stream: &Stream<Burst<Record>>, addr: String) -> Result<Stream<()>> { … }
+//  => wingfoil_next.$ARGUMENTS_write(stream, addr)
+```
+
+- `source` marker → receiver is `&GraphBuilder`; no marker → receiver is
+  `&Stream<T>` (sink or transform). A sink's `Stream<()>` erases to `None`.
+- `name` **must differ** from the fn's own name — the macro emits a
+  `#[pyfunction]` of that name beside it. Hence the short `read` / `write` /
+  `sub` / `source`; the module is already `$ARGUMENTS`.
+- The `impl Trait for GraphBuilder` form still works but **prefer the free fn**:
+  the trait exists only to give the macro a receiver, and costs a throwaway
+  trait plus a second copy of every signature. A binding never calls itself
+  fluently from Rust.
+- Params become `#[pyfunction]` params, so they must be `FromPyObject`. A
+  Rust-only handle (`Rc<RefCell<…>>`) cannot cross.
+- Values edge-convert: `T: TryFrom<&PyElement>` in, `U: Into<PyElement>` out.
+
+### Bindings are fallible
+
+Real adapters validate at wiring — run window, run mode, config. Return
+`Result<Stream<T>>` and `#[pyadapter]` generates a `PyResult` fn, so the
+rejection raises a Python exception instead of aborting a later run.
+
+### Optional arguments
+
+Put `#[pyo3(signature = (…))]` on the adapter fn over **your own** params; the
+macro forwards it and injects the `graph`/`stream` receiver.
+
+### Run mode / run window become arguments
+
+A Python `Graph` does not know its run mode until `run()`, so a source that
+needs the window (to slice queries) or the mode (to reject the wrong one) at
+*wiring* takes it explicitly — `start_nanos` / `duration_nanos` / `realtime` —
+and the docstring must say they have to match the eventual `graph.run(...)`.
+
+`crate::adapters::common` already carries the conversions:
+`historical_params(start_nanos, duration_nanos)`, `realtime_params()`,
+`run_mode(realtime)`, `secs_to_nanotime(secs)`. Use them; add to that module
+when you find the next repeated one.
+
+**Expose the unified `$ARGUMENTS_source` where the Rust adapter has one.** It is
+the mode-agnostic wiring, and Python — where the run mode is an argument anyway
+— is exactly where that ergonomic pays off.
+
+### Bursts
+
+Most real adapters are burst-shaped. `Stream<Burst<T>>` erases to a Python
+**`list`** per tick (the same-instant group, losslessly); on the way *in* a
+Python `list`/`tuple` rebuilds a multi-value burst, anything else a
+single-element burst. So a burst source round-trips into a burst sink.
+
+Do **not** collapse a burst to its last value to get a scalar-per-tick shape.
+Legacy `py_postgres_read` did, and silently dropped rows sharing a timestamp;
+next's read is lossless and the caller writes `[0]` for the single-row case.
+
+### Dynamic payloads
+
+Where a Rust caller writes a record struct, Python has none — supply a dynamic
+stand-in:
+
+- **Reads** decode into a plain-Rust intermediate implementing
+  `From<T> for PyElement`. It must contain **no `Py<PyAny>`**: rows are decoded
+  on the adapter's worker thread and cross a channel, so the intermediate has to
+  be `Send` Rust data, with the Python object built later on the graph thread.
+  See `PyPgValue` / `PyPgRow`.
+- **Writes** usually need a runtime `columns`-style argument to interpret the
+  Python value, and that argument is not in scope at the `typed_burst_input`
+  seam. Keep the sink's input **erased** (`&Stream<Burst<PyElement>>`, via the
+  identity `PyElement: TryFrom<&PyElement>`) and marshal inside the fn with a
+  `try_map`.
+
+**Marshaling fails loudly.** A missing key, an unsupported declared type, a
+wrong-typed value, or an unsupported column type from the wire aborts the run
+with a message naming the field and listing what *is* supported. Never a silent
+`NULL`, `None`, or empty string. (Legacy prometheus/otlp do
+`elem.str().unwrap_or_default()` — a failed conversion becomes an empty string.
+Do not port that; note it as a deviation.)
+
+**Prefer string arguments to `#[pyclass]` enums** for mode/type selectors, with
+a loud error listing the accepted values — the convention postgres set for SQL
+column types. Legacy uses enum pyclasses for `AeronMode` /
+`Iceoryx2ServiceVariant` / `Iceoryx2Mode`; a string keeps the module surface
+small and needs no extra class registration. Note the deviation.
+
+### Shapes `#[pyadapter]` does not cover
+
+The macro emits free functions over a `&GraphBuilder` or `&Stream<T>` receiver.
+It has **no handle-receiver form**, so a stateful server/exporter object —
+legacy's `WebServer` (constructed, `.port()`, `.sub(topic)`) and
+`PrometheusExporter` (`.serve()`, `.register(name, stream)`) — is not a shape it
+can generate. Hand-write those as a `#[pyclass]` with `#[pymethods]`, wiring
+through the same `PyGraph`/`PyStream` seams the macro uses
+(`builder()`, `erase_source`, `typed_input`, …). Flag it in the PR rather than
+bending the adapter into a free fn that loses the lifecycle.
+
+## 5. Boundary rules
+
+- **Attach the GIL once per burst, never per element.** `PyGraph::run`
+  *detaches* for the duration of the run, so the graph thread does not hold the
+  GIL while cycling and every `Python::attach` inside a cycle is a real
+  `PyGILState_Ensure`/`Release` pair. Nested attaches short-circuit on a
+  thread-local count, so hoisting one attach around a whole burst turns the
+  per-element ones into the cheap path. The seams
+  (`erase_burst_source` / `erased_burst_output` / `typed_burst_input`) already
+  do this; if your binding does its own per-element Python work in a `map` or
+  `try_map`, wrap the whole burst the same way.
+- **Nothing holding a `Py<PyAny>` crosses to a worker thread** — see dynamic
+  payloads above.
+- **Real-time sources need the GIL released.** `PyGraph::run` does this. If you
+  add a live-tail binding, cover it with an integration test that produces
+  **from another Python thread mid-run** — that is the only test shape which
+  catches a regression here. Without it, a live source only ever sees data that
+  already existed, and every unit test still passes.
+
+## 6. Tests — three tiers, all in the same PR
+
+1. **Rust `#[cfg(test)]` marshaling tests** in the binding module: record →
+   `dict`, `dict` → typed params, every error path, any query/frame
+   construction. These run in `next-python-test.yml` via
+   `cargo test -p wingfoil-next-python --features all-adapters`.
+2. **`tests/test_$ARGUMENTS.py`**, in two groups:
+   - unit-level, **no service**, run by default: the module exposes the
+     expected names, wiring constructs a `Stream`, optional args have defaults,
+     wiring-time rejections raise, marshaling errors raise. Use an address that
+     is guaranteed unreachable rather than a live one.
+   - `@pytest.mark.requires_$ARGUMENTS` integration tests, **deselected by
+     default** via the `addopts` in `pyproject.toml`. Register the marker there.
+     They must **fail loudly** without the service, not skip.
+   Give the module a docstring saying which group is which and how to start the
+   service locally (a `docker run` line), as `test_postgres.py` does.
+3. **A Python leg in `.github/workflows/$ARGUMENTS-next-integration.yml`**:
+   start the service on its fixed port (the Rust tests use testcontainers, the
+   Python ones need a known host/port), `maturin develop -F $ARGUMENTS`, then
+   `pytest -m requires_$ARGUMENTS tests/test_$ARGUMENTS.py -v`. Add the binding
+   and test paths to the workflow's `paths:` triggers.
+
+## 7. Docs bookkeeping
+
+- The binding module's `//!` header: the entry-point table (Python name → Rust
+  fn → shape), how the dynamic edge works, and a numbered **deviations from the
+  legacy `wingfoil-python` bindings** section. `postgres.rs` is the model.
+- `next/docs/port-plan.md` — Phase 6, the "Per-adapter Python bindings" bullet:
+  add `$ARGUMENTS` and keep the remaining count honest.
+- `next/docs/python-interop.md` — the "Per-adapter Python bindings" row of the
+  build-list table, same.
+- `next/docs/deviation-register.md` — any cross-cutting legacy↔next difference.
+
+## 8. Pre-commit checklist
+
+**Run every command in the FOREGROUND and wait.** Do not background
+`cargo lint-all` and move on — that is the most common way this work strands
+with nothing committed.
+
+```bash
+cargo fmt --all
+cargo lint
+cargo lint-all
+cargo test -p wingfoil-next-python --features all-adapters
+cd next/crates/wingfoil-next-python && maturin develop -F $ARGUMENTS && pytest -q
+```
+
+Sandbox caveat (same as `/new-adapter-next`): `cargo lint-all` is a workspace
+all-features build and also compiles the classic **aeron** C library, which
+fails without the native toolchain. When that blocks you, substitute the scoped
+equivalent and say so in the PR:
+
+```bash
+cargo clippy -p wingfoil-next-python --features all-adapters --all-targets -- -D warnings
+```
+
+## 9. Self-review with a fresh context
+
+Before opening the PR, run a clean-context review pass as a subagent:
+
+1. Re-read this file, then walk `git diff next...HEAD` against steps 1–8 and
+   produce a present / missing / diverged checklist.
+2. Diff the binding against legacy `py_$ARGUMENTS.rs` one more time: every
+   entry point, argument, and default → equivalent or a numbered deviation in
+   the module docs.
+3. Check the boundary rules in step 5 hold — especially the per-burst attach and
+   that no `Py<PyAny>` reaches a worker thread.
+4. Confirm the three test tiers exist, that the unit tier really needs no
+   service, and that a live-tail binding has the cross-thread test.
+5. Run the step-8 checklist and confirm every command passes.
+6. Review for quality: no speculative abstraction, no dead code, no comments
+   restating the code.

--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -854,117 +854,25 @@ existing hub exactly as the classic adapters do:
 
 ### Exposing the adapter to Python — `#[pyadapter]`
 
-`wingfoil-next-python` is now the go-forward Python binding (it **supersedes**
-the legacy `wingfoil-python`; see `next/docs/python-interop.md`). A next adapter
+`wingfoil-next-python` is the go-forward Python binding (it **supersedes** the
+legacy `wingfoil-python`; see `next/docs/python-interop.md`). A next adapter
 reaches Python through the `#[pyadapter]` proc macro — values erase to
-`PyElement` at the boundary, the adapter's interior stays natively typed:
+`PyElement` at the boundary while the adapter's interior stays natively typed.
 
-Write the binding as **free functions**, receiver first — not as a trait. The
-`impl Trait for GraphBuilder` form also works, but its trait exists only to give
-the macro a receiver and costs a throwaway trait plus a second copy of every
-signature; a binding never calls itself fluently from Rust. `name` must differ
-from the fn's own name (the macro emits a `#[pyfunction]` of that name beside
-it), which is why the fns below are short — the module is already `$ARGUMENTS`.
+That is its own recipe, and it is long enough to have its own skill:
 
-- **Source** — `#[pyadapter(name = $ARGUMENTS_read, source)]` on
-  `fn read(g: &GraphBuilder, args…) -> Result<Stream<T>>` emits
-  `wingfoil_next.$ARGUMENTS_read(graph, args…) -> Stream`.
-- **Sink** — `#[pyadapter(name = $ARGUMENTS_write)]` (no `source` marker) on
-  `fn write(stream: &Stream<T>, args…) -> Result<Stream<()>>` emits
-  `wingfoil_next.$ARGUMENTS_write(stream, args…)`.
+**Run `/bind-adapter-next $ARGUMENTS`** (`.claude/commands/bind-adapter-next.md`)
+— it covers the free-fn source/sink/burst shapes, feature gating and the two
+roll-ups (`all-adapters` vs the maturin wheel), module registration, fallible
+wiring and forwarded `#[pyo3(signature = …)]`, the run-mode-as-argument rule and
+the `adapters::common` helpers, dynamic payloads, the GIL rules, the three test
+tiers, and the CI leg.
 
-The `ramp_source` (source) and `list_sink` (sink) demos in `src/python.rs` are
-the minimal templates, and `tests/plugin_seam.rs` shows the same from an
-external crate. **For a real, service-backed adapter, copy
-`crates/wingfoil-next-python/src/adapters/postgres.rs`** — the first one bound,
-and the template for everything below.
-
-**Where it goes, and how it is gated.** A real adapter binding lives in its own
-module, `crates/wingfoil-next-python/src/adapters/<name>.rs`, behind a
-`wingfoil-next-python` cargo feature of the same name that turns on the matching
-engine feature (`<name> = ["wingfoil-next/<name>", …]`) and is added to the
-`all-adapters` roll-up. Register the generated `#[pyfunction]`s in
-`python.rs`'s `register_adapters` under the same `#[cfg]`, importing them **by
-name** (`wrap_pyfunction!` needs pyo3's hidden wrapper in scope, so a
-module-qualified path does not resolve). List the feature in `pyproject.toml`'s
-`[tool.maturin] features` only if the adapter is pure Rust — one needing a
-system library at build time must stay opt-in or it breaks the wheel for
-everyone.
-
-**Fallible wiring.** Real adapters validate at wiring (run window, run mode,
-config), so the fn returns `Result<Stream<T>>`; `#[pyadapter]` then generates a
-`PyResult`-returning function and the error surfaces as a Python exception.
-
-**Optional arguments.** Put `#[pyo3(signature = (…))]` on the adapter fn over
-*your own* params — the macro forwards it and injects the generated
-`graph`/`stream` receiver.
-
-**Shared run-shape helpers.** `crate::adapters::common` already carries what
-every mode-aware source binding needs: `historical_params(start_nanos,
-duration_nanos)`, `realtime_params()`, `run_mode(realtime)` and
-`secs_to_nanotime(secs)`. Use them rather than rebuilding `RunParams` inline; add
-to that module when you find the next repeated conversion.
-
-**Dynamic payloads.** Where a Rust caller writes a record struct, Python has
-none — supply a dynamic stand-in. Reads decode into a plain-Rust intermediate
-(no `Py<PyAny>` inside, so it can cross to the adapter's worker thread) that
-implements `From<T> for PyElement`. Writes usually need a runtime `columns`-style
-argument to interpret the Python value, which is not in scope at the
-`typed_burst_input` seam — so keep the sink's input erased
-(`impl … for Stream<Burst<PyElement>>`, using the identity
-`PyElement: TryFrom<&PyElement>`) and marshal inside the method with a
-`try_map`. Marshaling must fail **loudly**: a missing key or wrong-typed value
-aborts the run rather than writing a silent `NULL`.
-
-**Tests, in the same PR**, split like the adapter's Rust tests:
-- Rust `#[cfg(test)]` marshaling tests in the binding module (row → `dict`,
-  `dict` → typed params, the error paths, query construction) — these run in
-  `next-python-test.yml` via `cargo test -p wingfoil-next-python --features
-  all-adapters`.
-- `crates/wingfoil-next-python/tests/test_<name>.py`, in two groups: unit-level
-  wiring tests with **no** service (argument defaults, wiring-time rejections,
-  marshaling errors) that run by default, and `@pytest.mark.requires_<name>`
-  integration tests, deselected by default via the `addopts` in
-  `pyproject.toml`. Register the marker there.
-- A Python leg in `.github/workflows/<name>-next-integration.yml`: start the
-  service on its fixed port (the Rust tests use testcontainers, the Python ones
-  need a known host/port), `maturin develop`, then
-  `pytest -m requires_<name> tests/test_<name>.py -v`. Add the binding and test
-  paths to the workflow's `paths:` triggers.
-
-`#[pyadapter]` handles **burst** adapters too — the common shape, since the
-layering conventions above make most real adapters `Stream<Burst<T>>`
-sources/sinks. A `Stream<Burst<T>>` erases to a Python **`list`** per tick
-(same-instant values grouped); on the way *in* a Python `list`/`tuple` rebuilds
-a multi-value burst (else a single-element burst), so a burst source
-round-trips into a burst sink. `Burst<T>` may appear as a source's return, a
-sink's `Self`, or a transform's output. Templates: the `pair_source` (burst
-source) and `burst_list_sink` (burst sink) demos in `src/python.rs`, and
-`burst_double` in `tests/plugin_seam.rs`.
-
-Constraints: the method's params become `#[pyfunction]` params, so they must be
-`FromPyObject` (`i64`/`f64`/`String`/`Py<PyAny>`/… — a Rust-only handle like
-`Rc<RefCell<…>>` can't cross); and the value type edge-converts
-(`T: TryFrom<&PyElement>` in, `U: Into<PyElement>` out).
-
-**A wiring-time `RunParams`/`RunMode` becomes an argument.** A Python `Graph`
-does not know its run mode until `run()`, so a source needing the run window (or
-the mode) at wiring — as `postgres_read` does to slice queries — takes it as
-explicit args (`start_nanos` / `duration_nanos` / `realtime`) that must match the
-eventual `graph.run(...)`. Expose the unified `<name>_source` too where the
-adapter has one: it is the mode-agnostic wiring, and Python is exactly where
-that ergonomic pays off.
-
-**Watch the GIL for real-time sources.** `PyGraph::run` releases the GIL for the
-duration of the run; without that a live-tail source's worker thread — and every
-other Python thread — is blocked until `run` returns, so the source only ever
-sees data that already existed. If you add a live-tail binding, cover it with an
-integration test that inserts **from another Python thread mid-run** — that is
-the only test shape which catches a regression here.
-
-So expose your adapter via `#[pyadapter]` (source, sink, or burst) and add the
-pytest case in the same PR — service-backed integration bindings follow the
-same recipe.
+Bind the adapter in the **same PR** as the port where you reasonably can — the
+binding is small once the Rust adapter exists, and a port that lands without one
+just becomes a second PR someone has to remember. If you do split it, say so in
+the PR and leave the Phase 6 bullet in `next/docs/port-plan.md` unticked for
+`$ARGUMENTS`.
 
 ## 13. Superset audit + roadmap bookkeeping
 

--- a/next/CLAUDE.md
+++ b/next/CLAUDE.md
@@ -86,8 +86,8 @@ day-to-day next work targets `main`.
 
 ## Skills — and they are living documents
 
-Two skills carry the step-by-step recipes for the two kinds of surface you
-add to next. **Use them for their respective tasks:**
+Three skills carry the step-by-step recipes for the kinds of surface you add
+to next. **Use them for their respective tasks:**
 
 - **`/new-op-next`** (`.claude/commands/new-op-next.md`) — adding a node/op to
   the catalog (`ops.rs` / `stats.rs`): the `Op` shape, `#[op(build = …)]`, the
@@ -96,15 +96,22 @@ add to next. **Use them for their respective tasks:**
 - **`/new-adapter-next`** (`.claude/commands/new-adapter-next.md`) — adding an
   I/O adapter under `src/adapters/`: source/sink shapes, feature gating, the
   parity obligation, and the adapter tests.
+- **`/bind-adapter-next`** (`.claude/commands/bind-adapter-next.md`) — adding
+  the **Python bindings** for an adapter that is already ported:
+  `#[pyadapter]` shapes, the feature/wheel roll-ups, dynamic payloads, the GIL
+  rules, and the three test tiers. `/new-adapter-next` links here for its
+  Python step, so a brand-new adapter runs both.
 
-**Both files are living documents — keep them current.** Every time you
-onboard a new op or adapter, *or change an existing one*, check whether the
-work surfaced something the matching skill doesn't yet capture — a recurring
-pitfall, a new invariant, a CI gate, a pattern worth codifying, a deviation
-that should become a rule — and fold it back into that skill (ideally in the
-same PR). The adapter skill already grew several of its rules exactly this
-way. A skill that has drifted from how we actually build ops/adapters is a
-bug; treat updating it as part of "done", not an optional extra.
+**All three are living documents — keep them current.** Every time you
+onboard a new op, adapter, or binding, *or change an existing one*, check
+whether the work surfaced something the matching skill doesn't yet capture — a
+recurring pitfall, a new invariant, a CI gate, a pattern worth codifying, a
+deviation that should become a rule — and fold it back into that skill
+(ideally in the same PR). The adapter skill already grew several of its rules
+exactly this way, and the binding skill was extracted out of it once the first
+real adapter binding landed. A skill that has drifted from how we actually
+build ops/adapters is a bug; treat updating it as part of "done", not an
+optional extra.
 
 ## Pre-commit checklist (same as repo root)
 

--- a/next/crates/wingfoil-next-python/src/graph.rs
+++ b/next/crates/wingfoil-next-python/src/graph.rs
@@ -40,6 +40,30 @@ use crate::PyElement;
 /// [`PyStream`] wired from it so `value()` works on whichever you kept.
 type RunnerSlot = Rc<RefCell<Option<Runner>>>;
 
+/// Erase one burst to a Python `list` of its members — the shared body of
+/// [`PyGraph::erase_burst_source`] and [`PyStream::erased_burst_output`].
+///
+/// The single [`Python::attach`] around the whole burst is load-bearing, not
+/// tidiness. [`PyGraph::run`] *detaches* for the duration of the run, so the
+/// graph thread does not hold the GIL while cycling; every `attach` inside a
+/// cycle is therefore a real `PyGILState_Ensure`/`Release` pair, contending
+/// with any other Python thread. `T: Into<PyElement>` attaches per element (as
+/// do `PyElement::list` and `Clone`), so erasing element-by-element cost one
+/// full acquire per row — a thousand-row burst paid a thousand of them per
+/// tick. Nested attaches short-circuit on a thread-local count, so hoisting one
+/// attach to the outside turns all of those into the cheap path and leaves a
+/// single acquire per burst. This mirrors the input direction, where
+/// [`PyStream::typed_burst_input`] already attaches once per burst.
+fn erase_burst<T>(burst: &Burst<T>) -> PyElement
+where
+    T: Clone + Default + Into<PyElement> + 'static,
+{
+    Python::attach(|_py| {
+        let items: Vec<PyElement> = burst.iter().map(|v| v.clone().into()).collect();
+        PyElement::list(&items)
+    })
+}
+
 /// A raw pointer marked `Send` purely to satisfy the bound on
 /// [`Python::detach`], which requires a `Send` closure even though it runs that
 /// closure in place on the calling thread. See the safety note in
@@ -157,10 +181,7 @@ impl PyGraph {
     where
         T: Clone + Default + Into<PyElement> + 'static,
     {
-        self.wrap(typed.map(|burst: &Burst<T>| {
-            let items: Vec<PyElement> = burst.iter().map(|v| v.clone().into()).collect();
-            PyElement::list(&items)
-        }))
+        self.wrap(typed.map(erase_burst::<T>))
     }
 
     /// Run the graph to its bound, storing the runner so retained
@@ -1005,10 +1026,7 @@ impl PyStream {
     where
         U: Clone + Default + Into<PyElement> + 'static,
     {
-        self.wrap(typed.map(|burst: &Burst<U>| {
-            let items: Vec<PyElement> = burst.iter().map(|v| v.clone().into()).collect();
-            PyElement::list(&items)
-        }))
+        self.wrap(typed.map(erase_burst::<U>))
     }
 
     /// The stream's current value after [`PyGraph::run`].

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -1204,7 +1204,30 @@ tests covered — not "legacy pytest passes unchanged."
   duplicated signature, and the shared run-shape helpers live in
   `crate::adapters::common` (`historical_params` / `realtime_params` /
   `run_mode` / `secs_to_nanotime`) for the mode-aware sources that follow.
-  Remaining: the other adapters.
+  The recipe now lives in its own skill, **`/bind-adapter-next`**, extracted
+  from the Python step of `/new-adapter-next`.
+  **Remaining: 14.** Legacy `wingfoil-python` binds 15 adapters, in four tiers:
+  - *mechanical* — csv, kafka, redis, etcd, fluvio, zmq: a scalar/bytes payload
+    over the free-fn form, close to copy-postgres-and-shrink;
+  - *dynamic payload* — kdb, fix: postgres-shaped, needing a `PyPgRow`-style
+    stand-in plus column marshaling;
+  - *handle pyclass* — web (`WebServer`), prometheus (`PrometheusExporter`):
+    stateful objects with a lifecycle, **not** a shape `#[pyadapter]` can
+    generate (it has no handle receiver), so these are hand-written over the
+    same `PyGraph`/`PyStream` seams;
+  - *stream transform* — augurs (six fns), otlp (`otlp_push`): legacy exposes
+    these as `stream.method(…)`; next uses free fns, a deliberate ergonomic
+    deviation for uniformity with the plugin story.
+
+  Two cross-cutting decisions carried by the skill: mode/type selectors take
+  **strings** with a loud error rather than `#[pyclass]` enums (legacy has
+  `AeronMode` / `Iceoryx2ServiceVariant` / `Iceoryx2Mode`), and conversions
+  **fail loudly** rather than defaulting (legacy prometheus/otlp
+  `str().unwrap_or_default()` turns a failed conversion into an empty string).
+  Both are deviations to note per binding. Sequencing note: adapters needing a
+  system library at build time (aeron, iceoryx2) must not join the
+  `all-adapters` roll-up that `next-python-test.yml` builds without that job
+  also gaining the toolchain install.
 - **`wingfoil_next::compat` (`Signal<T>`)** stays a *Rust-side* classic-idiom
   ergonomic (free `ticker`/`constant`, `stream.run`/`peek_value`; `tests/
   compat.rs`) — it is **not** the Python-binding path (that is the object-form

--- a/next/docs/python-interop.md
+++ b/next/docs/python-interop.md
@@ -5,7 +5,7 @@
 arity, optional builder, including compiled islands), `#[pyadapter]` (source,
 sink, burst, fallible, defaults), the edge conversions, and Python-defined
 nodes in both the composition and subclass forms. What remains is breadth, not
-mechanism: the per-adapter bindings (postgres done, seven to go) and the
+mechanism: the per-adapter bindings (postgres done, fourteen to go) and the
 Phase 4.5 mutable frontier for extending a *running* graph.
 **`wingfoil-next-python`
 is the go-forward Python binding: it supersedes the legacy `wingfoil-python`
@@ -218,6 +218,28 @@ method, where that argument is in scope. `PyElement: TryFrom<&PyElement>` (the
 identity conversion) is what lets such an adapter still go through the standard
 `typed_burst_input` seam rather than a hand-written `#[pyfunction]`.
 
+**What `#[pyadapter]` does not cover: a handle receiver.** The macro emits free
+functions over a `&GraphBuilder` (source) or `&Stream<T>` (sink/transform)
+receiver. A *stateful* server/exporter object — legacy's `WebServer`
+(constructed, then `.port()` / `.sub(topic)`) and `PrometheusExporter`
+(`.serve()` / `.register(name, stream)`) — has a lifecycle the free-fn form
+cannot express, so those two bindings are hand-written as a `#[pyclass]` with
+`#[pymethods]`, wiring through the same `PyGraph`/`PyStream` seams the macro
+uses. Two adapters is not enough surface to justify a handle form in the macro;
+revisit if a third appears.
+
+**Erasing a burst attaches the GIL once, not once per element.** `PyGraph::run`
+*detaches* for the duration of the run, so the graph thread does not hold the
+GIL while cycling and every `Python::attach` inside a cycle is a real
+`PyGILState_Ensure`/`Release` pair, contending with any other Python thread.
+`T: Into<PyElement>` attaches per element (as do `PyElement::list` and `Clone`),
+so an element-by-element erasure cost one full acquire per row — a thousand-row
+burst paid a thousand of them per tick. Nested attaches short-circuit on a
+thread-local count, so all three burst seams (`erase_burst_source`,
+`erased_burst_output`, `typed_burst_input`) hoist a single attach around the
+whole burst. A binding doing its own per-element Python work in a `map` /
+`try_map` must do the same.
+
 ### `#[pygraph]` — expose user wiring logic
 
 Write the wiring as a function over the shared builder; `#[pygraph]` exposes it
@@ -308,7 +330,7 @@ only the wiring seams are dynamic.
 | `#[pyop]` extensions | **done** — `State` is any `Default`-seedable type (re-seeded per run); `In<'a> = (&A, &B)` emits `module.name(stream, other)` over `wire_op2`, `(&A, &B, &C)` emits `module.name(stream, second, third)` over `wire_op3` / `Builder::register_op3` (the general form of the `Join3`-specialised `trimap`), and `(&A, …, &D)` over `wire_op4` / `register_op4`; stream parameters are named, so they take keywords. A tuple `Cfg` destructures into one named Python parameter per element via `arg = (p1, p2, …)`. The emitter is arity-generic — arity 5+ needs only a `register_op<n>`/`wire_op<n>` pair plus a parameter name. Note this ceiling is on *Rust-authored* ops (heterogeneous static input types, no variadic generics); a Python-defined node via `Graph.custom_node` takes any number of erased upstreams | ✅ done |
 | `#[pygraph]` macro (wiring reuse) | expose a Rust-authored sub-graph as a Python callable, spliced into the caller's graph; interior runs at native types, only the edges erase. **Any arity**: N `&Stream<T>` inputs, and a single `Stream<U>` or a tuple of them out (Python gets a tuple of streams). An optional leading `&GraphBuilder` — for wiring that creates nodes of its own — makes the generated fn take the graph first; builder-only (no stream inputs) is a *source* sub-graph, erasing via `erase_source`. Over the `typed_input`/`erased_output` seams | ✅ done |
 | `#[pyadapter]` macro (source + sink + burst) | **source, sink/transform, and burst adapters done** — `#[pyadapter(name = …, source)]` on `impl Trait for GraphBuilder { … -> Stream<T> }` emits `module.m(graph, …)`; `#[pyadapter(name = …)]` (no marker) on `impl Trait for Stream<T> { … -> Stream<U> }` emits `module.m(stream, …)`. `Stream<Burst<T>>` erases to a Python `list` per tick, and on the way in a Python `list`/`tuple` rebuilds a multi-value burst (else a single-element burst) — so a burst source round-trips into a burst sink. Over the `builder`/`erase_source`/`erase_burst_source` and `typed_input`/`typed_burst_input`/`erased_output`/`erased_burst_output` seams; a sink's `Stream<()>` erases to `None`. Adapter method params must be `FromPyObject`. **Fallible wiring** (`Result<Stream<T>>` → a `PyResult` fn, wiring errors raised as Python exceptions) and **forwarded `#[pyo3(signature = …)]`** (Python defaults for optional args, with the generated receiver injected), and the **free-fn form** (receiver as the first param — no throwaway trait, no duplicated signature; the impl form remains for adapters wanting a fluent Rust trait) landed with the first real adapter binding | ✅ done |
-| Per-adapter Python bindings (`crate::adapters::*`) | The `#[pyadapter]` exposure of the real `wingfoil_next::adapters::*` I/O adapters, each behind a cargo feature of the same name and registered in the `#[pymodule]` under the same `#[cfg]`. **postgres done**: `postgres_read` / `postgres_sub` / `postgres_source` / `postgres_write` / `postgres_notify_trigger_sql`, with a dynamic row↔`dict` edge (`PyPgRow`) and declared-column write marshaling; unit-level marshaling tests plus a service-backed pytest leg in `postgres-next-integration.yml`. Remaining: the other adapters as they are bound | 🟡 postgres done |
+| Per-adapter Python bindings (`crate::adapters::*`) | The `#[pyadapter]` exposure of the real `wingfoil_next::adapters::*` I/O adapters, each behind a cargo feature of the same name and registered in the `#[pymodule]` under the same `#[cfg]`. **postgres done**: `postgres_read` / `postgres_sub` / `postgres_source` / `postgres_write` / `postgres_notify_trigger_sql`, with a dynamic row↔`dict` edge (`PyPgRow`) and declared-column write marshaling; unit-level marshaling tests plus a service-backed pytest leg in `postgres-next-integration.yml`. The recipe is the `/bind-adapter-next` skill. **Remaining: 14** — legacy `wingfoil-python` binds 15 adapters in all, in four tiers: *mechanical* (csv, kafka, redis, etcd, fluvio, zmq — a scalar/bytes payload and the free-fn form); *dynamic payload* (kdb, fix — a `PyPgRow`-shaped stand-in plus column marshaling); *handle pyclass* (web's `WebServer`, prometheus's `PrometheusExporter` — **not** a shape `#[pyadapter]` can generate, see below); and *stream transform* (augurs' six fns, otlp's `otlp_push` — legacy exposes these as `stream.method(…)`, next as free fns) | 🟡 postgres done, 14 to go |
 | Compiled graph reachable from Python | **done, and better than the original POC** — rather than one hard-coded `compiled()` graph, a `graph!`-generated **`nested()` island** is exposed through `#[pygraph]`: its signature is `(&GraphBuilder, &Stream<In>…) -> Stream<Out>`, i.e. exactly a builder-taking `#[pygraph]` wiring fn, so no island-specific machinery was needed. The interior is monomorphized straight-line code; Python wires around it dynamically. A pytest asserts the island's values *and* tick times match its interpreted twin, and that it composes with Python `map` on both sides. Still true: `compiled()`/`nested()` are not Python-*splittable* — an island is one opaque node | ✅ done |
 | Edge-conversion trait bounds | **done** — every integer width (`i8`…`isize`, `u8`…`usize`), `f32`/`f64`, `bool`, `String`/`&str`, `()`→`None`, `Vec<u8>`→**`bytes`** (not a list of ints), and `Option<T>`→`None`/value with the inner conversion propagating a wrong-typed value as an error rather than a silent `None`. A user record type crosses via its own `From`/`TryFrom` impls — legal from a downstream crate under the orphan rules, proven by a `Trade` struct defined in the external seam-test crate | ✅ done |
 | Mutable-frontier engine (extend a *running* graph) | Phase 4.5 dirty-list; only needed for post-`run` mutation | 🟡 Phase 4.5 |


### PR DESCRIPTION
Groundwork before binding the remaining adapters to Python. Two independent pieces, plus doc bookkeeping.

## The burst erasure seams attached the GIL per element

`PyGraph::run` detaches for the duration of the run, so the graph thread does **not** hold the GIL while cycling — every `Python::attach` inside a cycle is a real `PyGILState_Ensure`/`Release` pair, contending with any other Python thread.

`erase_burst_source` / `erased_burst_output` mapped each burst member through `T: Into<PyElement>`, which attaches per element (as do `PyElement::list` and `PyElement::clone`). So a thousand-row burst paid a thousand full acquires per tick.

Nested attaches short-circuit on a thread-local count — `AttachGuard::try_attach` (pyo3 0.29 `internal/state.rs:87`) reads `ATTACH_COUNT` and returns `assume()` when it is already positive, with no FFI call. Hoisting one attach around the whole burst therefore turns all the inner ones into the cheap path and leaves a single acquire per burst. Both seams now share one `erase_burst` helper that does this, mirroring the input direction where `typed_burst_input` already attached once per burst.

This is a seam-level fix on purpose: every burst adapter binding inherits it, and the layering conventions make most real adapters burst-shaped.

Behaviour is unchanged — the existing burst round-trip tests (`plugin_seam.rs`, `test_interop.py`) are the guard. **No new test:** how many times the GIL was acquired is not observable through pyo3's public API, so the rationale is documented at the helper rather than asserted.

## `/bind-adapter-next` is now its own skill

The recipe lived as a section inside `/new-adapter-next`, whose task is "implement an adapter end to end" — the wrong tool for adding bindings to the fourteen adapters that are already ported. Extracted to `.claude/commands/bind-adapter-next.md`, which adds, beyond what was inlined:

- the parity obligation against legacy `wingfoil-python/src/py_<name>.rs`;
- the distinction between the two feature roll-ups — `all-adapters` (what `next-python-test.yml` builds, with only `protobuf-compiler` + `patchelf` installed) vs `[tool.maturin] features` (what ships in the default wheel);
- the per-burst attach rule above, as a boundary rule bindings must follow in their own `map`/`try_map`;
- the shapes `#[pyadapter]` **cannot** generate — it has no handle receiver, so `WebServer` / `PrometheusExporter` must be hand-written over the same `PyGraph`/`PyStream` seams;
- two cross-cutting conventions, both already set by postgres: string selectors rather than `#[pyclass]` enums, and fail-loudly conversions rather than legacy's `str().unwrap_or_default()`.

`/new-adapter-next` now points at it for its Python step, and `next/CLAUDE.md` lists three skills instead of two.

## Doc bookkeeping

`python-interop.md` and `port-plan.md` both read "postgres done, seven to go". Legacy `wingfoil-python` binds **15** adapters, so **14** remain. Both now carry the tiering and the conventions above:

| Tier | Adapters |
|---|---|
| Mechanical (scalar/bytes payload, free-fn form) | csv, kafka, redis, etcd, fluvio, zmq |
| Dynamic payload (postgres-shaped) | kdb, fix |
| Handle pyclass (not macro-generatable) | web, prometheus |
| Stream transform | augurs, otlp |

Plus a sequencing note: adapters needing a system library at build time (aeron, iceoryx2) must not join `all-adapters` without `next-python-test.yml` also gaining the toolchain install.

## Testing

- `cargo fmt --all` ✅
- `cargo lint` (default features, full workspace) ✅ — needed `protobuf-compiler` installed first
- `cargo test -p wingfoil-next-python --features all-adapters` ✅ 85 tests
- `pytest` ✅ 100 passed, 2 skipped, 8 deselected

`cargo lint-all` **was substituted**: it is a workspace all-features build that also compiles the classic aeron adapter's C library, which needs CMake ≥3.30 against the sandbox's 3.28 — the caveat `/new-adapter-next` documents. Ran the scoped equivalent instead, which covers all of the changed code:

```
cargo clippy -p wingfoil-next-python --features all-adapters --all-targets -- -D warnings
```

CI's all-features leg is the first real check on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgapk3HgHd5JezDGjicseq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgapk3HgHd5JezDGjicseq)_