### PR TITLE
Fix import ordering left by the wingfoil_next repoint

### DIFF
--- a/next/crates/wingfoil-next/benches/iceoryx2_modes.rs
+++ b/next/crates/wingfoil-next/benches/iceoryx2_modes.rs
@@ -28,11 +28,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use iceoryx2::prelude::ZeroCopySend;
-use wingfoil_next::{RunFor, RunMode};
 use wingfoil_next::adapters::iceoryx2::{
     Iceoryx2Mode, Iceoryx2ServiceVariant, Iceoryx2SinkOps, Iceoryx2SubOpts, iceoryx2_sub_opts,
 };
 use wingfoil_next::prelude::*;
+use wingfoil_next::{RunFor, RunMode};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, ZeroCopySend)]

--- a/next/crates/wingfoil-next/examples/latency_e2e/fix_gw.rs
+++ b/next/crates/wingfoil-next/examples/latency_e2e/fix_gw.rs
@@ -45,11 +45,11 @@ mod shared;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use wingfoil_next::{NanoTime, RunFor, RunMode};
 use wingfoil_next::adapters::fix::{FixMessage, FixSender, FixSessionStatus, fix_connect_tls};
 use wingfoil_next::adapters::iceoryx2::{Iceoryx2SinkOps, iceoryx2_sub};
 use wingfoil_next::latency::{LatencyStreamOps, Traced};
 use wingfoil_next::prelude::*;
+use wingfoil_next::{NanoTime, RunFor, RunMode};
 
 use shared::{
     RoundTrip, RoundTripLatency, SIDE_BUY, SVC_FILLS, SVC_ORDERS, env_u64, pin_current_from_env,

--- a/next/crates/wingfoil-next/examples/latency_e2e/ws_server.rs
+++ b/next/crates/wingfoil-next/examples/latency_e2e/ws_server.rs
@@ -44,7 +44,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use iceoryx2::prelude::ZeroCopySend;
-use wingfoil_next::{NanoTime, RunFor, RunMode};
 use wingfoil_next::adapters::iceoryx2::{Iceoryx2SinkOps, iceoryx2_sub};
 use wingfoil_next::adapters::otlp::{OtlpAttributeBuffer, OtlpConfig, OtlpSpanOps};
 use wingfoil_next::adapters::prometheus::{PrometheusExporter, PrometheusSinkOps};
@@ -53,6 +52,7 @@ use wingfoil_next::latency::{
     Latency, LatencyReportOps, LatencyStats, LatencyStreamOps, StageStats, Traced,
 };
 use wingfoil_next::prelude::*;
+use wingfoil_next::{NanoTime, RunFor, RunMode};
 
 use shared::{
     EchoFrame, FillFrame, OrderFrame, RoundTrip, RoundTripLatency, SVC_FILLS, SVC_ORDERS,

--- a/next/crates/wingfoil-next/src/bencher.rs
+++ b/next/crates/wingfoil-next/src/bencher.rs
@@ -42,11 +42,11 @@
 use crate::fluent::{GraphBuilder, Stream, Upstream};
 use crate::op::{Activation, Tick};
 
+use crate::{RunFor, RunMode};
 use criterion::Criterion;
 use std::cell::RefCell;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
-use crate::{RunFor, RunMode};
 
 /// Used to add a wingfoil-next bench to criterion.
 ///


### PR DESCRIPTION
`next` is currently failing `cargo fmt --all -- --check`. My fault, and this
fixes it.

## What happened

The six 3.x branches were all written before the dependency inversion landed,
so each one that added Rust used `use wingfoil::{NanoTime, RunFor, RunMode}` —
the edge that change had just removed. I repointed them onto `wingfoil_next::`
while merging, but did it with `sed`, which preserved the *position* of each
import. rustfmt disagrees: a bare `wingfoil_next::{RunFor, RunMode}` sorts
**after** `wingfoil_next::adapters::…` and `wingfoil_next::prelude::*`, not
before them.

Four files, import order only, no other change:

- `next/crates/wingfoil-next/src/bencher.rs`
- `next/crates/wingfoil-next/benches/iceoryx2_modes.rs`
- `next/crates/wingfoil-next/examples/latency_e2e/fix_gw.rs`
- `next/crates/wingfoil-next/examples/latency_e2e/ws_server.rs`

## Why it reached `next`

I verified with `cargo fmt --all -- --check 2>&1 | tail -3`. A pipeline's exit
status is the last command's, so `tail` returned 0 and masked rustfmt's 1 — the
diff was right there in the output and the check still looked like it passed.
Worth avoiding: check the exit code before the pipe, or don't pipe.

## Verification

```
cargo fmt --all -- --check                              exit 0
cargo check -p wingfoil-next --features bench --benches  exit 0
```

Both exit codes read directly, not through a pipe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeYR1ssyiikQqjTrtmoE34)_