### PR TITLE
Generate interpreted Builder methods for all op shapes

### DIFF
--- a/.claude/commands/new-op-next.md
+++ b/.claude/commands/new-op-next.md
@@ -10,8 +10,9 @@ reference implementations; read them before writing code:
 
 - `src/ops.rs` — the core catalog. `Map` (`#[op(build = map)]`, the smallest
   single-input shape), `Fold` (`init_arg` seeded accumulator), `Ticker` /
-  `Const` (`no_builder` sources), `Sample` (`passive = [0]`), the multi-input
-  `bimap`/`trimap`/`join` family.
+  `Const` (sources, with a `start` hook), `Sample` (`passive = [0]`), `Delay`
+  (a tick-flag edge), the multi-input `join`/`join3` family and the
+  runtime-flag `bimap`/`trimap` methods they back.
 - `src/stats.rs` — `StatisticsOps`, the template for an op that lives in its
   own extension trait outside the prelude (EWMA family).
 - `src/op.rs` — the `Op` trait itself: `Cfg` / `State` / `In<'a>` / `Out` /
@@ -70,14 +71,36 @@ When you open the PR, its **base branch must be `next`** — not `main`.
 The shape decides how much you write and which engines you reach for free.
 Read the touch-point table in `port-plan.md` ("Adding an op"); the summary:
 
-| Shape | `In<'a>` | Interpreted (`ops.rs`) | `graph!` / compiled | Reference |
+**`#[op(build = name)]` generates the interpreted `Builder` method for every
+shape below** — one `Handle` parameter per edge of `In<'a>`, in `In` order,
+then the `Cfg` (omitted when it is `()`), returning the output `Handle`. So the
+shape decides what you *write in the op*, not how much wiring you hand-code:
+
+| Shape | `In<'a>` | Attribute | Generated `Builder` signature | Reference |
 |---|---|---|---|---|
-| **Single-input** | `(&'a I,)` | `#[op(build = name)]` — generates `Builder::name` over `register_op1` | **zero-touch** — `#[op]` emits the forwarders | `Map`, `Filter`, `Distinct` |
-| **Seeded accumulator** | `(&'a I,)` + init | `#[op(build = name, init_arg)]` (implies `no_builder`) + hand `Builder` method | zero-touch — attribute flags carry it | `Fold` |
-| **Passive edge** (read, don't trigger) | `(&'a I,)` | `#[op(build = name, passive = [0])]` | zero-touch | `Sample` |
-| **Multi-input, all-active** | `(&'a A, &'a B)` | `#[op(build = name, no_builder)]` + `register_op2`-based fluent method | zero-touch — `&stream` args classify as edges | `bimap` / `join` |
-| **Source** (no input) | `()` | `#[op(build = name, no_builder)]` + hand `Builder` method that `schedule`s | fluent-only if it's a cycle/IO source | `Ticker`, `Const` |
-| **Doesn't fit** (3+ inputs, tick-flag inputs, lifecycle hooks, custom state seed) | — | hand-written `Builder` method | add by hand or leave interpreted-only | see `port-plan.md` |
+| **Single-input** | `(&'a I,)` | `#[op(build = name)]` | `name(src, cfg)` | `Map`, `Distinct` |
+| **Multi-input, all-active** | `(&'a A, &'a B, …)` | `#[op(build = name)]` | `name(a, b, …, cfg)` | `Join`, `Filter`, `Join3` |
+| **Passive edge** (read, don't trigger) | any | `#[op(build = name, passive = [0])]` | same — the mask only changes dispatch | `Sample`, `JoinPassive` |
+| **Tick-flag edge** (needs "did it tick?") | `(&'a T, bool)` or `((&'a T, bool), …)` | `#[op(build = name)]` | same — the flag comes from the engine | `Delay`, `Merge2` |
+| **Lifecycle hooks** (`start`/`stop`/`teardown`) | any | `#[op(build = name)]` | same — hooks attached automatically | `Ticker`, `Window`, `Timed`, `Finally` |
+| **Seeded accumulator** | `(&'a I,)` + init | `#[op(build = name, init_arg)]` | `name(src, init, cfg)` — seeds state *and* slot | `Fold` |
+| **Source** (no input) | `()` | `#[op(build = name)]` + `start` that `schedule`s | `name(cfg)` | `Ticker`, `Const` |
+| **Signature ≠ shape** | any | `#[op(build = name, no_builder)]` + hand `Builder` method | — | `WithTime` |
+
+`no_builder` is the last resort, not the default: reach for it only when the
+interpreted method must have a *different signature* from the op's shape —
+`with_time` seeds its value slot from the input's current value so it never
+requires `Out: Default`, and `bimap`/`trimap` take runtime active/passive flags
+rather than a compile-time mask (those are extra hand-written methods over
+`Join`/`Join3`, alongside the generated `join`/`join_passive`/`join3`). If you
+find yourself adding `no_builder` for any other reason, the shape probably fits
+and you should check `expand_builder` in the macro crate first.
+
+`#[op]` is **in-crate tooling**: its output names `crate::interp::Builder`, so
+an op defined outside `wingfoil-next` writes its forwarders by hand and wires
+the interpreted side through the public `register_op1`…`register_op4` (or
+`bimap` / `fold`) primitives — see `tests/custom_op.rs`, which keeps a worked
+example of both.
 
 The two hard constraints behind this (from `macro-extensibility-decision.md`):
 a proc macro sees **tokens, not resolved types**, so `graph!` can't introspect
@@ -143,7 +166,8 @@ Rules the existing ops encode — follow them:
   capture. (See the `Map` doc comment for the full rationale.)
 - **`State: Default`** — the interpreted `#[op]` path seeds it with
   `Default::default()` per run (re-seeded each run, so a graph re-runs clean).
-  A non-`Default` seed needs a hand-written `Builder` method (`no_builder`).
+  A seed that must come from the call site is the `init_arg` shape (`Fold`),
+  which `#[op]` also generates — not a reason to hand-write a builder.
 - **Convert config once in `start`**, not per `cycle`, when the conversion is
   non-trivial (`Ticker` converts its `Duration` period to `NanoTime` in
   `start`).
@@ -178,13 +202,15 @@ A source's fluent method goes on `SourceOps` and calls `GraphBuilder::source`
 
 ## 5. `graph!` / compiled coverage
 
-For a single-input `#[op]` op this is **zero-touch**: the attribute emits the
+For any `#[op]` op this is **zero-touch**: the attribute emits the
 forwarder functions (`__wf_op_<name>_cycle`, `__WF_OP_<NAME>_ACTIVATION`) that
 compiled/nested emission dispatches through by naming convention, and rustc's
 inference resolves the op type the macro never names. Nothing to edit.
 
-For a shape outside `#[op]`'s scope (multi-input beyond `register_op2`,
-tick-flag inputs, cyclic/IO sources), the op may land **interpreted-only** —
+For a shape `#[op]` cannot parse (cyclic/IO sources; an `In` the uniform
+one-`(value, tick)`-pair-per-edge form can't express, as
+`DelayWithReset` — see its `DelayWithResetFwd` witness for the way out), the op
+may land **interpreted-only** —
 that is allowed, but it must be *consciously* placed: either give it an
 equivalent forwarder, or add it to the documented fluent-only allowlist in
 `tests/op_completeness.rs` (see step 6). Never leave it silently in neither.
@@ -355,8 +381,9 @@ Before opening a PR, run a clean-context review pass as a subagent:
    divergence, even intentional ones.
 2. **Validate the artifacts**: branch cut from `next`, PR base `next` (step 1);
    the `Op` impl with correct `ACTIVATION` and `Tick` variants (steps 2–3);
-   closure configs are `Fn` not `FnMut`; `State: Default` (or a justified
-   `no_builder`); a hand-written fluent method on the right trait, out of the
+   closure configs are `Fn` not `FnMut`; `State: Default` (or `init_arg`); a
+   `no_builder` is justified by a signature that differs from the shape, not by
+   the shape itself; a hand-written fluent method on the right trait, out of the
    prelude for a domain op (step 4); `graph!`/compiled coverage is zero-touch or
    the op is a documented fluent-only entry (step 5); catalog tests assert
    values **and** tick times and the op appears in `op_completeness.rs` (a

--- a/next/crates/wingfoil-next-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-macros/src/lib.rs
@@ -957,13 +957,20 @@ pub fn graph(input: TokenStream) -> TokenStream {
 /// emits the interpreted engine's `Builder::<name>` wiring method, so an op's
 /// semantics and its interpreted entry point are single-sourced.
 ///
-/// Scoped to the **single-active-input** shape: `type In<'a> = (&'a I,)`,
-/// engine-owned `Cfg`/`State` with `State: Default`, and no lifecycle hooks
-/// (the common case — `map`, `distinct`, `ewma`, …). The generated method is a
-/// thin wrapper over [`Builder::register_op1`], with the node label derived
-/// from `type_name::<X>()` rather than a hand-written string. Ops that don't
-/// fit (multiple inputs, passive edges, tick-flag inputs, sources, custom
-/// state seeds, lifecycle hooks) keep their hand-written `Builder` methods.
+/// The generated method takes one `Handle` parameter per edge of the op's
+/// `type In<'a>`, in order, then the op's `Cfg` (omitted when it is `()`), and
+/// returns the output `Handle`. It covers every `In` shape the macro parses:
+/// **sources** (`In = ()`), **single- and multi-input** ops, edges read with
+/// their **tick flag** (`(&'a T, bool)` — `delay`, `merge`), any per-edge
+/// **`passive` mask**, the op's **`start` / `stop` / `teardown` hooks**, and —
+/// with `init_arg` — a **seeded accumulator** whose state and value slot come
+/// from a call-site argument rather than `Default`. Node labels derive from
+/// `type_name::<X>()` rather than a hand-written string.
+///
+/// `no_builder` opts out, for ops whose interpreted *signature* deliberately
+/// differs from their shape: `bimap`/`trimap` take runtime active/passive
+/// flags rather than a compile-time mask, and `with_time` seeds its value slot
+/// from the input's current value so it never requires `Out: Default`.
 #[proc_macro_attribute]
 pub fn op(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as OpArgs);
@@ -980,8 +987,9 @@ pub fn op(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Parsed `#[op(...)]` arguments:
 ///
 /// - `build = <name>` — the fluent/graph method name (required, first);
-/// - `no_builder` — skip the interpreted `Builder` method (ops with
-///   hand-written builder wiring: sources, multi-input, seeded shapes);
+/// - `no_builder` — skip the interpreted `Builder` method, for the few ops
+///   whose hand-written wiring has a deliberately different signature
+///   (`bimap`/`trimap`, `with_time`);
 /// - `passive = [i, ...]` — the listed edge positions are **passive** (read
 ///   but not activating; sample's data edge is `passive = [0]`). Becomes the
 ///   `__WF_OP_<NAME>_PASSIVE` bitmask const the emission folds into dispatch
@@ -989,9 +997,9 @@ pub fn op(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// - `init_arg` — the **seeded-accumulator** shape (fold): the call site's
 ///   single plain argument is the initial `State`, cloned into both the
 ///   state and the value slot (so passive reads before the first tick see
-///   the seed), and the op's `Cfg` is a literal closure passed by value.
-///   Implies `no_builder` (the interpreted side needs a seeded slot, which
-///   `register_op1` does not express).
+///   the seed), and the op's `Cfg` is a literal closure passed by value. The
+///   generated `Builder` method takes that seed as an `init` parameter ahead
+///   of the config — `fold(src, init, f)`.
 struct OpArgs {
     build: Ident,
     no_builder: bool,
@@ -1045,14 +1053,6 @@ impl Parse for OpArgs {
                 }
             }
         }
-        if init_arg && !no_builder {
-            return Err(syn::Error::new(
-                build.span(),
-                "`init_arg` requires `no_builder`: the interpreted Builder method for a \
-                 seeded op must seed its value slot, which the generated `register_op1` \
-                 wrapper does not express — write it by hand",
-            ));
-        }
         Ok(OpArgs {
             build,
             no_builder,
@@ -1060,23 +1060,6 @@ impl Parse for OpArgs {
             passive,
         })
     }
-}
-
-/// The `T` of a single-element reference tuple type `(&'a T,)`, or an error if
-/// the type is not that shape (which is how `#[op]` scopes its *Builder
-/// method* generation; the `graph!` forwarders support any [`InShape`]).
-fn single_ref_tuple_elem(ty: &Type) -> syn::Result<Type> {
-    if let Type::Tuple(tup) = ty
-        && tup.elems.len() == 1
-        && let Type::Reference(r) = &tup.elems[0]
-    {
-        return Ok((*r.elem).clone());
-    }
-    Err(syn::Error::new(
-        ty.span(),
-        "#[op] generates a Builder method only for single-input ops (`type In<'a>` = `(&'a T,)`); \
-         add `no_builder` to keep a hand-written Builder method and still get graph! forwarders",
-    ))
 }
 
 /// True for the unit type `()` — a `Cfg = ()` op takes no config argument.
@@ -1150,6 +1133,11 @@ struct InShape {
     edge_ref_tys: Vec<Type>,
     /// Per-edge value types (`T`), for `'static` predicates.
     edge_val_tys: Vec<Type>,
+    /// Per edge: does the op's `In` actually read that edge's tick flag? The
+    /// interpreted builder only reads the engine's tick vector for edges
+    /// where it does (every other edge's flag is a constant `false` the op
+    /// never looks at).
+    edge_uses_tick: Vec<bool>,
     /// Builds the op's `In` from the pairs param `__input`.
     in_expr: TokenStream2,
 }
@@ -1163,6 +1151,7 @@ fn parse_in_shape(in_ty: &Type) -> syn::Result<InShape> {
     };
     let mut edge_ref_tys = Vec::new();
     let mut edge_val_tys = Vec::new();
+    let mut edge_uses_tick: Vec<bool> = Vec::new();
     let mut elems: Vec<TokenStream2> = Vec::new();
     for elem in &tup.elems {
         match elem {
@@ -1170,6 +1159,7 @@ fn parse_in_shape(in_ty: &Type) -> syn::Result<InShape> {
                 let ix = syn::Index::from(edge_ref_tys.len());
                 edge_ref_tys.push(strip_lifetimes(elem));
                 edge_val_tys.push(strip_lifetimes(&r.elem));
+                edge_uses_tick.push(false);
                 elems.push(quote! { __input.#ix.0 });
             }
             Type::Tuple(pair)
@@ -1183,6 +1173,7 @@ fn parse_in_shape(in_ty: &Type) -> syn::Result<InShape> {
                 };
                 edge_ref_tys.push(strip_lifetimes(&pair.elems[0]));
                 edge_val_tys.push(strip_lifetimes(&r.elem));
+                edge_uses_tick.push(true);
                 elems.push(quote! { (__input.#ix.0, __input.#ix.1) });
             }
             other if is_bool(other) => {
@@ -1192,7 +1183,9 @@ fn parse_in_shape(in_ty: &Type) -> syn::Result<InShape> {
                         "#[op]: a bare `bool` In element must follow the edge it is the tick of",
                     ));
                 }
-                let ix = syn::Index::from(edge_ref_tys.len() - 1);
+                let last = edge_ref_tys.len() - 1;
+                edge_uses_tick[last] = true;
+                let ix = syn::Index::from(last);
                 elems.push(quote! { __input.#ix.1 });
             }
             other => {
@@ -1212,6 +1205,7 @@ fn parse_in_shape(in_ty: &Type) -> syn::Result<InShape> {
     Ok(InShape {
         edge_ref_tys,
         edge_val_tys,
+        edge_uses_tick,
         in_expr,
     })
 }
@@ -1225,6 +1219,7 @@ fn expand_op(args: &OpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
     let (mut in_ty, mut cfg_ty, mut state_ty, mut out_ty) = (None, None, None, None);
     let mut activation_expr: Option<Expr> = None;
     let mut overrides_start = false;
+    let (mut overrides_stop, mut overrides_teardown) = (false, false);
     for it in &imp.items {
         match it {
             ImplItem::Type(t) => match t.ident.to_string().as_str() {
@@ -1237,9 +1232,12 @@ fn expand_op(args: &OpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
             ImplItem::Const(c) if c.ident == "ACTIVATION" => {
                 activation_expr = Some(c.expr.clone());
             }
-            ImplItem::Fn(f) if f.sig.ident == "start" => {
-                overrides_start = true;
-            }
+            ImplItem::Fn(f) => match f.sig.ident.to_string().as_str() {
+                "start" => overrides_start = true,
+                "stop" => overrides_stop = true,
+                "teardown" => overrides_teardown = true,
+                _ => {}
+            },
             _ => {}
         }
     }
@@ -1289,6 +1287,12 @@ fn expand_op(args: &OpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
     for val_ty in &shape.edge_val_tys {
         preds.push(quote! { #val_ty: 'static });
     }
+    // The forwarders always seed the value slot with `Default::default()`;
+    // the generated `Builder` method does too *unless* `init_arg` seeds it
+    // from the call site, so that predicate is added per consumer rather than
+    // baked into the shared list (an `init_arg` accumulator need not be
+    // `Default` — `fold` over a non-`Default` type stays legal fluently).
+    let base_preds = preds.clone();
     preds.push(quote! { #out_ty: ::core::default::Default });
     let generics = if bare_params.is_empty() {
         quote! {}
@@ -1617,53 +1621,327 @@ fn expand_op(args: &OpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
         #seed_value
     };
 
-    // ---- interpreted Builder method (single-input ops only) ----------------
+    // ---- interpreted Builder method ----------------------------------------
     let builder = if args.no_builder {
         quote! {}
     } else {
-        let input_ty = single_ref_tuple_elem(&in_ty)?;
-        let has_cfg = !is_unit_type(&cfg_ty);
-        let cfg_param = if has_cfg {
-            quote! { , cfg: #cfg_ty }
-        } else {
-            quote! {}
-        };
-        let cfg_arg = if has_cfg {
-            quote! { cfg }
-        } else {
-            quote! { () }
-        };
-        let doc = format!("Interpreted-engine wiring for [`{name}`]. Generated by `#[op]`.");
-        quote! {
-            impl crate::interp::Builder {
-                #[doc = #doc]
-                pub fn #name #generics (
-                    &mut self,
-                    src: crate::interp::Handle<#input_ty>
-                    #cfg_param
-                ) -> crate::interp::Handle<#out_ty>
-                #where_tokens
-                {
-                    self.register_op1(
-                        src,
-                        ::core::any::type_name::<#self_ty>(),
-                        <#self_ty as crate::op::Op>::ACTIVATION,
-                        #cfg_arg,
-                        // A factory, not a value, so the interpreted engine can
-                        // re-seed the op's state on a re-run (see `ResetFn`).
-                        || ::core::default::Default::default(),
-                        |__cfg, __state, __a, __ctx| {
-                            <#self_ty as crate::op::Op>::cycle(__cfg, __state, (__a,), __ctx)
-                        },
-                    )
-                }
-            }
-        }
+        expand_builder(
+            args,
+            &BuilderShape {
+                self_ty,
+                shape: &shape,
+                cfg_ty: &cfg_ty,
+                state_ty: &state_ty,
+                out_ty: &out_ty,
+                generics: &generics,
+                preds: &base_preds,
+                overrides_start,
+                overrides_stop,
+                overrides_teardown,
+            },
+        )?
     };
 
     Ok(quote! {
         #forwarders
         #builder
+    })
+}
+
+/// What [`expand_builder`] needs from the `#[op]` impl to write the op's
+/// interpreted `Builder` method.
+struct BuilderShape<'a> {
+    self_ty: &'a Type,
+    shape: &'a InShape,
+    cfg_ty: &'a Type,
+    state_ty: &'a Type,
+    out_ty: &'a Type,
+    /// The impl's generic parameters, bare (`<A, B, F>`).
+    generics: &'a TokenStream2,
+    /// The impl's own bounds, routed into one `where` list. Does **not**
+    /// include the `Out: Default` the forwarders add — see `base_preds`.
+    preds: &'a [TokenStream2],
+    overrides_start: bool,
+    overrides_stop: bool,
+    overrides_teardown: bool,
+}
+
+/// Generate the op's interpreted `Builder` method — the wiring the engine
+/// would otherwise carry by hand, once per op.
+///
+/// This covers **every** `In` shape [`parse_in_shape`] accepts: zero or more
+/// edges, each read by value (`&T`) or with its tick flag (`(&T, bool)`, or a
+/// trailing bare `bool`), any per-edge `passive` mask, the op's `start` /
+/// `stop` / `teardown` hooks, and either a `Default`-seeded state or an
+/// `init_arg` seed taken from the call site. The emitted body is exactly the
+/// sequence the `#[op]` wiring seam on `Builder` exposes
+/// (`next_node_index` → `slot`/`new_slot` → `push_node` → the `set_*`
+/// attachers), so a hand-written builder and a generated one are the same
+/// code; the remaining hand-written ones exist because their *signature*
+/// differs from the op's shape (`bimap`/`trimap` take runtime active/passive
+/// flags; `with_time` seeds its slot from the input rather than `Default`),
+/// not because the shape is out of reach.
+fn expand_builder(args: &OpArgs, b: &BuilderShape<'_>) -> syn::Result<TokenStream2> {
+    let (self_ty, shape) = (b.self_ty, b.shape);
+    let (cfg_ty, state_ty, out_ty) = (b.cfg_ty, b.state_ty, b.out_ty);
+    let (generics, name) = (b.generics, &args.build);
+    let n = shape.edge_ref_tys.len();
+    if n > 26 {
+        return Err(syn::Error::new(
+            self_ty.span(),
+            "#[op]: a generated Builder method supports at most 26 input edges",
+        ));
+    }
+    if n < 32 && args.passive >> n != 0 {
+        return Err(syn::Error::new(
+            self_ty.span(),
+            format!("#[op]: `passive` names an edge position beyond this op's {n} inputs"),
+        ));
+    }
+
+    // One parameter per edge, in `In` order — `src` when there is only one
+    // (reading `map(src, f)`), else `a`, `b`, `c`, … (reading `join(a, b, f)`).
+    let edge_names: Vec<Ident> = (0..n)
+        .map(|i| {
+            if n == 1 {
+                format_ident!("src")
+            } else {
+                format_ident!("{}", char::from(b'a' + i as u8))
+            }
+        })
+        .collect();
+    let slot_ids: Vec<Ident> = (0..n).map(|i| format_ident!("__slot{i}")).collect();
+    let up_ids: Vec<Ident> = (0..n).map(|i| format_ident!("__up{i}")).collect();
+    let borrow_ids: Vec<Ident> = (0..n).map(|i| format_ident!("__val{i}")).collect();
+    let edge_params = edge_names
+        .iter()
+        .zip(&shape.edge_val_tys)
+        .map(|(nm, ty)| quote! { #nm: crate::interp::Handle<#ty> });
+
+    // Active vs passive edges: an active edge triggers the node when it ticks
+    // (it goes into `push_node`'s upstream list); a passive one is read but
+    // recorded separately, only so `build()` can raise this node's dispatch
+    // layer above the value it reads.
+    let (mut active, mut passive) = (Vec::new(), Vec::new());
+    for (i, up) in up_ids.iter().enumerate() {
+        if args.passive & (1 << i) == 0 {
+            active.push(up);
+        } else {
+            passive.push(up);
+        }
+    }
+    let passive_stmt = if passive.is_empty() {
+        quote! {}
+    } else {
+        quote! { self.set_passive_ups(__idx, ::std::vec![#(#passive),*]); }
+    };
+
+    // Only edges whose `In` shape reads a tick flag cost a lookup in the
+    // engine's tick vector; the rest are handed a constant `false` the op
+    // never reads.
+    let uses_ticks = shape.edge_uses_tick.iter().any(|t| *t);
+    let ticked_let = if uses_ticks {
+        quote! { let __ticked = self.ticked_flags(); }
+    } else {
+        quote! {}
+    };
+    let tick_lets = shape
+        .edge_uses_tick
+        .iter()
+        .enumerate()
+        .filter(|(_, used)| **used)
+        .map(|(i, _)| {
+            let (t, up) = (format_ident!("__tick{i}"), &up_ids[i]);
+            quote! { let #t = __ticked.borrow()[#up]; }
+        });
+    let tick_exprs: Vec<TokenStream2> = shape
+        .edge_uses_tick
+        .iter()
+        .enumerate()
+        .map(|(i, used)| {
+            if *used {
+                let t = format_ident!("__tick{i}");
+                quote! { #t }
+            } else {
+                quote! { false }
+            }
+        })
+        .collect();
+
+    // The call into the op, with every edge's slot borrowed for exactly the
+    // duration of the call: the borrows end with the block, before the tick's
+    // value is written back to the output slot.
+    let in_expr = &shape.in_expr;
+    let cycle_call = if n == 0 {
+        quote! { <#self_ty as crate::op::Op>::cycle(__cfg, __state, (), &mut __ctx)? }
+    } else {
+        quote! {{
+            #(let #borrow_ids = #slot_ids.borrow();)*
+            let __input = ( #((&*#borrow_ids, #tick_exprs),)* );
+            <#self_ty as crate::op::Op>::cycle(__cfg, __state, #in_expr, &mut __ctx)?
+        }}
+    };
+
+    // `Cfg = ()` ops take no config argument; an `init_arg` op takes its
+    // accumulator seed ahead of the config, matching `fold(src, init, f)`.
+    let has_cfg = !is_unit_type(cfg_ty);
+    let cfg_param = if has_cfg {
+        quote! { cfg: #cfg_ty, }
+    } else {
+        quote! {}
+    };
+    let cfg_arg = if has_cfg {
+        quote! { cfg }
+    } else {
+        quote! { () }
+    };
+    let (init_param, state_seed, out_seed, reset_init) = if args.init_arg {
+        (
+            quote! { init: #state_ty, },
+            quote! { ::core::clone::Clone::clone(&init) },
+            quote! { ::core::clone::Clone::clone(&init) },
+            quote! { let __init_reset = init; },
+        )
+    } else {
+        (
+            quote! {},
+            quote! { <#state_ty as ::core::default::Default>::default() },
+            quote! { <#out_ty as ::core::default::Default>::default() },
+            quote! {},
+        )
+    };
+    let (state_reseed, out_reseed) = if args.init_arg {
+        (
+            quote! { ::core::clone::Clone::clone(&__init_reset) },
+            quote! { ::core::clone::Clone::clone(&__init_reset) },
+        )
+    } else {
+        (
+            quote! { <#state_ty as ::core::default::Default>::default() },
+            quote! { <#out_ty as ::core::default::Default>::default() },
+        )
+    };
+
+    // Lifecycle hooks: emitted only where the impl overrides one, so an op
+    // without them pays nothing (`push_node`'s defaults are no-ops).
+    let hook = |cell: &Ident, method: &Ident| {
+        quote! {
+            ::std::boxed::Box::new(move |__k| {
+                let (__cfg, __state) = &mut *#cell.borrow_mut();
+                let mut __ctx = crate::op::Ctx::new(__k, __idx);
+                <#self_ty as crate::op::Op>::#method(__cfg, __state, &mut __ctx)
+            })
+        }
+    };
+    let (start_clone, start_hook) = if b.overrides_start {
+        let cell = format_ident!("__cs_start");
+        let body = hook(&cell, &format_ident!("start"));
+        (quote! { let #cell = __cs.clone(); }, body)
+    } else {
+        (
+            quote! {},
+            quote! { ::std::boxed::Box::new(|_| ::core::result::Result::Ok(())) },
+        )
+    };
+    let (stop_clone, stop_stmt) = if b.overrides_stop {
+        let cell = format_ident!("__cs_stop");
+        let body = hook(&cell, &format_ident!("stop"));
+        (
+            quote! { let #cell = __cs.clone(); },
+            quote! { self.set_stop(#body); },
+        )
+    } else {
+        (quote! {}, quote! {})
+    };
+    let (teardown_clone, teardown_stmt) = if b.overrides_teardown {
+        let cell = format_ident!("__cs_teardown");
+        let body = hook(&cell, &format_ident!("teardown"));
+        (
+            quote! { let #cell = __cs.clone(); },
+            quote! { self.set_teardown(#body); },
+        )
+    } else {
+        (quote! {}, quote! {})
+    };
+
+    let mut preds: Vec<TokenStream2> = b.preds.to_vec();
+    preds.push(quote! { #cfg_ty: 'static });
+    preds.push(quote! { #state_ty: 'static });
+    preds.push(quote! { #out_ty: 'static });
+    if args.init_arg {
+        preds.push(quote! { #state_ty: ::core::clone::Clone });
+    } else {
+        preds.push(quote! { #state_ty: ::core::default::Default });
+        preds.push(quote! { #out_ty: ::core::default::Default });
+    }
+
+    let doc = format!(
+        "Interpreted-engine wiring for [`{name}`]. Generated by `#[op]` from the op's \
+         `In` shape — one `Handle` parameter per input edge, then its config."
+    );
+    Ok(quote! {
+        impl crate::interp::Builder {
+            #[doc = #doc]
+            #[allow(clippy::too_many_arguments)]
+            pub fn #name #generics (
+                &mut self,
+                #(#edge_params,)*
+                #init_param
+                #cfg_param
+            ) -> crate::interp::Handle<#out_ty>
+            where #(#preds),*
+            {
+                let __idx = self.next_node_index();
+                #(let #up_ids = #edge_names.index();)*
+                #(let #slot_ids = self.slot(#edge_names);)*
+                let __out = self.new_slot::<#out_ty>(#out_seed);
+                let __cs = ::std::rc::Rc::new(::core::cell::RefCell::new((
+                    #cfg_arg,
+                    #state_seed,
+                )));
+                #reset_init
+                #ticked_let
+                #start_clone
+                #stop_clone
+                #teardown_clone
+                let __cs_cycle = __cs.clone();
+                let __out_cycle = __out.clone();
+                let (__cs_reset, __out_reset) = (__cs, __out);
+                self.push_node(
+                    ::std::vec![#(#active),*],
+                    <#self_ty as crate::op::Op>::ACTIVATION,
+                    crate::interp::short_type_name(::core::any::type_name::<#self_ty>()),
+                    ::std::boxed::Box::new(move |__k| {
+                        let (__cfg, __state) = &mut *__cs_cycle.borrow_mut();
+                        let mut __ctx = crate::op::Ctx::new(__k, __idx);
+                        #(#tick_lets)*
+                        let __tick = #cycle_call;
+                        match __tick {
+                            crate::op::Tick::Value(__v) => {
+                                *__out_cycle.borrow_mut() = __v;
+                                ::core::result::Result::Ok(true)
+                            }
+                            crate::op::Tick::Silent(__v) => {
+                                *__out_cycle.borrow_mut() = __v;
+                                ::core::result::Result::Ok(false)
+                            }
+                            crate::op::Tick::Quiet => ::core::result::Result::Ok(false),
+                        }
+                    }),
+                    #start_hook,
+                );
+                #stop_stmt
+                #teardown_stmt
+                #passive_stmt
+                // A re-run restores the op's state and value slot to their
+                // wiring-time values (see `ResetFn`).
+                self.set_reset(::std::boxed::Box::new(move || {
+                    __cs_reset.borrow_mut().1 = #state_reseed;
+                    *__out_reset.borrow_mut() = #out_reseed;
+                }));
+                self.make_handle(__idx)
+            }
+        }
     })
 }
 

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -1058,7 +1058,7 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         F: Fn(&T, &B) -> C + 'static,
     {
         let other = other.handle();
-        self.wire(|b, h| b.bimap(h, true, other, false, f))
+        self.wire(|b, h| b.join_passive(h, other, f))
     }
 
     fn join3<B, C, D, F>(&self, b: &Stream<B>, c: &Stream<C>, f: F) -> Stream<D>
@@ -1069,7 +1069,7 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         F: Fn(&T, &B, &C) -> D + 'static,
     {
         let (bh, ch) = (b.handle(), c.handle());
-        self.wire(|bld, h| bld.trimap(h, true, bh, true, ch, true, f))
+        self.wire(|bld, h| bld.join3(h, bh, ch, f))
     }
 
     fn try_join<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
@@ -1079,7 +1079,7 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         F: Fn(&T, &B) -> Result<C> + 'static,
     {
         let other = other.handle();
-        self.wire(|b, h| b.try_bimap(h, true, other, true, f))
+        self.wire(|b, h| b.try_join(h, other, f))
     }
 
     fn try_join_passive<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
@@ -1089,7 +1089,7 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         F: Fn(&T, &B) -> Result<C> + 'static,
     {
         let other = other.handle();
-        self.wire(|b, h| b.try_bimap(h, true, other, false, f))
+        self.wire(|b, h| b.try_join_passive(h, other, f))
     }
 
     fn try_join3<B, C, D, F>(&self, b: &Stream<B>, c: &Stream<C>, f: F) -> Stream<D>
@@ -1100,7 +1100,7 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         F: Fn(&T, &B, &C) -> Result<D> + 'static,
     {
         let (bh, ch) = (b.handle(), c.handle());
-        self.wire(|bld, h| bld.try_trimap(h, true, bh, true, ch, true, f))
+        self.wire(|bld, h| bld.try_join3(h, bh, ch, f))
     }
 
     fn filter(&self, condition: &Stream<bool>) -> Stream<T>
@@ -1124,7 +1124,7 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         T: Clone + Default + 'static,
     {
         let other = other.handle();
-        self.wire(|b, h| b.merge2(h, other))
+        self.wire(|b, h| b.merge(h, other))
     }
 
     fn merge_all(&self, others: &[&Stream<T>]) -> Stream<T>

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -39,7 +39,6 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
 
 use anyhow::{Result, bail};
 
@@ -52,11 +51,7 @@ use crate::Burst;
 use crate::channel::{ChannelSender, Message, Tx};
 use crate::latency::{HasLatency, LatencyReport, LatencyReportCfg, LatencyStats};
 use crate::op::{Activation, CompositePhase, Ctx, Op, Tick};
-use crate::ops::{
-    Const, Delay, DelayState, DelayWithReset, DelayWithResetState, Filter, Finally, Fold, Join,
-    Join3, Merge2, Never, Poll, Sample, Throttle, Ticker, TickerState, Timed, TimedState, TryJoin,
-    TryJoin3, Window, WindowState, WithTime,
-};
+use crate::ops::{Join, Join3, Never, Poll, TryJoin, TryJoin3, WithTime};
 use wingfoil::codegen::{Kernel, KernelWaker, ReadyReceiver, waker_channel};
 use wingfoil::{NanoTime, RunFor, RunMode, TimeQueue};
 
@@ -237,7 +232,7 @@ fn pump_historical<T: Clone + Default>(
 
 impl Builder {
     /// Mint a [`Handle`] stamped with this builder's id.
-    fn make_handle<T>(&self, idx: usize) -> Handle<T> {
+    pub(crate) fn make_handle<T>(&self, idx: usize) -> Handle<T> {
         Handle {
             idx,
             builder_id: self.id,
@@ -308,9 +303,9 @@ pub(crate) fn short_type_name(s: &'static str) -> &'static str {
     head.rsplit("::").next().unwrap_or(head)
 }
 
-type CycleFn = Box<dyn FnMut(&mut Kernel) -> Result<bool>>;
+pub(crate) type CycleFn = Box<dyn FnMut(&mut Kernel) -> Result<bool>>;
 /// Start / stop / teardown all share this shape.
-type LifecycleFn = Box<dyn FnMut(&mut Kernel) -> Result<()>>;
+pub(crate) type LifecycleFn = Box<dyn FnMut(&mut Kernel) -> Result<()>>;
 /// A node's re-run hook: restore its engine-owned state and value slot to
 /// their **wiring-time initial values**, so a second [`Runner::run`] starts
 /// from a clean slate (the kernel is rebuilt from `t=0` each run, and each
@@ -319,7 +314,7 @@ type LifecycleFn = Box<dyn FnMut(&mut Kernel) -> Result<()>>;
 /// *between* runs, when no kernel exists. Restoring a stored value is
 /// infallible, so unlike the other hooks it returns nothing. Defaults to a
 /// no-op (a stateless node with no persistent slot needs no reset).
-type ResetFn = Box<dyn FnMut()>;
+pub(crate) type ResetFn = Box<dyn FnMut()>;
 
 /// A graph mutation staged by an in-graph node during its `cycle` (where it
 /// cannot borrow the `Runner`), applied by [`Runner::run_dynamic`] at the next
@@ -961,6 +956,20 @@ impl Builder {
         self.async_rt.inner.set_override(handle);
     }
 
+    /// The index the *next* [`push_node`](Self::push_node) will occupy — the
+    /// node's own index, which its `cycle` closure needs to build a [`Ctx`].
+    /// Part of the `#[op]` wiring seam (see [`push_node`](Self::push_node)).
+    pub(crate) fn next_node_index(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// The shared per-node tick flags for the cycle in progress, indexed by
+    /// node index. Part of the `#[op]` wiring seam: an op whose `In` shape
+    /// carries an edge's tick flag (`delay`, `merge`) reads it from here.
+    pub(crate) fn ticked_flags(&self) -> Rc<RefCell<Vec<bool>>> {
+        self.ticked.clone()
+    }
+
     pub(crate) fn slot<T: 'static>(&self, h: Handle<T>) -> SlotRef<T> {
         debug_assert_eq!(
             h.builder_id, self.id,
@@ -974,7 +983,7 @@ impl Builder {
         )
     }
 
-    fn new_slot<T: 'static>(&mut self, init: T) -> SlotRef<T> {
+    pub(crate) fn new_slot<T: 'static>(&mut self, init: T) -> SlotRef<T> {
         let cell = Rc::new(RefCell::new(init));
         self.slots.push(cell.clone() as Rc<dyn Any>);
         SlotRef::new(cell)
@@ -982,8 +991,19 @@ impl Builder {
 
     /// Register a node: its slot must already have been pushed (so slot and
     /// node indices stay aligned). `stop`/`teardown` default to no-ops; a node
-    /// that needs them (e.g. `finally`) overwrites the field after pushing.
-    fn push_node(
+    /// that needs them (e.g. `finally`) attaches one with
+    /// [`set_stop`](Self::set_stop) / [`set_teardown`](Self::set_teardown)
+    /// right after pushing.
+    ///
+    /// This — with `next_node_index` / `new_slot` / `slot` / `ticked_flags`
+    /// and the three `set_*` attachers — is the **`#[op]` wiring seam**: the
+    /// `Builder` method `#[op(build = …)]` generates is exactly this sequence,
+    /// which is why these are `pub(crate)` rather than private. The generated
+    /// code lives in this crate (it names `crate::interp::Builder`), so the
+    /// seam never widens past it; third-party ops wire through the public
+    /// [`register_op1`](Self::register_op1)…[`register_op4`](Self::register_op4)
+    /// primitives instead.
+    pub(crate) fn push_node(
         &mut self,
         active_ups: Vec<usize>,
         activation: Activation,
@@ -1009,11 +1029,33 @@ impl Builder {
     /// registration methods right after `push_node`, so a second
     /// [`Runner::run`] restores that node's state and value slot. See
     /// [`ResetFn`].
-    fn set_reset(&mut self, reset: ResetFn) {
+    pub(crate) fn set_reset(&mut self, reset: ResetFn) {
         self.nodes
             .last_mut()
             .expect("invariant: set_reset called immediately after push_node")
             .reset = reset;
+    }
+
+    /// Attach a `stop` hook to the node most recently pushed — the end-of-run
+    /// hook that still sees the last cycle's state (`timed`'s summary). Part
+    /// of the `#[op]` wiring seam; emitted only for ops that override
+    /// [`Op::stop`](crate::op::Op::stop).
+    pub(crate) fn set_stop(&mut self, stop: LifecycleFn) {
+        self.nodes
+            .last_mut()
+            .expect("invariant: set_stop called immediately after push_node")
+            .stop = stop;
+    }
+
+    /// Attach a `teardown` hook to the node most recently pushed — the hook
+    /// that runs after the run ends *even if a cycle aborted it* (`finally`).
+    /// Part of the `#[op]` wiring seam; emitted only for ops that override
+    /// [`Op::teardown`](crate::op::Op::teardown).
+    pub(crate) fn set_teardown(&mut self, teardown: LifecycleFn) {
+        self.nodes
+            .last_mut()
+            .expect("invariant: set_teardown called immediately after push_node")
+            .teardown = teardown;
     }
 
     /// Record the passive upstream edges of the node at `idx` (the node just
@@ -1021,9 +1063,11 @@ impl Builder {
     /// not trigger, so they stay out of `active_ups`/`active_downs`; they are
     /// tracked only so `build()` (and dynamic `fix_layers`) can raise the
     /// node's dispatch `layer` above every value it reads. Called by the
-    /// handful of passive-capable builders (`sample`, `bimap`, `trimap`, and
-    /// their `try_` variants); all-active shapes leave it empty.
-    fn set_passive_ups(&mut self, idx: usize, passive_ups: Vec<usize>) {
+    /// `bimap` / `trimap` family (whose active/passive split is a runtime
+    /// argument) and by the `#[op]`-generated wiring of any op declaring a
+    /// `passive = [..]` mask (`sample`, `join_passive`); all-active shapes
+    /// leave it empty.
+    pub(crate) fn set_passive_ups(&mut self, idx: usize, passive_ups: Vec<usize>) {
         self.nodes[idx].passive_ups = passive_ups;
     }
 
@@ -1316,80 +1360,6 @@ impl Builder {
         self.make_handle(idx)
     }
 
-    pub fn ticker(&mut self, period: Duration) -> Handle<()> {
-        let idx = self.nodes.len();
-        let out = self.new_slot(());
-        let cs = Self::cell(period, TickerState::default());
-        let cs2 = cs.clone();
-        let cs_reset = cs.clone();
-        self.push_node(
-            Vec::new(),
-            Ticker::ACTIVATION,
-            "ticker",
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                match Ticker::cycle(cfg, state, (), &mut ctx)? {
-                    Tick::Value(v) => {
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs2.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                Ticker::start(cfg, state, &mut ctx)
-            }),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = TickerState::default();
-        }));
-        self.make_handle(idx)
-    }
-
-    pub fn constant<T: Clone + Default + 'static>(&mut self, value: T) -> Handle<T> {
-        let idx = self.nodes.len();
-        let out = self.new_slot(T::default());
-        let cs = Self::cell(value, ());
-        let cs2 = cs.clone();
-        let out_reset = out.clone();
-        self.push_node(
-            Vec::new(),
-            Const::<T>::ACTIVATION,
-            "constant",
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                match Const::<T>::cycle(cfg, state, (), &mut ctx)? {
-                    Tick::Value(v) => {
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs2.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                Const::<T>::start(cfg, state, &mut ctx)
-            }),
-        );
-        self.set_reset(Box::new(move || {
-            *out_reset.borrow_mut() = T::default();
-        }));
-        self.make_handle(idx)
-    }
-
     /// A source that never ticks (the classic `never`). No upstreams and no
     /// scheduling, so the engine never cycles it; used as an inert trigger.
     pub fn never(&mut self) -> Handle<()> {
@@ -1493,96 +1463,6 @@ impl Builder {
         );
         self.set_reset(Box::new(move || {
             *out_reset.borrow_mut() = (NanoTime::ZERO, src_reset.borrow().clone());
-        }));
-        self.make_handle(idx)
-    }
-
-    /// Rate-limit: emit at most once per `interval`.
-    pub fn throttle<T: Clone + Default + 'static>(
-        &mut self,
-        src: Handle<T>,
-        interval: Duration,
-    ) -> Handle<T> {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let out = self.new_slot(T::default());
-        let cs = Self::cell(interval, None::<NanoTime>);
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
-            vec![src.idx],
-            Throttle::<T>::ACTIVATION,
-            "throttle",
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let a = src_slot.borrow();
-                match Throttle::<T>::cycle(cfg, state, (&a,), &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = None;
-            *out_reset.borrow_mut() = T::default();
-        }));
-        self.make_handle(idx)
-    }
-
-    /// Buffer values and flush them as a `Vec` on each `interval` boundary
-    /// (and once more on the last cycle).
-    pub fn window<T: Clone + Default + 'static>(
-        &mut self,
-        src: Handle<T>,
-        interval: Duration,
-    ) -> Handle<Vec<T>> {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let out = self.new_slot(Vec::<T>::new());
-        let cs = Self::cell(interval, WindowState::<T>::default());
-        let cs2 = cs.clone();
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
-            vec![src.idx],
-            Window::<T>::ACTIVATION,
-            "window",
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let a = src_slot.borrow();
-                match Window::<T>::cycle(cfg, state, (&a,), &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs2.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                Window::<T>::start(cfg, state, &mut ctx)
-            }),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = WindowState::<T>::default();
-            *out_reset.borrow_mut() = Vec::new();
         }));
         self.make_handle(idx)
     }
@@ -1742,143 +1622,6 @@ impl Builder {
         self.make_handle(idx)
     }
 
-    pub fn filter<T: Clone + Default + 'static>(
-        &mut self,
-        src: Handle<T>,
-        condition: Handle<bool>,
-    ) -> Handle<T> {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let cond_slot = self.slot(condition);
-        let out = self.new_slot(T::default());
-        let out_reset = out.clone();
-        self.push_node(
-            vec![src.idx, condition.idx],
-            Filter::<T>::ACTIVATION,
-            "filter",
-            Box::new(move |k| {
-                let mut ctx = Ctx::new(k, idx);
-                let v = src_slot.borrow();
-                let c = cond_slot.borrow();
-                match Filter::<T>::cycle(&mut (), &mut (), (&v, &c), &mut ctx)? {
-                    Tick::Value(value) => {
-                        drop(v);
-                        *out.borrow_mut() = value;
-                        Ok(true)
-                    }
-                    Tick::Silent(value) => {
-                        drop(v);
-                        *out.borrow_mut() = value;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            *out_reset.borrow_mut() = T::default();
-        }));
-        self.make_handle(idx)
-    }
-
-    pub fn fold<A, B, F>(&mut self, src: Handle<A>, init: B, f: F) -> Handle<B>
-    where
-        A: 'static,
-        B: Clone + 'static,
-        F: Fn(&mut B, &A) + 'static,
-    {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let init_reset = init.clone();
-        let out = self.new_slot(init.clone());
-        let cs = Self::cell(f, init);
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
-            vec![src.idx],
-            Fold::<A, B, F>::ACTIVATION,
-            "fold",
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let a = src_slot.borrow();
-                match Fold::<A, B, F>::cycle(cfg, state, (&a,), &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = init_reset.clone();
-            *out_reset.borrow_mut() = init_reset.clone();
-        }));
-        self.make_handle(idx)
-    }
-
-    /// Sample `src` (passively) whenever `trigger` ticks.
-    pub fn sample<T: Clone + Default + 'static>(
-        &mut self,
-        src: Handle<T>,
-        trigger: Handle<()>,
-    ) -> Handle<T> {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let out = self.new_slot(T::default());
-        let out_reset = out.clone();
-        self.push_node(
-            vec![trigger.idx],
-            Sample::<T>::ACTIVATION,
-            "sample",
-            Box::new(move |k| {
-                let mut ctx = Ctx::new(k, idx);
-                let v = src_slot.borrow();
-                match Sample::<T>::cycle(&mut (), &mut (), (&v, &()), &mut ctx)? {
-                    Tick::Value(value) => {
-                        drop(v);
-                        *out.borrow_mut() = value;
-                        Ok(true)
-                    }
-                    Tick::Silent(value) => {
-                        drop(v);
-                        *out.borrow_mut() = value;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            *out_reset.borrow_mut() = T::default();
-        }));
-        // `src` is read passively (only `trigger` activates the sample), so it
-        // does not appear in `active_ups`; record it as a passive edge so the
-        // sample's layer sits above the value it samples.
-        self.set_passive_ups(idx, vec![src.idx]);
-        self.make_handle(idx)
-    }
-
-    /// Join two streams with a closure; ticks when either input ticks.
-    pub fn join<A, B, C, F>(&mut self, a: Handle<A>, b: Handle<B>, f: F) -> Handle<C>
-    where
-        A: 'static,
-        B: 'static,
-        C: Clone + Default + 'static,
-        F: Fn(&A, &B) -> C + 'static,
-    {
-        self.bimap(a, true, b, true, f)
-    }
-
     /// The classic `bimap`: combine two streams, each independently *active*
     /// (triggers the node when it ticks) or *passive* (read but not
     /// triggering). Both values are always read; only the active inputs
@@ -2018,156 +1761,6 @@ impl Builder {
         self.make_handle(idx)
     }
 
-    /// Delay `src` by a fixed interval.
-    pub fn delay<T: Clone + Default + PartialEq + 'static>(
-        &mut self,
-        src: Handle<T>,
-        delay: Duration,
-    ) -> Handle<T> {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let out = self.new_slot(T::default());
-        let ticked = self.ticked.clone();
-        let is = src.idx;
-        let cs = Self::cell(delay, DelayState::<T>::default());
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
-            vec![src.idx],
-            Delay::<T>::ACTIVATION,
-            "delay",
-            Box::new(move |k| {
-                let src_ticked = ticked.borrow()[is];
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let v = src_slot.borrow();
-                // Zero-delay inline emit and first-value seeding (via
-                // `Tick::Silent`) live in `Delay::cycle` itself, so every
-                // engine gets them from the one implementation.
-                let (write, did): (Option<T>, bool) =
-                    match Delay::<T>::cycle(cfg, state, (&v, src_ticked), &mut ctx)? {
-                        Tick::Value(value) => (Some(value), true),
-                        Tick::Silent(value) => (Some(value), false),
-                        Tick::Quiet => (None, false),
-                    };
-                drop(v);
-                if let Some(w) = write {
-                    *out.borrow_mut() = w;
-                }
-                Ok(did)
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = DelayState::<T>::default();
-            *out_reset.borrow_mut() = T::default();
-        }));
-        self.make_handle(idx)
-    }
-
-    /// [`delay`](Self::delay) with a reset trigger (the classic
-    /// `delay_with_reset`): when `trigger` ticks, the output snaps to the
-    /// current upstream value and the pending queue is cleared. `trigger` is
-    /// read for its *tick* only — its value type is irrelevant — so it is an
-    /// active edge alongside the upstream.
-    pub fn delay_with_reset<T: Clone + Default + PartialEq + 'static, U: 'static>(
-        &mut self,
-        src: Handle<T>,
-        trigger: Handle<U>,
-        delay: Duration,
-    ) -> Handle<T> {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let out = self.new_slot(T::default());
-        let ticked = self.ticked.clone();
-        let (is, it) = (src.idx, trigger.idx);
-        let cs = Self::cell(delay, DelayWithResetState::<T>::default());
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
-            vec![src.idx, trigger.idx],
-            DelayWithReset::<T>::ACTIVATION,
-            "delay_with_reset",
-            Box::new(move |k| {
-                let (src_ticked, trig_ticked) = {
-                    let t = ticked.borrow();
-                    (t[is], t[it])
-                };
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let v = src_slot.borrow();
-                let (write, did): (Option<T>, bool) = match DelayWithReset::<T>::cycle(
-                    cfg,
-                    state,
-                    (&v, src_ticked, trig_ticked),
-                    &mut ctx,
-                )? {
-                    Tick::Value(value) => (Some(value), true),
-                    Tick::Silent(value) => (Some(value), false),
-                    Tick::Quiet => (None, false),
-                };
-                drop(v);
-                if let Some(w) = write {
-                    *out.borrow_mut() = w;
-                }
-                Ok(did)
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = DelayWithResetState::<T>::default();
-            *out_reset.borrow_mut() = T::default();
-        }));
-        self.make_handle(idx)
-    }
-
-    /// Merge two streams; the earliest-supplied ticked input wins.
-    pub fn merge2<T: Clone + Default + 'static>(
-        &mut self,
-        a: Handle<T>,
-        b: Handle<T>,
-    ) -> Handle<T> {
-        let idx = self.nodes.len();
-        let a_slot = self.slot(a);
-        let b_slot = self.slot(b);
-        let out = self.new_slot(T::default());
-        let out_reset = out.clone();
-        let ticked = self.ticked.clone();
-        let (ia, ib) = (a.idx, b.idx);
-        self.push_node(
-            vec![a.idx, b.idx],
-            Merge2::<T>::ACTIVATION,
-            "merge",
-            Box::new(move |k| {
-                let (ta, tb) = {
-                    let t = ticked.borrow();
-                    (t[ia], t[ib])
-                };
-                let mut ctx = Ctx::new(k, idx);
-                let va = a_slot.borrow();
-                let vb = b_slot.borrow();
-                match Merge2::<T>::cycle(&mut (), &mut (), ((&va, ta), (&vb, tb)), &mut ctx)? {
-                    Tick::Value(value) => {
-                        drop(va);
-                        drop(vb);
-                        *out.borrow_mut() = value;
-                        Ok(true)
-                    }
-                    Tick::Silent(value) => {
-                        drop(va);
-                        drop(vb);
-                        *out.borrow_mut() = value;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            *out_reset.borrow_mut() = T::default();
-        }));
-        self.make_handle(idx)
-    }
-
     /// A busy-poll source: `f` runs once per engine cycle, ticking on
     /// `Some`. Lossless and ordered (one value per cycle, no coalescing).
     /// The graph becomes a busy-spin loop in realtime mode — the kernel
@@ -2204,118 +1797,6 @@ impl Builder {
             }),
             Box::new(|_| Ok(())),
         );
-        self.make_handle(idx)
-    }
-
-    /// Run `f` once at teardown — after the run ends, even if a cycle aborted
-    /// it. Observes `src` (recording its last value) but emits nothing and
-    /// never triggers downstream. Cleanup that must happen regardless of how
-    /// the run terminated.
-    pub fn finally<A, F>(&mut self, src: Handle<A>, f: F) -> Handle<()>
-    where
-        A: Clone + Default + 'static,
-        F: Fn(&A) -> Result<()> + 'static,
-    {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let out = self.new_slot(());
-        let cs = Self::cell(f, A::default());
-        let cs2 = cs.clone();
-        let cs_reset = cs.clone();
-        self.push_node(
-            vec![src.idx],
-            Finally::<A, F>::ACTIVATION,
-            "finally",
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let a = src_slot.borrow();
-                match Finally::<A, F>::cycle(cfg, state, (&a,), &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        // Finally's whole purpose is its teardown hook.
-        let node = self
-            .nodes
-            .last_mut()
-            .expect("invariant: finally node just pushed");
-        node.teardown = Box::new(move |k| {
-            let (cfg, state) = &mut *cs2.borrow_mut();
-            let mut ctx = Ctx::new(k, idx);
-            Finally::<A, F>::teardown(cfg, state, &mut ctx)
-        });
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = A::default();
-        }));
-        self.make_handle(idx)
-    }
-
-    /// The classic `timed`: pass `src` through unchanged, recording the
-    /// wall-clock start (`start` hook) and printing a performance summary at
-    /// `stop`. Hand-written (not `#[op]`) because it carries start + stop
-    /// hooks.
-    pub fn timed<T: Clone + Default + 'static>(&mut self, src: Handle<T>) -> Handle<T> {
-        let idx = self.nodes.len();
-        let src_slot = self.slot(src);
-        let out = self.new_slot(T::default());
-        let cs = Self::cell((), TimedState::<T>::default());
-        let cs_start = cs.clone();
-        let cs_stop = cs.clone();
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
-            vec![src.idx],
-            Timed::<T>::ACTIVATION,
-            "timed",
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let a = src_slot.borrow();
-                match Timed::<T>::cycle(cfg, state, (&a,), &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs_start.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                Timed::<T>::start(cfg, state, &mut ctx)
-            }),
-        );
-        // `timed`'s summary prints at stop, after the last cycle.
-        let node = self
-            .nodes
-            .last_mut()
-            .expect("invariant: timed node just pushed");
-        node.stop = Box::new(move |k| {
-            let (cfg, state) = &mut *cs_stop.borrow_mut();
-            let mut ctx = Ctx::new(k, idx);
-            Timed::<T>::stop(cfg, state, &mut ctx)
-        });
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = TimedState::<T>::default();
-            *out_reset.borrow_mut() = T::default();
-        }));
         self.make_handle(idx)
     }
 
@@ -3613,7 +3094,7 @@ impl Extension<'_> {
             let (cfg, state) = &mut *cs.borrow_mut();
             let mut ctx = Ctx::new(k, idx);
             let a = src_slot.borrow();
-            match Fold::<A, B, F>::cycle(cfg, state, (&a,), &mut ctx)? {
+            match crate::ops::Fold::<A, B, F>::cycle(cfg, state, (&a,), &mut ctx)? {
                 Tick::Value(v) => {
                     drop(a);
                     *out.borrow_mut() = v;
@@ -3630,7 +3111,7 @@ impl Extension<'_> {
         self.runner.rt_append_node(
             vec![src.idx],
             Vec::new(),
-            Fold::<A, B, F>::ACTIVATION,
+            crate::ops::Fold::<A, B, F>::ACTIVATION,
             "fold",
             cycle,
             Box::new(|_| Ok(())),

--- a/next/crates/wingfoil-next/src/lib.rs
+++ b/next/crates/wingfoil-next/src/lib.rs
@@ -49,10 +49,10 @@
 //!   the sources), and **[`stats`]** — EWMA and rolling-window statistics as a
 //!   separate opt-in [`StatisticsOps`](stats::StatisticsOps) trait. An op is
 //!   single-sourced through **one mechanism**: `#[op(build = name)]` on its
-//!   `Op` impl generates the interpreted `Builder` method (single-input
-//!   shapes) *and* the `graph!` forwarder functions every compiled/nested
-//!   emission dispatches through — there is no per-op table in the macro, so
-//!   built-in and user ops take the identical path — see
+//!   `Op` impl generates the interpreted `Builder` method *and* the `graph!`
+//!   forwarder functions every compiled/nested emission dispatches through,
+//!   both derived from the op's declared shape — there is no per-op table in
+//!   the macro, so built-in and user ops take the identical path — see
 //!   `next/docs/port-plan.md` "Adding an op".
 //! - **Sources in every activation mode**: `Activation::THREADED`
 //!   [`external`](fluent::SourceOps::external), busy-spin `Activation::ALWAYS`

--- a/next/crates/wingfoil-next/src/ops.rs
+++ b/next/crates/wingfoil-next/src/ops.rs
@@ -4,15 +4,21 @@
 //! the logic is identical, but here it is written once and executed by every
 //! engine, interpreted or compiled.
 //!
-//! Every op carries `#[op(build = name)]` (or hand-written equivalents),
-//! which generates the `graph!` forwarder functions (`__wf_op_<name>_*`) that
-//! all compiled/nested emission dispatches through, plus — for single-input
-//! shapes — the interpreted [`Builder`](crate::interp::Builder) wiring method
-//! (over `register_op1`), with the node label derived from `type_name`.
-//! Attribute flags cover every shape in the catalog: `passive = [..]` marks
-//! non-activating edges (sample), `init_arg` is the seeded-accumulator shape
-//! (fold), and multi-input and source ops use `no_builder` to keep their
-//! hand-written `Builder` methods.
+//! Every op carries `#[op(build = name)]`, which generates *both* engines'
+//! wiring from the op's declared shape: the `graph!` forwarder functions
+//! (`__wf_op_<name>_*`) that all compiled/nested emission dispatches through,
+//! and the interpreted [`Builder`](crate::interp::Builder) method, with the
+//! node label derived from `type_name`. That covers every shape in the
+//! catalog — sources (`In = ()`), single- and multi-input ops, edges read with
+//! their tick flag (delay, merge), lifecycle hooks (ticker, window, timed,
+//! finally), `passive = [..]` non-activating edges (sample), and `init_arg`
+//! seeded accumulators (fold). `no_builder` is left for the one op whose
+//! interpreted signature deliberately differs from its shape — `with_time`,
+//! which seeds its value slot from the input so it never needs
+//! `Out: Default`. (`bimap`/`trimap` are *extra* hand-written `Builder`
+//! methods over [`Join`]/[`Join3`], taking runtime active/passive flags rather
+//! than a compile-time mask; they sit alongside the generated `join` /
+//! `join_passive` / `join3`, they are not opt-outs.)
 //! See `next/docs/port-plan.md` "Adding an op" for the full recipe.
 
 use std::collections::VecDeque;
@@ -41,7 +47,7 @@ pub struct TickerState {
     next: Option<NanoTime>,
 }
 
-#[op(build = ticker, no_builder)]
+#[op(build = ticker)]
 impl Op for Ticker {
     /// The interval as passed at the call site (`Duration`, per the uniform
     /// arg-is-the-config convention); converted to engine time in `start`.
@@ -76,7 +82,7 @@ impl Op for Ticker {
 /// Ticks once with a fixed value, on the first cycle.
 pub struct Const<T>(PhantomData<T>);
 
-#[op(build = constant, no_builder)]
+#[op(build = constant)]
 impl<T: Clone + 'static> Op for Const<T> {
     type Cfg = T;
     type State = ();
@@ -262,7 +268,7 @@ impl<T: Clone + 'static> Op for Limit<T> {
 /// convention; converted to engine time in `cycle`), `State` = last emit time.
 pub struct Throttle<T>(PhantomData<T>);
 
-#[op(build = throttle, no_builder)]
+#[op(build = throttle)]
 impl<T: Clone + 'static> Op for Throttle<T> {
     type Cfg = Duration;
     type State = Option<NanoTime>;
@@ -325,9 +331,8 @@ where
 /// printing (a) drops the unbounded `Vec` buffer classic grows one entry per
 /// tick for the whole run, (b) streams output as the run progresses rather
 /// than in one dump at the end, and (c) still prints what was seen if a later
-/// cycle aborts the run. Shedding the teardown hook also lets `print` be an
-/// ordinary single-input `#[op]` (no hand-written `Builder` method), the same
-/// shape as `map` / `limit`.
+/// cycle aborts the run. Shedding the teardown hook also leaves `print` the
+/// same plain single-input shape as `map` / `limit`.
 pub struct Print<T>(PhantomData<T>);
 
 #[op(build = print)]
@@ -414,7 +419,7 @@ impl<T> Default for TimedState<T> {
 /// the wall-vs-engine speedup rather than branching on historical/realtime.
 pub struct Timed<T>(PhantomData<T>);
 
-#[op(build = timed, no_builder)]
+#[op(build = timed)]
 impl<T: Clone + 'static> Op for Timed<T> {
     type Cfg = ();
     type State = TimedState<T>;
@@ -480,7 +485,7 @@ impl<T> Default for WindowState<T> {
     }
 }
 
-#[op(build = window, no_builder)]
+#[op(build = window)]
 impl<T: Clone + 'static> Op for Window<T> {
     type Cfg = Duration;
     type State = WindowState<T>;
@@ -555,7 +560,7 @@ impl<T: Clone + 'static> Op for Buffer<T> {
 /// all three values are read. `Fn`, like [`Join`].
 pub struct Join3<A, B, C, D, F>(PhantomData<(A, B, C, D, F)>);
 
-#[op(build = join3, no_builder)]
+#[op(build = join3)]
 impl<A, B, C, D, F> Op for Join3<A, B, C, D, F>
 where
     A: 'static,
@@ -586,7 +591,7 @@ where
 /// [`Join3`].
 pub struct TryJoin3<A, B, C, D, F>(PhantomData<(A, B, C, D, F)>);
 
-#[op(build = try_join3, no_builder)]
+#[op(build = try_join3)]
 impl<A, B, C, D, F> Op for TryJoin3<A, B, C, D, F>
 where
     A: 'static,
@@ -2400,7 +2405,7 @@ impl Op for TimeWindowedMedianTimeWeighted {
 /// Emits its source value when the condition stream's current value is true.
 pub struct Filter<T>(PhantomData<T>);
 
-#[op(build = filter, no_builder)]
+#[op(build = filter)]
 impl<T: Clone + 'static> Op for Filter<T> {
     type Cfg = ();
     type State = ();
@@ -2429,7 +2434,7 @@ impl<T: Clone + 'static> Op for Filter<T> {
 /// which the engine owns.
 pub struct Fold<A, B, F>(PhantomData<(A, B, F)>);
 
-#[op(build = fold, no_builder, init_arg)]
+#[op(build = fold, init_arg)]
 impl<A, B, F> Op for Fold<A, B, F>
 where
     A: 'static,
@@ -2501,7 +2506,7 @@ impl<T: Clone + 'static> Op for Accumulate<T> {
 /// marks the data edge as non-activating), and its unit value is ignored.
 pub struct Sample<T>(PhantomData<T>);
 
-#[op(build = sample, no_builder, passive = [0])]
+#[op(build = sample, passive = [0])]
 impl<T: Clone + 'static> Op for Sample<T> {
     type Cfg = ();
     type State = ();
@@ -2583,7 +2588,7 @@ where
 /// source's last value. Emits nothing during the run.
 pub struct Finally<A, F>(PhantomData<(A, F)>);
 
-#[op(build = finally, no_builder)]
+#[op(build = finally)]
 impl<A, F> Op for Finally<A, F>
 where
     A: Clone + Default + 'static,
@@ -2611,7 +2616,7 @@ where
 /// upstreams: ticks when either input ticks, reading both current values.
 pub struct Join<A, B, C, F>(PhantomData<(A, B, C, F)>);
 
-#[op(build = join, no_builder)]
+#[op(build = join)]
 impl<A, B, C, F> Op for Join<A, B, C, F>
 where
     A: 'static,
@@ -2637,7 +2642,7 @@ where
 /// like [`Join`].
 pub struct TryJoin<A, B, C, F>(PhantomData<(A, B, C, F)>);
 
-#[op(build = try_join, no_builder)]
+#[op(build = try_join)]
 impl<A, B, C, F> Op for TryJoin<A, B, C, F>
 where
     A: 'static,
@@ -2658,16 +2663,16 @@ where
 
 /// The `graph!`/compiled forwarder witness for [`join_passive`] — [`Join`]'s
 /// semantics with the **second** edge passive (read but not activating: the
-/// `bimap(Active, Passive)` shape a feedback input takes). The interpreted path
-/// wires this shape through [`Builder::bimap`](crate::interp::Builder::bimap)
-/// (`join_passive` = `bimap(_, true, _, false)`); this separate witness exists
-/// only so `#[op(passive = [1])]` can emit the `__wf_op_join_passive_*`
-/// forwarders — a second `#[op]` cannot be attached to [`Join`], and the
-/// passive mask is the only thing that differs. `cycle` delegates to [`Join`]
+/// `bimap(Active, Passive)` shape a feedback input takes). This separate
+/// witness exists because a second `#[op]` cannot be attached to [`Join`] and
+/// the passive mask is the only thing that differs; carrying it lets
+/// `#[op(passive = [1])]` emit both the `__wf_op_join_passive_*` forwarders
+/// *and* the interpreted `Builder::join_passive`
+/// (`bimap(_, true, _, false)`'s generated twin). `cycle` delegates to [`Join`]
 /// so the semantics are single-sourced.
 pub struct JoinPassive<A, B, C, F>(PhantomData<(A, B, C, F)>);
 
-#[op(build = join_passive, no_builder, passive = [1])]
+#[op(build = join_passive, passive = [1])]
 impl<A, B, C, F> Op for JoinPassive<A, B, C, F>
 where
     A: 'static,
@@ -2692,7 +2697,7 @@ where
 /// needed.
 pub struct TryJoinPassive<A, B, C, F>(PhantomData<(A, B, C, F)>);
 
-#[op(build = try_join_passive, no_builder, passive = [1])]
+#[op(build = try_join_passive, passive = [1])]
 impl<A, B, C, F> Op for TryJoinPassive<A, B, C, F>
 where
     A: 'static,
@@ -2734,7 +2739,7 @@ impl<T: PartialEq> Default for DelayState<T> {
     }
 }
 
-#[op(build = delay, no_builder)]
+#[op(build = delay)]
 impl<T: Clone + PartialEq + 'static> Op for Delay<T> {
     type Cfg = Duration;
     type State = DelayState<T>;
@@ -2784,7 +2789,7 @@ impl<T: Clone + PartialEq + 'static> Op for Delay<T> {
 /// wins. Tick flags arrive as input data, not via engine lookups.
 pub struct Merge2<T>(PhantomData<T>);
 
-#[op(build = merge, no_builder)]
+#[op(build = merge)]
 impl<T: Clone + 'static> Op for Merge2<T> {
     type Cfg = ();
     type State = ();
@@ -2814,9 +2819,10 @@ impl<T: Clone + 'static> Op for Merge2<T> {
 /// its unit value is never observed downstream. The idiomatic inert trigger —
 /// e.g. a [`DelayWithReset`] that never resets degrades to a plain [`Delay`].
 ///
-/// Kept a plain `Op` (no `#[op]`, hand-written `Builder::never`) because it is
-/// a zero-input source, the shape the single-input `#[op]` scope does not
-/// cover.
+/// Kept a plain `Op` with a hand-written `Builder::never` (no `#[op]`):
+/// nothing about the shape prevents the attribute — `#[op]` builds sources
+/// fine — but a node that never ticks has no `graph!`/compiled meaning worth
+/// forwarding, so it stays an interpreted-engine primitive.
 pub struct Never;
 
 impl Op for Never {
@@ -2856,8 +2862,10 @@ impl<T: PartialEq> Default for DelayWithResetState<T> {
 /// [`Delay`] receives its upstream tick flag; `SCHEDULES` grants the delayed
 /// re-emit its `Ctx::schedule`.
 ///
-/// Hand-written `Builder` (no `#[op]`): two tick-flag inputs plus custom state
-/// seeding put it outside the single-input `#[op]` scope, like [`Delay`].
+/// No `#[op]` on *this* impl: its `In` puts two tick flags in a row with no
+/// second value edge, which the uniform one-`(value, tick)`-pair-per-edge form
+/// cannot express. [`DelayWithResetFwd`] below restates the same shape in the
+/// two-edge form and carries the attribute for both engines.
 pub struct DelayWithReset<T>(PhantomData<T>);
 
 impl<T: Clone + PartialEq + 'static> Op for DelayWithReset<T> {
@@ -2931,7 +2939,7 @@ impl<T: Clone + PartialEq + 'static> Op for DelayWithReset<T> {
 /// [`delay_with_reset`](crate::fluent::StreamOps::delay_with_reset)`<U>`.
 pub struct DelayWithResetFwd<T, U>(PhantomData<(T, U)>);
 
-#[op(build = delay_with_reset, no_builder)]
+#[op(build = delay_with_reset)]
 impl<T: Clone + PartialEq + 'static, U: 'static> Op for DelayWithResetFwd<T, U> {
     type Cfg = Duration;
     type State = DelayWithResetState<T>;

--- a/next/crates/wingfoil-next/tests/custom_op.rs
+++ b/next/crates/wingfoil-next/tests/custom_op.rs
@@ -609,7 +609,11 @@ fn multi_input_custom_op_in_nested_island() {
 // The two formerly-"exotic" shapes, as USER ops — proving they are ordinary:
 // a passive-edge op (sample's shape) and a seeded accumulator (fold's shape).
 // The hand-written forwarders below are exactly what `#[op(build = snap,
-// passive = [0])]` / `#[op(build = ratchet, init_arg)]` emit for in-crate ops.
+// passive = [0])]` / `#[op(build = ratchet, init_arg)]` emit for in-crate ops
+// (an out-of-crate op writes them by hand, as here, and wires the interpreted
+// side through the public `register_op*` / `bimap` / `fold` primitives — the
+// attribute's generated `Builder` method names `crate::interp::Builder`, so it
+// only applies inside this crate).
 // ---------------------------------------------------------------------------
 
 /// User sample: emit the (passive) data value when the trigger ticks.

--- a/next/crates/wingfoil-next/tests/merge_tiebreak.rs
+++ b/next/crates/wingfoil-next/tests/merge_tiebreak.rs
@@ -4,7 +4,7 @@
 //! construction, so the tie-break arm never runs and the compiled tick-pair
 //! ordering could be swapped with the tests staying green).
 //!
-//! `merge2` is `if a_ticked { a } else if b_ticked { b }` — the earliest-
+//! `merge` is `if a_ticked { a } else if b_ticked { b }` — the earliest-
 //! supplied ticked input wins. Two tickers of the *same* period tick on every
 //! cycle, so the merge fires its tie-break arm every cycle and the first input
 //! (`a`) must win. All three emission paths (interpreted, compiled, nested)

--- a/next/crates/wingfoil-next/tests/op_builder_shapes.rs
+++ b/next/crates/wingfoil-next/tests/op_builder_shapes.rs
@@ -1,0 +1,331 @@
+//! `#[op]`-generated `Builder` methods, one test per **shape**.
+//!
+//! `#[op(build = name)]` writes the op's interpreted wiring from its `In`
+//! shape. It used to cover only the single-active-input case, so every other
+//! shape carried a hand-written `Builder` method that repeated the same
+//! twenty-line sequence (`slot` → `new_slot` → `push_node` → reset hook). Those
+//! are gone: the attribute now generates the method for sources, multi-input
+//! ops, passive edges, tick-flag edges, lifecycle hooks, and seeded
+//! accumulators alike.
+//!
+//! The whole fluent surface runs through those generated methods, so the rest
+//! of the suite is the behavioural oracle. What *this* file pins down is the
+//! part that has no other guard: the **generated method itself** — that it
+//! exists for each shape, with the signature the shape implies (one `Handle`
+//! per edge in `In` order, then `init`, then `Cfg`), and that the wiring it
+//! emits carries each shape's distinguishing property:
+//!
+//! | Shape | Op | Property under test |
+//! |---|---|---|
+//! | source (`In = ()`) | `ticker`, `constant` | no upstreams; `start` schedules |
+//! | multi-input | `join3`, `filter` | every edge read, every edge triggers |
+//! | passive mask | `sample`, `join_passive` | passive edge read but not triggering |
+//! | tick flags | `delay`, `merge` | the engine's per-edge tick flag reaches `In` |
+//! | lifecycle hooks | `finally`, `timed` | `start`/`stop`/`teardown` attached |
+//! | seeded accumulator | `fold` | `init` seeds state *and* value slot |
+//!
+//! Every op is wired by calling its generated `Builder` method **directly**
+//! (through `GraphBuilder::source` / `Stream::wire`) rather than through its
+//! fluent method, so a shape losing its generated method is a compile error
+//! here even if the fluent layer is later re-pointed at something else.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const P: Duration = Duration::from_nanos(100);
+
+// --- source shape (`In = ()`) ----------------------------------------------
+
+/// A source op has no edges, so its generated method takes the config alone.
+/// `Ticker`'s `start` hook seeds the first schedule (without it the graph
+/// would never cycle) and `Const`'s ticks once at the start instant.
+#[test]
+fn source_shape_takes_config_only_and_runs_its_start_hook() {
+    let g = GraphBuilder::new();
+    let ticks: Stream<()> = g.source(|b| b.ticker(P));
+    let seven: Stream<u64> = g.source(|b| b.constant(7u64));
+    let stamped = ticks.count().with_time().accumulate();
+    let consts = seven.with_time().accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+
+    assert_eq!(
+        vec![
+            (NanoTime::ZERO, 1),
+            (NanoTime::new(100), 2),
+            (NanoTime::new(200), 3),
+        ],
+        runner.value(&stamped),
+        "ticker: anchored at the start instant, then one tick per period",
+    );
+    assert_eq!(
+        vec![(NanoTime::ZERO, 7)],
+        runner.value(&consts),
+        "constant: exactly one tick, at the start instant",
+    );
+}
+
+// --- multi-input shape ------------------------------------------------------
+
+/// Three edges, all active: the generated `join3` takes them positionally in
+/// `In` order and then the closure config. Any of the three ticking runs the
+/// node, and all three values are read.
+#[test]
+fn multi_input_shape_reads_and_is_triggered_by_every_edge() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let a = count.map(|n: &u64| *n);
+    let b = count.map(|n: &u64| *n * 10);
+    let c = count.map(|n: &u64| *n * 100);
+
+    let (bh, ch) = (b.handle(), c.handle());
+    let joined: Stream<u64> =
+        a.wire(move |bld, h| bld.join3(h, bh, ch, |x: &u64, y: &u64, z: &u64| x + y + z));
+    let out = joined.accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![111, 222, 333], runner.value(&out));
+}
+
+/// Two edges of *different* types (`&T` and `&bool`): the generated `filter`
+/// takes `Handle<T>` then `Handle<bool>`, matching `In = (&T, &bool)`.
+#[test]
+fn multi_input_shape_types_each_edge_from_the_in_tuple() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let even = count.map(|n: &u64| n.is_multiple_of(2));
+
+    let cond = even.handle();
+    let kept: Stream<u64> = count.wire(move |b, h| b.filter(h, cond));
+    let out = kept.accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(vec![2, 4], runner.value(&out));
+}
+
+// --- passive-mask shape -----------------------------------------------------
+
+/// `#[op(passive = [0])]`: edge 0 is read but does **not** trigger the node, so
+/// `sample` emits only when its trigger ticks — and emits the data edge's
+/// current value, which it could not see if the mask merely dropped the edge.
+#[test]
+fn passive_mask_shape_reads_the_passive_edge_without_being_triggered_by_it() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let flags = count.map(|n: &u64| n.is_multiple_of(3));
+    let every_third = count.filter(&flags).map(|_: &u64| ());
+
+    let trigger = every_third.handle();
+    let sampled: Stream<u64> = count.wire(move |b, h| b.sample(h, trigger));
+    let out = sampled.with_time().accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(7)).unwrap();
+    assert_eq!(
+        vec![(NanoTime::new(200), 3), (NanoTime::new(500), 6)],
+        runner.value(&out),
+        "one emission per trigger tick, carrying the passive edge's live value",
+    );
+}
+
+/// The passive mask on a *join*: `join_passive`'s second edge is read on every
+/// tick of the first, but never triggers one of its own. Compare with `join`
+/// (both edges active) over the same pair of streams — the passive form emits
+/// strictly less often.
+#[test]
+fn passive_mask_shape_suppresses_activation_from_the_masked_edge() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let active_side = count.filter(&count.map(|n: &u64| n.is_multiple_of(2)));
+    let passive_side = count.map(|n: &u64| *n * 100);
+
+    let ph = passive_side.handle();
+    let joined: Stream<u64> =
+        active_side.wire(move |b, h| b.join_passive(h, ph, |x: &u64, y: &u64| x + y));
+    let out = joined.accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(
+        vec![202, 404],
+        runner.value(&out),
+        "only the active edge's ticks produce output; the passive value is live",
+    );
+}
+
+// --- tick-flag shape --------------------------------------------------------
+
+/// `Delay`'s `In = (&T, bool)` — the trailing `bool` is the source edge's tick
+/// flag for this cycle, which the generated wiring reads out of the engine's
+/// tick vector. Without it `delay` could not tell "my source ticked" from "a
+/// scheduled callback woke me", and would re-queue its stale value every wake.
+#[test]
+fn tick_flag_shape_passes_the_engines_per_edge_tick_into_the_op() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+
+    let delayed: Stream<u64> = count.wire(|b, h| b.delay(h, Duration::from_nanos(200)));
+    let out = delayed.with_time().accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(200), 1),
+            (NanoTime::new(300), 2),
+            (NanoTime::new(400), 3),
+            (NanoTime::new(500), 4),
+        ],
+        runner.value(&out),
+        "each value re-emitted exactly once, 200ns after it arrived",
+    );
+}
+
+/// `Merge2`'s `In = ((&T, bool), (&T, bool))` — a tick flag per edge, in the
+/// pair form. Both edges tick on the same instant here, so the earliest-wins
+/// tie-break is only decidable from the flags.
+#[test]
+fn tick_flag_shape_carries_one_flag_per_edge() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let evens = count.filter(&count.map(|n: &u64| n.is_multiple_of(2)));
+    let odds = count.filter(&count.map(|n: &u64| !n.is_multiple_of(2)));
+
+    let odd_h = odds.handle();
+    let merged: Stream<u64> = evens.wire(move |b, h| b.merge(h, odd_h));
+    let out = merged.accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(
+        vec![1, 2, 3, 4],
+        runner.value(&out),
+        "whichever edge ticked wins; the two never tick together here",
+    );
+}
+
+// --- lifecycle-hook shape ---------------------------------------------------
+
+/// An op that overrides `teardown` gets the hook attached to its node. The
+/// generated wiring is the only thing that can attach it, and the hook must see
+/// the op's state (`Finally` replays the source's last value into the closure).
+#[test]
+fn lifecycle_shape_attaches_the_teardown_hook() {
+    let seen: Rc<RefCell<Vec<u64>>> = Rc::default();
+    let recorder = seen.clone();
+
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let _sink: Stream<()> = count.wire(move |b, h| {
+        b.finally(h, move |last: &u64| {
+            recorder.borrow_mut().push(*last);
+            Ok(())
+        })
+    });
+
+    let mut runner = g.build();
+    assert!(
+        seen.borrow().is_empty(),
+        "teardown must not run before the run"
+    );
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![3],
+        *seen.borrow(),
+        "teardown ran once, after the run, seeing the last value",
+    );
+}
+
+/// `Timed` overrides both `start` and `stop`; it passes values through
+/// unchanged, so the observable proof that the hooks were attached is that the
+/// run completes (a missing `start` leaves `wall_start` unset, which `stop`
+/// reports on) with the values untouched.
+#[test]
+fn lifecycle_shape_attaches_start_and_stop_hooks() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let timed: Stream<u64> = count.wire(|b, h| b.timed(h));
+    let out = timed.accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1, 2, 3], runner.value(&out));
+}
+
+// --- seeded-accumulator shape (`init_arg`) ----------------------------------
+
+/// An accumulator that is deliberately **not** `Default`: `init_arg` seeds both
+/// the state and the value slot from the call site, so the generated method
+/// must not require `Out: Default` the way every other shape does.
+#[derive(Clone, Debug, PartialEq)]
+struct Tally(u64);
+
+#[test]
+fn seeded_shape_takes_init_before_cfg_and_needs_no_default() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    // `fold(src, init, cfg)` — the seed sits between the edge and the closure.
+    let tallied: Stream<Tally> =
+        count.wire(|b, h| b.fold(h, Tally(100), |acc: &mut Tally, v: &u64| acc.0 += *v));
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        Tally(106),
+        runner.value(&tallied),
+        "seeded at 100, then folded 1 + 2 + 3",
+    );
+}
+
+/// A second `run()` re-seeds the accumulator from `init` rather than continuing
+/// the first run's total — the reset hook the generated wiring attaches.
+#[test]
+fn seeded_shape_re_seeds_from_init_between_runs() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let tallied: Stream<Tally> =
+        count.wire(|b, h| b.fold(h, Tally(100), |acc: &mut Tally, v: &u64| acc.0 += *v));
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(Tally(106), runner.value(&tallied));
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        Tally(106),
+        runner.value(&tallied),
+        "the re-run restarts from the seed, not from 106",
+    );
+}
+
+/// The `Default`-seeded shapes reset the same way: state *and* value slot go
+/// back to their wiring-time values, so a re-run replays identically.
+#[test]
+fn default_seeded_shape_resets_state_and_slot_between_runs() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(P).count();
+    let throttled: Stream<u64> = count.wire(|b, h| b.throttle(h, Duration::from_nanos(250)));
+    let out = throttled.with_time().accumulate();
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    let first = runner.value(&out);
+    assert_eq!(
+        vec![(NanoTime::ZERO, 1), (NanoTime::new(300), 4)],
+        first,
+        "throttle emits, then suppresses until the interval has passed",
+    );
+    runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(
+        first,
+        runner.value(&out),
+        "the second run replays the first exactly (last-emit time was re-seeded)",
+    );
+}

--- a/next/crates/wingfoil-next/tests/op_completeness.rs
+++ b/next/crates/wingfoil-next/tests/op_completeness.rs
@@ -76,7 +76,10 @@
 //!       `DelayWithReset::cycle`.
 //!     - `with_time` — `#[op(build = with_time, no_builder)]` on the op itself
 //!       (the hand-written `Builder::with_time` stays for its `T: Clone`-only
-//!       interpreted seeding). Inside `graph!`/compiled the output must be
+//!       interpreted seeding — it is now the catalog's *only* `no_builder`
+//!       op; every other shape gets its `Builder` method generated, and the
+//!       `bimap`/`trimap` family are extra hand-written methods over the
+//!       `Join`/`Join3` ops, not opt-outs). Inside `graph!`/compiled the output must be
 //!       `Default` (`(NanoTime, T): Default`), which holds for every value type
 //!       used here; the differing pre-first-tick seed is never observed because
 //!       the op ticks in lockstep with its source.

--- a/next/docs/macro-extensibility-decision.md
+++ b/next/docs/macro-extensibility-decision.md
@@ -199,10 +199,13 @@ Zero table rows edited; zero engine-semantics changes; full suite + clippy
 2. **stop/teardown in compiled()** — pre-existing gap, same forwarder pattern.
 3. **Collision hygiene**: a denylist for `Stream`'s own inherent methods
    (`clone`, `handle`, `wire`) so typos there keep a curated error.
-4. **`#[op]` for multi-input ops**: the derive currently generates
-   forwarders for the single-input `In` shape only; extending it to emit the
-   n-ary forwarders + a `register_op2`-based builder method is the same
-   mechanical pattern (the macro-side emission already handles any arity).
+4. ~~**`#[op]` for multi-input ops**~~ ✅ **done** (Phase 5). The forwarders
+   already handled any arity; the *builder* emission was the single-input part,
+   and it is now derived from the op's `In` shape for every shape the macro
+   parses — arity, tick-flag edges, passive masks, lifecycle hooks, seeded
+   accumulators. Thirteen ops dropped their hand-written `Builder` methods; see
+   port-plan Phase 5 and `tests/op_builder_shapes.rs`. (Item 1 above is
+   unchanged: the generated builder is still an in-crate inherent impl.)
 
 ## 5. Convergence: how the residue was absorbed (the table is deleted)
 

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -341,9 +341,9 @@ Recipe per node, in this order, no exceptions:
 2. move the classic `cycle` body verbatim into the op (same logic, inputs
    passed in instead of read from upstream `Rc`s);
 3. wire it up (see **Adding an op** below): `#[op(build = name)]` on the impl
-   generates the interpreted `Builder` method for single-input ops; add the
-   fluent method; for `graph!`/compiled support add the `OpKind` variant +
-   `info()` row + parse arm (IO-edge ops skip the macro);
+   generates the interpreted `Builder` method from the op's `In` shape *and*
+   the `graph!`/compiled forwarders the emission dispatches through; add the
+   fluent method (the one piece still hand-written);
 4. port the classic node's unit tests as parity tests (values **and** tick
    times).
 
@@ -362,12 +362,26 @@ is small and explained by two hard constraints on proc macros:
 What's automated:
 
 - **Interpreted engine** — `#[op(build = name)]` on `impl Op for X` generates
-  `Builder::name` (a thin wrapper over `Builder::register_op1`), for the
-  single-active-input shape (`In<'a> = (&'a I,)`, `State: Default`, no lifecycle
-  hooks). Node labels come from `type_name::<X>()` (shortened), not hand-written
-  strings. Ops that don't fit (multi-input, passive edges, tick-flag inputs,
-  sources, custom state seeds, lifecycle hooks) keep a hand-written `Builder`
-  method.
+  `Builder::name` from the op's declared shape: one `Handle` parameter per edge
+  of `In<'a>`, in order, then the `Cfg` (omitted when it is `()`). This covers
+  **every** shape the macro parses — sources (`In = ()`), single- and
+  multi-input ops, edges read with their tick flag (`(&'a T, bool)` — `delay`,
+  `merge`), `passive = [..]` non-activating edges, `start`/`stop`/`teardown`
+  lifecycle hooks, and `init_arg` seeded accumulators — so no op keeps a
+  hand-written `Builder` method for want of tooling. Node labels come from
+  `type_name::<X>()` (shortened), not hand-written strings. `no_builder` is
+  left for the case where the interpreted *signature* deliberately differs
+  from the shape: `with_time` (seeds its value slot from the input's current
+  value, so it never requires `Out: Default`) is the catalog's only one. The
+  `bimap`/`trimap` family are *additional* hand-written methods over the
+  `Join`/`Join3` ops — their active/passive split is a runtime argument rather
+  than the compile-time `passive` mask — alongside the generated `join` /
+  `join_passive` / `join3`. The generated body is the same
+  `next_node_index` → `slot`/`new_slot` → `push_node` → `set_*` sequence a
+  hand-written builder contains, against a `pub(crate)` seam on `Builder`; the
+  public `register_op1`…`register_op4` primitives remain the wiring path for
+  **out-of-crate** ops, which write their forwarders by hand (`#[op]`'s output
+  names `crate::…`, so it is in-crate tooling — see `tests/custom_op.rs`).
 - **Compiled / `graph!`** — one `OpKind::info()` row per op (an `OpInfo`:
   op type, dispatch flags, and the `Inputs`/`CfgInit`/`StateInit` shapes) drives
   every emitter. Named fields make a half-filled row a compile error.
@@ -377,9 +391,11 @@ zero-touch; there is no macro table**:
 
 | Op shape | Interpreted | `graph!`/compiled |
 |---|---|---|
-| Single-input (`#[op]` scope) | `ops.rs` (`impl` + attr) + fluent method | nothing — `#[op]`'s forwarders cover it |
-| Multi-input, values-only, all-active (the `join` shape) | `ops.rs` `impl` (+ attr with `no_builder`) + `register_op2`-based fluent method | nothing — `&stream` args classify as edges |
-| Passive edges (`passive = [..]`) / seeded accumulators (`init_arg`) | hand `Builder` method + fluent method (`bimap` / `fold` are the public primitives) | nothing — attribute flags on `#[op]` |
+| Single-input | `ops.rs` (`impl` + attr) + fluent method | nothing — `#[op]`'s forwarders cover it |
+| Multi-input, values-only, all-active (the `join` shape) | same — `ops.rs` (`impl` + attr) + fluent method | nothing — `&stream` args classify as edges |
+| Source (`In = ()`), lifecycle hooks, tick-flag edges | same — `ops.rs` (`impl` + attr) + fluent method | nothing |
+| Passive edges (`passive = [..]`) / seeded accumulators (`init_arg`) | same — `ops.rs` (`impl` + attr, with the flag) + fluent method | nothing — attribute flags on `#[op]` |
+| Interpreted signature ≠ the op's shape (`with_time`) | `no_builder` + a hand-written `Builder` method + fluent method | nothing |
 
 Constraint #1 still holds (a proc macro sees tokens, not types), but it is
 routed around rather than paid per-op: every method call is emitted through
@@ -449,13 +465,16 @@ not thread-offload. islands already cover *static* subgraphs composed procedural
 (append / active-passive splice / remove / recycle), `Builder::dynamic_group`,
 and `Builder::demux` on the interpreted engine.
 
-**Engine coverage note:** `never`, `combine`, and `delay_with_reset` land as
-interpreted-engine (fluent) ports — like `feedback` — since a zero-input
-source, an n-ary fan-in, and a two-tick-flag scheduling op fall outside the
-`#[op]` single-input scope that auto-emits the `graph!`/compiled forwarders.
+**Engine coverage note:** `never` and `combine` land as interpreted-engine
+(fluent) ports — like `feedback` — since a source that never ticks and an
+n-ary fan-in have no `Op` witness for `#[op]` to hang forwarders on (`combine`'s
+arity is a runtime slice, which the fixed-arity tuple `In` cannot express).
+`delay_with_reset` since reached all three engines through its
+`DelayWithResetFwd` witness op, which restates its two-tick-flag `In` in the
+uniform one-`(value, tick)`-pair-per-edge form `#[op]` parses.
 `split`/`collapse` are pure sugar over `map`/`map_filter`, so they reach every
-engine for free. Extending `combine`/`delay_with_reset` to `graph!`/compiled is
-a follow-up (as it is for `feedback`).
+engine for free. Extending `combine` to `graph!`/compiled is a follow-up (as it
+is for `feedback`).
 
 **Gate 2:** every classic node test has a next twin producing identical
 values and tick times.
@@ -1145,16 +1164,39 @@ dynamism is an interpreted-engine capability, matching classic. See the Phase
   labels). Deferred deliberately — we want a better introspection/visualization
   story than a one-off GML dump, to be designed and scoped separately later
   rather than ported as-is from classic.
-- **`#[node]` retirement**: replaced by `Op` impls.
+- **`#[node]` retirement** ✅ **done in next**: replaced by `Op` impls. There
+  is no `#[node]`, and no dependency on `wingfoil-derive`, anywhere under
+  `next/` — every node in the catalog, the adapters, and the tests is an `Op`
+  impl (semantics as associated functions, `Cfg`/`State`/`In`/`Out`), which is
+  what let one body serve all three engines. The user-facing escape hatch
+  `#[node]` existed for — writing a node by hand — is
+  `GraphBuilder::custom_node` plus the public `register_op1`…`register_op4`
+  primitives (`tests/custom_node.rs`, `tests/custom_op.rs`). Deleting the
+  `wingfoil-derive` *crate* belongs to the cutover, when the legacy tree it
+  serves is removed; nothing in next blocks it.
 - **`#[op]` tooling** ✅ **landed**: `#[op(build = name)]` generates the
-  interpreted `Builder` method (over `register_op1`) for single-input ops;
-  labels derive from `type_name`; the `graph!`/compiled path is table-driven
-  (`OpKind::info`). See **Adding an op** under Phase 2. The completeness test
-  guarding against one-sided registration ✅ landed in Phase 1 as a
-  compile-guard (`tests/op_completeness.rs`) — see **Adding an op**. Still
-  open: extending `#[op]` coverage to more shapes; optionally generating the
-  fluent method (only clean as inherent-on-`Stream`, deliberately deferred to
-  keep it trait-based).
+  interpreted `Builder` method *and* the `graph!`/compiled forwarders from one
+  attribute, with labels derived from `type_name`; there is no per-op table in
+  the macro (see `macro-extensibility-decision.md`). See **Adding an op**
+  under Phase 2. The completeness test guarding against one-sided registration
+  ✅ landed in Phase 1 as a compile-guard (`tests/op_completeness.rs`) — see
+  **Adding an op**.
+  - **Shape coverage ✅ complete.** The generated `Builder` method used to be
+    scoped to the single-active-input shape, so ~13 ops kept a hand-written
+    method that repeated the same twenty-line wiring. It is now derived from
+    the op's `In` shape and covers all of them: sources (`In = ()`),
+    multi-input, tick-flag edges (`(&'a T, bool)`), `passive = [..]` masks,
+    `start`/`stop`/`teardown` hooks, and `init_arg` seeded accumulators —
+    `ticker`, `constant`, `throttle`, `window`, `timed`, `filter`, `fold`,
+    `sample`, `finally`, `join`, `delay`, `merge` and `delay_with_reset` all
+    dropped their hand-written wiring, and `try_join` / `join3` / `try_join3` /
+    `join_passive` / `try_join_passive` gained generated methods the fluent
+    layer now wires through. `no_builder` survives for one op, `with_time`,
+    whose signature deliberately differs from its shape (see **Adding an op**).
+    Per-shape tests in `tests/op_builder_shapes.rs`.
+  - Still open (deliberate): generating the **fluent** method too. Only clean
+    as inherent-on-`Stream`, which would close the open op vocabulary that the
+    extension-trait design exists to keep — deferred, not owed.
 
 ## Phase 6 — Python bindings, examples, benches
 


### PR DESCRIPTION
## Summary

Extend the `#[op(build = name)]` macro to generate the interpreted `Builder` method for **every** op shape, not just single-input ops. This eliminates hand-written boilerplate across the catalog and makes the wiring seam explicit and reusable.

## Key Changes

- **Macro expansion** (`wingfoil-next-macros/src/lib.rs`):
  - Removed the `single_ref_tuple_elem` restriction that limited generation to `In<'a> = (&'a T,)` only
  - Added `edge_uses_tick` tracking to detect which edges read the engine's per-edge tick flag
  - Implemented `expand_builder()` to generate `Builder` methods for all `In` shapes: sources (`In = ()`), multi-input ops, passive-masked edges, tick-flag edges, lifecycle hooks (`start`/`stop`/`teardown`), and seeded accumulators (`init_arg`)
  - Generated method signature: one `Handle` parameter per edge in `In` order, then `init` (if `init_arg`), then `Cfg` (omitted when `()`), returning output `Handle`

- **Interpreter wiring seam** (`wingfoil-next/src/interp.rs`):
  - Made `Builder` methods `pub(crate)`: `make_handle`, `next_node_index`, `ticked_flags`, `new_slot`, `push_node`, `set_reset`, `set_stop`, `set_teardown`, `set_passive_ups`
  - Added `next_node_index()` and `ticked_flags()` accessors for the generated code to build `Ctx` and read tick flags
  - Removed hand-written `Builder` methods for `ticker`, `constant`, `throttle`, `window`, `filter`, `fold`, `sample`, `join`, `join3`, `try_join`, `try_join3`, `delay`, `delay_with_reset`, `merge`, `timed`, `finally` — all now generated
  - Removed unused imports (`Duration`, many ops from `crate::ops`)

- **Op definitions** (`wingfoil-next/src/ops.rs`):
  - Removed `no_builder` from `Ticker` and `Const` (now generated as sources with `start` hooks)
  - Updated module documentation to reflect that `#[op]` now covers every shape

- **Fluent API** (`wingfoil-next/src/fluent.rs`):
  - Simplified `join` to call the generated `join_passive` instead of hand-written `bimap`

- **Tests** (`wingfoil-next/tests/op_builder_shapes.rs`):
  - Added comprehensive test suite covering each shape: sources, multi-input, passive masks, tick flags, lifecycle hooks, seeded accumulators
  - Tests call generated `Builder` methods directly to ensure they exist and wire correctly

- **Documentation** (`docs/port-plan.md`, `.claude/commands/new-op-next.md`, `docs/macro-extensibility-decision.md`):
  - Updated to reflect that `#[op]` generates for all shapes
  - Clarified that `no_builder` is now only for ops whose *signature* differs from their shape (e.g., `with_time`)
  - Noted that `bimap`/`trimap` are *additional* hand-written methods over `Join`/`Join3`, not opt-outs

## Implementation Details

The generated `Builder` method body is the exact sequence the wiring seam exposes:
1. `next_node_index()` — get the node's index
2. `new_slot()` — allocate the output slot
3. `push_node()` — register the node with active upstreams and activation
4. `set_reset()` / `set_stop()` / `set_teardown()` — attach lifecycle hooks (only if overridden)
5. `set_passive_ups()` — mark passive edges (only if `passive` mask is non-empty)
6. `make_handle()` — return the output handle

This is identical to the hand-written builders it replaces,

https://claude.ai/code/session_01J5FywqyWzZCFpQduvmo2sX