### PR TITLE
Parallelize Rust CI jobs and add concurrency controls to all workflows

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,12 @@
 [profile.default]
 slow-timeout = { period = "10s", terminate-after = 1 }
+
+# The trybuild suites drive a nested `cargo build` over the macro compile-fail
+# cases, which on a cold target dir compiles a dependency tree of its own. The
+# 10s hard kill above is sized for the engine's unit tests and would terminate
+# them mid-compile — it did, the first time `wingfoil-next`'s tests ran under
+# nextest. Warn here instead of killing; the job's `timeout-minutes` is the
+# real backstop.
+[[profile.default.overrides]]
+filter = 'binary(trybuild)'
+slow-timeout = { period = "60s" }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,11 @@
 
 ## CI (run on push / PR)
 
-* `rust-test.yml` — Rust build, test, clippy, coverage upload.
+* `rust-test.yml` — three parallel jobs: `Test (wingfoil) & Coverage`,
+  `Test (wingfoil-next)`, and `Lint (fmt & clippy)`. They were one serial job
+  until they were split; the legs share no build artifacts (coverage builds
+  into `target/llvm-cov-target` under `-C instrument-coverage`, the next-engine
+  tests build a third feature set), so serialising them bought nothing.
 * `python-test.yml` — Python (`wingfoil-python`) build + pytest with coverage.
 * `security-audit.yml` — fails on dependencies with known advisories
   (`cargo audit` for Cargo, `pnpm audit` for `wingfoil-js`, and
@@ -27,6 +31,18 @@ workflows below. `all-tests.yml` runs `rust-test.yml` + `python-test.yml` +
 * `kafka-python-integration.yml` — Kafka via Redpanda service container.
 * `zmq-etcd-integration.yml` — ZMQ + etcd Python tests.
 * `web-integration.yml` — `wingfoil-wasm` build + `wingfoil-js` typecheck.
+
+The per-adapter integration workflows above are the *only* place their
+`tests/*_integration.rs` binaries are executed. `rust-test.yml` compiles them
+(so they stay type- and link-checked) but filters them out of its test run:
+without the service each one needs, they only exercise connection-timeout
+paths, and they are slow doing it.
+
+Every push/PR workflow declares a `concurrency` group so a superseded PR push
+cancels its predecessor. The group name is a literal per file rather than
+`${{ github.workflow }}` — under `workflow_call` that expression resolves to
+the *caller's* workflow name, which would put every fanned-out leg of
+`integration-tests.yml` in one group where they cancel each other.
 
 ## Release & publish (manual dispatch)
 

--- a/.github/workflows/adapter-integration.yml
+++ b/.github/workflows/adapter-integration.yml
@@ -10,6 +10,16 @@ on:
       - 'wingfoil/src/adapters/kafka/**'
       - 'wingfoil/src/adapters/zmq/**'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: adapter-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'wingfoil/src/adapters/aeron/**'
       - '.github/workflows/aeron-integration.yml'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: aeron-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/aeron-next-integration.yml
+++ b/.github/workflows/aeron-next-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'next/crates/wingfoil-next/tests/aeron_adapter.rs'
       - 'next/crates/wingfoil-next/tests/aeron_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: aeron-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/augurs-integration.yml
+++ b/.github/workflows/augurs-integration.yml
@@ -16,6 +16,16 @@ on:
       - 'wingfoil-python/tests/test_augurs.py'
       - '.github/workflows/augurs-integration.yml'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: augurs-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'wingfoil-python/src/py_etcd.rs'
       - 'wingfoil-python/tests/test_etcd.py'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: etcd-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/etcd-next-integration.yml
+++ b/.github/workflows/etcd-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/etcd**'
       - 'next/crates/wingfoil-next/tests/etcd_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: etcd-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/fix-next-integration.yml
+++ b/.github/workflows/fix-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/fix**'
       - 'next/crates/wingfoil-next/tests/fix_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: fix-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/fluvio-next-integration.yml
+++ b/.github/workflows/fluvio-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/fluvio**'
       - 'next/crates/wingfoil-next/tests/fluvio_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: fluvio-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'wingfoil-python/src/py_iceoryx2.rs'
       - 'wingfoil-python/tests/test_iceoryx2.py'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: iceoryx2-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/iceoryx2-next-integration.yml
+++ b/.github/workflows/iceoryx2-next-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'next/crates/wingfoil-next/tests/iceoryx2_adapter.rs'
       - 'next/crates/wingfoil-next/tests/iceoryx2_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: iceoryx2-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/kafka-next-integration.yml
+++ b/.github/workflows/kafka-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/kafka**'
       - 'next/crates/wingfoil-next/tests/kafka_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: kafka-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/kafka-python-integration.yml
+++ b/.github/workflows/kafka-python-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'wingfoil-python/tests/test_kafka.py'
       - 'wingfoil/src/adapters/kafka/**'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: kafka-python-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -10,6 +10,16 @@ on:
       - "wingfoil-python/src/py_kdb.rs"
       - "wingfoil-python/tests/test_kdb.py"
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: kdb-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/kdb-next-integration.yml
+++ b/.github/workflows/kdb-next-integration.yml
@@ -10,6 +10,16 @@ on:
       - "next/crates/wingfoil-next/src/adapters/common.rs"
       - "next/crates/wingfoil-next/tests/kdb_integration.rs"
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: kdb-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/next-python-test.yml
+++ b/.github/workflows/next-python-test.yml
@@ -16,6 +16,16 @@ on:
       - "next/crates/wingfoil-next/**"
   workflow_dispatch:
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: next-python-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'wingfoil-python/src/py_otlp.rs'
       - 'wingfoil-python/tests/test_otlp.py'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: otlp-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/otlp-next-integration.yml
+++ b/.github/workflows/otlp-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/otlp**'
       - 'next/crates/wingfoil-next/tests/otlp_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: otlp-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -10,6 +10,16 @@ on:
       - 'wingfoil-python/src/py_postgres.rs'
       - 'wingfoil-python/tests/test_postgres.py'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: postgres-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/postgres-next-integration.yml
+++ b/.github/workflows/postgres-next-integration.yml
@@ -11,6 +11,16 @@ on:
       - 'next/crates/wingfoil-next-python/src/adapters/postgres.rs'
       - 'next/crates/wingfoil-next-python/tests/test_postgres.py'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: postgres-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -7,6 +7,16 @@ on:
     paths:
       - 'wingfoil/src/adapters/prometheus/**'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: prometheus-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/prometheus-next-integration.yml
+++ b/.github/workflows/prometheus-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/prometheus**'
       - 'next/crates/wingfoil-next/tests/prometheus_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: prometheus-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,6 +7,16 @@ on:
       - "wingfoil-python/**"
   workflow_dispatch:
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: python-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'wingfoil-python/src/py_redis.rs'
       - 'wingfoil-python/tests/test_redis.py'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: redis-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/redis-next-integration.yml
+++ b/.github/workflows/redis-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/redis**'
       - 'next/crates/wingfoil-next/tests/redis_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: redis-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -2,15 +2,26 @@ name: test.rust
 
 on:
   workflow_call:
+  # No `paths-ignore: .github/workflows/**` here. It meant a change to this
+  # file was the one change CI never validated — a broken gate only showed up
+  # after it had merged. The legs below are parallel and cancel superseded PR
+  # pushes, so paying for the run on a workflow edit is cheap.
   push:
     branches: [ "main", "next" ]
-    paths-ignore:
-      - ".github/workflows/**"
   pull_request:
     branches: [ "main", "next" ]
-    paths-ignore:
-      - ".github/workflows/**"
   workflow_dispatch:
+
+# One in-flight run per ref. Superseded PR pushes are cancelled (the older
+# result is worthless once a new commit lands); pushes to main/next are not,
+# so every merged commit keeps a status of its own. The group name is a
+# literal, not ${{ github.workflow }}: when this workflow is reached through
+# `workflow_call` (from test.all) that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: rust-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,50 +31,44 @@ defaults:
   run:
     shell: bash
 
+# The three jobs below were one serial job ("Build, Test, & Lint") that took
+# ~17 minutes. They share no artifacts in practice — coverage builds into
+# `target/llvm-cov-target` with `-C instrument-coverage`, the next-engine tests
+# build a third feature set — so running them in parallel costs a little extra
+# runner time and roughly halves wall clock. Each keeps its own cargo cache
+# (`shared-key`) because each holds a different feature set's artifacts.
+
 jobs:
-  ci:
-    name: Build, Test, & Lint
+  test:
+    name: Test (wingfoil) & Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust Toolchains
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-          
+          components: llvm-tools-preview
+
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
-
-      - name: Install clippy-sarif
-        uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: clippy-sarif
-
-      - name: Install sarif-fmt
-        uses: taiki-e/cache-cargo-install-action@v2
-        with:
-          tool: sarif-fmt
+          shared-key: rust-test-coverage
+          # Only main/next write the cache. Otherwise every PR branch races to
+          # save a multi-GB entry, and the repo's 10GB cache budget evicts the
+          # warm entries everything else restores from.
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
-
-      - name: Build
-        run: cargo build --verbose
-
       - name: Install nextest
         uses: taiki-e/install-action@nextest
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
 
       - name: Run tests with coverage
         # Restrict to --lib --tests: the 33 example binaries each statically link
@@ -71,18 +76,11 @@ jobs:
         # instrumentation exhausts the runner's disk (lld dies with SIGBUS writing
         # past EOF on its mmap'd output). Examples run no tests, so they add zero
         # coverage; they are still compile-checked by the clippy --all-targets step.
+        #
+        # `--no-capture` forces `--test-threads=1` in nextest, so these 500+ tests
+        # run serially. That is deliberate: they take 30s either way, and several
+        # bind loopback sockets, so the parallelism is not worth the flake risk.
         run: cargo llvm-cov nextest -p wingfoil --features full --lib --tests --no-capture --lcov --output-path lcov.info
-        env:
-          RUST_LOG: INFO
-
-      - name: Run wingfoil-next tests
-        # The coverage run above is scoped to `-p wingfoil`, so the next-engine
-        # crate's tests — the adapter parity suites (lines/csv/augurs) and the
-        # trybuild cases — would otherwise never execute in CI. Run them here
-        # with all features so the feature-gated csv/augurs adapters are
-        # exercised. `--lib --tests` skips the example binaries (already
-        # compile-checked by the workspace clippy step below).
-        run: cargo test -p wingfoil-next --all-features --lib --tests
         env:
           RUST_LOG: INFO
 
@@ -94,11 +92,97 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-      - name: Run rustfmt
+  test-next:
+    name: Test (wingfoil-next)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-test-next
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' }}
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
+
+      - name: Run wingfoil-next tests
+        # The coverage job is scoped to `-p wingfoil`, so the next-engine crate's
+        # tests — the adapter parity suites (lines/csv/augurs) and the trybuild
+        # cases — would otherwise never execute in CI. Run them here with all
+        # features so the feature-gated csv/augurs adapters are exercised.
+        # `--lib --tests` skips the example binaries (already compile-checked by
+        # the workspace clippy job).
+        #
+        # nextest, not `cargo test`: `cargo test` runs one test *binary* at a
+        # time, and wingfoil-next has ~70 of them.
+        #
+        # The `*_integration` binaries are compiled (so they stay type- and
+        # link-checked) but not run here. Each has a dedicated workflow that
+        # first stands up the service it needs — a KDB+ container, an etcd
+        # container, an Aeron media driver. Without those services they only
+        # exercise their connection-timeout paths, and they are slow doing it:
+        # `aeron_integration` alone spent 1m46s of a 3m17s test run sleeping
+        # through timeouts.
         run: |
-          cargo fmt --all -- --check
+          cargo nextest run -p wingfoil-next --all-features --lib --tests \
+            -E 'not binary(/_integration$/)'
+        env:
+          RUST_LOG: INFO
+
+  lint:
+    name: Lint (fmt & clippy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-lint
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' }}
+
+      - name: Install clippy-sarif
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: clippy-sarif
+
+      - name: Install sarif-fmt
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: sarif-fmt
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
+
+      - name: Run rustfmt
+        run: cargo fmt --all -- --check
 
       - name: Run rust-clippy
+        # Both passes are needed: `--all-features` is not a superset of default
+        # in every crate, and the default pass is what most contributors run.
+        # They are separate artifact sets (different feature unification), so
+        # neither reuses the other's work.
         run: |
           set -o pipefail
           cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -16,6 +16,16 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: security-audit-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -10,6 +10,16 @@ on:
       - 'wingfoil-wasm/**'
       - 'wingfoil-js/**'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: web-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/web-next-integration.yml
+++ b/.github/workflows/web-next-integration.yml
@@ -8,6 +8,16 @@ on:
       - 'next/crates/wingfoil-next/src/adapters/web/**'
       - 'next/crates/wingfoil-next/tests/web_adapter.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: web-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/zmq-etcd-integration.yml
+++ b/.github/workflows/zmq-etcd-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'wingfoil-python/src/py_zmq.rs'
       - 'wingfoil-python/tests/test_zmq.py'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: zmq-etcd-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/zmq-next-integration.yml
+++ b/.github/workflows/zmq-next-integration.yml
@@ -9,6 +9,16 @@ on:
       - 'next/crates/wingfoil-next/tests/zmq_integration.rs'
       - 'next/crates/wingfoil-next/tests/zmq_etcd_integration.rs'
 
+# One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
+# main/next are not, so every merged commit keeps a status of its own. The
+# group name is a literal, not ${{ github.workflow }}: when this workflow is
+# reached through `workflow_call` that expression resolves to the *caller's*
+# name, which would make every reusable leg share one group and cancel its
+# siblings.
+concurrency:
+  group: zmq-next-integration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary

This PR restructures the Rust CI workflow to run three independent jobs in parallel instead of serially, and adds concurrency controls to all GitHub Actions workflows to prevent redundant runs and improve CI efficiency.

## Key Changes

### `rust-test.yml` refactoring
- **Split monolithic job into three parallel jobs:**
  - `test`: Runs wingfoil tests with coverage instrumentation (`cargo llvm-cov nextest`)
  - `test-next`: Runs wingfoil-next adapter tests with all features (excludes `*_integration` binaries)
  - `lint`: Runs rustfmt and clippy checks
  
- **Removed `paths-ignore` for workflow files:** The previous exclusion meant workflow edits were never validated by CI. Now all workflow changes are tested, with minimal cost since the three legs run in parallel and cancel superseded PR pushes.

- **Added separate cargo caches per job:** Each job uses a distinct `shared-key` because they build different feature sets (coverage uses `-C instrument-coverage`, next-engine uses `--all-features`). This prevents cache conflicts and improves hit rates.

- **Optimized cache save strategy:** Only main/next branches save the cache to avoid 10GB budget exhaustion from PR branches racing to persist multi-GB artifacts.

- **Switched to `dtolnay/rust-toolchain`:** Replaced deprecated `actions-rs/toolchain@v1` with the maintained alternative.

- **Improved test filtering:** wingfoil-next tests now use `cargo nextest` with `-E 'not binary(/_integration$/)'` to skip integration test binaries that require external services (KDB+, etcd, Aeron, etc.). These are run in dedicated integration workflows instead.

### Concurrency controls added to all workflows
- Added `concurrency` block to 30+ workflow files (all integration tests, python tests, security audit, web integration, etc.)
- **Group naming:** Uses literal workflow names (e.g., `rust-test-${{ github.ref }}`) instead of `${{ github.workflow }}` to avoid cross-cancellation when workflows are called via `workflow_call`
- **Behavior:** Superseded PR pushes cancel their predecessors; pushes to main/next retain independent status

### Documentation updates
- Updated `.github/workflows/README.md` to explain the parallel job structure and why integration tests are separated
- Added comments explaining the concurrency strategy and why literal group names are necessary

## Implementation Details

- The three Rust jobs share no build artifacts in practice, so parallelization roughly halves wall-clock time with minimal extra runner overhead
- Integration test binaries (`*_integration.rs`) are compiled (for type/link checking) but filtered out of the test run in `rust-test.yml` — they execute only in their dedicated workflows where required services are available
- The `--no-capture` flag in the coverage test run forces serial execution (`--test-threads=1`) to avoid flakiness from parallel loopback socket binding
- Cache save-if logic prevents PR branches from evicting warm cache entries used by main/next

https://claude.ai/code/session_01S9XHmts5VCtUzSW6d8BnTZ