### PR TITLE
Port the telemetry example, correct the Phase 6 Python ledger

### DIFF
--- a/next/crates/wingfoil-next/examples/telemetry/README.md
+++ b/next/crates/wingfoil-next/examples/telemetry/README.md
@@ -1,0 +1,83 @@
+# Telemetry Examples (wingfoil-next)
+
+Wingfoil provides two adapters for exporting metrics. Both work with Grafana as a
+visualisation layer — they differ only in how data is transported.
+
+A port of the classic `wingfoil/examples/telemetry` guide onto the next engine.
+
+## Which should I use?
+
+| | `prometheus` | `otlp` |
+|---|---|---|
+| **Model** | Pull — Prometheus scrapes your app | Push — your app pushes to a collector |
+| **Best for** | Existing Prometheus/Grafana stacks | Cloud-native / multi-vendor stacks |
+| **Backends** | Prometheus, Mimir, Thanos | Grafana Alloy, Datadog, Honeycomb, New Relic, … |
+| **Setup** | Zero config — just expose a port | Requires an OTel collector |
+| **Standard** | De facto today | Emerging standard (growing fast) |
+
+When in doubt, start with `prometheus` — it works with everything and needs no extra infrastructure.
+Use `otlp` if you're pushing to a cloud backend or already running an OTel collector.
+
+## Historical / backtesting mode
+
+Both adapters are **silent no-ops** in historical mode (`RunMode::HistoricalFrom`).
+The stream is consumed and discarded without connecting to any external service.
+This means you can include telemetry in a strategy graph and run backtests freely —
+no metrics will be emitted and no connections will be attempted.
+
+## Examples
+
+The two example programs live at the top of `examples/`, alongside the other
+per-adapter examples:
+
+| Example | Adapter | Source |
+|---|---|---|
+| `prometheus_adapter` | `PrometheusExporter` + `prometheus_gauge` | [`../prometheus_adapter.rs`](../prometheus_adapter.rs) |
+| `otlp_adapter` | the above plus `otlp_push` | [`../otlp_adapter.rs`](../otlp_adapter.rs) |
+
+## Running
+
+This directory carries the Grafana + Prometheus stack and a wrapper that brings
+it up and launches either example against it:
+
+```sh
+./run.sh              # prometheus (pull) — the default
+./run.sh otlp         # prometheus + OTLP push
+```
+
+- **Grafana** on <http://localhost:3000> (anonymous admin, no login)
+- **Prometheus** on <http://localhost:9090>, scraping the example on port 9091
+
+Press `Ctrl+C` to stop; the stack is torn down on exit.
+
+To run an example without the stack — the exporter is a server in its own right,
+so `curl` is enough to see it working:
+
+```sh
+cargo run -p wingfoil-next --example prometheus_adapter --features prometheus &
+curl http://localhost:9091/metrics
+# # TYPE wingfoil_ticks_total gauge
+# wingfoil_ticks_total 3
+```
+
+The OTLP half needs a collector listening on 4318:
+
+```sh
+docker run --rm -p 4318:4318 otel/opentelemetry-collector:0.149.0
+OTLP_ENDPOINT=http://localhost:4318 \
+    cargo run -p wingfoil-next --example otlp_adapter --features otlp,prometheus
+```
+
+## Deviations from classic
+
+- **One `run.sh` instead of two.** Classic ships
+  `telemetry/prometheus/run.sh` and `telemetry/otlp/run.sh`, which differ only
+  in the example they launch; this takes the example name as an argument.
+- **The docker stack lives with the example.** Classic's compose file sits
+  under the adapter source tree (`wingfoil/src/adapters/prometheus/docker/`)
+  because its integration tests share it; next's adapter tests need no stack,
+  so it belongs here.
+- **No `grafana-init` service.** That container exists to mint a Grafana API
+  token for the classic adapter's integration tests. No example reads it, and
+  classic's `otlp/run.sh` blocked for up to 30s waiting on a token it never
+  used.

--- a/next/crates/wingfoil-next/examples/telemetry/docker/docker-compose.yml
+++ b/next/crates/wingfoil-next/examples/telemetry/docker/docker-compose.yml
@@ -1,0 +1,46 @@
+# Grafana + Prometheus stack for the wingfoil-next telemetry examples.
+#
+# A port of the classic `wingfoil/src/adapters/prometheus/docker/docker-compose.yml`,
+# minus its `grafana-init` service — that exists to mint a Grafana API token for
+# the classic adapter's integration tests, which the examples never read.
+#
+# Prometheus scrapes `host.docker.internal:9091`, the port both examples bind
+# their `PrometheusExporter` to.
+services:
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: wingfoil-next-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    container_name: wingfoil-next-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./provisioning/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    # host.docker.internal resolves to the Docker host — where the example
+    # process binds its PrometheusExporter.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s

--- a/next/crates/wingfoil-next/examples/telemetry/docker/provisioning/datasources/prometheus.yml
+++ b/next/crates/wingfoil-next/examples/telemetry/docker/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/next/crates/wingfoil-next/examples/telemetry/docker/provisioning/prometheus/prometheus.yml
+++ b/next/crates/wingfoil-next/examples/telemetry/docker/provisioning/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: wingfoil
+    static_configs:
+      # host.docker.internal resolves to the Docker host — where the wingfoil
+      # test process binds its PrometheusExporter
+      - targets: ["host.docker.internal:9091"]
+    metrics_path: /metrics

--- a/next/crates/wingfoil-next/examples/telemetry/run.sh
+++ b/next/crates/wingfoil-next/examples/telemetry/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bring up the Grafana + Prometheus stack, then run one of the two telemetry
+# examples against it.
+#
+#   ./run.sh              # prometheus (pull) — the default
+#   ./run.sh prometheus
+#   ./run.sh otlp         # prometheus + OTLP push
+#
+# A port of the classic `wingfoil/examples/telemetry/{prometheus,otlp}/run.sh`,
+# collapsed into one script since the two differed only in which example they
+# launched.
+set -euo pipefail
+
+EXAMPLE="${1:-prometheus}"
+case "$EXAMPLE" in
+prometheus)
+    TARGET=prometheus_adapter
+    FEATURES=prometheus
+    ;;
+otlp)
+    TARGET=otlp_adapter
+    FEATURES=otlp,prometheus
+    ;;
+*)
+    echo "ERROR: unknown example \"$EXAMPLE\" — expected prometheus or otlp" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v docker &>/dev/null; then
+    echo "ERROR: docker is not installed — https://docs.docker.com/get-docker/" >&2
+    exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE="docker compose -f $HERE/docker/docker-compose.yml"
+
+echo "==> Starting Docker stack..."
+$COMPOSE up -d
+
+trap 'echo ""; echo "==> Stopping Docker stack..."; $COMPOSE down' EXIT
+
+EXPLORE_URL='http://localhost:3000/explore?orgId=1&refresh=1s&left=%7B%22datasource%22%3A%22Prometheus%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22rate%28wingfoil_ticks_total%5B1s%5D%29%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1m%22%2C%22to%22%3A%22now%22%7D%7D'
+
+link() { printf '\e]8;;%s\e\\%s\e]8;;\e\\\n' "$1" "$2"; }
+
+echo "==> Stack ready."
+printf "    Grafana (metric, 1s auto-refresh): "
+link "$EXPLORE_URL" "$EXPLORE_URL"
+printf "    Prometheus: "
+link "http://localhost:9090" "http://localhost:9090"
+echo ""
+
+if [ "$EXAMPLE" = otlp ]; then
+    echo "    NOTE: metrics reach Grafana via Prometheus scraping port 9091."
+    echo "          The OTLP push to port 4318 needs a separate OTel collector:"
+    echo "            docker run --rm -p 4318:4318 otel/opentelemetry-collector:0.149.0"
+    echo ""
+fi
+
+echo "==> Running example (Ctrl+C to stop)..."
+RUST_LOG=info \
+    cargo run --manifest-path "$ROOT/Cargo.toml" -p wingfoil-next \
+    --example "$TARGET" --features "$FEATURES"

--- a/next/docs/port-plan.md
+++ b/next/docs/port-plan.md
@@ -1456,10 +1456,12 @@ tests covered — not "legacy pytest passes unchanged."
   a `cycle(values) -> bool` + `peek()` protocol), so a Python object can be a
   graph node (legacy's `CustomStream`). Single-run in v1 (caller-owned Python
   state has no engine reset hook); next-python *regular* graphs re-run.
-- **Surface build-out** 🟡 *in progress*: grow `PyStream`/`PyGraph` to cover
-  the legacy combinator surface (`fold`/`sample`/`count`/`limit`/`difference`/
-  `with_time`/`collect`/`buffer`/`window`/`not`, a `sum`/`mean` statistics
-  bridge), then the per-adapter Python bindings as each Rust adapter lands.
+- **Surface build-out** ✅ *landed*: `PyStream`/`PyGraph` cover the legacy
+  combinator surface — `fold`/`sample`/`count`/`limit`/`difference`/
+  `with_time`/`collect`/`buffer`/`window`/`not_`, the `sum`/`mean` statistics
+  bridge, plus `filter_map`/`filter_value`/`filter_none`/`reduce`/`bimap`/
+  `split`/`dataframe` (all in `graph.rs`, each with a unit test). The
+  per-adapter bindings that followed are the next bullet.
 - **Per-adapter Python bindings** 🟡 *mechanical + stream-transform tiers landed (9 of 15)*: the `#[pyadapter]`
   exposure of the real `adapters::*` I/O adapters, each behind a
   `wingfoil-next-python` cargo feature of the same name (`crate::adapters::*`,
@@ -1639,12 +1641,14 @@ tests covered — not "legacy pytest passes unchanged."
   become strings (legacy had two `#[pyclass]` enums). One legacy capability is
   deliberately **not** ported: the `stages` latency-tracing path, which split a
   `[u64; N]` header off each sample into `TracedBytes` / `Latency` pyclasses.
-  Those belong to legacy's `latency` module, which has no next equivalent yet;
-  they return with the tracing port, and that is recorded here rather than
-  faked. Its round-trip tier needs no service at all — the `"local"` variant
+  It is blocked on the **next-python latency surface** (see the separate
+  bullet below), not on the engine — `wingfoil-next/src/latency.rs` landed in
+  Phase 5, so the earlier wording here, that these types "belong to legacy's
+  `latency` module, which has no next equivalent yet", named the wrong
+  blocker. Its round-trip tier needs no service at all — the `"local"` variant
   talks in-process over the heap, and `"ipc"` is daemonless.
 
-  **Remaining: 0 — the Python binding surface is complete.** Legacy
+  **Remaining: 0 — the per-adapter binding surface is complete.** Legacy
   `wingfoil-python` binds 15 adapters, in four tiers, all now done:
   - *mechanical* — **done**: kafka, redis, etcd, fluvio, csv, zmq;
   - *dynamic payload* — **done**: kdb, fix;
@@ -1668,6 +1672,20 @@ tests covered — not "legacy pytest passes unchanged."
   system library at build time (aeron, iceoryx2) must not join the
   `all-adapters` roll-up that `next-python-test.yml` builds without that job
   also gaining the toolchain install.
+- **Python latency surface** ⏳ *not started* — the one legacy Python
+  capability next-python does not yet have, and the last non-adapter gap in
+  the binding. Legacy ships a whole `py_latency` module
+  (`wingfoil-python/src/py_latency.rs`): `Latency` and `TracedBytes`
+  pyclasses, a *runtime* stage list (Python cannot name a compile-time `Stage`
+  type, so stages are `Vec<String>` and stamping goes by index), and
+  `PyStampNode` / `PyLatencyReportNode`. It is what legacy's iceoryx2 `stages`
+  argument is built on — that argument splits a `[u64; N]` little-endian
+  header off each raw sample into `TracedBytes`, which is why the iceoryx2
+  binding above could not port it. The **engine** side is not the blocker:
+  `wingfoil-next/src/latency.rs` landed in Phase 5. What the binding needs is
+  the dynamic-stage twin of it, in the same shape as the other
+  dynamic-payload bindings (kdb, fix). Scoped as its own change, not folded
+  into an adapter binding.
 - **`wingfoil_next::compat` (`Signal<T>`)** stays a *Rust-side* classic-idiom
   ergonomic (free `ticker`/`constant`, `stream.run`/`peek_value`; `tests/
   compat.rs`) — it is **not** the Python-binding path (that is the object-form
@@ -1677,18 +1695,30 @@ tests covered — not "legacy pytest passes unchanged."
   keeping classic versions until Phase 7. 🟢 *landed so far*: order_book,
   breadth_first, run_mode, statistics, threading, async, feedback, and the
   runtime-dynamism pair `dynamic` (`dynamic_group`) + `demux` (`demux_it`),
-  `tracing` (the `log` mode — the `logged` debug tap through `env_logger`), and
+  `tracing` (the `log` mode — the `logged` debug tap through `env_logger`),
   `latency` (`examples/latency/{pub,sub}.rs` — the cross-process
   `latency_stages!` + `Traced` + `.stamp::<Stage>()` + `latency_report` loop
   over an iceoryx2 hop, closing the Phase-5 infrastructure end to end; it fixes
-  two defects in the classic pair, see that example's README).
-  Remaining: `telemetry` (adapter/cross-process); and the `tracing`
-  example's other two modes — `tracing` (route events through a
-  `tracing-subscriber`) and `instruments` (engine spans around `run`/cycle) —
-  which are ⏳ *blocked* on porting next's `tracing` / `instrument-*` engine
-  features (the op catalog logs through `log` only, and the engine has no span
-  instrumentation yet). Tracked as a Phase-6 follow-up, landing with the
-  instrumentation port, not as example work.
+  two defects in the classic pair, see that example's README), and `telemetry`.
+
+  **`telemetry`** was already ported as graph code — `prometheus_adapter.rs`
+  and `otlp_adapter.rs`. What landed now is the rest of the classic example:
+  the pull-vs-push guide, a self-contained Grafana + Prometheus compose stack
+  (`examples/telemetry/docker/`), and a `run.sh` that brings it up and launches
+  either example. **Deviations**: one `run.sh` taking the example name instead
+  of classic's two near-identical scripts; the compose file lives with the
+  example rather than under the adapter source tree (classic keeps it there
+  because its integration tests share it — next's adapter tests need no
+  stack); and no `grafana-init` service, which exists to mint a Grafana API
+  token for those classic tests that no example reads (classic's `otlp/run.sh`
+  blocked up to 30s waiting on a token it never used).
+
+  Remaining: the `tracing` example's other two modes — `tracing` (route events
+  through a `tracing-subscriber`) and `instruments` (engine spans around
+  `run`/cycle) — which are ⏳ *blocked* on porting next's `tracing` /
+  `instrument-*` engine features (the op catalog logs through `log` only, and
+  the engine has no span instrumentation yet). Tracked as a Phase-6 follow-up,
+  landing with the instrumentation port, not as example work.
 - **Benchmarks**: the four-way `tiers` bench 🟢 *landed* — each workload now
   runs a `classic` (legacy interpreted) bar beside next's
   `interpreted`/`compiled`/`nested`, so `next-interpreted ≥ classic-interpreted`


### PR DESCRIPTION
Rebased onto `next`. This branch originally also ported the latency example; #634 landed that independently while this was open, and **its version is kept as-is** — see the note at the bottom. What remains here is the telemetry example plus the Phase 6 plan corrections.

## `telemetry` — `examples/telemetry/`

Already ported as graph code (`prometheus_adapter.rs`, `otlp_adapter.rs`); what lands here is the rest of the classic example — the pull-vs-push guide, a self-contained Grafana + Prometheus compose stack, and a `run.sh` that brings it up and launches either example.

Deviations from classic:

- One `run.sh` taking the example name instead of classic's two near-identical scripts.
- The compose file lives with the example rather than under the adapter source tree. Classic keeps it there because its integration tests share it; next's adapter tests need no stack.
- No `grafana-init` service. It mints a Grafana API token for those classic tests, which no example reads — classic's `otlp/run.sh` blocked up to 30s waiting on a token it never used.

## port-plan Phase 6 corrections

- **Surface build-out** marked landed — the whole legacy combinator list is in `graph.rs` with unit tests; the `🟡 in progress` marker was stale.
- **The iceoryx2 binding's `stages` note named the wrong blocker.** It said the `TracedBytes`/`Latency` pyclasses "belong to legacy's `latency` module, which has no next equivalent yet" — untrue since Phase 5 landed `wingfoil-next/src/latency.rs`. The real gap is that next-python has no equivalent of legacy's `py_latency` module: those pyclasses and their runtime (string-list) stage handling, which is what legacy's `stages` argument is built on. Now recorded as its own scoped item; it is the last non-adapter gap in the Python surface.
- **"Remaining: 0 — the Python binding surface is complete"** was true of *adapters* but not of the binding as a whole, and is qualified accordingly.

Phase 6 examples after this: only the `tracing` example's `tracing` and `instruments` modes remain, still blocked on the engine instrumentation port.

## On the overlap with #634

Both branches ported `examples/latency/` and independently found two of the same classic defects (the missing `#[type_name(...)]` pin, and that Ctrl-C never reaches teardown so the report never printed). My version additionally switched the stamps to `.stamp_precise()`, on the strength of a run where the `publish -> receive` IPC row came back with **no samples** under `.stamp()` — the subscriber's cycle-start snap predating the publisher's stamp, so `observe()` skipped every pair as out of order.

I could not reproduce that. Running #634's version as landed, the IPC row was populated in **10 of 10 trials**. Since I can't substantiate the claim, I dropped my version entirely rather than churn a landed example — `examples/latency/` and its `Cargo.toml` entries here are byte-identical to `next`. Recording the one-off observation only in case it resurfaces; the zero in-process deltas that #634's README documents are expected and unrelated.

## Verification

- `cargo fmt --all -- --check`, `cargo lint`, `cargo lint-all` all pass post-rebase. (`lint-all` needed the CMake ≥ 3.30 install CLAUDE.md documents, plus `protoc`.)
- `prometheus_adapter` verified serving a scrapeable `/metrics` over loopback; `run.sh` parses.
- **Not verified: the telemetry docker stack** — no docker daemon in this environment. It is a faithful port of the known-good classic compose file rather than new wiring, but it has not been brought up.

No library code changed — only new example assets and docs.