### PR TITLE
Add an n-ary merge, closing the Phase 4.5 wide fan-in gate violation

### DIFF
--- a/.claude/commands/new-op-next.md
+++ b/.claude/commands/new-op-next.md
@@ -86,6 +86,7 @@ shape decides what you *write in the op*, not how much wiring you hand-code:
 | **Seeded accumulator** | `(&'a I,)` + init | `#[op(build = name, init_arg)]` | `name(src, init, cfg)` — seeds state *and* slot | `Fold` |
 | **Source** (no input) | `()` | `#[op(build = name)]` + `start` that `schedule`s | `name(cfg)` | `Ticker`, `Const` |
 | **Signature ≠ shape** | any | `#[op(build = name, no_builder)]` + hand `Builder` method | — | `WithTime` |
+| **Variadic** (any number of same-type edges) | `&'a [(&'a T, bool)]` | no attribute — hand `Builder` method *and* hand forwarders | `name(&[Handle<T>])` | `MergeN` |
 
 `no_builder` is the last resort, not the default: reach for it only when the
 interpreted method must have a *different signature* from the op's shape —
@@ -95,6 +96,34 @@ rather than a compile-time mask (those are extra hand-written methods over
 `Join`/`Join3`, alongside the generated `join`/`join_passive`/`join3`). If you
 find yourself adding `no_builder` for any other reason, the shape probably fits
 and you should check `expand_builder` in the macro crate first.
+
+**Variadic ops** (`MergeN`, the n-ary merge behind `merge_all`/`fan`) are the
+one shape `#[op]` cannot touch at all: it parses `In` as a fixed-arity tuple, and
+a fan-in of runtime width has none. The route that works, if you need another:
+
+- Declare `In<'a> = &'a [(&'a T, bool)]` — the same uniform `(value, tick)` pairs
+  every other op gets, as a slice.
+- Hand-write the `Builder` method (`Builder::merge_n`, next to `combine`) and the
+  `__wf_op_<name>_*` forwarders + `__WF_OP_<NAME>_{ACTIVATION,PASSIVE}` consts.
+  Mirror what `expand_builder` / the forwarder block in the macro crate emit —
+  in particular `_start` must be **fully erased** (`<__Cfg, __State>`, no op
+  generics) unless the op overrides `start`, because `start` takes no input to
+  anchor them from. Getting that wrong fails at the call site with E0282, not in
+  the op.
+- On the `graph!` side, set `NodeDef::variadic` where you build the node;
+  `cycle_input` then emits a pair *slice* rather than a tuple, and the dispatch
+  condition drops the passive mask (a variadic op is all-active, and the mask is
+  a `u32` a wide fan-in would shift past).
+- **Do not** make the interpreted path materialise the slice: borrowing all N
+  slots per cycle allocates, which on a wide fan-in costs more than the node you
+  removed. Factor the semantics into a shared associated fn (`MergeN::winner`)
+  that both `Op::cycle` and the interpreted closure call, so they cannot drift.
+- **Gate the shape, not just the results.** A variadic op usually replaces a
+  chain of binary ones, and the two produce *identical values* — every
+  results-parity test passes either way, which is exactly how the merge chain's
+  1.86x loss against classic survived for so long. Assert on
+  `Runner::node_count()` that the wiring costs one node (`tests/merge_n.rs`), and
+  add a benchmark bar at a width where the difference can show.
 
 `#[op]` is **in-crate tooling**: its output names `crate::interp::Builder`, so
 an op defined outside `wingfoil-next` writes its forwarders by hand and wires
@@ -209,7 +238,8 @@ inference resolves the op type the macro never names. Nothing to edit.
 
 For a shape `#[op]` cannot parse (cyclic/IO sources; an `In` the uniform
 one-`(value, tick)`-pair-per-edge form can't express, as
-`DelayWithReset` — see its `DelayWithResetFwd` witness for the way out), the op
+`DelayWithReset` — see its `DelayWithResetFwd` witness for the way out;
+variadic, as `MergeN` — see step 2 for its route), the op
 may land **interpreted-only** —
 that is allowed, but it must be *consciously* placed: either give it an
 equivalent forwarder, or add it to the documented fluent-only allowlist in

--- a/next/crates/wingfoil-next-macros/src/lib.rs
+++ b/next/crates/wingfoil-next-macros/src/lib.rs
@@ -163,6 +163,15 @@ struct NodeDef {
     plain: Vec<Expr>,
     /// At most one literal-closure argument.
     closure: Option<Expr>,
+    /// The op takes its edges as a **pair slice** (`&[(value, tick), ..]`)
+    /// rather than a fixed-arity tuple, so it accepts a fan-in of any width
+    /// from one signature. Set only by the fan-in arms of `apply_call`
+    /// (`fan` / `merge_all`, both of which emit the variadic `merge_n`); every
+    /// other node keeps the uniform tuple input. A variadic op is all-active
+    /// by construction, so its dispatch condition skips the passive mask —
+    /// which also keeps the mask's `>> position` shift inside `u32` when the
+    /// fan-in is wider than 32.
+    variadic: bool,
 }
 
 impl NodeDef {
@@ -384,7 +393,20 @@ impl ChainWalker {
             refs,
             plain,
             closure,
+            variadic: false,
         });
+        ix
+    }
+
+    /// Push the single n-ary `merge_n` node that fans `tails` back in, in
+    /// supplied order (so the tie-break stays "earliest supplied that ticked
+    /// wins"). One tail needs no merge at all — it *is* the result.
+    fn push_merge_n(&mut self, name: Ident, span: proc_macro2::Span, tails: Vec<usize>) -> usize {
+        if let [only] = tails[..] {
+            return only;
+        }
+        let ix = self.push_node(name, Some(Ident::new("merge_n", span)), tails, vec![], None);
+        self.nodes[ix].variadic = true;
         ix
     }
 
@@ -600,25 +622,30 @@ impl ChainWalker {
                 let tails: Vec<usize> = (0..n)
                     .map(|_| self.walk_template(&param, cur, &closure.body))
                     .collect::<syn::Result<_>>()?;
-                // Left-fold the branch tails through binary merges, matching
-                // the fluent layer's N-ary "first supplied that ticked wins".
-                let merge = Ident::new("merge", method.span());
-                let mut merged = tails[0];
-                for (j, &tail) in tails.iter().enumerate().skip(1) {
-                    let node_name = if j + 1 == tails.len() {
-                        name.clone()
-                    } else {
-                        self.anon_name(method.span())
-                    };
-                    merged = self.push_node(
-                        node_name,
-                        Some(merge.clone()),
-                        vec![merged, tail],
-                        vec![],
-                        None,
-                    );
+                // Fan the branch tails back in through one n-ary merge, as the
+                // fluent `fan` does — "first supplied that ticked wins", and a
+                // 256-way fan stays 1 merge node deep instead of 255.
+                self.push_merge_n(name, method.span(), tails)
+            }
+            // The n-ary merge, spelled as the fluent method: its argument is a
+            // slice *literal* of stream references, which the generic arm
+            // cannot classify (a `&[..]` expression is not a `&stream` edge),
+            // so its elements are destructured into edges here.
+            "merge_all" => {
+                expect_arity(method, args, 1)?;
+                let elems = match args[0] {
+                    Expr::Reference(r) => match &*r.expr {
+                        Expr::Array(a) => &a.elems,
+                        _ => return Err(merge_all_arg_error(args[0])),
+                    },
+                    Expr::Array(a) => &a.elems,
+                    _ => return Err(merge_all_arg_error(args[0])),
+                };
+                let mut tails = vec![cur];
+                for elem in elems {
+                    tails.push(self.stream_ref_arg(elem)?);
                 }
-                merged
+                self.push_merge_n(name, method.span(), tails)
             }
             // Everything else — built-in or user op — dispatches through its
             // naming-convention forwarders. A typo (or an op with no
@@ -701,6 +728,18 @@ fn expect_arity(method: &Ident, args: &[&Expr], want: usize) -> syn::Result<()> 
             ),
         ))
     }
+}
+
+/// The `merge_all` bad-argument error. Its fan-in must be spelled as a slice
+/// literal of stream references so the macro can see the individual edges; a
+/// runtime-built slice would make the DAG non-static, like a non-literal
+/// `map_n` count.
+fn merge_all_arg_error(arg: &Expr) -> syn::Error {
+    syn::Error::new(
+        arg.span(),
+        "`.merge_all(..)` takes a slice literal of stream references — \
+         `merge_all(&[&a, &b])` — so the merged edges are visible statically",
+    )
 }
 
 impl Parse for GraphDef {
@@ -2174,12 +2213,18 @@ fn node_dispatch(def: &GraphDef, target: Target, i: usize) -> TokenStream2 {
     let act = node.op_const("ACTIVATION");
     let passive = node.op_const("PASSIVE");
 
+    // A variadic op is all-active by construction, so it needs no per-edge
+    // passive-mask guard — and must not have one: the mask is a `u32`, so a
+    // fan-in wider than 32 would shift past its width.
     let mut cond_parts: Vec<TokenStream2> = node
         .refs
         .iter()
         .enumerate()
         .map(|(pos, &u)| {
             let t = format_ident!("__t_{}", def.nodes[u].name);
+            if node.variadic {
+                return quote! { #t };
+            }
             let p = pos as u32;
             quote! { (((#passive >> #p) & 1) == 0 && #t) }
         })
@@ -2515,6 +2560,12 @@ fn cycle_input(def: &GraphDef, node: &NodeDef) -> TokenStream2 {
         let t = format_ident!("__t_{}", def.nodes[u].name);
         quote! { (#v, #t) }
     });
+    // A variadic op takes the same pairs as a *slice*, which is what lets one
+    // forwarder signature serve a fan-in of any width (a tuple impl would cap
+    // at whatever arity the crate spelled out).
+    if node.variadic {
+        return quote! { &[ #(#pairs,)* ] };
+    }
     quote! { ( #(#pairs,)* ) }
 }
 
@@ -2541,5 +2592,8 @@ fn lifecycle_input(def: &GraphDef, node: &NodeDef) -> TokenStream2 {
         };
         quote! { (#v, false) }
     });
+    if node.variadic {
+        return quote! { &[ #(#pairs,)* ] };
+    }
     quote! { ( #(#pairs,)* ) }
 }

--- a/next/crates/wingfoil-next/benches/tiers.rs
+++ b/next/crates/wingfoil-next/benches/tiers.rs
@@ -22,6 +22,10 @@
 //! - `dense_chain` — a deep linear map/filter/fold chain (dispatch-bound);
 //! - `fanout` — the classic 10x10 wide fan-out -> fan-in (shared wiring, every
 //!   node fires every cycle);
+//! - `fan_in_16` / `fan_in_64` / `fan_in_256` — a *busy* fan-in at three
+//!   widths, all branches ticking every cycle. The width sweep is the point:
+//!   `fanout` is only 10 wide, which is why it missed the n-ary-merge gap for
+//!   as long as it did (see below);
 //! - `accumulate` — a fold-accumulate hot loop over many cycles (scheduler-loop
 //!   bound);
 //! - `sparse` / `sparse_wide` — a hot chain in a graph that is ~97% quiet, at
@@ -59,18 +63,37 @@
 //! mostly-quiet interior is exactly its worst case, the mirror image of the
 //! dense wins.
 //!
-//! The second finding was the interpreted growth itself, and it led to a fix.
-//! 2.70ms -> 4.39ms for 4x the padding looked like a violation of "work
+//! The second finding was the interpreted growth itself, and it led to two
+//! fixes. 2.70ms -> 4.39ms for 4x the padding looked like a violation of "work
 //! proportional to active nodes" and was not one: node count is genuinely free
 //! (dangling padding of the same size costs nothing measurable). What grew was
-//! *depth*. `fan` left-folds its branches into a binary merge chain, so 256
-//! branches is a ~256-deep graph, and the drain used to walk `0..=max_layer`
+//! *depth*. `fan` used to left-fold its branches into a binary merge chain, so
+//! 256 branches was a ~256-deep graph, and the drain used to walk `0..=max_layer`
 //! testing every bucket — `O(active + deepest active layer)` per cycle. Classic
 //! never showed it, its `merge(vec)` being one N-ary node (depth 1).
 //!
 //! The drain now scans an occupied-layer bitmask instead (64 layers per word
 //! test), which took the slope between these two groups from +63% to +8%:
-//! ~2.94ms and ~3.18ms. See Phase 4.5 in `next/docs/port-plan.md`.
+//! ~2.94ms and ~3.18ms.
+//!
+//! **The `fan_in_*` groups exist because chasing that depth term turned up its
+//! root cause, and it was a parity gap rather than a tuning opportunity**: next
+//! had no n-ary merge, so `merge_all`/`fan` cost `n - 1` merge nodes where
+//! classic's `merge(vec)` costs 1. On a *busy* fan-in — every branch ticking,
+//! the common case — that was a straight loss against classic that widened with
+//! width (1.45x at 16, 1.73x at 64, 1.86x at 256), i.e. a violation of the
+//! `next-interpreted >= classic-interpreted` gate. `fanout` could not see it at
+//! 10 wide: the 9 extra merge nodes were lost among ~105 others. next now wires
+//! a single [`MergeN`](wingfoil_next::ops::MergeN) node, and the node counts
+//! below match the classic twins exactly, which they did not before.
+//!
+//! Measured after the fix (10k cycles): interpreted 4.35ms / 13.08ms / 48.85ms
+//! against classic's 5.43ms / 16.76ms / 64.15ms — **0.80x / 0.78x / 0.76x**. The
+//! flatness across the three widths is the thing to check, not any one bar: the
+//! failure mode was a ratio that grew with width, so a regression reappears as a
+//! rising slope long before any single group looks slow.
+//!
+//! See Phase 4.5 in `next/docs/port-plan.md`.
 
 use std::rc::Rc;
 use std::time::Duration;
@@ -110,6 +133,45 @@ wingfoil_next::graph! {
 // codegen suite all measure the identical DAG shape. Defines module `fanout`
 // with a top-level `const PERIOD`.
 include!("../bench_support/fanout_10x10.rs");
+
+// --- Workload 2b: a *busy* fan-in, swept across three widths ----------------
+//
+// One source feeds `width` one-map branches that all fan back into a single
+// merge, so every branch ticks on every cycle. This is the shape the n-ary
+// merge exists for, and the shape `fanout` is too narrow to measure: the cost
+// of a fan-in's *merge* only separates from the cost of its *branches* once the
+// width is large. Compare the `interpreted` and `classic` bars within each
+// group, then read the three groups as a slope — a merge chain regression shows
+// up as a ratio that grows with width, not as any single bad number.
+wingfoil_next::graph! {
+    fn fan_in_16(g: &GraphBuilder) -> Stream<u64> {
+        let src = g.ticker(STEP).count();
+        let out = src
+            .fan(16, |s| s.map(|i: &u64| std::hint::black_box(i.wrapping_add(1))))
+            .fold(0u64, |acc, v| *acc = acc.wrapping_add(*v));
+        out
+    }
+}
+
+wingfoil_next::graph! {
+    fn fan_in_64(g: &GraphBuilder) -> Stream<u64> {
+        let src = g.ticker(STEP).count();
+        let out = src
+            .fan(64, |s| s.map(|i: &u64| std::hint::black_box(i.wrapping_add(1))))
+            .fold(0u64, |acc, v| *acc = acc.wrapping_add(*v));
+        out
+    }
+}
+
+wingfoil_next::graph! {
+    fn fan_in_256(g: &GraphBuilder) -> Stream<u64> {
+        let src = g.ticker(STEP).count();
+        let out = src
+            .fan(256, |s| s.map(|i: &u64| std::hint::black_box(i.wrapping_add(1))))
+            .fold(0u64, |acc, v| *acc = acc.wrapping_add(*v));
+        out
+    }
+}
 
 // --- Workload 3: a fold-accumulate hot loop (scheduler-loop bound) ----------
 //
@@ -213,6 +275,29 @@ fn fanout_classic() -> Rc<dyn wingfoil::Stream<u64>> {
         })
         .collect::<Vec<_>>();
     classic_merge(branches)
+}
+
+fn fan_in_classic_n(width: usize) -> Rc<dyn wingfoil::Stream<u64>> {
+    let src = classic_ticker(STEP).count();
+    let branches = (0..width)
+        .map(|_| {
+            src.clone()
+                .map(|i: u64| std::hint::black_box(i.wrapping_add(1)))
+        })
+        .collect::<Vec<_>>();
+    classic_merge(branches).fold(|acc: &mut u64, v: u64| *acc = acc.wrapping_add(v))
+}
+
+fn fan_in_16_classic() -> Rc<dyn wingfoil::Stream<u64>> {
+    fan_in_classic_n(16)
+}
+
+fn fan_in_64_classic() -> Rc<dyn wingfoil::Stream<u64>> {
+    fan_in_classic_n(64)
+}
+
+fn fan_in_256_classic() -> Rc<dyn wingfoil::Stream<u64>> {
+    fan_in_classic_n(256)
 }
 
 fn accumulate_classic() -> Rc<dyn wingfoil::Stream<u64>> {
@@ -329,8 +414,38 @@ fn tiers(c: &mut Criterion) {
         10_000u32
     );
 
-    // fanout: ticker + count + sample + fold + 10*10 maps + 10-way merge.
-    tier_group!(c, "fanout", fanout, fanout_classic, 10 * 10 + 5, 10_000u32);
+    // fanout: ticker + count + 10*10 maps + the 10-way merge = 103, the same
+    // count as the classic twin now that the fan-in is one n-ary node.
+    tier_group!(c, "fanout", fanout, fanout_classic, 10 * 10 + 3, 10_000u32);
+
+    // fan_in_*: ticker + count + `width` maps + the n-ary merge + fold. Every
+    // branch ticks every cycle, so this is the busy fan-in the n-ary merge
+    // exists for; the three widths make a merge-chain regression visible as a
+    // slope against `classic`.
+    tier_group!(
+        c,
+        "fan_in_16",
+        fan_in_16,
+        fan_in_16_classic,
+        16 + 4,
+        10_000u32
+    );
+    tier_group!(
+        c,
+        "fan_in_64",
+        fan_in_64,
+        fan_in_64_classic,
+        64 + 4,
+        10_000u32
+    );
+    tier_group!(
+        c,
+        "fan_in_256",
+        fan_in_256,
+        fan_in_256_classic,
+        256 + 4,
+        10_000u32
+    );
 
     // accumulate: ticker + count + fold, run long so the loop dominates.
     tier_group!(
@@ -343,16 +458,17 @@ fn tiers(c: &mut Criterion) {
     );
 
     // sparse: hot (ticker + count + 6 maps) + cold (ticker + count + 64*3 maps
-    // + 63 merges) + the joining merge + fold = 267 nodes, ~8 of them active.
-    tier_group!(c, "sparse", sparse, sparse_classic, 267, 10_000u32);
+    // + the n-ary merge) + the joining merge + fold = 205 nodes, ~8 of them
+    // active. (Was 267 while `fan` unrolled to 63 binary merges.)
+    tier_group!(c, "sparse", sparse, sparse_classic, 205, 10_000u32);
 
-    // sparse_wide: the same, with 256 cold branches — 1035 nodes, ~8 active.
+    // sparse_wide: the same, with 256 cold branches — 781 nodes, ~8 active.
     tier_group!(
         c,
         "sparse_wide",
         sparse_wide,
         sparse_wide_classic,
-        1035,
+        781,
         10_000u32
     );
 }

--- a/next/crates/wingfoil-next/src/fluent.rs
+++ b/next/crates/wingfoil-next/src/fluent.rs
@@ -801,13 +801,12 @@ pub trait StreamOps<T>: Sized {
     /// this stream first, then `others` in slice order. `merge_all(&[])` is
     /// just this stream.
     ///
-    /// This unrolls to a left-associated chain of 2-ary
-    /// [`merge`](StreamOps::merge)s (`self.merge(a).merge(b)…`), which is
-    /// exactly equivalent — 2-ary merge's earliest-wins tie-break is
-    /// associative, so the chain and a single n-ary node fire identically. It
-    /// closes the n-ary-merge vocabulary gap without a bespoke variadic op (the
-    /// same sugar-over-primitive approach as [`fan`](StreamOps::fan) /
-    /// [`map_n`](StreamOps::map_n)).
+    /// Wires a **single** n-ary [`MergeN`](crate::ops::MergeN) node — classic
+    /// `merge(vec)`'s twin — not a left-associated chain of 2-ary
+    /// [`merge`](StreamOps::merge)s. The two are semantically identical (2-ary
+    /// merge's earliest-wins tie-break is associative), but a chain costs
+    /// `n - 1` extra nodes and `n - 1` extra depth, which measured 1.86x
+    /// classic on a busy 256-wide fan-in; see [`MergeN`](crate::ops::MergeN).
     fn merge_all(&self, others: &[&Stream<T>]) -> Stream<T>
     where
         T: Clone + Default + 'static;
@@ -825,6 +824,10 @@ pub trait StreamOps<T>: Sized {
     /// of this stream — and merge their outputs back into one stream (earliest-
     /// supplied ticked branch wins, as `merge`). `n` must be at least 1. Inside
     /// `graph!` the count must be a literal so the DAG stays static.
+    ///
+    /// The fan-in is one n-ary [`merge_all`](StreamOps::merge_all) node, so a
+    /// 256-way fan costs 256 branch tails plus **one** merge — not the
+    /// 255-node, 255-deep binary chain it used to build.
     fn fan<B, F>(&self, n: usize, branch: F) -> Stream<B>
     where
         B: Clone + Default + 'static,
@@ -1131,11 +1134,18 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
     where
         T: Clone + Default + 'static,
     {
-        let mut merged = self.clone();
-        for other in others {
-            merged = merged.merge(other);
+        // No node at all for the degenerate case: `merge_all(&[])` is this
+        // stream, exactly as the old empty fold produced.
+        if others.is_empty() {
+            return self.clone();
         }
-        merged
+        let rest: Vec<Handle<T>> = others.iter().map(|s| s.handle()).collect();
+        self.wire(move |b, h| {
+            let mut srcs = Vec::with_capacity(rest.len() + 1);
+            srcs.push(h);
+            srcs.extend(rest);
+            b.merge_n(&srcs)
+        })
     }
 
     fn map_n<F>(&self, n: usize, f: F) -> Stream<T>
@@ -1156,11 +1166,12 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         F: Fn(Stream<T>) -> Stream<B>,
     {
         assert!(n >= 1, "`fan` requires at least one branch");
-        let mut merged = branch(self.clone());
-        for _ in 1..n {
-            merged = merged.merge(&branch(self.clone()));
-        }
-        merged
+        // Build every branch first, then fan them in through a single n-ary
+        // merge — the branch tails are the merge's upstreams, in branch order,
+        // so the tie-break stays "earliest branch that ticked wins".
+        let branches: Vec<Stream<B>> = (0..n).map(|_| branch(self.clone())).collect();
+        let rest: Vec<&Stream<B>> = branches[1..].iter().collect();
+        branches[0].merge_all(&rest)
     }
 
     fn limit(&self, limit: u32) -> Stream<T>

--- a/next/crates/wingfoil-next/src/interp.rs
+++ b/next/crates/wingfoil-next/src/interp.rs
@@ -51,7 +51,7 @@ use crate::Burst;
 use crate::channel::{ChannelSender, Message, Tx};
 use crate::latency::{HasLatency, LatencyReport, LatencyReportCfg, LatencyStats};
 use crate::op::{Activation, CompositePhase, Ctx, Op, Tick};
-use crate::ops::{Join, Join3, Never, Poll, TryJoin, TryJoin3, WithTime};
+use crate::ops::{Join, Join3, MergeN, Never, Poll, TryJoin, TryJoin3, WithTime};
 use wingfoil::codegen::{Kernel, KernelWaker, ReadyReceiver, waker_channel};
 use wingfoil::{NanoTime, RunFor, RunMode, TimeQueue};
 
@@ -1430,6 +1430,60 @@ impl Builder {
         self.make_handle(idx)
     }
 
+    /// Merge N same-type streams into one — the n-ary [`MergeN`] node backing
+    /// `merge_all` / `fan`. The earliest-supplied upstream that ticked this
+    /// cycle wins; quiet when none ticked.
+    ///
+    /// Hand-written for the same reason as [`combine`](Self::combine): a
+    /// variadic fan-in does not fit the `Op` trait's fixed-arity tuple `In`,
+    /// so `#[op]` cannot generate the wiring. Unlike the generated shapes this
+    /// does **not** hand `Op::cycle` a materialised `&[(&T, bool)]` — that
+    /// would mean borrowing all N slots (and allocating) every cycle, which on
+    /// a wide merge costs more than the `n - 1` chained nodes it replaces.
+    /// Instead it applies [`MergeN::winner`] — the shared rule the op's own
+    /// `cycle` uses — to the engine's tick flags and clones only the winning
+    /// slot.
+    ///
+    /// `srcs` must be non-empty; a zero-input merge has no value to produce
+    /// (the fluent `merge_all(&[])` short-circuits to the receiver instead of
+    /// wiring a node).
+    pub fn merge_n<T: Clone + Default + 'static>(&mut self, srcs: &[Handle<T>]) -> Handle<T> {
+        assert!(
+            !srcs.is_empty(),
+            "invariant: Builder::merge_n requires at least one upstream"
+        );
+        let idx = self.nodes.len();
+        let indices: Vec<usize> = srcs.iter().map(|h| h.idx).collect();
+        let slots: Vec<SlotRef<T>> = srcs.iter().map(|h| self.slot(*h)).collect();
+        let out = self.new_slot(T::default());
+        let out_reset = out.clone();
+        let ticked = self.ticked.clone();
+        self.push_node(
+            indices.clone(),
+            MergeN::<T>::ACTIVATION,
+            "merge_n",
+            Box::new(move |_k| {
+                let winner = {
+                    let t = ticked.borrow();
+                    MergeN::<T>::winner(indices.iter().map(|&i| t[i]))
+                };
+                match winner {
+                    Some(i) => {
+                        let value = slots[i].borrow().clone();
+                        *out.borrow_mut() = value;
+                        Ok(true)
+                    }
+                    None => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        self.set_reset(Box::new(move || {
+            *out_reset.borrow_mut() = T::default();
+        }));
+        self.make_handle(idx)
+    }
+
     /// Pair each value with the current engine time: `(time, value)`. Kept
     /// hand-written (not `#[op]`): the output `(NanoTime, T)` is seeded from
     /// the input's current value, so it never requires `T: Default`.
@@ -2579,10 +2633,12 @@ impl Runner {
         // The *occupied* layers are found through `occupied`, a bitmask with one
         // bit per layer, rather than by walking `0..=max_layer` and testing each
         // bucket. That walk made per-cycle cost `O(active + depth)`, which a deep
-        // graph pays every cycle even when almost none of it fires — and `fan`
-        // left-folds its branches into a merge chain, so a wide fan-in *is* deep
-        // (see Phase 4.5 in `next/docs/port-plan.md`). Scanning the mask skips 64
-        // empty layers per word test, leaving `O(active + depth/64)`.
+        // graph pays every cycle even when almost none of it fires — and back when
+        // `fan` left-folded its branches into a merge chain, a wide fan-in *was*
+        // deep (see Phase 4.5 in `next/docs/port-plan.md`; `fan` now fans in
+        // through one `merge_n`, but depth is still cheap to build by hand).
+        // Scanning the mask skips 64 empty layers per word test, leaving
+        // `O(active + depth/64)`.
         //
         // Deliberately a bitmask and not a heap of occupied layers: a heap would
         // be `O(active log active)` with a push/pop *per layer*, and on a linear
@@ -2733,6 +2789,23 @@ impl Runner {
     #[doc(hidden)]
     pub fn node_visits(&self) -> u64 {
         self.node_visits
+    }
+
+    /// How many nodes the wired graph holds — the *static* counterpart of
+    /// [`node_visits`](Runner::node_visits)'s per-run count.
+    ///
+    /// Exists so a test can pin the cost of a wiring shape rather than of a
+    /// run. The gate it was added for: an n-way `merge_all` / `fan` must cost
+    /// **one** merge node, not the `n - 1` a binary chain costs. That
+    /// distinction is invisible to a results-parity test (a chain and an n-ary
+    /// node produce identical values) and was invisible to the benchmarks too,
+    /// which is how a 1.86x loss against classic on a wide fan-in survived —
+    /// see `MergeN`.
+    ///
+    /// Hidden: an engine-observability hook for the perf gates, not public API.
+    #[doc(hidden)]
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
     }
 
     /// Layer-scan steps performed by the most recent [`run`](Runner::run) — the

--- a/next/crates/wingfoil-next/src/ops.rs
+++ b/next/crates/wingfoil-next/src/ops.rs
@@ -2814,6 +2814,145 @@ impl<T: Clone + 'static> Op for Merge2<T> {
     }
 }
 
+/// Merges **N** streams: the earliest-supplied input that ticked this cycle
+/// wins — the n-ary generalisation of [`Merge2`], and the twin of classic
+/// wingfoil's `merge(vec)`.
+///
+/// It exists as its own op rather than as sugar over a chain of [`Merge2`]s
+/// because the chain is not free: `merge_all`/`fan` used to left-fold into
+/// `n - 1` binary merges, costing `n - 1` extra *nodes* and `n - 1` extra
+/// *depth* against classic's single node. On a busy 256-wide fan-in that
+/// measured 1.86x classic — a Phase 6 gate violation, not a tuning
+/// opportunity. Rebalancing the chain recovers only the depth half; only a
+/// real n-ary node removes both.
+///
+/// The catalog's only **variadic** op: its `In` is a *slice* of
+/// `(value, tick)` pairs rather than a fixed-arity tuple, so `#[op]` cannot
+/// parse its shape. Its interpreted wiring
+/// ([`Builder::merge_n`](crate::interp::Builder::merge_n)) and its
+/// `graph!`/compiled forwarders (below) are hand-written instead — the same
+/// concession [`Builder::combine`](crate::interp::Builder::combine) makes for
+/// the other n-ary fan-in.
+pub struct MergeN<T>(PhantomData<T>);
+
+impl<T: Clone> MergeN<T> {
+    /// The n-ary merge rule itself: the position of the earliest-supplied
+    /// input that ticked, or `None` when none did.
+    ///
+    /// Factored out because the interpreted engine cannot call
+    /// [`Op::cycle`] directly here. Building the `&[(&T, bool)]` slice
+    /// `cycle` wants means borrowing every upstream slot at once, which for a
+    /// 256-wide merge is a heap allocation on every cycle — exactly the cost
+    /// this op exists to remove. The interpreted path therefore finds the
+    /// winner from the engine's tick flags and borrows only *that* slot,
+    /// routing through this shared rule so the two paths cannot disagree
+    /// about which input wins.
+    #[inline]
+    pub fn winner(ticks: impl IntoIterator<Item = bool>) -> Option<usize> {
+        ticks.into_iter().position(|ticked| ticked)
+    }
+}
+
+impl<T: Clone + 'static> Op for MergeN<T> {
+    type Cfg = ();
+    type State = ();
+    type In<'a> = &'a [(&'a T, bool)];
+    type Out = T;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        _state: &mut (),
+        input: &[(&T, bool)],
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<T>> {
+        Ok(
+            match Self::winner(input.iter().map(|&(_, ticked)| ticked)) {
+                Some(i) => Tick::Value(input[i].0.clone()),
+                None => Tick::Quiet,
+            },
+        )
+    }
+}
+
+// ---- `merge_n` graph!/compiled forwarders (hand-written) -------------------
+//
+// `#[op]` generates these from an op's `In` shape; it cannot for a variadic
+// op, so they are written out here. The `graph!` emission calls them by the
+// same naming convention as every generated family — the only difference is
+// that a variadic node's `cycle_input` is a pair *slice* (`&[(v, t), ..]`)
+// rather than a fixed-arity tuple, which is what lets one signature serve a
+// fan-in of any width.
+
+/// [`MergeN`] never schedules itself — it is driven purely by upstream ticks.
+#[doc(hidden)]
+pub const __WF_OP_MERGE_N_ACTIVATION: Activation = <MergeN<()> as Op>::ACTIVATION;
+
+/// Bit i set = edge i is passive. A variadic merge is all-active by
+/// construction: every input it is given can trigger it.
+#[doc(hidden)]
+pub const __WF_OP_MERGE_N_PASSIVE: u32 = 0;
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_merge_n_cycle<T: Clone + 'static>(
+    __cfg: &mut (),
+    __state: &mut (),
+    __input: &[(&T, bool)],
+    __ctx: &mut Ctx<'_>,
+) -> Result<Tick<T>> {
+    <MergeN<T> as Op>::cycle(__cfg, __state, __input, __ctx)
+}
+
+/// [`MergeN`] does not override `start`, so — exactly as `#[op]` does for a
+/// hook-free op — this is a **fully erased** no-op. A forwarder carrying the
+/// op's `T` would leave it un-inferable at the call site: `start` takes no
+/// input, so nothing there anchors it.
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_merge_n_start<__Cfg, __State>(
+    _cfg: &mut __Cfg,
+    _state: &mut __State,
+    _ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    Ok(())
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_merge_n_stop<T: Clone + 'static>(
+    __cfg: &mut (),
+    __state: &mut (),
+    __input: &[(&T, bool)],
+    __ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    let _ = __input;
+    <MergeN<T> as Op>::stop(__cfg, __state, __ctx)
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_merge_n_teardown<T: Clone + 'static>(
+    __cfg: &mut (),
+    __state: &mut (),
+    __input: &[(&T, bool)],
+    __ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    let _ = __input;
+    <MergeN<T> as Op>::teardown(__cfg, __state, __ctx)
+}
+
+#[doc(hidden)]
+#[inline(always)]
+#[allow(clippy::unused_unit)]
+pub fn __wf_op_merge_n_seed_state<__P>(_cfg: &__P) -> () {}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_merge_n_seed_value<T: Default, __P>(_cfg: &__P) -> T {
+    T::default()
+}
+
 /// A source that never ticks — the classic `never` node. It has no upstreams
 /// and never schedules itself, so it stays [`Tick::Quiet`] for the whole run;
 /// its unit value is never observed downstream. The idiomatic inert trigger —

--- a/next/crates/wingfoil-next/tests/merge_n.rs
+++ b/next/crates/wingfoil-next/tests/merge_n.rs
@@ -1,0 +1,303 @@
+//! The n-ary merge (`MergeN` / `Builder::merge_n`), which backs `merge_all`
+//! and `fan`.
+//!
+//! `merge_all` used to left-fold into a chain of `n - 1` binary `merge`s. That
+//! is *semantically* identical — 2-ary merge's earliest-wins tie-break is
+//! associative — which is exactly why it survived: every results-parity test
+//! passed. What it cost was `n - 1` extra nodes and `n - 1` extra depth, and
+//! on a busy 256-wide fan-in that measured **1.86x** classic wingfoil's single
+//! `merge(vec)` node — a Phase 6 gate violation
+//! (`next-interpreted >= classic-interpreted`).
+//!
+//! So these tests come in two halves, and the first is the one that would have
+//! caught it:
+//!
+//! * **Shape** — `merge_all(k inputs)` wires exactly one node
+//!   (`wide_merge_costs_one_node`, `fan_costs_one_merge_node`). Asserted on
+//!   `Runner::node_count()`, so it is a pass/fail gate in CI rather than a
+//!   benchmark reading.
+//! * **Semantics** — the tie-break, burst delivery, the empty case, and
+//!   three-engine agreement, i.e. everything that was *already* right and must
+//!   stay so through the rewrite.
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil_next::prelude::*;
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+/// A `k`-way `merge_all` costs **one** merge node, whatever `k` is.
+///
+/// The graph is `k` branches (3 nodes each: ticker + count + map) fanned into
+/// one merge, plus an `accumulate` to read it — so the expected total is
+/// `3k + 1 (merge) + 1 (accumulate)`. Under the old chain it was
+/// `3k + (k - 1) + 1`: at `k = 64`, **194 nodes rather than 256**.
+#[test]
+fn wide_merge_costs_one_node() {
+    const K: usize = 64;
+
+    let g = GraphBuilder::new();
+    let branches: Vec<Stream<u64>> = (0..K)
+        .map(|i| {
+            g.ticker(Duration::from_nanos(10 + i as u64))
+                .count()
+                .map(move |c| *c * 1000 + i as u64)
+        })
+        .collect();
+    let rest: Vec<&Stream<u64>> = branches[1..].iter().collect();
+    let out = branches[0].merge_all(&rest).accumulate();
+    let runner = g.build();
+
+    assert_eq!(
+        runner.node_count(),
+        3 * K + 2,
+        "a {K}-way merge_all is one merge node ({} under the old binary chain)",
+        3 * K + (K - 1) + 1
+    );
+    // The handle is live wiring, not decoration — keep it used so the shape
+    // under test is the shape that would actually run.
+    let _ = out;
+}
+
+/// Same gate for `fan`, whose fan-in is the one that made the depth term
+/// visible in the first place: an `n`-way fan is `n` branch tails plus one
+/// merge, so its *depth* no longer grows with `n` either.
+#[test]
+fn fan_costs_one_merge_node() {
+    const N: usize = 32;
+
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_nanos(10)).count();
+    let fanned = src.fan(N, |s| s.map(|c| *c + 1));
+    let out = fanned.accumulate();
+    let runner = g.build();
+
+    // ticker + count + N branch maps + 1 merge + accumulate.
+    assert_eq!(
+        runner.node_count(),
+        2 + N + 2,
+        "a {N}-way fan is one merge node, not a {}-deep chain",
+        N - 1
+    );
+    let _ = out;
+}
+
+/// A single-branch `fan` needs no merge at all — it is just the branch.
+#[test]
+fn single_branch_fan_wires_no_merge() {
+    let g = GraphBuilder::new();
+    let src = g.ticker(Duration::from_nanos(10)).count();
+    let out = src.fan(1, |s| s.map(|c| *c + 1)).accumulate();
+    let runner = g.build();
+
+    // ticker + count + the one branch map + accumulate — no merge.
+    assert_eq!(runner.node_count(), 4);
+    let _ = out;
+}
+
+/// `merge_all(&[])` is the receiver itself, wiring nothing.
+#[test]
+fn empty_merge_all_is_the_receiver() {
+    let g = GraphBuilder::new();
+    let lone = g.ticker(Duration::from_nanos(10)).count();
+    let merged = lone.merge_all(&[]);
+
+    assert_eq!(
+        merged.handle().index(),
+        lone.handle().index(),
+        "merge_all(&[]) returns the same node, not a new one"
+    );
+    assert_eq!(g.build().node_count(), 2, "ticker + count, no merge node");
+}
+
+/// The tie-break, with **every** input ticking in the same cycle: the
+/// earliest-supplied one wins, in `[receiver, others…]` order.
+///
+/// Four tickers of the same period tick together on every cycle, so the
+/// tie-break arm runs every cycle and only the receiver's values may appear.
+/// A merge that picked the last ticked input (or iterated its upstreams in
+/// registration order rather than supplied order) fails here.
+#[test]
+fn n_ary_tie_break_takes_the_earliest_supplied() {
+    let g = GraphBuilder::new();
+    let period = Duration::from_nanos(10);
+    let a = g.ticker(period).count();
+    let b = g.ticker(period).count().map(|c| *c + 100);
+    let c = g.ticker(period).count().map(|c| *c + 200);
+    let d = g.ticker(period).count().map(|c| *c + 300);
+
+    let out = a.merge_all(&[&b, &c, &d]).accumulate();
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+
+    assert_eq!(runner.value(&out), vec![1, 2, 3, 4]);
+}
+
+/// When the earliest-supplied input is *quiet*, the next ticked one wins —
+/// the arm the same-period test above can never reach.
+///
+/// `a` ticks every 30ns, `b` every 10ns, so on the cycles where both are due
+/// `a` wins and on the others `b` does.
+#[test]
+fn quiet_inputs_are_skipped_in_supplied_order() {
+    let g = GraphBuilder::new();
+    let a = g.ticker(Duration::from_nanos(30)).count().map(|c| *c + 100);
+    let b = g.ticker(Duration::from_nanos(10)).count().map(|c| *c + 200);
+
+    let out = a.merge_all(&[&b]).with_time().accumulate();
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+
+    // Both tickers are due at t=0 and t=30 (`a` wins those); `b` alone at
+    // 10, 20, 40, 50.
+    assert_eq!(
+        runner.value(&out),
+        vec![
+            (NanoTime::new(0), 101),
+            (NanoTime::new(10), 202),
+            (NanoTime::new(20), 203),
+            (NanoTime::new(30), 102),
+            (NanoTime::new(40), 205),
+            (NanoTime::new(50), 206),
+        ]
+    );
+}
+
+/// The n-ary node is a drop-in for the chain it replaced: the same inputs
+/// produce the same series either way. This is the oracle the shape gates
+/// above cannot be: it pins that removing `n - 1` nodes removed no behaviour.
+#[test]
+fn n_ary_merge_matches_the_binary_chain() {
+    fn drivers(g: &GraphBuilder) -> (Stream<u64>, Stream<u64>, Stream<u64>) {
+        let a = g.ticker(Duration::from_nanos(30)).count();
+        let b = g.ticker(Duration::from_nanos(10)).count().map(|c| *c + 100);
+        let c = g.ticker(Duration::from_nanos(20)).count().map(|c| *c + 200);
+        (a, b, c)
+    }
+
+    let g1 = GraphBuilder::new();
+    let (a, b, c) = drivers(&g1);
+    let n_ary = a.merge_all(&[&b, &c]).accumulate();
+    let mut r1 = g1.build();
+    r1.run(HISTORICAL, RunFor::Cycles(12)).unwrap();
+
+    let g2 = GraphBuilder::new();
+    let (a, b, c) = drivers(&g2);
+    let chained = a.merge(&b).merge(&c).accumulate();
+    let mut r2 = g2.build();
+    r2.run(HISTORICAL, RunFor::Cycles(12)).unwrap();
+
+    assert!(!r1.value(&n_ary).is_empty());
+    assert_eq!(
+        r1.value(&n_ary),
+        r2.value(&chained),
+        "the n-ary node and the binary chain it replaced agree"
+    );
+}
+
+/// Burst inputs ride through the merge whole — the earliest-supplied ticked
+/// input's burst is forwarded, never flattened or latest-wins collapsed.
+#[test]
+fn merge_all_forwards_bursts_intact() {
+    let g = GraphBuilder::new();
+    let a = g.replay_results(vec![
+        Ok((1u32, NanoTime::new(10))),
+        Ok((2, NanoTime::new(10))),
+        Ok((3, NanoTime::new(30))),
+    ]);
+    let b = g.replay_results(vec![
+        Ok((10u32, NanoTime::new(20))),
+        Ok((11, NanoTime::new(20))),
+    ]);
+
+    let out = a.merge_all(&[&b]).with_time().accumulate();
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Forever).unwrap();
+
+    let got: Vec<(NanoTime, Vec<u32>)> = runner
+        .value(&out)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().copied().collect()))
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            (NanoTime::new(10), vec![1, 2]),
+            (NanoTime::new(20), vec![10, 11]),
+            (NanoTime::new(30), vec![3]),
+        ],
+        "same-instant values stay grouped in one burst through the merge"
+    );
+}
+
+// ---- graph! / compiled / nested coverage ----------------------------------
+//
+// Both fan-in spellings now emit a single n-ary node on the compiled paths
+// too, so each block is also the two-sided registration guard `op_completeness`
+// describes: it only compiles if the fluent method and the `merge_n`
+// forwarders both exist.
+
+wingfoil_next::graph! {
+    fn merged(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let a = g.ticker(std::time::Duration::from_nanos(30)).count();
+        let b = g.ticker(std::time::Duration::from_nanos(10)).count().map(|c| *c + 100);
+        let c = g.ticker(std::time::Duration::from_nanos(20)).count().map(|c| *c + 200);
+        let out = a.merge_all(&[&b, &c]).accumulate();
+        out
+    }
+}
+
+wingfoil_next::graph! {
+    fn fanned(g: &GraphBuilder) -> Stream<Vec<u64>> {
+        let src = g.ticker(std::time::Duration::from_nanos(10)).count();
+        let out = src.fan(4, |s| s.map(|c| *c + 1)).accumulate();
+        out
+    }
+}
+
+/// `merge_all` inside `graph!` — new capability: it used to be fluent-only
+/// ("sugar over a primitive — spell the primitive"), because a chain was all
+/// it was. Now it is a real op with real forwarders, so all three engines
+/// emit it and must agree.
+#[test]
+fn graph_merge_all_agrees_across_engines() {
+    let run_for = RunFor::Cycles(12);
+
+    let (mut runner, out) = merged::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    let interpreted = runner.value(out);
+
+    let (compiled,) = merged::compiled(HISTORICAL, run_for).unwrap();
+
+    let g = GraphBuilder::new();
+    let island = merged::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, run_for).unwrap();
+
+    assert!(!interpreted.is_empty());
+    assert_eq!(interpreted, compiled, "interpreted == compiled");
+    assert_eq!(interpreted, r.value(&island), "interpreted == nested");
+}
+
+/// `fan` inside `graph!` emits one n-ary merge on the compiled paths, matching
+/// the fluent wiring it is derived from.
+#[test]
+fn graph_fan_agrees_across_engines() {
+    let run_for = RunFor::Cycles(8);
+
+    let (mut runner, out) = fanned::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    let interpreted = runner.value(out);
+
+    let (compiled,) = fanned::compiled(HISTORICAL, run_for).unwrap();
+
+    let g = GraphBuilder::new();
+    let island = fanned::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, run_for).unwrap();
+
+    assert!(!interpreted.is_empty());
+    assert_eq!(interpreted, compiled, "interpreted == compiled");
+    assert_eq!(interpreted, r.value(&island), "interpreted == nested");
+}

--- a/next/crates/wingfoil-next/tests/op_completeness.rs
+++ b/next/crates/wingfoil-next/tests/op_completeness.rs
@@ -41,10 +41,19 @@
 //!   * `for_each` — a fallible IO sink; lives at the runtime boundary.
 //!
 //! **2. Sugar over a primitive — spell the primitive in `graph!`:**
-//!   * `merge_all` → a chain of 2-ary `merge`s; `not` → `map(|b| !b)`;
-//!     `collapse` → `map_filter`; `split` → two `map`s. (`map_n` / `fan` are
-//!     the *exception* — the macro recognises them as repetition sugar, so they
-//!     ARE expressible; covered in `surface_sugar` below.)
+//!   * `not` → `map(|b| !b)`; `collapse` → `map_filter`; `split` → two `map`s.
+//!     (`map_n` / `fan` / `merge_all` are the *exception* — the macro
+//!     recognises them, unrolling the first two as repetition sugar and
+//!     emitting the last two through the variadic `merge_n`; covered in
+//!     `surface_sugar` below and in `merge_n.rs`.)
+//!
+//!     `merge_all` was in this list while it *was* sugar (a chain of 2-ary
+//!     `merge`s). It is now a real op — `MergeN`, the catalog's only variadic
+//!     one — because the chain cost `n - 1` extra nodes and lost to classic's
+//!     single `merge(vec)` on a wide fan-in. Its forwarders are hand-written
+//!     (a slice `In` is unparseable by `#[op]`), so the two-sided guard this
+//!     file provides matters more for it than for a generated op, not less:
+//!     the `graph!` blocks in `merge_n.rs` are what pin them.
 //!
 //! **2b. Ergonomic fluent signature ≠ the op's `Cfg` — fluent-only:**
 //!   * `logged` — the `Logged` op's `Cfg` is `(String, log::Level)`, but the
@@ -185,7 +194,9 @@ wingfoil_next::graph! {
         let count = g.ticker(P).count();
         let deep = count.map_n(3, |i| *i + 1);
         let fanned = deep.fan(2, |s| s.map(|i| *i * 2));
-        let out = fanned.accumulate();
+        let other = count.map(|i| *i + 100);
+        let merged = fanned.merge_all(&[&other]);
+        let out = merged.accumulate();
         out
     }
 }

--- a/next/crates/wingfoil-next/tests/rerun.rs
+++ b/next/crates/wingfoil-next/tests/rerun.rs
@@ -168,9 +168,11 @@ fn single_run_graph_errors_on_second_run() {
     );
 }
 
-/// `merge_all` (the n-ary merge sugar) is exactly the left-associated chain of
-/// 2-ary merges — same values, same earliest-wins tie-break — and both match a
-/// fresh graph.
+/// `merge_all` (one n-ary merge node) produces exactly what the left-associated
+/// chain of 2-ary merges it replaced did — same values, same earliest-wins
+/// tie-break — and both re-run cleanly. The *shape* difference the rewrite was
+/// for (one node, not `n - 1`) is gated in `merge_n.rs`; this is the
+/// behavioural half.
 #[test]
 fn merge_all_matches_chained_merge() {
     fn wire_nary(g: &GraphBuilder) -> Stream<Vec<u64>> {

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -117,7 +117,7 @@ today's interpreted engine.
   deferred 4.5 arena rework can also improve on. Next resets its *tick* state
   sparsely (only the nodes that fired) but shares the kernel's `O(N)` dirty-flag
   clear; it measures as negligible. Its measurable non-active term is depth, not
-  `N` — see Phase 4.5, "What the gate does *not* cover".
+  `N` — see Phase 4.5, "The `O(depth)` drain term" (measured, then fixed).
 ¹² Sparse dirty-list dispatch (classic's `dirty_nodes_by_layer` model) has
   landed as the default: per-cycle work ∝ active nodes, results byte-identical
   to classic and to the old full sweep (retained as `Dispatch::FullSweep`, an
@@ -291,12 +291,19 @@ register A2 — the earlier "classic re-runs I/O sources" claim was incorrect.
 - Variadic gaps: `Join3` (trimap) ✅, n-ary merge ✅, `try_map`/`try_bimap`/
   `try_trimap` ✅ (trivial once cycle is fallible — the closure returns
   `Result`, the op `?`s it). **n-ary merge** landed as `StreamOps::merge_all`
-  (`fluent.rs`) — sugar that unrolls to a left-associated chain of 2-ary
-  `merge`s. 2-ary merge's earliest-wins tie-break is associative, so the chain
-  and a single variadic node fire identically; the sugar-over-primitive
-  approach matches `fan`/`map_n`, and a dedicated variadic op would add engine
-  complexity for zero observable difference (`tests/rerun.rs::
-  merge_all_matches_chained_merge`).
+  (`fluent.rs`), backed by the variadic `MergeN` op and `Builder::merge_n`.
+
+  It shipped first as *sugar* — a left-associated chain of 2-ary `merge`s, on
+  the reasoning that 2-ary merge's earliest-wins tie-break is associative, so
+  the chain and a single variadic node fire identically and "a dedicated
+  variadic op would add engine complexity for zero observable difference". The
+  premise was right and the conclusion wrong: the difference is not observable
+  in *values*, but a chain costs `n-1` extra nodes and `n-1` extra depth, which
+  measured up to 1.86x classic on a busy wide fan-in — a Phase 6 gate
+  violation. Replaced by a real variadic op; see Phase 4.5, "The missing n-ary
+  merge". Worth remembering as a pattern: "identical results" is not the same
+  claim as "identical cost", and only the first of those the parity suite can
+  check.
 - **Multi-output islands — re-deferred (written rationale).** An `Op`/island
   produces a single `Out`; classic multi-output nodes (`demux`,
   `dynamic_group`) would need projection nodes that fan a tuple output into N
@@ -482,7 +489,12 @@ arity is a runtime slice, which the fixed-arity tuple `In` cannot express).
 uniform one-`(value, tick)`-pair-per-edge form `#[op]` parses.
 `split`/`collapse` are pure sugar over `map`/`map_filter`, so they reach every
 engine for free. Extending `combine` to `graph!`/compiled is a follow-up (as it
-is for `feedback`).
+is for `feedback`) — and it is now a *smaller* one than this note implies: the
+other n-ary fan-in, `merge_n`, reached all three engines by declaring
+`In<'a> = &'a [(&'a T, bool)]` and having `graph!` emit a variadic node's edges
+as a pair slice rather than a tuple. `combine` can follow the same route; the
+"fixed-arity tuple `In` cannot express it" obstacle applies to `#[op]`
+generation, not to the engines.
 
 **Gate 2:** every classic node test has a next twin producing identical
 values and tick times.
@@ -1045,6 +1057,17 @@ routing on a same-cycle mark-dirty primitive — no add/remove). Removed slots a
 tombstoned, not freed (classic parity). Parity tests in
 `tests/dynamic_graph.rs`.
 
+**N-ary merge: ✅ landed.** `merge_all` and `fan` wire a single variadic
+`MergeN` node rather than a chain of `n-1` binary merges, matching classic's
+`merge(vec)` in both node count and depth. This was the phase's one open *gate*
+violation (up to 1.86x classic on a busy wide fan-in) rather than a deferred
+nicety — see "The missing n-ary merge" below.
+
+**Status of the phase.** Scheduling, the `O(depth)` drain term, dynamism and the
+n-ary merge are all closed. The arena/SoA value store is deferred on measured
+evidence (not pending work — see its section), and compiled-path region gating
+is argued *against* by the sparse benchmarks. Nothing here blocks the cutover.
+
 **Known parity gaps (for the cutover audit).** The runtime *behaviour* is a
 faithful twin (values + tick times match classic's oracles). The two
 dynamic-graph ergonomic gaps below are now **closed** (both were ergonomic
@@ -1107,11 +1130,17 @@ walked `0..=max_layer` **testing every bucket**, so per-cycle cost was really
 `O(active + deepest active layer)`, and a graph that is merely *deep* paid for
 its depth on every cycle even when almost none of it fired.
 
-Depth is not an exotic shape here: next's `fan` sugar **left-folds its branches
-into a binary merge chain**, so a 256-way fan-in is a ~256-deep graph (classic's
-`merge(vec)` is a single N-ary node, depth 1, which is why classic never showed
-the term). It also needs an *active* node above the quiet depth to bite — a join
-like `hot.merge(&deep)` — since otherwise `max_layer` never rises.
+Depth was not an exotic shape here: next's `fan` sugar **left-folded its
+branches into a binary merge chain**, so a 256-way fan-in was a ~256-deep graph
+(classic's `merge(vec)` is a single N-ary node, depth 1, which is why classic
+never showed the term). It also needs an *active* node above the quiet depth to
+bite — a join like `hot.merge(&deep)` — since otherwise `max_layer` never rises.
+
+That particular source of depth is gone: `fan` now fans in through one `merge_n`
+node (see the next section), so a 256-way fan is depth 1 like classic's. The
+drain fix below stands on its own regardless — depth is trivial to build with an
+ordinary chain of ops, and the gate that pins it does exactly that rather than
+going through `fan`.
 
 **Fixed** (`interp.rs`): the drain now finds occupied layers through an
 `occupied` bitmask — one bit per layer, set on enqueue, cleared on drain — so one
@@ -1127,16 +1156,16 @@ across the two padding widths) to **+8%** (2.94ms → 3.18ms). Gated by
 `quiet_depth_does_not_cost_per_cycle` (`tests/sparse_graph.rs`), which fails at
 636 against a bound of 39 if the walk returns.
 
-### The missing n-ary merge — a real Phase 6 gate violation ⚠️
+### The missing n-ary merge — a Phase 6 gate violation, ✅ now closed
 
-Chasing the depth term turned up its root cause, which is a **parity gap, not a
-tuning opportunity**: next has no n-ary merge node. `merge_all` and `fan` both
-unroll to a left-associated chain of binary `merge2`s (deliberately — "closes the
-n-ary-merge vocabulary gap without a bespoke variadic op"), so an n-way fan-in
-costs next `n-1` nodes where classic's `merge(vec)` costs **1**.
+Chasing the depth term turned up its root cause, which was a **parity gap, not a
+tuning opportunity**: next had no n-ary merge node. `merge_all` and `fan` both
+unrolled to a left-associated chain of binary `merge2`s (deliberately — "closes
+the n-ary-merge vocabulary gap without a bespoke variadic op"), so an n-way
+fan-in cost next `n-1` nodes where classic's `merge(vec)` costs **1**.
 
-On a *busy* fan-in — every branch ticking every cycle, the common case — that is
-a straight loss against classic, and it widens with width (20k cycles):
+On a *busy* fan-in — every branch ticking every cycle, the common case — that was
+a straight loss against classic, and it widened with width (20k cycles):
 
 | width | next (chain) | next (balanced tree) | classic | chain/classic |
 |-------|--------------|----------------------|---------|---------------|
@@ -1144,24 +1173,78 @@ a straight loss against classic, and it widens with width (20k cycles):
 | 64    | 48.3ms       | 41.8ms               | 28.0ms  | **1.73x**     |
 | 256   | 194.4ms      | 157.2ms              | 104.7ms | **1.86x**     |
 
-This violates the Phase 6 gate **`next-interpreted ≥ classic-interpreted`**. The
-`fanout` benchmark misses it because it is only 10 wide, where the 9 extra merge
+This violated the Phase 6 gate **`next-interpreted ≥ classic-interpreted`**. The
+`fanout` benchmark missed it because it is only 10 wide, where the 9 extra merge
 nodes are lost among ~105 others — the loss needs width to show.
 
-**A balanced merge tree is not the fix.** The third column measures it: `O(log n)`
-depth recovers roughly 40% of the gap (1.86x → 1.50x) and stops there, because
-the remaining cost is the `n-1` extra *nodes*, which rebalancing does not remove.
-Depth and node count are separate halves and only a real n-ary node removes both.
+**A balanced merge tree was not the fix.** The third column measures it: `O(log
+n)` depth recovers roughly 40% of the gap (1.86x → 1.50x) and stops there,
+because the remaining cost is the `n-1` extra *nodes*, which rebalancing does not
+remove. Depth and node count are separate halves and only a real n-ary node
+removes both.
 
-The fix is therefore a genuine variadic merge. The engine side is easier than the
-`merge_all` doc implies: `push_node` already takes `Vec<usize>` upstreams, so
-arbitrary arity is native and only the registration closure is hardcoded to two
-slots. The work is a `merge_n` in `interp.rs` capturing `Vec<SlotRef<T>>`, the
-fluent `merge_all`/`fan` redirected onto it, exact tie-break parity tests
-("first supplied that ticked wins", plus burst semantics), and the harder part —
-teaching `graph!`/compiled emission to emit an n-ary node instead of a chain.
-Worth a widened `fanout` benchmark bar at the same time, so the gate that missed
-this can catch it next time.
+**Landed: `MergeN`, the catalog's only variadic op.** `merge_all` and `fan` now
+wire a single node of arbitrary arity, so a k-way fan-in costs 1 merge node and 1
+layer of depth, matching classic's `merge(vec)` exactly. The pieces:
+
+- **The op** (`ops.rs`): `MergeN<T>` with `In<'a> = &'a [(&'a T, bool)]` — a pair
+  *slice* rather than the fixed-arity tuple every other op declares, which is
+  what lets one definition serve any width.
+- **Interpreted** (`Builder::merge_n`, `interp.rs`): hand-written, as
+  `Builder::combine` already is for the other n-ary fan-in — `#[op]` cannot parse
+  a variadic `In`. It does **not** hand `Op::cycle` a materialised slice: that
+  would mean borrowing all N slots (and allocating) every cycle, costing more
+  than the `n-1` chained nodes it replaces. Instead both paths route through one
+  shared rule, `MergeN::winner`, so they cannot disagree about which input wins;
+  the interpreted path applies it to the engine's tick flags and clones only the
+  winning slot.
+- **`graph!` / compiled**: `NodeDef` gained a `variadic` flag, set by the `fan`
+  and `merge_all` arms of `apply_call`. A variadic node's `cycle_input` emits the
+  uniform `(value, tick)` pairs as a *slice* instead of a tuple — which is the
+  whole trick, since a tuple-shaped forwarder would cap at whatever arity the
+  crate spelled out, and `fan(256)` is a real call. Its dispatch condition also
+  skips the passive mask (a variadic op is all-active by construction, and the
+  mask is a `u32` that a >32-wide fan-in would shift past). The
+  `__wf_op_merge_n_*` forwarders are hand-written alongside the op, following the
+  same rules `#[op]` follows — notably a *fully erased* `_start`, since `start`
+  takes no input to anchor `T` from.
+- **`merge_all` is now dual-mode**, where it used to be fluent-only ("sugar over
+  a primitive — spell the primitive"). Inside `graph!` it takes a slice literal
+  of stream references (`merge_all(&[&a, &b])`) so the merged edges stay
+  statically visible, the same constraint `map_n`/`fan` put on their counts.
+
+**Measured after** (a different machine from the table above, so read the two
+right-hand columns, not the milliseconds — 10k cycles, one map per branch):
+
+| width | next chain (old) | next n-ary (new) | classic | new/classic | old/new |
+|-------|------------------|------------------|---------|-------------|---------|
+| 16    | 7.61ms           | 3.83ms           | 5.43ms  | **0.80x**   | 1.98x   |
+| 64    | 31.93ms          | 13.16ms          | 16.76ms | **0.78x**   | 2.43x   |
+| 256   | 117.45ms         | 45.46ms          | 64.15ms | **0.76x**   | 2.58x   |
+
+The gate is not merely met but inverted — next-interpreted is now *faster* than
+classic at every width — and, more importantly, the ratio no longer degrades
+with width (1.45x → 1.73x → 1.86x against classic became 0.80x → 0.78x →
+0.76x). That flatness is the actual claim: the old numbers were bad because the
+cost grew with `n`, so a fixed improvement at one width would have proved
+nothing.
+
+**Gated by shape, not just by results** (`tests/merge_n.rs`). The regression that
+hid here for as long as it did was invisible to every results-parity test — a
+chain and an n-ary node produce identical values — so the new gate asserts the
+*wiring*: `Runner::node_count()` (a new hidden observability hook beside
+`node_visits`) must show one merge node for a 64-way `merge_all` and for a 32-way
+`fan`. Alongside it: the tie-break with all inputs ticking, the tie-break with
+the earliest input quiet, burst delivery, `merge_all(&[])` as identity,
+equivalence with the binary chain it replaced, and three-engine agreement for
+both `merge_all` and `fan`.
+
+**And the benchmark bar that missed it is widened**: `benches/tiers.rs` gains
+`fan_in_16` / `fan_in_64` / `fan_in_256` — busy fan-ins at the three widths of
+the table above, each with its classic twin, so the ratio is readable as a slope
+rather than a single number. The `sparse` groups' node counts fell out of this
+too (267 → 205, 1035 → 781, since `fan(64)`/`fan(256)` no longer contribute 63
+and 255 merge nodes), and now match their classic twins exactly.
 
 ### Tier ranking on sparse graphs: no crossover, but `nested` inverts
 
@@ -1182,7 +1265,14 @@ runs its whole compiled interior on every outer activation, so a mostly-quiet
 interior is its worst case. Worth knowing before recommending islands as a
 general accelerator: they pay off in proportion to how *busy* the interior is.
 
-**Two follow-ons remain, both deliberately separated from the scheduler:**
+**One follow-on remains, deliberately separated from the scheduler.** With the
+n-ary merge landed, Phase 4.5's buildable work is done — scheduling, the depth
+term, dynamism and the n-ary merge have all closed. What is left is the arena,
+which is deferred on measured evidence rather than pending (below), and
+compiled-path region gating, which the sparse benchmarks argue *against* doing
+at all (see "Tier ranking on sparse graphs" — compiled already beats the
+dirty-list on a ~97%-quiet graph, so the cost region gating would remove is
+small). Neither blocks the cutover.
 
 ### Arena / SoA value store — deferred perf follow-on (boundary frozen by type)
 
@@ -1265,7 +1355,11 @@ dynamism is an interpreted-engine capability, matching classic. See the Phase
   arena/perf pass.
 - Bench gate ties to Phase 6: `next-interpreted ≥ classic-interpreted` on the
   sparse workloads holds — `benches/tiers.rs` measures ~2.70ms vs classic's
-  ~3.23ms on the `sparse` group (and next wins the dense groups too).
+  ~3.23ms on the `sparse` group (and next wins the dense groups too). The one
+  workload where it did *not* hold — a busy wide fan-in — is the n-ary merge
+  gap above, now closed and covered by the new `fan_in_16/64/256` bars.
+  Regenerate them before claiming the gate: the widths exist precisely because
+  no single width would have caught it.
 
 ## Phase 5 — infrastructure
 
@@ -1522,7 +1616,7 @@ tests covered — not "legacy pytest passes unchanged."
 | Risk | Impact | Mitigation |
 |---|---|---|
 | Engine-owned init / evaluation-timing drift across the three emission paths | silent wrong values — the macro crate's interpreted/compiled/nested paths are the biggest drift surface; op-`cycle` semantics agree but engine-owned *seeding* and *timing* do not (fold init, closure-factory re-eval) | table-driven three-engine parity test (one micro-graph per macro-supported combinator, `interpreted == compiled == nested`); seed with the known divergences; single seed/init field per op so all three paths read one source |
-| Interpreted engine slower than classic on sparse graphs | perf parity claim | ✅ **Phase 4.5 dirty-list landed** (`Dispatch::Sparse`, classic's `dirty_nodes_by_layer` model; `FullSweep` retained as oracle) — results byte-identical, work ∝ active nodes; gated deterministically by `sparse_work_is_independent_of_graph_size` (`tests/sparse_graph.rs`), and `benches/tiers.rs` measures next-interpreted ahead of classic on the sparse groups. Qualifier: ⚠️ **wide *active* fan-ins are 1.45–1.86x slower than classic** — next has no n-ary merge node, so an n-way fan-in costs `n-1` nodes against classic's 1. A Phase 6 gate violation the 10-wide `fanout` bench misses; see Phase 4.5 |
+| Interpreted engine slower than classic on sparse graphs | perf parity claim | ✅ **Phase 4.5 dirty-list landed** (`Dispatch::Sparse`, classic's `dirty_nodes_by_layer` model; `FullSweep` retained as oracle) — results byte-identical, work ∝ active nodes; gated deterministically by `sparse_work_is_independent_of_graph_size` (`tests/sparse_graph.rs`), and `benches/tiers.rs` measures next-interpreted ahead of classic on the sparse groups. Former qualifier, ✅ **resolved**: wide *active* fan-ins were 1.45–1.86x slower than classic because next had no n-ary merge node, so an n-way fan-in cost `n-1` nodes against classic's 1 — a Phase 6 gate violation the 10-wide `fanout` bench could not see. `MergeN` / `Builder::merge_n` closed it (one node at any width, all three engines); pinned by `node_count` shape gates in `tests/merge_n.rs` and measured by the new `fan_in_16/64/256` bars. See Phase 4.5 |
 | Arena/SoA slot swap forces a second pass over the ported catalog | rework cost — registrations capture the slot type | ✅ **resolved: boundary frozen by type.** `SlotRef<T>` (`interp.rs`) is the sole access path (`slot()`/`new_slot()` return it; ops only `borrow`/`borrow_mut`); the arena is an internal swap of its innards, zero capture sites touched. Macro uses locals; `Stream::__slot` returns `SlotRef` too |
 | Burst/replay semantics drift | backtest determinism is the product | Phase 0.3 spike; classic tests as oracle; fallback design named in advance |
 | Feedback timing mismatch | correctness of feedback graphs | engine-level edge + classic's 4 feedback tests; fluent-only v1 |


### PR DESCRIPTION
## The problem

`merge_all` and `fan` left-folded into a chain of `n - 1` binary merges. That is *semantically* identical to a single n-ary node — 2-ary merge's earliest-wins tie-break is associative — which is exactly why it survived: every results-parity test passed either way.

What it cost was `n - 1` extra nodes and `n - 1` extra depth, against classic wingfoil's single `merge(vec)`. On a **busy** fan-in (every branch ticking, the common case) that was a straight loss that widened with width — 1.45x at 16, 1.73x at 64, **1.86x at 256** — i.e. a violation of the Phase 6 gate `next-interpreted >= classic-interpreted`. The `fanout` benchmark could not see it at 10 wide: the 9 extra merge nodes were lost among ~105 others.

A balanced merge tree is not the fix — it recovers ~40% and stops, because the remaining cost is the `n - 1` extra *nodes*, which rebalancing does not remove.

## The change

`MergeN`, the catalog's only **variadic** op: `In<'a> = &'a [(&'a T, bool)]` — a pair slice rather than the fixed-arity tuple every other op declares, so one definition serves a fan-in of any width. All three engines emit one node.

Two decisions worth review attention:

- **The interpreted path deliberately does not call `Op::cycle`.** Handing it a materialised `&[(&T, bool)]` means borrowing all N slots per cycle, which allocates — on a wide merge that costs more than the `n - 1` chained nodes being removed, i.e. it would have undone the fix. Both paths instead route through one shared rule, `MergeN::winner`, so they cannot drift on which input wins. `Builder::merge_n` is hand-written for the same reason `Builder::combine` already is: `#[op]` parses `In` as a fixed-arity tuple.
- **`graph!` emits a variadic node's edges as a slice, not a tuple.** A tuple-shaped forwarder would cap at whatever arity the crate spelled out, and `fan(256)` is a real call in the benchmarks. `NodeDef` gained a `variadic` flag set by the `fan` / `merge_all` arms; `cycle_input` and `lifecycle_input` emit `&[..]` for it, and the dispatch condition drops the passive mask — a variadic op is all-active by construction, and the mask is a `u32` that a >32-wide fan-in would shift past.

The `__wf_op_merge_n_*` forwarders are hand-written alongside the op, mirroring what `#[op]` emits — notably a *fully erased* `_start`, since `start` takes no input to anchor `T` from.

`merge_all` becomes **dual-mode** as a consequence (it was only fluent-only because it *was* sugar). Inside `graph!` it takes a slice literal — `merge_all(&[&a, &b])` — so the merged edges stay statically visible, the same constraint `map_n`/`fan` put on their counts.

## Gate the shape, not just the results

The regression was invisible to value parity, which is how it survived. So `tests/merge_n.rs` asserts on the **wiring**, via a new hidden `Runner::node_count()` hook beside `node_visits`: a 64-way `merge_all` and a 32-way `fan` must each cost one merge node. Alongside it — tie-break with all inputs ticking, tie-break with the earliest input quiet, burst delivery, `merge_all(&[])` as identity, equivalence with the chain it replaced, and interpreted/compiled/nested agreement for both spellings.

`benches/tiers.rs` gains `fan_in_16` / `fan_in_64` / `fan_in_256` with classic twins, so the bar that missed this can catch it next time. The `sparse` groups' node counts fell out of the change too (267 → 205, 1035 → 781) and now match their classic twins exactly.

## Measured

10k cycles, one map per branch:

| width | was (chain) | now (n-ary) | classic | now/classic | was/now |
|-------|-------------|-------------|---------|-------------|---------|
| 16    | 7.61ms      | 3.83ms      | 5.43ms  | **0.80x**   | 1.98x   |
| 64    | 31.93ms     | 13.16ms     | 16.76ms | **0.78x**   | 2.43x   |
| 256   | 117.45ms    | 45.46ms     | 64.15ms | **0.76x**   | 2.58x   |

next-interpreted now beats classic at every width, and — the actual claim — the ratio is **flat** across the sweep rather than degrading with it. The old numbers were bad because the cost grew with `n`, so a fixed improvement at one width would have proved nothing.

## Docs

`port-plan.md` marks the section closed with the after-table and records the phase's status: scheduling, the `O(depth)` drain term, dynamism and the n-ary merge are all closed; the arena stays deferred on measured evidence and compiled-path region gating is argued *against* by the sparse benchmarks. Neither blocks the cutover. The Phase 1 entry that originally chose sugar over a variadic op is annotated with why the reasoning failed — "identical results" is not the same claim as "identical cost", and only the first is what the parity suite checks.

`/new-op-next` gains the variadic-op shape and its route, per the living-skill rule in `next/CLAUDE.md`.

## Verification

`cargo fmt --all`, `cargo lint`, `cargo lint-all` and `cargo test -p wingfoil-next --all-features` all pass. The only failing test binaries are the `*_integration` ones, which need a Docker socket the sandbox does not have (`failed to initialize a docker client`) — unrelated to this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG8T1fmuBj85C5BsrpMGpR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KG8T1fmuBj85C5BsrpMGpR)_