### PR TITLE
Port remaining augurs operators: changepoint, seasons, DTW, clustering

### DIFF
--- a/.claude/commands/new-adapter-next.md
+++ b/.claude/commands/new-adapter-next.md
@@ -888,6 +888,28 @@ Then update `next/docs/port-plan.md`: mark `$ARGUMENTS` in the Phase 4 list
 (✅/🟡 with a one-line summary and the test-file name), matching how `csv`
 and `augurs` entries read.
 
+**Completing an earlier *partial* port** (an adapter already ✅ but with some
+classic operators/modes left behind) has three extra bookkeeping steps that are
+easy to miss because the adapter already looks done:
+
+1. **Widen the dependency's sub-feature list** in
+   `next/crates/wingfoil-next/Cargo.toml` to match classic's. The first pass
+   deliberately enabled only the sub-features its subset needed (augurs shipped
+   `ets, mstl, outlier`; the other four operators needed `changepoint, seasons,
+   dtw, clustering`), and the comment above the dep says so — update both.
+2. **Delete the capability-gap bullet from the module's `# Deviations from
+   classic` block.** A stale "only N of classic's M operators are ported" line
+   is worse than none: it is the first thing a cutover audit reads.
+3. **Flip the register row** in `next/docs/deviation-register.md` from ⚪ to ✅
+   with a `~~strikethrough~~` of the old gap text and a "**Resolved.**" note (the
+   C1/C5 rows are the template), and add the row to the "Resolved / ratified"
+   paragraph at the bottom. Any *new* deviation the completion introduces gets
+   its own D-row.
+
+Also sweep the prose that described the subset — the module docs' op list, the
+`src/adapters/mod.rs` bullet, `next/README.md`'s example table, and the
+example's own `//!` header all tend to name the ported subset explicitly.
+
 ## 14. Pre-commit checklist
 
 **Run every command in the FOREGROUND and wait for it to finish. Do NOT

--- a/next/README.md
+++ b/next/README.md
@@ -142,7 +142,7 @@ Every example is runnable with `cargo run -p wingfoil-next --example <name>`
 |---|---|
 | [`csv_adapter`](crates/wingfoil-next/examples/csv_adapter.rs) | Replay a CSV as a deterministic historical burst stream, transform each row, write back to CSV. |
 | [`etcd_adapter`](crates/wingfoil-next/examples/etcd_adapter.rs) | Watch an etcd key prefix, transform values, and write the result back. |
-| [`augurs_adapter`](crates/wingfoil-next/examples/augurs_adapter.rs) | On-graph forecasting and outlier detection over sliding windows with the augurs toolkit. |
+| [`augurs_adapter`](crates/wingfoil-next/examples/augurs_adapter.rs) | On-graph forecasting, outlier / changepoint / season detection, DTW and clustering over sliding windows with the augurs toolkit. |
 | [`lines_adapter`](crates/wingfoil-next/examples/lines_adapter.rs) | Dependency-free line-oriented file adapter — replay a text file, transform it, write it out. |
 | [`async_source`](crates/wingfoil-next/examples/async_source.rs) | Bridge an async producer of timestamped values into a wingfoil-next graph. |
 

--- a/next/crates/wingfoil-next/Cargo.toml
+++ b/next/crates/wingfoil-next/Cargo.toml
@@ -49,17 +49,21 @@ serde-aux = { version = "4.7.0", optional = true }
 sha2 = { version = "0.10", optional = true }
 bincode = { version = "1.3.3", optional = true }
 
-# `augurs` feature: on-graph time-series forecasting + outlier detection. A
-# pure-Rust compute library (no external service), so — like the classic
-# `wingfoil` augurs adapter — coverage lives behind `--features augurs` with no
-# integration-test split. Pinned and default-features-off, mirroring the classic
-# crate; only the `ets`, `mstl`, and `outlier` sub-features are enabled, matching
-# the two ported ops (Prophet is deliberately excluded — it needs a bundled Stan
-# toolchain).
+# `augurs` feature: on-graph time-series analysis — forecasting, outlier /
+# changepoint / season detection, DTW and clustering. A pure-Rust compute
+# library (no external service), so — like the classic `wingfoil` augurs
+# adapter — coverage lives behind `--features augurs` with no integration-test
+# split. Pinned, default-features-off, and with the same sub-feature set as the
+# classic crate, one per ported op (Prophet is deliberately excluded — it needs
+# a bundled Stan toolchain).
 augurs = { version = "0.10.2", default-features = false, features = [
     "ets",
     "mstl",
     "outlier",
+    "changepoint",
+    "seasons",
+    "dtw",
+    "clustering",
 ], optional = true }
 
 # `etcd` feature: streaming key-prefix snapshot + watch source and a key-value

--- a/next/crates/wingfoil-next/examples/augurs_adapter.rs
+++ b/next/crates/wingfoil-next/examples/augurs_adapter.rs
@@ -1,4 +1,4 @@
-//! augurs adapter example — on-graph forecasting and outlier detection.
+//! augurs adapter example — on-graph time-series analysis.
 //!
 //! Run with the `augurs` feature:
 //!
@@ -7,24 +7,28 @@
 //! ```
 //!
 //! augurs is a pure-Rust time-series toolkit, so there is no service to start.
-//! wingfoil-next currently ports two of the classic adapter's six operators —
-//! forecasting and outlier detection. (The other four — seasonality,
-//! changepoint detection, DTW, and clustering — remain classic-only for now, a
-//! tracked capability gap; see `next/docs/port-plan.md` and the deviation
-//! register C5.) This example
-//! drives a synthetic stream through each op, on the graph clock:
+//! This example drives synthetic streams through each of the adapter's six ops,
+//! on the graph clock:
 //!
 //! 1. a noisy upward ramp fed to `augurs_forecast`, printing the 5-step-ahead
-//!    forecast and its 90% prediction interval each tick; and
+//!    forecast and its 90% prediction interval each tick;
 //! 2. four monitored series — three moving together and one that diverges
 //!    half-way through — fed to `augurs_outlier`, printing which series the MAD
-//!    detector flags.
+//!    detector flags;
+//! 3. a seasonal signal fed to `augurs_seasons`, printing the detected period;
+//! 4. a series with a regime shift fed to `augurs_changepoint`, printing where
+//!    the changepoint lands; and
+//! 5. five series — two tight pairs plus a wild one — fed to `augurs_dtw` and
+//!    `augurs_cluster`, printing the pairwise warping distances and the DBSCAN
+//!    cluster labels they produce.
 
 use std::time::Duration;
 
 use wingfoil::{NanoTime, RunFor, RunMode};
 use wingfoil_next::adapters::augurs::{
-    AugursForecastConfig, AugursForecastOps, AugursOutlierConfig, AugursOutlierOps,
+    AugursChangepointConfig, AugursChangepointOps, AugursClusterConfig, AugursClusterOps,
+    AugursDtwConfig, AugursDtwOps, AugursForecastConfig, AugursForecastOps, AugursOutlierConfig,
+    AugursOutlierOps, AugursSeasonsConfig, AugursSeasonsOps,
 };
 use wingfoil_next::prelude::*;
 
@@ -79,8 +83,108 @@ fn outlier_detection() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn seasonality() -> anyhow::Result<()> {
+    println!("\n== seasonality detection (periodogram) ==");
+
+    let g = GraphBuilder::new();
+
+    // A period-24 sine wave. The periodogram gives a coarse (approximate)
+    // estimate, so it reports the season is present at roughly this scale.
+    let seasons = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| (*n as f64 * std::f64::consts::TAU / 24.0).sin())
+        .augurs_seasons(AugursSeasonsConfig::new(120));
+
+    let _sink = seasons.with_time().for_each(|(time, seasons)| {
+        if let Some(period) = seasons.dominant() {
+            println!("  {time}  seasonal period ~= {period} samples (true 24)");
+        }
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(120))?;
+    Ok(())
+}
+
+fn changepoints() -> anyhow::Result<()> {
+    println!("\n== changepoint detection (BOCPD) ==");
+
+    let g = GraphBuilder::new();
+
+    // A series that jumps from ~0 to ~50 after tick 30.
+    let changes = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|n| if *n > 30 { 50.0 } else { 0.0 })
+        .augurs_changepoint(AugursChangepointConfig::new(60));
+
+    let _sink = changes.with_time().for_each(|(time, changes)| {
+        if changes.any() {
+            println!(
+                "  {time}  changepoint at window index {:?}",
+                changes.indices
+            );
+        }
+        Ok(())
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(50))?;
+    Ok(())
+}
+
+fn similarity() -> anyhow::Result<()> {
+    println!("\n== DTW distances + DBSCAN clustering (5 series) ==");
+
+    let g = GraphBuilder::new();
+
+    // Series 0/1 track a low sine, series 2/3 a high one, series 4 is wild.
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|n| {
+        let t = *n as f64;
+        let low = (t * 0.3).sin();
+        let high = (t * 0.3).sin() + 20.0;
+        vec![
+            low,
+            low + 0.02,
+            high,
+            high + 0.02,
+            50.0 * (t * 0.9).cos() + 100.0,
+        ]
+    });
+
+    let distances = readings.augurs_dtw(AugursDtwConfig::new(30));
+    let clusters = readings.augurs_cluster(AugursClusterConfig::new(30, 1.0, 2));
+
+    // Report once, on the last cycle, when the window is full.
+    let _sink = distances
+        .join(&clusters, |d, c| (d.clone(), c.clone()))
+        .with_time()
+        .for_each(|(time, (distances, clusters))| {
+            if *time == NanoTime::new(29_000_000_000) {
+                println!("  {time}  distance from series 0:");
+                for (j, d) in distances.rows[0].iter().enumerate() {
+                    println!("    -> series {j}: {d:.2}");
+                }
+                println!(
+                    "  {time}  cluster labels (-1 = noise): {:?}",
+                    clusters.labels
+                );
+            }
+            Ok(())
+        });
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))?;
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
     forecasting()?;
     outlier_detection()?;
+    seasonality()?;
+    changepoints()?;
+    similarity()?;
     Ok(())
 }

--- a/next/crates/wingfoil-next/src/adapters/augurs.rs
+++ b/next/crates/wingfoil-next/src/adapters/augurs.rs
@@ -16,26 +16,36 @@
 //!   ([MAD](augurs::outlier::MADDetector) or
 //!   [DBSCAN](augurs::outlier::DbscanDetector)) and emits an [`AugursOutliers`]
 //!   (which series are outlying + their latest scores).
+//! - [`AugursChangepointOps::augurs_changepoint`] — Bayesian online changepoint
+//!   detection over a window of an `f64` stream, emitting the
+//!   [`AugursChangepoints`] indices within the window.
+//! - [`AugursSeasonsOps::augurs_seasons`] — periodogram seasonality detection
+//!   over a window of an `f64` stream, emitting the detected [`AugursSeasons`]
+//!   period lengths.
+//! - [`AugursDtwOps::augurs_dtw`] — dynamic time warping distance matrix over a
+//!   window of a `Vec<f64>` (multi-series) stream, emitting an
+//!   [`AugursDistanceMatrix`].
+//! - [`AugursClusterOps::augurs_cluster`] — DBSCAN clustering of the series in a
+//!   `Vec<f64>` window using their DTW distances, emitting the per-series
+//!   [`AugursClusters`] labels.
 //!
 //! # Layering
 //!
 //! Following the [`stats`](crate::stats) module's pattern, the ops are *not*
 //! in the [`prelude`](crate::prelude): bring in the extension traits explicitly
-//! with `use wingfoil_next::adapters::augurs::{AugursForecastOps, AugursOutlierOps};`.
+//! with `use wingfoil_next::adapters::augurs::AugursForecastOps;` (and the
+//! `AugursOutlierOps` / `AugursChangepointOps` / `AugursSeasonsOps` /
+//! `AugursDtwOps` / `AugursClusterOps` siblings).
 //!
 //! Models are fitted inside `cycle()`. This is pure CPU work on the
-//! single-threaded engine (no locks, no I/O), but refitting is not free —
-//! throttle the input with [`throttle`](crate::fluent::StreamOps::throttle)
-//! upstream if you do not need a fresh fit on every tick.
+//! single-threaded engine (no locks, no I/O), but it is not free: each cycle
+//! recomputes over the whole window — the ETS model search, a BOCPD re-scan of
+//! the window, and DTW at `O(n² · window²)` for `n` series. Throttle the input
+//! with [`throttle`](crate::fluent::StreamOps::throttle) upstream if you do not
+//! need a fresh result on every tick.
 //!
 //! # Deviations from classic
 //!
-//! - **Only 2 of classic's 6 operators are ported** — `augurs_forecast` and
-//!   `augurs_outlier`. The remaining four —
-//!   `augurs_changepoint`, `augurs_seasons`, `augurs_dtw`, and `augurs_cluster`
-//!   — are **not ported** (a tracked, deliberate capability gap; deviation
-//!   register C5 and `docs/port-plan.md` Phase-4 augurs). They have no next twin
-//!   yet because nothing downstream needs them.
 //! - **Config is validated inside `cycle` (fallibly), not at wiring (by panic).**
 //!   Classic's outlier detector construction panics at wiring on a bad
 //!   sensitivity (`MADDetector::with_sensitivity(...).unwrap_or_else(|e|
@@ -43,14 +53,26 @@
 //!   `anyhow` error (`.map_err(...)` / `anyhow::bail!`) so a bad config aborts
 //!   the run with a clear message rather than panicking during graph
 //!   construction — a deliberate improvement over the classic behaviour.
+//! - **`augurs_cluster` floors its effective window at 2, as `augurs_dtw`
+//!   already does.** Classic's cluster node sizes its buffer for two samples but
+//!   still evicts against the raw `window`, so a `window` of 1 never reaches the
+//!   two-sample warm-up and the node never ticks. Next grows the effective
+//!   window to the warm-up floor for both ops — the same "grow the window to the
+//!   floor so the node still emits" rule the forecast/seasons ops follow.
 
 use std::collections::VecDeque;
 
 use anyhow::{Context, Result};
+use augurs::changepoint::{
+    Detector as ChangepointDetector, NormalGammaDetector, dist::NormalGamma,
+};
+use augurs::clustering::DbscanClusterer;
+use augurs::dtw::Dtw;
 use augurs::ets::AutoETS;
 use augurs::ets::trend::AutoETSTrendModel;
 use augurs::mstl::MSTLModel;
 use augurs::outlier::{DbscanDetector, MADDetector, OutlierDetector, OutlierOutput};
+use augurs::seasons::{Detector as SeasonsDetector, PeriodogramDetector};
 use augurs::{Fit, Predict};
 use wingfoil_next_macros::op;
 
@@ -75,8 +97,11 @@ fn push_windowed<T>(buffer: &mut VecDeque<T>, value: T, window: usize) {
 /// forward-filled with the series' previous value so every column spans the
 /// full window. A series that first appears part-way through the window has its
 /// leading gap back-filled with its own first observed value — never a
-/// fabricated `0.0`, which would read as a large deviation to the outlier
-/// detector for the rest of the window.
+/// fabricated `0.0`, which would read as a large deviation to the outlier / DTW
+/// ops for the rest of the window.
+///
+/// Shared by the multi-series ops ([`augurs_outlier`](AugursOutlierOps),
+/// [`augurs_dtw`](AugursDtwOps), [`augurs_cluster`](AugursClusterOps)).
 fn transpose_window(buffer: &VecDeque<Vec<f64>>) -> Vec<Vec<f64>> {
     let n_series = buffer.iter().map(Vec::len).max().unwrap_or(0);
     let mut series: Vec<Vec<Option<f64>>> = vec![Vec::with_capacity(buffer.len()); n_series];
@@ -142,6 +167,75 @@ impl AugursOutliers {
     #[must_use]
     pub fn is_outlier(&self, index: usize) -> bool {
         self.outlying.contains(&index)
+    }
+}
+
+/// The result of [`AugursChangepointOps::augurs_changepoint`] for one cycle —
+/// the indices, within the current window, at which a changepoint was detected.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursChangepoints {
+    /// Changepoint indices relative to the start of the current window.
+    pub indices: Vec<usize>,
+}
+
+impl AugursChangepoints {
+    /// Whether any changepoint was detected in the current window.
+    #[must_use]
+    pub fn any(&self) -> bool {
+        !self.indices.is_empty()
+    }
+}
+
+/// The result of [`AugursSeasonsOps::augurs_seasons`] for one cycle — the
+/// seasonal period lengths (in samples) detected in the current window.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursSeasons {
+    /// Detected seasonal period lengths, longest signal first.
+    pub periods: Vec<u32>,
+}
+
+impl AugursSeasons {
+    /// The dominant (first-reported) seasonal period, if any.
+    #[must_use]
+    pub fn dominant(&self) -> Option<u32> {
+        self.periods.first().copied()
+    }
+}
+
+/// A row-major square distance matrix produced by
+/// [`AugursDtwOps::augurs_dtw`]. `rows[i][j]` is the DTW distance between series
+/// `i` and series `j` over the current window.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursDistanceMatrix {
+    /// Row-major `n × n` distances, where `n` is the number of series.
+    pub rows: Vec<Vec<f64>>,
+}
+
+impl AugursDistanceMatrix {
+    /// The distance between series `i` and series `j`, if both are in range.
+    #[must_use]
+    pub fn get(&self, i: usize, j: usize) -> Option<f64> {
+        self.rows.get(i).and_then(|row| row.get(j)).copied()
+    }
+}
+
+/// The result of [`AugursClusterOps::augurs_cluster`] for one cycle — a cluster
+/// label per series. A label of `-1` marks a noise point (unclustered);
+/// non-negative labels group series into clusters.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct AugursClusters {
+    /// Cluster label for each series (`-1` = noise).
+    pub labels: Vec<i32>,
+}
+
+impl AugursClusters {
+    /// The number of distinct (non-noise) clusters found.
+    #[must_use]
+    pub fn cluster_count(&self) -> usize {
+        let mut seen: Vec<i32> = self.labels.iter().copied().filter(|&l| l >= 0).collect();
+        seen.sort_unstable();
+        seen.dedup();
+        seen.len()
     }
 }
 
@@ -559,6 +653,527 @@ impl AugursOutlierOps for Stream<Vec<f64>> {
             window: config.window.max(2),
         };
         self.wire(|b, h| b.augurs_outlier(h, cfg))
+    }
+}
+
+// -------------------------------------------------------------------------
+// Changepoint detection.
+// -------------------------------------------------------------------------
+
+/// Configuration for [`AugursChangepointOps::augurs_changepoint`].
+#[derive(Debug, Clone)]
+pub struct AugursChangepointConfig {
+    /// Number of recent points retained as the detection window.
+    pub window: usize,
+    /// Minimum number of buffered points before detection runs. Until this many
+    /// points have arrived the node does not tick.
+    pub min_points: usize,
+    /// Hazard rate for the Bayesian online changepoint detector: the prior
+    /// expected run length between changepoints. Larger values make the detector
+    /// more conservative (fewer changepoints). Defaults to `250`.
+    pub hazard_lambda: f64,
+}
+
+impl AugursChangepointConfig {
+    /// Detect changepoints over the last `window` points with the default hazard
+    /// rate.
+    #[must_use]
+    pub fn new(window: usize) -> Self {
+        Self {
+            window,
+            min_points: 8,
+            hazard_lambda: 250.0,
+        }
+    }
+
+    /// Set the hazard rate (prior expected run length between changepoints).
+    #[must_use]
+    pub fn with_hazard(mut self, hazard_lambda: f64) -> Self {
+        self.hazard_lambda = hazard_lambda;
+        self
+    }
+
+    /// Set the minimum number of points required before detection begins.
+    #[must_use]
+    pub fn with_min_points(mut self, min_points: usize) -> Self {
+        self.min_points = min_points;
+        self
+    }
+}
+
+impl From<usize> for AugursChangepointConfig {
+    /// `window`, with the default hazard rate.
+    fn from(window: usize) -> Self {
+        Self::new(window)
+    }
+}
+
+/// Resolved changepoint config: the hazard rate, the warm-up floor, and the
+/// effective window (the configured `window` grown to `min_points` so a window
+/// below the floor still lets the node fill up and emit rather than never
+/// ticking).
+#[derive(Debug, Clone)]
+pub struct ChangepointCfg {
+    hazard_lambda: f64,
+    min_points: usize,
+    window: usize,
+}
+
+/// Changepoint op: buffers a window of an `f64` stream and re-scans it with
+/// Bayesian online changepoint detection each cycle. `Cfg` = resolved config,
+/// `State` = the sliding window buffer.
+pub struct AugursChangepointOp;
+
+#[op(build = augurs_changepoint)]
+impl Op for AugursChangepointOp {
+    type Cfg = ChangepointCfg;
+    type State = VecDeque<f64>;
+    type In<'a> = (&'a f64,);
+    type Out = AugursChangepoints;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut ChangepointCfg,
+        buffer: &mut VecDeque<f64>,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<AugursChangepoints>> {
+        push_windowed(buffer, *input.0, cfg.window);
+        if buffer.len() < cfg.min_points {
+            return Ok(Tick::Quiet);
+        }
+
+        let data: Vec<f64> = buffer.iter().copied().collect();
+        // BOCPD is stateful (it steps through the series), so build a fresh
+        // detector each cycle and re-scan the current window.
+        let mut detector = NormalGammaDetector::normal_gamma(
+            cfg.hazard_lambda,
+            NormalGamma::new_unchecked(0.0, 1.0, 1.0, 1.0),
+        );
+        // BOCPD always reports index 0 (the start of the first run) as a
+        // changepoint; it is an artifact of the window start, not a real regime
+        // change, so drop it.
+        let indices = detector
+            .detect_changepoints(&data)
+            .into_iter()
+            .filter(|&i| i != 0)
+            .collect();
+        Ok(Tick::Value(AugursChangepoints { indices }))
+    }
+}
+
+/// Adds the [`augurs_changepoint`](AugursChangepointOps::augurs_changepoint) op
+/// to `f64` streams. Bring it into scope with
+/// `use wingfoil_next::adapters::augurs::AugursChangepointOps;`.
+pub trait AugursChangepointOps {
+    /// Maintain a sliding window of this stream and, once `min_points` have
+    /// arrived, emit an [`AugursChangepoints`] each tick with the indices,
+    /// within the window, at which Bayesian online changepoint detection found a
+    /// changepoint. The window-start index (`0`), which BOCPD always reports, is
+    /// excluded — only genuine internal regime changes are returned.
+    fn augurs_changepoint(
+        &self,
+        config: impl Into<AugursChangepointConfig>,
+    ) -> Stream<AugursChangepoints>;
+}
+
+impl AugursChangepointOps for Stream<f64> {
+    fn augurs_changepoint(
+        &self,
+        config: impl Into<AugursChangepointConfig>,
+    ) -> Stream<AugursChangepoints> {
+        let config = config.into();
+        let cfg = ChangepointCfg {
+            hazard_lambda: config.hazard_lambda,
+            min_points: config.min_points,
+            window: config.window.max(config.min_points),
+        };
+        self.wire(|b, h| b.augurs_changepoint(h, cfg))
+    }
+}
+
+// -------------------------------------------------------------------------
+// Seasonality detection.
+// -------------------------------------------------------------------------
+
+/// Configuration for [`AugursSeasonsOps::augurs_seasons`].
+#[derive(Debug, Clone)]
+pub struct AugursSeasonsConfig {
+    /// Number of recent points retained as the detection window.
+    pub window: usize,
+    /// Minimum number of buffered points before detection runs.
+    pub min_points: usize,
+    /// Shortest seasonal period to consider (in samples). `None` uses the augurs
+    /// default.
+    pub min_period: Option<u32>,
+    /// Longest seasonal period to consider (in samples). `None` uses the augurs
+    /// default (derived from the window length).
+    pub max_period: Option<u32>,
+}
+
+impl AugursSeasonsConfig {
+    /// Detect seasonal periods over the last `window` points using the default
+    /// period bounds.
+    #[must_use]
+    pub fn new(window: usize) -> Self {
+        Self {
+            window,
+            min_points: (window / 2).max(16),
+            min_period: None,
+            max_period: None,
+        }
+    }
+
+    /// Restrict detection to periods within `[min_period, max_period]` samples.
+    #[must_use]
+    pub fn with_period_range(mut self, min_period: u32, max_period: u32) -> Self {
+        self.min_period = Some(min_period);
+        self.max_period = Some(max_period);
+        self
+    }
+
+    /// Set the minimum number of points required before detection begins.
+    #[must_use]
+    pub fn with_min_points(mut self, min_points: usize) -> Self {
+        self.min_points = min_points;
+        self
+    }
+}
+
+impl From<usize> for AugursSeasonsConfig {
+    /// `window`, with the default period bounds.
+    fn from(window: usize) -> Self {
+        Self::new(window)
+    }
+}
+
+/// Resolved seasons config: the periodogram detector (built once at wiring from
+/// the requested period bounds), the warm-up floor, and the effective window.
+#[derive(Debug)]
+pub struct SeasonsCfg {
+    detector: PeriodogramDetector,
+    min_points: usize,
+    window: usize,
+}
+
+/// Seasons op: buffers a window of an `f64` stream and runs periodogram
+/// seasonality detection over it each cycle. `Cfg` = the built detector plus the
+/// resolved window, `State` = the sliding window buffer.
+pub struct AugursSeasonsOp;
+
+#[op(build = augurs_seasons)]
+impl Op for AugursSeasonsOp {
+    type Cfg = SeasonsCfg;
+    type State = VecDeque<f64>;
+    type In<'a> = (&'a f64,);
+    type Out = AugursSeasons;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut SeasonsCfg,
+        buffer: &mut VecDeque<f64>,
+        input: (&f64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<AugursSeasons>> {
+        push_windowed(buffer, *input.0, cfg.window);
+        if buffer.len() < cfg.min_points {
+            return Ok(Tick::Quiet);
+        }
+
+        let data: Vec<f64> = buffer.iter().copied().collect();
+        Ok(Tick::Value(AugursSeasons {
+            periods: cfg.detector.detect(&data),
+        }))
+    }
+}
+
+/// Adds the [`augurs_seasons`](AugursSeasonsOps::augurs_seasons) op to `f64`
+/// streams. Bring it into scope with
+/// `use wingfoil_next::adapters::augurs::AugursSeasonsOps;`.
+pub trait AugursSeasonsOps {
+    /// Maintain a sliding window of this stream and, once `min_points` have
+    /// arrived, emit an [`AugursSeasons`] each tick with the seasonal period
+    /// lengths detected by a periodogram.
+    ///
+    /// augurs estimates periods with a Welch periodogram over power-of-two FFT
+    /// segments, so the reported lengths are **approximate** (coarsely binned) —
+    /// good for spotting *that* a season exists and its rough scale, not for
+    /// exact period recovery.
+    fn augurs_seasons(&self, config: impl Into<AugursSeasonsConfig>) -> Stream<AugursSeasons>;
+}
+
+impl AugursSeasonsOps for Stream<f64> {
+    fn augurs_seasons(&self, config: impl Into<AugursSeasonsConfig>) -> Stream<AugursSeasons> {
+        let config = config.into();
+        let mut builder = PeriodogramDetector::builder();
+        if let Some(min_period) = config.min_period {
+            builder = builder.min_period(min_period);
+        }
+        if let Some(max_period) = config.max_period {
+            builder = builder.max_period(max_period);
+        }
+        let cfg = SeasonsCfg {
+            detector: builder.build(),
+            min_points: config.min_points,
+            // Grow the window to at least `min_points` so a `window` below the
+            // warm-up floor still lets the node fill up and emit rather than
+            // never ticking.
+            window: config.window.max(config.min_points),
+        };
+        self.wire(|b, h| b.augurs_seasons(h, cfg))
+    }
+}
+
+// -------------------------------------------------------------------------
+// Dynamic time warping.
+// -------------------------------------------------------------------------
+
+/// The pointwise distance metric used by [`Dtw`] when warping two series.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AugursDtwMetric {
+    /// Euclidean (L2) distance between aligned points.
+    #[default]
+    Euclidean,
+    /// Manhattan (L1) distance between aligned points.
+    Manhattan,
+}
+
+/// Configuration for [`AugursDtwOps::augurs_dtw`].
+#[derive(Debug, Clone)]
+pub struct AugursDtwConfig {
+    /// Number of recent samples retained as the window over which each series'
+    /// history is compared.
+    pub window: usize,
+    /// Pointwise distance metric used inside the DTW alignment.
+    pub metric: AugursDtwMetric,
+}
+
+impl AugursDtwConfig {
+    /// Compute the DTW distance matrix over the last `window` samples using the
+    /// Euclidean metric.
+    #[must_use]
+    pub fn new(window: usize) -> Self {
+        Self {
+            window,
+            metric: AugursDtwMetric::Euclidean,
+        }
+    }
+
+    /// Use the given pointwise distance metric.
+    #[must_use]
+    pub fn with_metric(mut self, metric: AugursDtwMetric) -> Self {
+        self.metric = metric;
+        self
+    }
+}
+
+impl From<usize> for AugursDtwConfig {
+    /// `window`, with the Euclidean metric.
+    fn from(window: usize) -> Self {
+        Self::new(window)
+    }
+}
+
+/// Compute the DTW distance matrix for `series` using `metric`. Returned as the
+/// augurs [`DistanceMatrix`](augurs::DistanceMatrix) so callers that need the
+/// raw rows can call [`into_inner`](augurs::DistanceMatrix::into_inner) and
+/// those feeding clustering can pass it straight through.
+fn distance_matrix(metric: AugursDtwMetric, series: &[&[f64]]) -> augurs::DistanceMatrix {
+    match metric {
+        AugursDtwMetric::Euclidean => Dtw::euclidean().distance_matrix(series),
+        AugursDtwMetric::Manhattan => Dtw::manhattan().distance_matrix(series),
+    }
+}
+
+/// Resolved DTW config: the metric and the effective window (floored at 2 —
+/// a DTW distance over length-1 columns is just `|x - y|`, not a
+/// windowed-history distance).
+#[derive(Debug, Clone)]
+pub struct DtwCfg {
+    metric: AugursDtwMetric,
+    window: usize,
+}
+
+/// DTW op: buffers a window of per-series readings and computes their pairwise
+/// dynamic time warping distances each cycle. `Cfg` = resolved config,
+/// `State` = the sliding window of per-tick multi-series samples.
+pub struct AugursDtwOp;
+
+#[op(build = augurs_dtw)]
+impl Op for AugursDtwOp {
+    type Cfg = DtwCfg;
+    type State = VecDeque<Vec<f64>>;
+    type In<'a> = (&'a Vec<f64>,);
+    type Out = AugursDistanceMatrix;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut DtwCfg,
+        buffer: &mut VecDeque<Vec<f64>>,
+        input: (&Vec<f64>,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<AugursDistanceMatrix>> {
+        push_windowed(buffer, input.0.clone(), cfg.window);
+        // Warm up: a DTW distance over length-1 columns is just |x - y|, not a
+        // windowed-history distance, so wait for at least two samples.
+        if buffer.len() < 2 {
+            return Ok(Tick::Quiet);
+        }
+
+        let series = transpose_window(buffer);
+        // Need at least two series for a distance matrix to be meaningful.
+        if series.len() < 2 {
+            return Ok(Tick::Quiet);
+        }
+        let refs: Vec<&[f64]> = series.iter().map(Vec::as_slice).collect();
+        Ok(Tick::Value(AugursDistanceMatrix {
+            rows: distance_matrix(cfg.metric, &refs).into_inner(),
+        }))
+    }
+}
+
+/// Adds the [`augurs_dtw`](AugursDtwOps::augurs_dtw) op to streams of per-series
+/// readings. Bring it into scope with
+/// `use wingfoil_next::adapters::augurs::AugursDtwOps;`.
+pub trait AugursDtwOps {
+    /// Maintain a sliding window of per-series readings (one `f64` per series
+    /// per tick) and emit an [`AugursDistanceMatrix`] each tick with the
+    /// pairwise dynamic time warping distances between the series' windowed
+    /// histories.
+    fn augurs_dtw(&self, config: impl Into<AugursDtwConfig>) -> Stream<AugursDistanceMatrix>;
+}
+
+impl AugursDtwOps for Stream<Vec<f64>> {
+    fn augurs_dtw(&self, config: impl Into<AugursDtwConfig>) -> Stream<AugursDistanceMatrix> {
+        let config = config.into();
+        let cfg = DtwCfg {
+            metric: config.metric,
+            window: config.window.max(2),
+        };
+        self.wire(|b, h| b.augurs_dtw(h, cfg))
+    }
+}
+
+// -------------------------------------------------------------------------
+// Clustering.
+// -------------------------------------------------------------------------
+
+/// Configuration for [`AugursClusterOps::augurs_cluster`].
+#[derive(Debug, Clone)]
+pub struct AugursClusterConfig {
+    /// Number of recent samples retained as the window over which each series'
+    /// history is compared.
+    pub window: usize,
+    /// DBSCAN neighbourhood radius: the maximum DTW distance between two series
+    /// for them to be considered neighbours.
+    pub epsilon: f64,
+    /// DBSCAN minimum cluster size: the number of neighbours (including itself)
+    /// a series needs to be a core point.
+    pub min_cluster_size: usize,
+    /// Pointwise distance metric used inside the DTW alignment.
+    pub metric: AugursDtwMetric,
+}
+
+impl AugursClusterConfig {
+    /// Cluster the series over the last `window` samples with the given DBSCAN
+    /// `epsilon` radius and `min_cluster_size`, using DTW/Euclidean distances.
+    #[must_use]
+    pub fn new(window: usize, epsilon: f64, min_cluster_size: usize) -> Self {
+        Self {
+            window,
+            epsilon,
+            min_cluster_size,
+            metric: AugursDtwMetric::Euclidean,
+        }
+    }
+
+    /// Use the given pointwise distance metric inside DTW.
+    #[must_use]
+    pub fn with_metric(mut self, metric: AugursDtwMetric) -> Self {
+        self.metric = metric;
+        self
+    }
+}
+
+impl From<(usize, f64, usize)> for AugursClusterConfig {
+    /// `(window, epsilon, min_cluster_size)` using the Euclidean metric.
+    fn from((window, epsilon, min_cluster_size): (usize, f64, usize)) -> Self {
+        Self::new(window, epsilon, min_cluster_size)
+    }
+}
+
+/// Resolved cluster config: the DBSCAN parameters, the DTW metric, and the
+/// effective window (floored at 2, as for [`DtwCfg`]).
+#[derive(Debug, Clone)]
+pub struct ClusterCfg {
+    epsilon: f64,
+    min_cluster_size: usize,
+    metric: AugursDtwMetric,
+    window: usize,
+}
+
+/// Cluster op: buffers a window of per-series readings and DBSCAN-clusters the
+/// series by their pairwise DTW distances each cycle. `Cfg` = resolved config,
+/// `State` = the sliding window of per-tick multi-series samples.
+pub struct AugursClusterOp;
+
+#[op(build = augurs_cluster)]
+impl Op for AugursClusterOp {
+    type Cfg = ClusterCfg;
+    type State = VecDeque<Vec<f64>>;
+    type In<'a> = (&'a Vec<f64>,);
+    type Out = AugursClusters;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        cfg: &mut ClusterCfg,
+        buffer: &mut VecDeque<Vec<f64>>,
+        input: (&Vec<f64>,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<AugursClusters>> {
+        push_windowed(buffer, input.0.clone(), cfg.window);
+        // Warm up: clustering over length-1 columns compares single points, not
+        // windowed histories, so wait for at least two samples.
+        if buffer.len() < 2 {
+            return Ok(Tick::Quiet);
+        }
+
+        let series = transpose_window(buffer);
+        // Need at least two series to cluster.
+        if series.len() < 2 {
+            return Ok(Tick::Quiet);
+        }
+        let refs: Vec<&[f64]> = series.iter().map(Vec::as_slice).collect();
+        let matrix = distance_matrix(cfg.metric, &refs);
+        let clusters = DbscanClusterer::new(cfg.epsilon, cfg.min_cluster_size).fit(&matrix);
+
+        Ok(Tick::Value(AugursClusters {
+            labels: clusters.iter().map(|c| c.as_i32()).collect(),
+        }))
+    }
+}
+
+/// Adds the [`augurs_cluster`](AugursClusterOps::augurs_cluster) op to streams
+/// of per-series readings. Bring it into scope with
+/// `use wingfoil_next::adapters::augurs::AugursClusterOps;`.
+pub trait AugursClusterOps {
+    /// Maintain a sliding window of per-series readings (one `f64` per series
+    /// per tick) and emit an [`AugursClusters`] each tick: a DBSCAN cluster
+    /// label per series (`-1` = noise), computed from the pairwise DTW distances
+    /// between the series' windowed histories.
+    fn augurs_cluster(&self, config: impl Into<AugursClusterConfig>) -> Stream<AugursClusters>;
+}
+
+impl AugursClusterOps for Stream<Vec<f64>> {
+    fn augurs_cluster(&self, config: impl Into<AugursClusterConfig>) -> Stream<AugursClusters> {
+        let config = config.into();
+        let cfg = ClusterCfg {
+            epsilon: config.epsilon,
+            min_cluster_size: config.min_cluster_size,
+            metric: config.metric,
+            window: config.window.max(2),
+        };
+        self.wire(|b, h| b.augurs_cluster(h, cfg))
     }
 }
 

--- a/next/crates/wingfoil-next/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next/src/adapters/mod.rs
@@ -13,9 +13,10 @@
 //!   the smallest complete demonstration of an I/O edge in both directions.
 //! - [`csv`] — a serde-typed CSV file adapter (historical replay source + file
 //!   sink) behind the `csv` feature, the parsing cousin of [`lines`].
-//! - [`augurs`] — on-graph time-series analysis (forecasting + outlier
-//!   detection) over sliding windows, behind the `augurs` feature. A pure-Rust
-//!   compute adapter (no service), so it is transform ops, not a source/sink.
+//! - [`augurs`] — on-graph time-series analysis (forecasting, outlier /
+//!   changepoint / season detection, DTW distances and clustering) over sliding
+//!   windows, behind the `augurs` feature. A pure-Rust compute adapter (no
+//!   service), so it is transform ops, not a source/sink.
 //! - [`etcd`] — a streaming key-prefix snapshot + watch source (`etcd_sub`) and
 //!   a key-value PUT sink (`EtcdSinkOps::etcd_pub`) for the etcd key-value
 //!   store, behind the `etcd` feature (built on the async `produce_async`

--- a/next/crates/wingfoil-next/tests/augurs_adapter.rs
+++ b/next/crates/wingfoil-next/tests/augurs_adapter.rs
@@ -1,11 +1,11 @@
 //! augurs adapter parity tests — ports the classic
-//! `wingfoil::adapters::augurs` forecast + outlier unit tests to the
+//! `wingfoil::adapters::augurs` unit tests for all six operators to the
 //! wingfoil-next Op-pattern engine. augurs models are deterministic given their
-//! input (AutoETS/MSTL are optimizers with no RNG; MAD/DBSCAN are deterministic
-//! detectors), so the same known input series yields the same output on every
-//! run — the assertions match the classic ones (thresholds on the forecast /
-//! flagged-series, not brittle bit-exact values). Everything runs in historical
-//! mode for reproducibility.
+//! input (AutoETS/MSTL are optimizers with no RNG; MAD/DBSCAN, BOCPD, the
+//! periodogram and DTW are deterministic), so the same known input series yields
+//! the same output on every run — the assertions match the classic ones
+//! (thresholds on the forecast / flagged-series, not brittle bit-exact values).
+//! Everything runs in historical mode for reproducibility.
 
 #![cfg(feature = "augurs")]
 
@@ -13,7 +13,9 @@ use std::time::Duration;
 
 use wingfoil::{NanoTime, RunFor, RunMode};
 use wingfoil_next::adapters::augurs::{
-    AugursForecastConfig, AugursForecastOps, AugursOutlierConfig, AugursOutlierOps,
+    AugursChangepointConfig, AugursChangepointOps, AugursClusterConfig, AugursClusterOps,
+    AugursDtwConfig, AugursDtwOps, AugursForecastConfig, AugursForecastOps, AugursOutlierConfig,
+    AugursOutlierOps, AugursSeasonsConfig, AugursSeasonsOps,
 };
 use wingfoil_next::prelude::*;
 
@@ -236,4 +238,355 @@ fn outlier_waits_for_two_samples() {
     // One cycle → fewer than two samples → never ticked, slot holds default.
     let last = r.value(&outliers);
     assert!(last.outlying.is_empty() && last.scores.is_empty());
+}
+
+// -------------------------------------------------------------------------
+// Changepoint detection.
+// -------------------------------------------------------------------------
+
+/// Classic `changepoint_detects_level_shift`: a series that jumps from a low
+/// mean to a high mean partway through produces a changepoint after the jump.
+#[test]
+fn changepoint_detects_level_shift() {
+    let g = GraphBuilder::new();
+    // First ~20 samples near 0, then a jump to near 50.
+    let series = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let noise = (n as f64 * 0.7).sin() * 0.5;
+        if n > 20 { 50.0 + noise } else { noise }
+    });
+    let changes = series.augurs_changepoint(AugursChangepointConfig::new(60));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(50))
+        .unwrap();
+
+    let last = r.value(&changes);
+    assert!(
+        last.any(),
+        "expected a changepoint after the level shift, got {last:?}"
+    );
+    // The shift happens around window index 20; a detected changepoint should
+    // land after the first few points.
+    assert!(
+        last.indices.iter().any(|&i| i >= 10),
+        "expected a changepoint past the initial regime, got {:?}",
+        last.indices
+    );
+}
+
+/// Classic `changepoint_quiet_when_steady`: a perfectly steady series yields no
+/// changepoints.
+#[test]
+fn changepoint_quiet_when_steady() {
+    let g = GraphBuilder::new();
+    let series = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| 10.0 + (n as f64 * 0.5).sin() * 0.1);
+    let changes = series.augurs_changepoint(40);
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+        .unwrap();
+    let last = r.value(&changes);
+    assert!(
+        !last.any(),
+        "steady series should have no changepoints, got {:?}",
+        last.indices
+    );
+}
+
+/// The changepoint op stays silent until `min_points` have arrived, and once it
+/// starts ticking it ticks on every upstream tick (one per ticker period).
+#[test]
+fn changepoint_waits_for_min_points() {
+    let g = GraphBuilder::new();
+    let series = g.ticker(Duration::from_secs(1)).count().map(|&n| n as f64);
+    let changes = series.augurs_changepoint(AugursChangepointConfig::new(40).with_min_points(10));
+    let ticks = changes.with_time().accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(12))
+        .unwrap();
+
+    // The ticker's first tick is at t=0, so the 10th sample lands at t=9s and
+    // the remaining three cycles each tick: one value per second, no gaps.
+    let times: Vec<NanoTime> = r.value(&ticks).iter().map(|(t, _)| *t).collect();
+    assert_eq!(
+        times,
+        vec![
+            NanoTime::new(9_000_000_000),
+            NanoTime::new(10_000_000_000),
+            NanoTime::new(11_000_000_000),
+        ]
+    );
+}
+
+// -------------------------------------------------------------------------
+// Seasonality detection.
+// -------------------------------------------------------------------------
+
+/// Classic `seasons_detects_known_period`: a clean period-12 sine wave is
+/// detected as having a ~12-sample season.
+#[test]
+fn seasons_detects_known_period() {
+    let g = GraphBuilder::new();
+    let series = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| (n as f64 * std::f64::consts::TAU / 12.0).sin());
+    let seasons = series.augurs_seasons(AugursSeasonsConfig::new(96));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(96))
+        .unwrap();
+
+    let last = r.value(&seasons);
+    assert!(
+        last.periods.iter().any(|&p| (10..=14).contains(&p)),
+        "expected a period near 12, got {:?}",
+        last.periods
+    );
+    let dominant = last.dominant().expect("a season was detected");
+    assert!((10..=14).contains(&dominant), "dominant was {dominant}");
+}
+
+/// Classic `seasons_window_below_floor_still_emits`: a `window` below the
+/// default `min_points` floor still warms up and emits rather than never
+/// ticking (the effective window grows to the floor).
+#[test]
+fn seasons_window_below_floor_still_emits() {
+    let g = GraphBuilder::new();
+    let series = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| (n as f64 * std::f64::consts::TAU / 6.0).sin());
+    // window 12 is below the default min_points floor of 16.
+    let seasons = series.augurs_seasons(AugursSeasonsConfig::new(12));
+    let ticks = seasons.accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(40))
+        .unwrap();
+    assert!(
+        !r.value(&ticks).is_empty(),
+        "should emit despite window < floor"
+    );
+}
+
+/// Classic `seasons_waits_for_min_points`: the op stays silent until
+/// `min_points` have arrived.
+#[test]
+fn seasons_waits_for_min_points() {
+    let g = GraphBuilder::new();
+    let series = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| (n as f64 * std::f64::consts::TAU / 12.0).sin());
+    let seasons = series.augurs_seasons(AugursSeasonsConfig::new(96).with_min_points(50));
+    let ticks = seasons.accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(20))
+        .unwrap();
+    assert!(r.value(&ticks).is_empty());
+}
+
+// -------------------------------------------------------------------------
+// Dynamic time warping.
+// -------------------------------------------------------------------------
+
+/// Classic `dtw_distances_reflect_similarity`: two similar series and one
+/// dissimilar one — the distance from the odd series out exceeds the distance
+/// between the similar pair.
+#[test]
+fn dtw_distances_reflect_similarity() {
+    let g = GraphBuilder::new();
+    // series 0 and 1 track each other; series 2 is scaled up and offset.
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let t = n as f64;
+        let a = (t * 0.3).sin();
+        vec![a, a + 0.02, 5.0 * (t * 0.3).sin() + 10.0]
+    });
+    let dists = readings.augurs_dtw(AugursDtwConfig::new(30));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+        .unwrap();
+
+    let m = r.value(&dists);
+    assert_eq!(m.rows.len(), 3, "3x3 distance matrix");
+    let d01 = m.get(0, 1).expect("in range");
+    let d02 = m.get(0, 2).expect("in range");
+    assert!(
+        m.get(0, 0).expect("in range") < 1e-9,
+        "self-distance is zero"
+    );
+    assert!(
+        d02 > d01,
+        "dissimilar series should be farther: d02={d02}, d01={d01}"
+    );
+}
+
+/// Classic `dtw_waits_for_two_samples`: with two series but only a single
+/// sample the op stays silent — a DTW distance over length-1 columns is not a
+/// windowed-history distance.
+#[test]
+fn dtw_waits_for_two_samples() {
+    let g = GraphBuilder::new();
+    let readings = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| vec![n as f64, n as f64 + 1.0]);
+    let dists = readings.augurs_dtw(8);
+    let ticks = dists.accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+        .unwrap();
+    assert!(r.value(&ticks).is_empty());
+}
+
+/// Classic `dtw_waits_for_two_series`: the op stays silent until it has at
+/// least two series.
+#[test]
+fn dtw_waits_for_two_series() {
+    let g = GraphBuilder::new();
+    let readings = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| vec![n as f64]);
+    let dists = readings.augurs_dtw(8);
+    let ticks = dists.accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10))
+        .unwrap();
+    assert!(r.value(&ticks).is_empty());
+}
+
+/// The Manhattan metric is selectable and still ranks a dissimilar series
+/// farther away than a near-identical one.
+#[test]
+fn dtw_manhattan_metric_ranks_similarity() {
+    use wingfoil_next::adapters::augurs::AugursDtwMetric;
+
+    let g = GraphBuilder::new();
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let t = n as f64;
+        let a = (t * 0.3).sin();
+        vec![a, a + 0.02, 5.0 * (t * 0.3).sin() + 10.0]
+    });
+    let dists =
+        readings.augurs_dtw(AugursDtwConfig::new(30).with_metric(AugursDtwMetric::Manhattan));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+        .unwrap();
+
+    let m = r.value(&dists);
+    assert_eq!(m.rows.len(), 3);
+    assert!(m.get(0, 2).expect("in range") > m.get(0, 1).expect("in range"));
+}
+
+// -------------------------------------------------------------------------
+// Clustering.
+// -------------------------------------------------------------------------
+
+/// Classic `cluster_groups_similar_series`: two tight groups of series plus one
+/// outlier form two clusters, with the outlier labelled as noise.
+#[test]
+fn cluster_groups_similar_series() {
+    let g = GraphBuilder::new();
+    // series 0,1 near a low sine; series 2,3 near a high sine; series 4 wild.
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let t = n as f64;
+        let low = (t * 0.3).sin();
+        let high = (t * 0.3).sin() + 20.0;
+        vec![
+            low,
+            low + 0.02,
+            high,
+            high + 0.02,
+            50.0 * (t * 0.9).cos() + 100.0,
+        ]
+    });
+    let clusters = readings.augurs_cluster(AugursClusterConfig::new(30, 1.0, 2));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+        .unwrap();
+
+    let last = r.value(&clusters);
+    assert_eq!(last.labels.len(), 5, "one label per series");
+    // series 0 and 1 belong to the same (non-noise) cluster.
+    assert!(last.labels[0] >= 0 && last.labels[0] == last.labels[1]);
+    // series 2 and 3 belong to the same cluster, distinct from 0/1.
+    assert!(last.labels[2] >= 0 && last.labels[2] == last.labels[3]);
+    assert_ne!(last.labels[0], last.labels[2]);
+    assert_eq!(last.cluster_count(), 2, "expected two clusters");
+    // the wild series is noise.
+    assert_eq!(last.labels[4], -1);
+}
+
+/// Classic `cluster_waits_for_two_series`: the op stays silent until it has at
+/// least two series.
+#[test]
+fn cluster_waits_for_two_series() {
+    let g = GraphBuilder::new();
+    let readings = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| vec![n as f64]);
+    let clusters = readings.augurs_cluster(AugursClusterConfig::new(8, 1.0, 2));
+    let ticks = clusters.accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10))
+        .unwrap();
+    assert!(r.value(&ticks).is_empty());
+}
+
+/// Classic `cluster_waits_for_two_samples`: with two series but only a single
+/// sample the op stays silent — clustering length-1 columns compares single
+/// points, not histories.
+#[test]
+fn cluster_waits_for_two_samples() {
+    let g = GraphBuilder::new();
+    let readings = g
+        .ticker(Duration::from_secs(1))
+        .count()
+        .map(|&n| vec![n as f64, n as f64 + 1.0]);
+    let clusters = readings.augurs_cluster(AugursClusterConfig::new(8, 1.0, 2));
+    let ticks = clusters.accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+        .unwrap();
+    assert!(r.value(&ticks).is_empty());
+}
+
+/// Classic `cluster_accepts_tuple_config`: `(window, epsilon,
+/// min_cluster_size)` tuples convert into a config.
+#[test]
+fn cluster_accepts_tuple_config() {
+    let g = GraphBuilder::new();
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let t = n as f64;
+        let low = (t * 0.3).sin();
+        vec![low, low + 0.02, low + 20.0, low + 20.02]
+    });
+    let clusters = readings.augurs_cluster((30, 1.0, 2));
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(30))
+        .unwrap();
+    assert_eq!(r.value(&clusters).labels.len(), 4);
+}
+
+/// Next-specific: a `window` of 1 still reaches the two-sample warm-up floor
+/// and emits (classic's cluster node would never tick — see the adapter's
+/// `# Deviations from classic`).
+#[test]
+fn cluster_window_below_floor_still_emits() {
+    let g = GraphBuilder::new();
+    let readings = g.ticker(Duration::from_secs(1)).count().map(|&n| {
+        let t = n as f64;
+        vec![t, t + 0.01, t + 20.0]
+    });
+    let clusters = readings.augurs_cluster(AugursClusterConfig::new(1, 1.0, 2));
+    let ticks = clusters.accumulate();
+    let mut r = g.build();
+    r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5))
+        .unwrap();
+    assert!(
+        !r.value(&ticks).is_empty(),
+        "should emit despite window < the two-sample floor"
+    );
 }

--- a/next/docs/deviation-register.md
+++ b/next/docs/deviation-register.md
@@ -129,7 +129,7 @@ motivated the reject only ever required two *mechanisms*, not two public
 | C2 | **zmq cross-language interop not ported.** | ⚪ | The `bincode` wire envelope is next-local; not wire-compatible with a classic/Python peer. Deferred with the Python bindings (Phase 6). `adapters/zmq.rs`. |
 | C3 | **Structural gaps** — multi-output islands; runtime graph-mutation surface; (closed: `StreamStore`, `demux_it` in #529). | ⚪ | See `port-plan.md` Phase 4.5 "Known parity gaps" and Phase 1 multi-output note. |
 | C4 | **Compiled-path IO ingestion** — busy-poll (`ALWAYS`) sources + bursts are not expressible in `compiled()`/`graph!`. | ⚪ | Deliberate exclusion; IO stays at the interpreted boundary + compiled islands. Full design + the gating decision (wake channel vs busy-spin) in `port-plan.md` "Deferred / post-v1 work". (was #502/#503) |
-| C5 | **augurs ports only `augurs_forecast` + `augurs_outlier`; `augurs_changepoint` / `augurs_seasons` / `augurs_dtw` / `augurs_cluster` are not ported.** | ⚪ | Deferred capability gap — 2 of classic's 6 operators ported; the 4 remaining are not yet needed downstream and have no next twin. `adapters/augurs.rs`; port-plan Phase-4 augurs. |
+| C5 | ~~**augurs ports only `augurs_forecast` + `augurs_outlier`; `augurs_changepoint` / `augurs_seasons` / `augurs_dtw` / `augurs_cluster` are not ported.**~~ | ✅ | **Resolved.** All 6 of classic's operators are ported: the four remaining ones landed as sliding-window transform ops in the same shape as the first two — `AugursChangepointOps::augurs_changepoint` (BOCPD, window-start index dropped), `AugursSeasonsOps::augurs_seasons` (periodogram, detector built once at wiring), `AugursDtwOps::augurs_dtw` (pairwise DTW distance matrix, Euclidean/Manhattan) and `AugursClusterOps::augurs_cluster` (DBSCAN over those distances). The `augurs` dep gained classic's `changepoint`/`seasons`/`dtw`/`clustering` sub-features. Classic's unit tests for all four are ported to `tests/augurs_adapter.rs`, and the example covers them. One new benign deviation, D12. `adapters/augurs.rs`; port-plan Phase-4 augurs. |
 
 ## D. Cosmetic / API — deliberate-and-benign (low review priority)
 
@@ -145,6 +145,7 @@ motivated the reject only ever required two *mechanisms*, not two public
 | D8 | **`print` emits per tick instead of buffering to teardown.** Classic `PrintStream` buffers every value in a `Vec` and prints the whole buffer at `Drop`; next's `Print` op prints each value immediately in `cycle`. | 🟢 | Deliberate — the observable value stream is identical (`print` is a pass-through); only the diagnostic emission differs. Per-tick printing drops the unbounded buffer (classic grows one entry/tick for the whole run), streams output as the run progresses, and survives a mid-run abort. Shedding the teardown hook also makes `print` a plain single-input `#[op]` (no hand-written `Builder`). `ops.rs::Print`. |
 | D10 | **kdb: credentials never reach an error message** — `KdbConnection::redacted()` returns `host:port` (the password is used only at the `QStream::connect` call site). | 🟢 | Credential-redaction rule (shared with postgres). Classic put no creds in error context either; next makes it explicit + test-pinned. |
 | D11 | **kdb: `kdb_read` takes classic's `buffer_size`.** | 🟢 | `kdb_read` is historical-only. The bound is **no longer inert**: after B5 (bounded historical back-pressure + lazy `chunk_stream` slicing) `buffer_size` now gives bounded-memory, pipelined historical replay (`Some(n)` paces slice fetches against the graph drain; `None` = unbounded, classic's default). `kdb_read_cached` stays unbounded like classic but streams lazily. The `kdb_write` sink takes a `buffer_size` per D3. |
+| D12 | **`augurs_cluster` floors its effective window at the two-sample warm-up.** Classic's cluster node sizes its buffer for two samples but evicts against the raw `window`, so a `window` of 1 never reaches the warm-up and the node never ticks; next grows the effective window to the floor (as classic's own `augurs_dtw` already does). | 🟢 | Only reachable for `window < 2`, where classic's behaviour is silent-never-tick. Same "grow the window to the model's floor so the node still emits" rule the forecast/seasons ops follow in both trees. `adapters/augurs.rs`; `tests/augurs_adapter.rs::cluster_window_below_floor_still_emits`. |
 | D9 | **`logged` always wires its node; classic skips it when the level is disabled.** Classic `logged` short-circuits at wiring (`log_enabled!` → return the source unchanged) and reads the tick time via `bimap` + `ticked_at_elapsed`; next always wires the op, leaning on `log!`'s internal enabled-check, and reads the time off `Ctx::time`. | 🟢 | Value stream identical (a pass-through); only the diagnostic differs, and a disabled level still costs only the internal `log!` check. Always-wiring keeps interpreted and compiled identical (a wiring-time skip is inexpressible in `compiled()`). `logged` is fluent-only (its `&str` param vs `String` cfg — see `tests/op_completeness.rs`). `ops.rs::Logged`. |
 
 ---
@@ -176,7 +177,10 @@ source, verified against `wingfoil/src/nodes/async_io.rs` + `channel.rs`; the
 register's "classic re-runs" was incorrect; the deterministic re-run subset was
 already at parity via the Phase-1 `reset` hook); **C1** (otlp trace/span export
 `OtlpSpanOps::otlp_spans` fully ported, landed with the Phase-5 latency
-infrastructure — was a ⚪ capability gap, now at metrics-parity).
+infrastructure — was a ⚪ capability gap, now at metrics-parity); **C5** (augurs
+`changepoint` / `seasons` / `dtw` / `cluster` ported, taking the adapter to all 6
+of classic's operators — was a ⚪ capability gap, now full-parity but for the
+benign D12 window floor).
 
 ## Keeping this current
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -856,20 +856,23 @@ Order chosen by (pure → request-shaped → streaming → build-painful):
    `spans_historical_mode_drains_without_connecting` in `tests/otlp_adapter.rs`
    and `otlp_spans_sends_successfully` in `tests/otlp_integration.rs`.
    ✅ **augurs** *(done)*: on-graph time-series analysis (a pure-Rust compute
-   adapter, no service/lifecycle), behind the `augurs` feature. Ports **2 of
-   classic's 6 operators** — `AugursForecastOps::augurs_forecast` (windowed ETS /
-   MSTL point forecast + prediction intervals) and
+   adapter, no service/lifecycle), behind the `augurs` feature. Ports **all 6 of
+   classic's operators** — `AugursForecastOps::augurs_forecast` (windowed ETS /
+   MSTL point forecast + prediction intervals),
    `AugursOutlierOps::augurs_outlier` (windowed MAD / DBSCAN multi-series outlier
-   detection) — both as sliding-window transform ops fitting their model inside
-   `cycle()` on the graph thread (same shape as the `stats` rolling ops). The
-   **4 unported operators** (`augurs_changepoint`, `augurs_seasons`,
-   `augurs_dtw`, `augurs_cluster`) are a tracked capability gap (register C5), not
-   yet needed downstream. **Deviations:** the ops validate config inside `cycle`
-   (returning `Result` / `anyhow::bail!`) rather than classic's wiring-time
-   `panic!` on a bad detector sensitivity — a deliberate improvement; see the
-   adapter's `# Deviations from classic` module-doc block plus
-   [`deviation-register.md`](./deviation-register.md). Test file
-   `tests/augurs_adapter.rs`; example `examples/augurs_adapter.rs`.
+   detection), `AugursChangepointOps::augurs_changepoint` (Bayesian online
+   changepoint detection), `AugursSeasonsOps::augurs_seasons` (periodogram
+   seasonality detection), `AugursDtwOps::augurs_dtw` (pairwise dynamic-time-warping
+   distance matrix) and `AugursClusterOps::augurs_cluster` (DBSCAN clustering over
+   those DTW distances) — all as sliding-window transform ops computing inside
+   `cycle()` on the graph thread (same shape as the `stats` rolling ops).
+   **Deviations:** the ops validate config inside `cycle` (returning `Result` /
+   `anyhow::bail!`) rather than classic's wiring-time `panic!` on a bad detector
+   sensitivity, and `augurs_cluster` floors its effective window at the
+   two-sample warm-up (classic's cluster node never ticks for `window == 1`) —
+   both deliberate improvements; see the adapter's `# Deviations from classic`
+   module-doc block plus [`deviation-register.md`](./deviation-register.md).
+   Test file `tests/augurs_adapter.rs`; example `examples/augurs_adapter.rs`.
 8. **aeron, iceoryx2, fluvio** last — build-environment pain (CMake/clang);
    their ring-buffer polling is the natural `ALWAYS`-cap shape.
    ✅ **fluvio** *(done)*: a streaming topic-partition consume source


### PR DESCRIPTION
Completes the augurs adapter port by adding the four remaining operators from classic: Bayesian online changepoint detection, periodogram seasonality detection, dynamic time warping distance matrices, and DBSCAN clustering.

## Summary

This PR completes the augurs adapter from a partial port (2 of 6 operators) to full coverage. All six classic augurs operators now have next implementations as sliding-window transform ops that fit/compute their models inside `cycle()` on the graph thread, following the same pattern as the existing forecast and outlier ops.

## Key Changes

- **Changepoint detection** (`augurs_changepoint`): Buffers a window of `f64` values and runs Bayesian online changepoint detection (BOCPD) each cycle, emitting indices of detected regime changes. Filters out the window-start artifact that BOCPD always reports.

- **Seasonality detection** (`augurs_seasons`): Buffers a window of `f64` values and runs periodogram-based seasonality detection, emitting detected seasonal period lengths (longest first). Includes configurable period bounds.

- **Dynamic time warping** (`augurs_dtw`): Buffers a window of multi-series readings (`Vec<f64>` per tick) and computes pairwise DTW distances each cycle, emitting a row-major distance matrix. Supports Euclidean and Manhattan metrics. Floors effective window at 2 (single-sample columns don't represent windowed history).

- **DBSCAN clustering** (`augurs_cluster`): Buffers a window of multi-series readings and clusters them by DTW distance using DBSCAN, emitting per-series cluster labels (`-1` for noise). Also floors effective window at 2, matching DTW's warm-up requirement.

- **Result types**: Added `AugursChangepoints`, `AugursSeasons`, `AugursDistanceMatrix`, and `AugursClusters` with helper methods (`any()`, `dominant()`, `get()`, `cluster_count()`).

- **Configuration**: Each operator has a builder-pattern config struct with sensible defaults (e.g., changepoint hazard rate 250, seasons min_points floor at window/2 or 16).

- **Shared utilities**: Extended `transpose_window()` documentation to note it's used by all multi-series ops (outlier, DTW, cluster).

## Implementation Details

- All four new ops follow the established pattern: `#[op]` macro, `VecDeque` sliding window buffer, `Activation::NONE` (no special activation), and `Tick::Quiet` until warm-up thresholds are met.

- Window floors are applied at wiring time (in the trait impl) to ensure nodes still emit even when configured with a window below the warm-up floor — the same "grow the window to the floor" rule forecast and seasons ops follow.

- Config validation happens inside `cycle()` (fallibly, returning `anyhow::Result`) rather than at wiring (by panic), improving error reporting.

- Augurs sub-features expanded in `Cargo.toml` from `ets, mstl, outlier` to include `changepoint, seasons, dtw, clustering`.

## Testing & Documentation

- Added comprehensive unit tests mirroring classic's test suite: level-shift detection, steady-series quiet behavior, warm-up waits, period detection, similarity ranking, clustering grouping, noise detection, and metric selection.

- Updated module documentation to remove the capability-gap note (C5 in deviation register) and clarify that all six operators are now ported.

- Updated examples to demonstrate all six ops with synthetic streams.

- Updated `port-plan.md` to mark augurs as fully complete (✅ all 6 operators).

- Updated `deviation-register.md` to remove C5 (the unported operators gap).

- Updated `new-adapter-next.md` with guidance for completing partial ports (widening sub-features, deleting capability-gap bullets, updating docs).

https://claude.ai/code/session_01WAD8Y4sPZSZZcscvZvT9hb