### PR TITLE
Fix the flaky spawn_map realtime assertion

### DIFF
--- a/next/crates/wingfoil-next/tests/spawn.rs
+++ b/next/crates/wingfoil-next/tests/spawn.rs
@@ -135,7 +135,39 @@ fn spawn_map_delivers_all_values_in_realtime() {
         .expect("realtime spawn_map run");
 
     let flat: Vec<u64> = runner.value(&collected).into_iter().flatten().collect();
-    assert_eq!(flat, vec![10, 20, 30, 40, 50]);
+
+    // The mapper sums each burst, and under realtime the grouping is timing
+    // dependent (as the doc comment says) — two counter values landing in one
+    // burst legitimately produce one summed output. Asserting
+    // `[10, 20, 30, 40, 50]` therefore asserted a *grouping*, not the values,
+    // and flaked on any runner that coalesced a pair: observed failures were
+    // `[10, 20, 70, 50]` (3+4 together) and `[10, 20, 120]` (3+4+5).
+    //
+    // So check what the transport actually promises: every value arrives, in
+    // order, grouped arbitrarily. Each output is `sum(group) * 10` over a
+    // contiguous run of the input, so walking the expected counts and
+    // consuming one run per output must reproduce the input exactly.
+    let mut expected = 1..=n;
+    for value in &flat {
+        assert_eq!(
+            0,
+            value % 10,
+            "each output is a burst sum scaled by 10: {flat:?}"
+        );
+        let mut remaining = value / 10;
+        while remaining > 0 {
+            let next = expected
+                .next()
+                .unwrap_or_else(|| panic!("more values delivered than sent: {flat:?}"));
+            remaining = remaining.checked_sub(next).unwrap_or_else(|| {
+                panic!("output {value} is not a run of consecutive counts: {flat:?}")
+            });
+        }
+    }
+    assert!(
+        expected.next().is_none(),
+        "not every value was delivered: {flat:?}"
+    );
 }
 
 /// `spawn_bounded` / `spawn_map_bounded`: a small transport bound applies


### PR DESCRIPTION
Independent of the binding stack — this one is not stacked and can merge whenever.

`spawn_map_delivers_all_values_in_realtime` has failed three times in CI over the last few hours, on branches that do not touch `spawn` at all (#615, #625, #628). Each failure looked different:

```
[10, 50, 40, 50]
[10, 20, 120]
[10, 20, 70, 50]
```

which reads like corruption. It isn't. The mapper is:

```rust
input.spawn_map(|s| s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10))
```

so each output is the **sum of whatever landed in one burst** — `120` is `3+4+5`, `70` is `3+4`. Under realtime the burst grouping is timing dependent, which the test's own doc comment already says ("values correct, grouping timing-dependent"). Asserting `[10, 20, 30, 40, 50]` therefore asserted a *grouping*, not the values, and any runner that coalesced a pair failed it.

## The fix

Assert what the transport actually promises: every value arrives, in order, grouped arbitrarily. Each output is `sum(group) * 10` over a contiguous run of the input, so walking the expected counts and consuming one run per output must reproduce the input exactly.

This is **stronger** than the old assertion where it matters, not weaker:

| observed | old | new |
|---|---|---|
| `[10, 20, 70, 50]` — coalesced, nothing lost | ❌ flake | ✅ |
| `[10, 20, 40, 50]` — value 3 dropped | ❌ | ❌ "not a run of consecutive counts" |
| `[10, 20, 30, 40]` — truncated | ❌ | ❌ "not every value was delivered" |

The sibling `spawn_source_delivers_all_values_in_realtime` needs no change: its worker emits values rather than sums, so flattening is genuinely order-preserving there and its assertion is already grouping-independent.

Ran the target test 8× locally; the file's other four tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgapk3HgHd5JezDGjicseq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgapk3HgHd5JezDGjicseq)_