### PR TITLE
Bind the otlp adapter, and drop the metric-name leak

### DIFF
--- a/next/crates/wingfoil-next-python/Cargo.toml
+++ b/next/crates/wingfoil-next-python/Cargo.toml
@@ -56,7 +56,9 @@ csv = ["wingfoil-next/csv", "dep:csv"]
 # `zmq-sys` builds libzmq from source rather than linking a system one, so a C
 # toolchain is all it needs.
 zmq = ["wingfoil-next/zmq"]
-all-adapters = ["postgres", "kafka", "redis", "etcd", "fluvio", "csv", "zmq"]
+# OTLP: the `otlp_push` gauge sink. Pure Rust (the OTel SDK over reqwest).
+otlp = ["wingfoil-next/otlp"]
+all-adapters = ["postgres", "kafka", "redis", "etcd", "fluvio", "csv", "zmq", "otlp"]
 
 [dependencies]
 # The erased boundary value. pyo3 stays without `extension-module` here so the

--- a/next/crates/wingfoil-next-python/pyproject.toml
+++ b/next/crates/wingfoil-next-python/pyproject.toml
@@ -45,6 +45,7 @@ features = [
     "fluvio",
     "csv",
     "zmq",
+    "otlp",
 ]
 # Mixed layout: the compiled extension is the *private* `wingfoil_next._wingfoil`
 # and the importable `wingfoil_next` is the Python package under `python/`, which

--- a/next/crates/wingfoil-next-python/src/adapters/mod.rs
+++ b/next/crates/wingfoil-next-python/src/adapters/mod.rs
@@ -20,7 +20,8 @@
     feature = "etcd",
     feature = "fluvio",
     feature = "csv",
-    feature = "zmq"
+    feature = "zmq",
+    feature = "otlp"
 ))]
 pub mod common;
 
@@ -32,6 +33,8 @@ pub mod etcd;
 pub mod fluvio;
 #[cfg(feature = "kafka")]
 pub mod kafka;
+#[cfg(feature = "otlp")]
+pub mod otlp;
 #[cfg(feature = "postgres")]
 pub mod postgres;
 #[cfg(feature = "redis")]

--- a/next/crates/wingfoil-next-python/src/adapters/otlp.rs
+++ b/next/crates/wingfoil-next-python/src/adapters/otlp.rs
@@ -1,0 +1,83 @@
+//! Python bindings for the wingfoil-next **OTLP** adapter
+//! ([`wingfoil_next::adapters::otlp`]).
+//!
+//! One graph entry point:
+//!
+//! | Python                   | Rust              | shape |
+//! |--------------------------|-------------------|-------|
+//! | `otlp_push(stream, …)`   | [`OtlpSinkOps`]   | push a gauge metric per tick |
+//!
+//! # The dynamic edge
+//!
+//! The Rust sink is generic over any `Display` value and stringifies each tick
+//! before parsing it as `f64`. The binding therefore takes the stream **erased**
+//! and stringifies via Python's `str()`, which is the same contract — a value
+//! that does not render as a bare number is the caller's error, not a shape
+//! mismatch.
+//!
+//! # Why the sink needed an engine change
+//!
+//! [`otlp_push`](OtlpSinkOps::otlp_push) took a `&'static str` metric name,
+//! because the OTel SDK's gauge builder wants a `'static` name. A binding's name
+//! arrives at runtime, so the legacy binding did
+//! `Box::leak(metric_name.into_boxed_str())` — a deliberate leak per wiring
+//! call. The SDK actually takes `impl Into<Cow<'static, str>>`, which an owned
+//! `String` satisfies, so the bound was tighter than it needed to be: the trait
+//! now takes `impl Into<Cow<'static, str>>` and the leak is gone. Every existing
+//! `&'static str` caller is unaffected.
+//!
+//! # Deviations from the legacy `wingfoil-python` bindings
+//!
+//! 1. **No leak.** See above — legacy leaked the metric name on every
+//!    `otlp_push` wiring call.
+//! 2. **Stringification fails loudly.** Legacy's `elem.str()…unwrap_or_default()`
+//!    turned an object whose `__str__` raised into an *empty string*, which then
+//!    parsed as `0.0` and was published as real telemetry. Here the run aborts.
+//! 3. **Historical runs are a no-op**, inherited from the Rust adapter: a
+//!    backtest never publishes fast-forwarded values to a live endpoint. Legacy
+//!    had no such guard.
+
+use anyhow::{Result, anyhow};
+use pyo3::prelude::*;
+use wingfoil_next::adapters::otlp::{OtlpConfig, OtlpSinkOps};
+use wingfoil_next::prelude::{Stream, StreamOps};
+
+use crate::{PyElement, pyadapter};
+
+/// Push each tick of this stream as an OTLP gauge metric.
+///
+/// Each value is rendered with Python's `str()` and parsed as a float, so the
+/// stream should carry numbers (or objects whose `__str__` is a bare number). A
+/// value whose `__str__` raises aborts the run; one that renders but does not
+/// parse as a number records `0.0` and logs a warning, as the Rust adapter does.
+///
+/// `endpoint` is the OTLP HTTP endpoint (e.g. `"http://localhost:4318"`) and
+/// `service_name` is reported in the resource attributes.
+///
+/// The sink is a **no-op under historical runs**, so a backtest never publishes
+/// fast-forwarded values to a live endpoint. Returns a terminal stream whose
+/// value is `None`; it must stay wired into the graph for anything to export.
+#[pyadapter(name = otlp_push)]
+#[pyo3(signature = (metric_name, endpoint, service_name))]
+fn push(
+    stream: &Stream<PyElement>,
+    metric_name: String,
+    endpoint: String,
+    service_name: String,
+) -> Result<Stream<()>> {
+    let text: Stream<String> = stream.try_map(|elem: &PyElement| {
+        if elem.is_none() {
+            return Err(anyhow!(
+                "otlp_push: stream value is empty (the upstream produced no value)"
+            ));
+        }
+        Python::attach(|py| {
+            elem.object()
+                .bind(py)
+                .str()
+                .map(|s| s.to_string())
+                .map_err(|e| anyhow!("otlp_push: str() on the stream value raised: {e}"))
+        })
+    });
+    text.otlp_push(metric_name, OtlpConfig::new(endpoint, service_name))
+}

--- a/next/crates/wingfoil-next-python/src/python.rs
+++ b/next/crates/wingfoil-next-python/src/python.rs
@@ -704,6 +704,11 @@ fn register_adapters(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_function(wrap_pyfunction!(csv_read, m)?)?;
         m.add_function(wrap_pyfunction!(csv_write, m)?)?;
     }
+    #[cfg(feature = "otlp")]
+    {
+        use crate::adapters::otlp::otlp_push;
+        m.add_function(wrap_pyfunction!(otlp_push, m)?)?;
+    }
     #[cfg(feature = "zmq")]
     {
         use crate::adapters::zmq::{zmq_pub, zmq_sub};

--- a/next/crates/wingfoil-next-python/tests/test_otlp.py
+++ b/next/crates/wingfoil-next-python/tests/test_otlp.py
@@ -1,0 +1,65 @@
+"""Tests for the wingfoil-next OTLP Python bindings.
+
+All of these run by default. `otlp_push` is a no-op under a historical run — the
+Rust adapter's guard, so a backtest never publishes fast-forwarded values to a
+live endpoint — which means the wiring and marshaling paths are exercisable
+without any collector listening.
+
+There is no `requires_otlp` tier: asserting an export arrived needs a collector
+and a scrape of its output, which the Rust adapter's own integration tests
+already cover end to end.
+"""
+
+import pytest
+
+import wingfoil_next as wf
+
+ENDPOINT = "http://127.0.0.1:4318"
+SECOND_NANOS = 1_000_000_000
+
+
+def test_module_exposes_otlp_push():
+    assert callable(wf.otlp_push)
+
+
+def test_push_constructs_a_terminal_stream():
+    g = wf.Graph()
+    values = g.values([1.5, 2.5], period_nanos=SECOND_NANOS)
+    assert isinstance(wf.otlp_push(values, "m", ENDPOINT, "svc"), wf.Stream)
+
+
+def test_a_historical_run_exports_nothing_and_succeeds():
+    """The adapter's run-mode guard: no exporter is built, so no endpoint is hit."""
+    g = wf.Graph()
+    values = g.values([1.5, 2.5, 3.5], period_nanos=SECOND_NANOS)
+    wf.otlp_push(values, "gauge", ENDPOINT, "svc")
+    # Completes despite nothing listening on 4318.
+    g.run(realtime=False, start_nanos=0, duration_nanos=10 * SECOND_NANOS)
+
+
+def test_non_numeric_values_are_accepted_by_the_binding():
+    """Stringification is the binding's job; parsing is the adapter's.
+
+    A value that renders but is not a number records 0.0 with a warning rather
+    than failing, matching the Rust adapter.
+    """
+    g = wf.Graph()
+    values = g.values(["not-a-number"], period_nanos=SECOND_NANOS)
+    wf.otlp_push(values, "gauge", ENDPOINT, "svc")
+    g.run(realtime=False, start_nanos=0, duration_nanos=5 * SECOND_NANOS)
+
+
+def test_a_value_whose_str_raises_aborts_the_run():
+    """Legacy turned this into an empty string, which published as 0.0."""
+
+    class Exploding:
+        def __str__(self):
+            raise ValueError("boom")
+
+    g = wf.Graph()
+    # Realtime, so the sink is not short-circuited by the historical guard.
+    values = g.values([Exploding()], period_nanos=SECOND_NANOS)
+    wf.otlp_push(values, "gauge", ENDPOINT, "svc")
+    with pytest.raises(RuntimeError) as excinfo:
+        g.run(realtime=True, duration_nanos=2 * SECOND_NANOS)
+    assert "str() on the stream value raised" in str(excinfo.value)

--- a/next/crates/wingfoil-next/src/adapters/otlp.rs
+++ b/next/crates/wingfoil-next/src/adapters/otlp.rs
@@ -97,6 +97,7 @@
 //! docker run --rm -p 4318:4318 otel/opentelemetry-collector:0.149.0
 //! ```
 
+use std::borrow::Cow;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
@@ -165,8 +166,10 @@ pub trait OtlpSinkOps<T> {
     /// Push every tick of this stream as an OTLP gauge metric named
     /// `metric_name`, exporting to `config`'s endpoint off the graph thread.
     ///
-    /// `metric_name` must be a `&'static str` (the OTel SDK's `f64_gauge`
-    /// builder requires a `'static` name). Values are converted to `f64` via
+    /// `metric_name` accepts a `&'static str` or an owned `String` — the OTel
+    /// SDK's gauge builder takes a `Cow<'static, str>`, so a name computed at
+    /// runtime (as a dynamic caller such as the Python binding has) needs no
+    /// leak. Values are converted to `f64` via
     /// `T::to_string().parse::<f64>()`; a value that does not format as a bare
     /// number records `0.0` and emits a `log::warn`.
     ///
@@ -191,7 +194,7 @@ pub trait OtlpSinkOps<T> {
     #[must_use = "otlp_push returns a sink Stream that must be added to the graph"]
     fn otlp_push(
         &self,
-        metric_name: &'static str,
+        metric_name: impl Into<Cow<'static, str>>,
         config: impl Into<OtlpConfig>,
     ) -> Result<Stream<()>>;
 }
@@ -202,10 +205,11 @@ where
 {
     fn otlp_push(
         &self,
-        metric_name: &'static str,
+        metric_name: impl Into<Cow<'static, str>>,
         config: impl Into<OtlpConfig>,
     ) -> Result<Stream<()>> {
         let config = config.into();
+        let metric_name = metric_name.into();
 
         // The off-thread export. `consume_async`'s consumer task runs on the
         // graph's runtime, so building the `rt-tokio` PeriodicReader and
@@ -219,7 +223,7 @@ where
             let result = build_and_record(
                 &mut gauge,
                 &mut provider,
-                metric_name,
+                metric_name.as_ref(),
                 &config,
                 &value.to_string(),
             );
@@ -258,7 +262,7 @@ where
 fn build_and_record(
     gauge: &mut Option<opentelemetry::metrics::Gauge<f64>>,
     provider: &mut Option<SdkMeterProvider>,
-    metric_name: &'static str,
+    metric_name: &str,
     config: &OtlpConfig,
     value_str: &str,
 ) -> anyhow::Result<()> {
@@ -279,7 +283,7 @@ fn build_and_record(
             .with_resource(resource)
             .build();
         let meter = built.meter("wingfoil");
-        *gauge = Some(meter.f64_gauge(metric_name).build());
+        *gauge = Some(meter.f64_gauge(metric_name.to_string()).build());
         *provider = Some(built);
     }
     let v: f64 = value_str.parse().unwrap_or_else(|_| {

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -1348,7 +1348,7 @@ tests covered — not "legacy pytest passes unchanged."
   the legacy combinator surface (`fold`/`sample`/`count`/`limit`/`difference`/
   `with_time`/`collect`/`buffer`/`window`/`not`, a `sum`/`mean` statistics
   bridge), then the per-adapter Python bindings as each Rust adapter lands.
-- **Per-adapter Python bindings** 🟡 *the whole mechanical tier landed (7 of 15)*: the `#[pyadapter]`
+- **Per-adapter Python bindings** 🟡 *mechanical tier + otlp landed (8 of 15)*: the `#[pyadapter]`
   exposure of the real `adapters::*` I/O adapters, each behind a
   `wingfoil-next-python` cargo feature of the same name (`crate::adapters::*`,
   registered in the `#[pymodule]` under the same `#[cfg]`). **postgres** is the
@@ -1424,7 +1424,14 @@ tests covered — not "legacy pytest passes unchanged."
   etcd-discovery twins (gated on both features) are bound; `ZmqStatus` erases to
   a `"connected"`/`"disconnected"` string, per the string-selector convention.
 
-  **Remaining: 8.** Legacy `wingfoil-python` binds 15 adapters, in four tiers:
+  **otlp** is the second binding to need an engine change, for the same reason
+  csv did: `otlp_push` took a `&'static str` metric name, so a dynamic caller
+  had to `Box::leak` it (as legacy's binding did, on every wiring call). The
+  OTel SDK's gauge builder actually takes `impl Into<Cow<'static, str>>`, which
+  an owned `String` satisfies — the bound was simply tighter than necessary, and
+  relaxing it removes the leak with no effect on existing callers.
+
+  **Remaining: 7.** Legacy `wingfoil-python` binds 15 adapters, in four tiers:
   - *mechanical* — **done**: kafka, redis, etcd, fluvio, csv, zmq;
   - *dynamic payload* — kdb, fix: postgres-shaped, needing a `PyPgRow`-style
     stand-in plus column marshaling;
@@ -1432,9 +1439,9 @@ tests covered — not "legacy pytest passes unchanged."
     stateful objects with a lifecycle, **not** a shape `#[pyadapter]` can
     generate (it has no handle receiver), so these are hand-written over the
     same `PyGraph`/`PyStream` seams;
-  - *stream transform* — augurs (six fns), otlp (`otlp_push`): legacy exposes
-    these as `stream.method(…)`; next uses free fns, a deliberate ergonomic
-    deviation for uniformity with the plugin story.
+  - *stream transform* — augurs (six fns) (otlp ✓): legacy exposes these as
+    `stream.method(…)`; next uses free fns, a deliberate ergonomic deviation
+    for uniformity with the plugin story.
 
   Two cross-cutting decisions carried by the skill: mode/type selectors take
   **strings** with a loud error rather than `#[pyclass]` enums (legacy has


### PR DESCRIPTION
First of the seven remaining, and the start of the *stream transform* tier.

## Surface

| Python | Rust | shape |
|---|---|---|
| `otlp_push(stream, metric_name, endpoint, service_name)` | `OtlpSinkOps` | push a gauge metric per tick |

The Rust sink is generic over `Display` and stringifies before parsing as `f64`, so the binding takes the stream **erased** and renders with Python's `str()` — the same contract, not a looser one.

## The engine change

`otlp_push` took a `&'static str` metric name, so a caller whose name is only known at runtime had to leak it. That's exactly what the legacy binding did:

```rust
let metric_name_static = Box::leak(metric_name.into_boxed_str());
```

— on **every wiring call**.

The OTel SDK's gauge builder actually takes `impl Into<Cow<'static, str>>`, which an owned `String` satisfies, so the bound was simply tighter than it needed to be. The trait now takes `impl Into<Cow<'static, str>>`; every existing `&'static str` caller is unaffected and the leak is gone.

Same shape as the csv change: relax the engine so a dynamic caller isn't forced into a hack, rather than reproduce the hack in the binding.

## Deviations from legacy `py_otlp.rs`

1. **No leak** — see above.
2. **Stringification fails loudly.** Legacy's `elem.str()…unwrap_or_default()` turned an object whose `__str__` raised into an *empty string*, which then parsed as `0.0` and was published as real telemetry. Here the run aborts naming the cause.
3. **Historical runs are a no-op**, inherited from the Rust adapter's guard — a backtest never publishes fast-forwarded values to a live endpoint. Legacy had no such guard.

## Testing

**5 pytest cases, all running by default.** The historical no-op is what makes this possible: the wiring and marshaling paths are exercisable with nothing listening on 4318, including the `__str__`-raises abort (driven under a *realtime* run so the guard doesn't short-circuit it).

No `requires_otlp` tier — asserting an export actually arrived needs a collector plus a scrape of its output, which the Rust adapter's own integration tests already cover end to end. Flagging that as a deliberate choice rather than an oversight.

Local: `cargo fmt`, `cargo lint`, `cargo test -p wingfoil-next-python --features all-adapters` (125 lib tests), `cargo test -p wingfoil-next --features otlp --test otlp_adapter` (4), `pytest tests/test_otlp.py` (5). `cargo lint-all` substituted for the usual sandbox reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgapk3HgHd5JezDGjicseq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgapk3HgHd5JezDGjicseq)_