### PR TITLE
docs(next): close the content gaps the doc build exposed

### DIFF
--- a/.claude/commands/bind-adapter-next.md
+++ b/.claude/commands/bind-adapter-next.md
@@ -202,6 +202,26 @@ rejection raises a Python exception instead of aborting a later run.
 Put `#[pyo3(signature = (…))]` on the adapter fn over **your own** params; the
 macro forwards it and injects the `graph`/`stream` receiver.
 
+### The `///` on the adapter fn *is* the published Python docstring
+
+`#[pyadapter]` (and `#[pyop]` / `#[pygraph]`) copy the annotated item's doc
+comment onto the generated `#[pyfunction]`, so it becomes what `help()` prints
+**and** the function's entry in the generated Sphinx reference
+(`crates/wingfoil-next-python/docs/`, "Generated reference"). There is nowhere
+else that prose gets written — `api.rst` carries a hand-written index, not
+per-function text.
+
+So write it for the **Python** caller, not a Rust reader: what one tick
+carries (`list` of dicts? `bytes`? a `(data, status)` tuple?), what every
+argument means, which selectors are strings and what the accepted set is, and
+what raises at wiring versus what aborts the run. On the impl form of
+`#[pyadapter]` the doc goes on the **method**, not the trait or the `impl`
+block. Check it landed:
+
+```python
+import wingfoil_next as wf; help(wf.my_adapter_sub)
+```
+
 ### Run mode / run window become arguments
 
 A Python `Graph` does not know its run mode until `run()`, so a source that

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![CI](https://img.shields.io/github/actions/workflow/status/wingfoil-io/wingfoil/rust-test.yml?branch=main&label=CI)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust-test.yml)
+[![codecov](https://codecov.io/gh/wingfoil-io/wingfoil/graph/badge.svg)](https://codecov.io/gh/wingfoil-io/wingfoil)
+
 # Wingfoil Next
 
 Wingfoil Next is a blazingly fast, highly scalable stream processing engine
@@ -32,8 +35,21 @@ streaming data across your entire stack.
   abort the run with context and cleanup still runs.
 - **Simple to use**: define your graph of calculations; Wingfoil manages its
   execution.
-- **Adapters**: integrations for CSV, etcd, the augurs time-series toolkit,
-  and line-oriented files, with async/Tokio at your graph edges.
+- **Adapters**: sixteen production-ready integrations — PostgreSQL, KDB+,
+  Kafka, Redis, etcd, Fluvio, ZeroMQ, FIX 4.4, iceoryx2, Aeron, WebSocket,
+  Prometheus, OpenTelemetry, CSV, augurs and line-oriented files — with
+  async/Tokio at your graph edges, plus an LRU file cache for time-sliced
+  readers. One runnable example each,
+  [indexed here](crates/wingfoil-next/examples/adapters/).
+- **Multi-language**: a Rust crate, a [Python
+  package](crates/wingfoil-next-python/) exposing the same graph model,
+  adapters and latency surface, and a [TypeScript/JavaScript client](js/) for
+  the web adapter.
+- **Latency tracing**: per-hop wall-clock stamps that survive a process hop and
+  aggregate into one report — see
+  [`showcase/`](crates/wingfoil-next/examples/showcase/).
+- **Graph dynamism**: add and remove nodes on a
+  [running graph](crates/wingfoil-next/examples/core/dynamic/), between cycles.
 - **Multi-threading**: distribute graph execution across threads through the
   channel layer.
 - **Extensible**: add sources, combinators, statistics and adapters as
@@ -198,6 +214,8 @@ to backtest.
 - Explore the [examples](crates/wingfoil-next/examples/)
 - Browse the [crates](crates/)
 - Read the [benchmarks](crates/wingfoil-next/benches/)
+- Use it from Python: [`wingfoil-next-python`](crates/wingfoil-next-python/)
+- Use it from the browser: [`@wingfoil/client`](js/)
 - See [CONTRIBUTING](CONTRIBUTING.md) to build, test and contribute
 
 

--- a/crates/wingfoil-next-python-macros/README.md
+++ b/crates/wingfoil-next-python-macros/README.md
@@ -69,7 +69,23 @@ All inputs are **active** — any one ticking runs the op. A passive edge needs 
 hand-written method, exactly as on the Rust side. Stream parameters are named, so
 they can be passed by keyword.
 
-`Cfg` may be `()` (no config parameter) or a single `FromPyObject` type.
+`Cfg` may be `()` (no config parameter), a single `FromPyObject` type
+(`arg = <name>`, defaulting to `cfg`), or a **tuple** destructured into one named
+parameter per element with `arg = (<p1>, <p2>, …)` — so an op with
+`Cfg = (usize, f64)` reads as `name(stream, window, alpha)`.
+
+## Doc comments carry across
+
+All three macros here — `#[pyop]`, `#[pygraph]` and `#[pyadapter]` — copy the
+annotated item's `///` docs onto the generated `#[pyfunction]`, so they become
+the callable's **Python docstring**: what `help()` prints, and what the Sphinx
+reference in [`../wingfoil-next-python/docs/`](../wingfoil-next-python/docs/)
+renders for it. There is nowhere else that prose gets written.
+
+Write it once, in Rust, for the *Python* caller: what one tick carries, what
+each argument means, what raises at wiring versus what aborts the run.
+`#[pyop]` reads the docs off the `impl` block, `#[pygraph]` off the wiring fn,
+`#[pyadapter]` off the free fn or the impl's method.
 
 ## See also
 

--- a/crates/wingfoil-next-python-macros/src/lib.rs
+++ b/crates/wingfoil-next-python-macros/src/lib.rs
@@ -50,6 +50,15 @@
 //! stateless, or e.g. `State = f64` for an accumulator — the engine re-seeds it
 //! from `Default` on each run, so re-runs start clean).
 //!
+//! **Doc comments carry across.** All three macros here (`#[pyop]`,
+//! `#[pygraph]`, `#[pyadapter]`) copy the annotated item's `///` docs onto the
+//! generated `#[pyfunction]`, so they become the callable's Python docstring —
+//! which is what `help()` prints and what the Sphinx reference in
+//! `crates/wingfoil-next-python/docs/` renders. Write the prose once, in Rust,
+//! aimed at the *Python* caller: name the Python argument shapes and say what a
+//! tick carries. `#[pyop]` reads them off the `impl` block, `#[pygraph]` off
+//! the wiring fn, `#[pyadapter]` off the free fn or the impl's method.
+//!
 //! Wider ops need a `register_op<n>`/`wire_op<n>` pair for their arity —
 //! `register_op4` mirrors `register_op3` line for line — plus the parameter
 //! name in `receiver_names`. The emitter itself is arity-generic, so nothing
@@ -372,9 +381,11 @@ fn expand_pygraph(args: &PyGraphArgs, func: &ItemFn) -> syn::Result<TokenStream2
         )
     };
 
+    let docs = doc_attrs(&func.attrs);
     Ok(quote! {
         #[pyo3::pyfunction]
         #[allow(clippy::too_many_arguments)]
+        #(#docs)*
         pub fn #py_name(
             #graph_param
             #(#receiver_params),*
@@ -588,7 +599,7 @@ fn expand_pyadapter_fn(args: &PyAdapterArgs, func: &ItemFn) -> syn::Result<Token
         out_ty,
         &param_decls,
         &param_names,
-        &pyo3_attrs(&func.attrs),
+        &forwarded_attrs(&func.attrs),
     )
 }
 
@@ -627,17 +638,33 @@ fn expand_pyadapter_impl(args: &PyAdapterArgs, imp: &ItemImpl) -> syn::Result<To
         out_ty,
         &param_decls,
         &param_names,
-        &pyo3_attrs(&method.attrs),
+        &forwarded_attrs(&method.attrs),
     )
 }
 
-/// The `#[pyo3(..)]` attributes written on the adapter fn — forwarded to the
-/// generated `#[pyfunction]`. That is how an adapter declares Python defaults,
-/// e.g. `#[pyo3(signature = (conn, chunk_secs = 3600, buffer_size = None))]`.
-fn pyo3_attrs(attrs: &[Attribute]) -> Vec<Attribute> {
+/// The attributes forwarded from the annotated item to the generated
+/// `#[pyfunction]`:
+///
+/// * `#[pyo3(..)]` — how an adapter declares its Python defaults, e.g.
+///   `#[pyo3(signature = (conn, chunk_secs = 3600, buffer_size = None))]`.
+/// * `#[doc]` (i.e. `///`) — the adapter's prose *is* its Python docstring, and
+///   therefore its entry in the generated Sphinx reference. Dropping it would
+///   leave every bound adapter undocumented on the Python side while the Rust
+///   source next to it carries the full explanation.
+fn forwarded_attrs(attrs: &[Attribute]) -> Vec<Attribute> {
     attrs
         .iter()
-        .filter(|a| a.path().is_ident("pyo3"))
+        .filter(|a| a.path().is_ident("pyo3") || a.path().is_ident("doc"))
+        .cloned()
+        .collect()
+}
+
+/// The `#[doc]` attributes of an item, for the generated functions that take no
+/// `#[pyo3(..)]` forwarding ([`pygraph`] and [`pyop`]).
+fn doc_attrs(attrs: &[Attribute]) -> Vec<Attribute> {
+    attrs
+        .iter()
+        .filter(|a| a.path().is_ident("doc"))
         .cloned()
         .collect()
 }
@@ -1117,8 +1144,10 @@ fn expand(args: &PyOpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
         .zip(&elems)
         .map(|(id, ty)| quote! { #id: &#ty });
 
+    let docs = doc_attrs(&imp.attrs);
     let body = quote! {
         #[pyo3::pyfunction]
+        #(#docs)*
         fn #name(
             #(#receiver_params),*
             #param

--- a/crates/wingfoil-next-python/README.md
+++ b/crates/wingfoil-next-python/README.md
@@ -1,135 +1,911 @@
 # wingfoil-next-python
 
-Python interop prototype for **wingfoil-next** (the Op-pattern engine at the
-repository root). See `docs/python-interop.md` for the design.
+Wingfoil is a blazingly fast, highly scalable stream processing framework
+designed for latency-critical use cases such as electronic trading and
+real-time AI systems. You define a graph of transformations over streams;
+Wingfoil drives their execution in a tightly scheduled
+[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph), either against
+live data or replayed history.
 
-The importable module is `wingfoil_next`, exposing `Graph` and `Stream`:
+**Wingfoil Next** is the Op-pattern engine that replaces the original wingfoil
+engine, and `wingfoil_next` is its Python binding. The Rust engine does the
+heavy lifting; this package exposes the same graph model, the combinator
+surface, all fifteen production I/O adapters and the latency-tracing surface —
+plus a plugin seam that lets you author ops, sub-graphs and adapters *in Rust*
+and compose them from Python.
+
+> Coming from the original `wingfoil` package? `wingfoil_next` supersedes it —
+> see the [migration guide](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-next-python/docs/migration.rst), which lists every renamed
+> entry point and every place next deliberately behaves differently.
+
+---
+
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Core Concepts](#core-concepts)
+  - [Run modes and the run window](#run-modes-and-the-run-window)
+  - [Bursts: why a source tick is a list](#bursts-why-a-source-tick-is-a-list)
+- [Stream Operators](#stream-operators)
+  - [Sources](#sources)
+  - [Transforming values](#transforming-values)
+  - [Gating and rate control](#gating-and-rate-control)
+  - [Combining and splitting](#combining-and-splitting)
+  - [Aggregation](#aggregation)
+  - [Observing and reading back](#observing-and-reading-back)
+  - [Statistics](#statistics)
+- [Python-defined nodes](#python-defined-nodes)
+- [Backtesting with historical mode](#backtesting-with-historical-mode)
+- [Pandas integration](#pandas-integration)
+- [Latency tracing](#latency-tracing)
+- [I/O adapters](#io-adapters)
+- [Authoring components in Rust](#authoring-components-in-rust)
+- [Build from source](#build-from-source)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Release status and feedback](#release-status-and-feedback)
+
+---
+
+## Features
+
+- **Fast** — ultra-low latency and high throughput from an efficient DAG
+  execution engine written in Rust. The Python edge boxes values only at the
+  boundary; wiring is done once, not per tick.
+- **Simple and obvious** — build a graph with fluent combinators; Wingfoil
+  manages scheduling and propagation.
+- **Backtesting out of the box** — the same graph runs against wall-clock time
+  or replays history deterministically; historical is the *default*.
+- **Lossless** — same-instant values ride a single burst, never coalesced to
+  latest-wins and never dropped, identically in both run modes.
+- **Fails loudly** — a missing field, a wrong-typed value or a raising callable
+  aborts the run naming the offender, rather than defaulting its way through.
+- **Fifteen production I/O adapters** — PostgreSQL, Kafka, Redis, etcd, Fluvio,
+  CSV, KDB+, ZeroMQ, FIX 4.4, augurs, Prometheus, OTLP, WebSocket, Aeron and
+  iceoryx2.
+- **Latency tracing** — per-hop wall-clock stamps that survive a hop to a Rust
+  peer, aggregated into the engine's own report.
+- **A plugin seam** — author an op, a sub-graph or an adapter in Rust and call
+  it from Python alongside the built-ins, with a compiled hot core under
+  dynamic Python wiring.
+
+---
+
+## Installation
+
+`wingfoil_next` is not on PyPI yet — the published `wingfoil` package is still
+the legacy engine. Until the cutover, install from a source checkout:
+
+```bash
+git clone https://github.com/wingfoil-io/wingfoil
+cd wingfoil/crates/wingfoil-next-python
+pip install maturin
+maturin develop
+```
+
+That builds the wheel's full adapter set (PostgreSQL, Kafka, Redis, etcd,
+Fluvio, CSV, ZeroMQ, OTLP, augurs, KDB+, FIX, Prometheus, web). Two adapters
+are opt-in because they would make the build platform-specific:
+
+```bash
+maturin develop -F iceoryx2       # Linux/POSIX shared memory
+maturin develop -F aeron          # needs clang, libuuid, CMake >= 3.30
+```
+
+`protoc` is needed at build time (etcd compiles its protos):
+`sudo apt-get install -y protobuf-compiler`.
+
+Adapter *clients* are compiled into the extension, so no extra Python packages
+are needed for them — only the backing service. `pandas` is needed at run time
+for [`stream.dataframe()`](#pandas-integration), and nothing else.
+
+Because the adapters are cargo features, the module surface reflects what you
+built. `hasattr(wingfoil_next, "kafka_sub")` is the check.
+
+---
+
+## Quick Start
 
 ```python
 import wingfoil_next as wf
 
 g = wf.Graph()
-out = g.counter(period_nanos=100).map(lambda n: n * 2)
-g.run(cycles=3)          # historical replay from t=0
-assert out.value() == 6  # 3rd tick -> 3 * 2
+(
+    g.counter(period_nanos=1_000_000_000)   # tick every second: 1, 2, 3, …
+     .map(lambda n: f"hello, world {n}")
+     .print()                               # print each value, pass it through
+)
+g.run(cycles=3)
 ```
 
-`map` takes a native Python callable; a raised exception aborts the run. Values
-cross the boundary as native Python objects and are boxed into the erased
-`PyElement` only at the edges.
+```
+hello, world 1
+hello, world 2
+hello, world 3
+```
 
-`wingfoil_next` is a Python package (`python/wingfoil_next/`) wrapping the
-compiled extension (`wingfoil_next._wingfoil`); everything the extension exports
-is re-exported unchanged, and the package adds what is better written in Python
-than through pyo3.
+`Graph.run()` blocks until the bound is reached, and defaults to deterministic
+historical replay from `t=0` — so the run above finishes instantly rather than
+taking three seconds. Pass any of:
+
+| Argument | Type | Meaning |
+| --- | --- | --- |
+| `realtime` | `bool` | `True` uses wall-clock time; `False` (the default) is historical replay. |
+| `start_nanos` | `int` | Historical start, in nanoseconds since the epoch. |
+| `duration_nanos` | `int` | Stop after this much graph time. |
+| `cycles` | `int` | Stop after this many engine cycles. Takes precedence over `duration_nanos`. |
+
+With neither `cycles` nor `duration_nanos`, the graph runs forever.
+
+---
+
+## Core Concepts
+
+- **Graph** — the builder you hold. Every source is created *on* it
+  (`g.counter(...)`, `wf.csv_read(g, ...)`), and `g.run(...)` executes
+  everything wired onto it. There is no ambient graph and no per-stream `run`.
+- **Stream** — a time-stamped channel of values. Combinators
+  (`.map`, `.filter_value`, `.distinct`, …) each return a new `Stream`, so
+  pipelines chain. Sinks return a terminal `Stream` whose value is `None`;
+  keep hold of it or not, it is wired either way.
+- **Value** — after the run, `stream.value()` reads back the last value the
+  stream carried.
+- **Tick** — a cycle in which a stream produced a value. A combinator that
+  drops a value simply does not tick, and its downstreams do not run.
+
+### Run modes and the run window
+
+- `realtime=True` — the engine follows the wall clock. Use it with live inputs
+  (sockets, brokers, shared memory).
+- `realtime=False` — **historical replay**, driven by event timestamps. The
+  graph runs as fast as the CPU allows and time advances purely from source
+  events, so it is deterministic: the right mode for tests and backtests.
+
+A Python `Graph` does not know its mode until `run()` is called, but several
+adapters need it at *wiring* time — a live subscriber has no timeline to
+replay, and a sliced historical read must know its window to build its queries.
+Those adapters take the fact as an **argument** (`realtime=`, or `start_nanos=`
+/ `duration_nanos=`), and it must match the eventual `run(...)`. Passing
+`realtime=False` to a live-only source raises there and then, rather than
+producing an empty run.
+
+### Bursts: why a source tick is a list
+
+A **burst** is the group of values sharing one instant — the messages that
+arrived between two graph cycles, or the rows of a replay carrying the same
+timestamp. The engine never collapses a burst to "latest wins" and never drops
+a member, so on the Python edge a burst erases to a **`list`**: one tick, one
+list, in arrival order.
+
+That is why every I/O source yields a list per tick, even when the list usually
+has one element. Index it for the single-value case:
+
+```python
+rows = wf.csv_read(g, "prices.csv", "time")
+first = rows.map(lambda batch: batch[0])
+```
+
+Sinks accept the same shape in reverse: a `list`/`tuple` writes a multi-value
+burst, anything else writes a single-element one.
+
+---
+
+## Stream Operators
+
+Every combinator below is a method on `Stream` unless marked otherwise.
+
+### Sources
+
+Sources are built on the `Graph`.
+
+| Source | Description |
+| --- | --- |
+| `g.counter(period_nanos)` | Emit the running tick count `1, 2, 3, …` every `period_nanos`. |
+| `g.constant(value)` | Emit `value` once, on the first cycle. |
+| `g.values(values, period_nanos)` | Replay a finite `list`, one value per tick, `period_nanos` apart. The straightforward way to feed real data in from Python. A graph containing it is single-run. |
+| `g.custom_node(upstreams, obj)` | Wire a Python object as a node — see [Python-defined nodes](#python-defined-nodes). |
+
+I/O sources are module-level functions taking the graph first — see
+[I/O adapters](#io-adapters).
+
+### Transforming values
+
+| Operator | Description |
+| --- | --- |
+| `.map(f)` | Apply `f(value)` to each tick. A raised exception aborts the run. |
+| `.filter_map(f)` | Map and filter in one: `f(value)` returning `None` drops the tick. |
+| `.fold(init, f)` | Fold into an accumulator seeded from `init`, emitting it after each fold. |
+| `.reduce(f)` | Like `fold`, but the first value seeds the accumulator. |
+| `.difference()` | Emit `value - previous` (quiet on the first). |
+| `getattr(s, 'not')()` | Arithmetic negation (`5 -> -5`). The method name is the Python keyword `not`, so reach it with `getattr`. |
+| `.bimap(other, f)` | Combine two streams through `f(this, other)`, whenever either ticks. |
+
+### Gating and rate control
+
+| Operator | Description |
+| --- | --- |
+| `.filter_value(pred)` | Keep a value only when `pred(value)` is truthy. **This is legacy `wingfoil`'s `filter`.** |
+| `.filter(condition)` | Emit only while another *stream*'s current value is truthy. Takes a `Stream`, not a callable. |
+| `.filter_none()` | Drop values that are `None`. |
+| `.distinct()` | Suppress consecutive duplicates — emit on change only. |
+| `.drop_small_change(is_small)` | Suppress ticks while `is_small(current, last_emitted)` is truthy. Compares against the last value *emitted*, so a slow drift still eventually ticks. |
+| `.limit(n)` | Pass the first `n` values through, then stay quiet. |
+| `.throttle(interval_nanos)` | Emit at most once per interval. |
+| `.sample(trigger)` | Re-emit the current value whenever `trigger` ticks. |
+| `.delay(delay_nanos)` | Re-emit each value that many nanoseconds later. |
+
+### Combining and splitting
+
+| Operator | Description |
+| --- | --- |
+| `.merge(other)` | Merge two streams; on a same-cycle tie the earliest-supplied input wins. |
+| `.merge_all([...])` | Merge several at once. |
+| `.split()` | Decompose a stream of 2-tuples into two streams. |
+
+### Aggregation
+
+| Operator | Description |
+| --- | --- |
+| `.count()` | Emit the running tick count, ignoring values. |
+| `.sum()` / `.mean()` | Cumulative running sum / mean. `.average()` is an alias of `.mean()`. |
+| `.accumulate()` | Collect every value into a growing `list`, re-emitted each tick. |
+| `.buffer(capacity)` | Flush a `list` once `capacity` values accumulate (and on the last cycle). |
+| `.window(interval_nanos)` | Flush a `list` on each time boundary (and on the last cycle). |
+| `.collect()` | Collect every `(nanos, value)` pair into a growing list of tuples. |
+| `.with_time()` | Pair each value with engine time as `(nanos, value)`. |
+| `.dataframe()` | Build a pandas `DataFrame` — see [Pandas integration](#pandas-integration). |
+
+### Observing and reading back
+
+| Operator | Description |
+| --- | --- |
+| `.inspect(f)` | Call `f(value)` and pass the value through. The pass-through tap (legacy's `for_each`). |
+| `.print()` | Print each value to stdout, passing it through. |
+| `.logged(label, level="info")` | Log `"{time} {label} {value}"` and pass through. `level` is `"trace"`/`"debug"`/`"info"`/`"warn"`/`"error"`. |
+| `.value()` | After the run, the stream's last value (legacy's `peek_value`). |
+
+### Statistics
+
+Cumulative `.sum()` and `.mean()` are `Stream` methods. The full windowed
+moment surface — rolling `variance`, `std`, `median`, `min`/`max`, time- and
+count-weighted windows, and `ewma` — lives in the engine's Rust `stats` layer
+and reaches Python through the [plugin seam](#authoring-components-in-rust),
+as a `#[pyop]` exposing exactly the window you want. That keeps the
+parameterisation where it can be type-checked rather than in extra Python
+classes. This is the one place the binding is currently narrower than legacy's;
+the engine already has the whole surface.
+
+### Example: most operators in one pipeline
+
+```python
+import wingfoil_next as wf
+
+g = wf.Graph()
+avg_of_odds = (
+    g.counter(period_nanos=100_000_000)   # 1, 2, 3, … every 100ms of graph time
+     .filter_value(lambda n: n % 2 == 1)  # 1, 3, 5, …
+     .map(float)
+     .mean()                              # cumulative running mean
+     .logged("avg")
+)
+g.run(cycles=10)
+print("last:", avg_of_odds.value())       # 5.0
+```
+
+---
 
 ## Python-defined nodes
 
-A Python object can be a graph node. Two forms, same machinery:
+A Python object can *be* a graph node. There are two forms over the same
+machinery.
+
+**Composition** — pass any object implementing `cycle(values) -> bool` (given
+the upstreams' current values, return whether it ticked) and `peek()` (its
+output when it did):
 
 ```python
-# Composition — pass an object implementing cycle(values) -> bool and peek().
-g.custom_node([source], RunningMax())
+class RunningMax:
+    def __init__(self):
+        self.best = None
 
-# Inheritance — legacy wingfoil's shape.
-class MyStream(wf.CustomStream):
-    def cycle(self):
-        total = sum(u.peek_value() for u in self.upstreams())
-        self.set_value(total)
-        return True
+    def cycle(self, values):
+        for value in values:
+            if value is not None and (self.best is None or value > self.best):
+                self.best = value
+        return self.best is not None
 
-MyStream(g, [a, b]).map(lambda x: x * 2)   # the constructor returns the Stream
+    def peek(self):
+        return self.best
+
+g = wf.Graph()
+source = g.counter(period_nanos=100)
+peak = g.custom_node([source], RunningMax()).print()
+g.run(cycles=5)
 ```
 
-Two deviations from legacy, both forced by the engine: the graph is passed
-explicitly (next has no ambient graph, and a `Stream` carries no reference back
-to its builder), and `upstreams()` yields this cycle's *values* rather than the
-upstream `Stream` objects — during a run the runner is mutably borrowed, so a
-Python `cycle` cannot read a sibling stream. A graph containing a
-Python-defined node is single-run: the instance's state is caller-owned and the
-engine has no hook to reset it, so a second `run()` raises.
+**Inheritance** — legacy wingfoil's shape. The constructor call *is* the wiring
+step and returns the wired `Stream`, so it chains:
+
+```python
+class Polynomial(wf.CustomStream):
+    """Sum of upstream[i] * 10**i."""
+
+    def cycle(self):
+        value = sum(
+            (u.peek_value() or 0) * 10**i for i, u in enumerate(self.upstreams())
+        )
+        self.set_value(value)
+        return True
+
+g = wf.Graph()
+source = g.counter(period_nanos=100)
+Polynomial(g, [source] * 3).map(lambda x: x * 0.01).logged("poly")
+g.run(cycles=5)
+```
+
+Two deviations from legacy, both forced by the engine rather than chosen:
+
+- **The graph is explicit** — `MyStream(graph, upstreams)`. Next has no ambient
+  graph, and a `Stream` carries no reference back to its builder.
+- **`upstreams()` yields value snapshots**, not the upstream `Stream` objects.
+  During a run the engine holds its runner mutably borrowed, so a Python
+  `cycle` cannot call back into the graph to read a sibling. The current values
+  are handed in, wrapped in objects exposing `peek_value()` — the only stream
+  method legacy `cycle` bodies use. A not-yet-ticked upstream reads as `None`.
+
+A graph containing a Python-defined node is **single-run**: the instance's
+state is caller-owned and the engine has no hook to reset it, so a second
+`run()` raises rather than replaying from dirty state.
+
+---
+
+## Backtesting with historical mode
+
+Historical replay is the default, and it is deterministic — the right mode for
+unit tests and strategy backtests. Time advances from source events rather than
+the wall clock, so a graph over a day of data finishes as fast as the CPU
+allows.
+
+```python
+import wingfoil_next as wf
+
+MINUTE_NANOS = 60_000_000_000
+JAN_2025 = 1_735_689_600_000_000_000   # 2025-01-01T00:00:00Z
+
+g = wf.Graph()
+average = g.counter(period_nanos=1_000_000_000).map(float).mean()
+g.run(start_nanos=JAN_2025, duration_nanos=MINUTE_NANOS)
+print(average.value())                 # 31.5 — a minute of ticks, replayed instantly
+```
+
+Keep an eye on what the graph *retains*: `.accumulate()` and `.collect()` grow a
+list per tick, so over a long replay prefer a running aggregate (as above) or a
+windowed flush (`.buffer(n)` / `.window(interval_nanos)`).
+
+Sources that read a bounded slice of history (`postgres_read`, `kdb_read`) take
+the same window at wiring, and it must match the `run(...)` call:
+
+```python
+rows = wf.postgres_read(
+    g, CONN_STR, "SELECT time, sym, price FROM trades", "time",
+    start_nanos=JAN_2025, duration_nanos=DAY_NANOS,
+)
+g.run(start_nanos=JAN_2025, duration_nanos=DAY_NANOS)
+```
+
+---
+
+## Pandas integration
+
+`stream.dataframe()` accumulates each value with its engine time and, on the
+final cycle, produces a `pandas.DataFrame` (columns `time`, `value`) as the
+stream's value. The frame is built in Rust, so there is no Python-side
+assembly step:
+
+```python
+import wingfoil_next as wf
+
+g = wf.Graph()
+frame = g.counter(period_nanos=10_000_000).map(lambda n: n * n).dataframe()
+g.run(cycles=5)
+print(frame.value())
+#        time  value
+# 0         0      1
+# 1  10000000      4
+# 2  20000000      9
+# ...
+```
+
+For a frame of several streams, map them into one dict-valued stream before
+framing it, or collect each with `.collect()` and join in pandas. (Legacy's
+multi-stream `build_dataframe` has no direct equivalent yet.)
+
+---
+
+## Latency tracing
+
+Stamp wall-clock timestamps onto messages as they hop through a graph — and
+across processes — then aggregate the per-stage deltas at the end of the
+pipeline. This surface is always present; it is not an adapter, so there is no
+feature to enable.
+
+```python
+import wingfoil_next as wf
+
+stages = ["ingest", "decode", "publish"]
+
+g = wf.Graph()
+messages = source.map(lambda payload: wf.TracedBytes(payload, wf.Latency(stages)))
+
+stamped = wf.stamp(wf.stamp(wf.stamp(messages, "ingest"), "decode"), "publish")
+sink, stats = wf.latency_report(stamped, stages, print_on_teardown=False)
+
+g.run(cycles=1000)
+print(stats["decode"]["p99_ns"])
+print(stats.report())
+```
+
+- `stamp` reads the cycle-start clock; `stamp_precise` takes a fresh clock read
+  per tick, for intra-cycle resolution.
+- Every entry point has an `_if(..., enabled)` variant that wires nothing when
+  disabled — and returns the same *shape*, so call sites do not branch.
+- `latency_report` returns a **tuple** `(sink, LatencyStats)`; the stats handle
+  is live, so the numbers are readable after the run.
+- Bursts are stamped **element-wise**: a value reaching `stamp` may be a list of
+  `TracedBytes`, and every member is stamped under one GIL attach.
+- `Latency.to_bytes()` / `Latency.from_bytes(data, stages)` are the
+  little-endian header a Rust peer reads straight back as its `latency_stages!`
+  record — and `iceoryx2_sub` / `iceoryx2_pub` will carry it for you, given a
+  `stages=` list.
+- Aggregation and report formatting are the engine's own, so a Python report is
+  byte-identical to a Rust one.
+
+---
 
 ## I/O adapters
 
-The `wingfoil_next::adapters::*` adapters are exposed as module-level functions
-(`src/adapters/`), each behind a cargo feature of the same name — a wheel only
-carries the adapters it was built with. **All fifteen are bound**: postgres,
-kafka, redis, etcd, fluvio, csv, zmq, kdb, fix, augurs, otlp, prometheus, web,
-aeron and iceoryx2. The published wheel ships every one except aeron and
-iceoryx2, which are opt-in (`maturin develop -F aeron`) because they would make
-it platform-specific.
+Every adapter is a module-level function (or, where it is stateful, a class)
+taking the graph or the stream as its first argument — never a `Stream` method.
+That is deliberate: a binding authored in a third-party crate cannot add a
+method to a `#[pyclass]` defined here, so making the built-ins free functions is
+what makes a third-party adapter indistinguishable from a built-in one.
 
-Every source is **burst-shaped**, so a tick is a Python `list` of the values
-that share that instant — never collapsed to latest-wins, never dropped. Index
-`[0]` for the single-value case.
+Two conventions run through all of them:
 
-postgres, as the worked example:
+**Selectors are strings, not enum classes.** A poll mode, a service variant, an
+etcd event kind, an augurs model — each is a plain `str`, and a wrong value
+raises listing the accepted set.
+
+**Conversion fails loudly.** A missing required field, a wrong-typed value, or a
+non-`dict` where a record was expected aborts the run naming the offending
+field, rather than defaulting to empty bytes or an empty burst.
+
+Every entry point carries a full docstring — `help(wf.kafka_sub)` — and the
+[API reference](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-next-python/docs/api.rst) tabulates the whole surface.
+
+### PostgreSQL
+
+`postgres_read` (sliced historical replay), `postgres_sub` (a live
+`LISTEN`/`NOTIFY` tail), `postgres_source` (one wiring call for either mode),
+`postgres_write`, and `postgres_notify_trigger_sql()` for the trigger DDL. Rows
+are `dict`s; a tick is a `list` of rows.
+
+```python
+import wingfoil_next as wf
+
+CONN_STR = "host=localhost user=postgres password=postgres dbname=postgres"
+DAY_NANOS = 86_400_000_000_000
+
+g = wf.Graph()
+
+# Historical, time-sliced replay.
+rows = wf.postgres_read(
+    g, CONN_STR, "SELECT time, sym, price FROM trades", "time",
+    start_nanos=START, duration_nanos=DAY_NANOS, chunk_secs=86400,
+)
+rows.map(lambda batch: [r["price"] for r in batch]).print()
+g.run(start_nanos=START, duration_nanos=DAY_NANOS)
+```
+
+```python
+# Streaming insert sink — declare the target columns in table order.
+wf.postgres_write(
+    trades, CONN_STR, "trades", [("sym", "text"), ("price", "float"), ("qty", "long")]
+)
+```
+
+### Kafka
+
+Events are `{topic, partition, offset, key, value}` dicts. `topic` is optional
+on the sink — a record naming its own target lets one sink write to many topics.
+
+```python
+BROKERS = "localhost:9092"
+
+produce = wf.Graph()
+records = produce.values(
+    [{"topic": "trades", "key": b"k", "value": b"alpha"}], period_nanos=1_000_000_000
+)
+wf.kafka_pub(records, BROKERS)
+produce.run(cycles=1)
+
+consume = wf.Graph()
+wf.kafka_sub(consume, BROKERS, "trades", "my-group").inspect(print)
+consume.run(realtime=True, duration_nanos=10_000_000_000)
+```
+
+### Redis
+
+Pub/Sub (`redis_sub` / `redis_pub`, events `{channel, payload}`) and persistent
+Streams (`redis_stream_read` / `redis_stream_write`, events `{key, id, fields}`).
+`channel` / `key` are optional fallbacks on the sinks; both sinks take a
+`buffer_size` back-pressure bound.
+
+```python
+URL = "redis://127.0.0.1:6379"
+
+# Subscribe, uppercase, republish — Redis Pub/Sub is fire-and-forget, so the
+# subscriber must be live before anything is published.
+g = wf.Graph()
+inbound = wf.redis_sub(g, URL, "source")
+outbound = inbound.map(
+    lambda batch: [{"channel": "dest", "payload": e["payload"].upper()} for e in batch]
+)
+wf.redis_pub(outbound, URL)
+g.run(realtime=True, duration_nanos=5_000_000_000)
+```
+
+### etcd
+
+Events are `{kind, key, value, revision}` with `kind` a string (`"put"` /
+`"delete"`). `endpoints` accepts a single `str` or a list, so a cluster is
+addressable.
+
+```python
+ENDPOINT = "http://localhost:2379"
+
+g = wf.Graph()
+
+# Publish: each dict is {"key": str, "value": bytes}, or a list of them per tick.
+entries = g.values(
+    [{"key": "/wf/item/1", "value": b"1"}], period_nanos=1_000_000_000
+)
+wf.etcd_pub(entries, ENDPOINT, lease_ttl_secs=30.0, force=True)
+
+# Subscribe: snapshot + watch under a prefix; each tick is a list of events.
+wf.etcd_sub(g, ENDPOINT, "/wf/").inspect(print)
+
+g.run(realtime=True, duration_nanos=2_000_000_000)
+```
+
+### Fluvio
+
+Events are `{key, value, offset}`. The key is **asymmetric** — a read yields
+`bytes | None`, a write expects `str | None` — because that is the adapter's own
+shape, so a round trip needs an explicit `.decode()`.
+
+```python
+g = wf.Graph()
+wf.fluvio_sub(g, "127.0.0.1:9003", "source", partition=0).inspect(print)
+g.run(realtime=True, duration_nanos=5_000_000_000)
+```
+
+### CSV
+
+Deterministic historical replay. Values are `str` on both sides (CSV has no
+types), column order follows the file header, and `buffer_size` bounds the
+replay look-ahead so a huge file is not read up front.
 
 ```python
 g = wf.Graph()
 
-# Historical, time-sliced replay. Each tick is a list of {column: value} dicts.
-rows = wf.postgres_read(
-    g, CONN_STR, "SELECT time, sym, price FROM trades", "time",
-    start_nanos=START, duration_nanos=ONE_DAY, chunk_secs=86400,
-)
-g.run(start_nanos=START, duration_nanos=ONE_DAY)
+# Read: `time` holds integer nanoseconds since the epoch. Each tick is a list
+# of the rows sharing that timestamp.
+rows = wf.csv_read(g, "prices.csv", "time")
+rows.inspect(print)
 
-# Streaming insert sink — declare the target columns in table order.
-wf.postgres_write(stream, CONN_STR, "trades",
-                  [("sym", "text"), ("price", "float")])
+g.run(start_nanos=0, duration_nanos=5_000_000_000)
 ```
-
-Also `postgres_sub` (a real-time `LISTEN`/`NOTIFY` live tail), `postgres_source`
-(one wiring call for either run mode) and `postgres_notify_trigger_sql`. Each
-adapter's module docs (`src/adapters/<name>.rs`) carry its entry-point table,
-its argument semantics, and how its surface differs from the legacy
-`wingfoil-python` binding — the same list `docs/migration.rst` collects.
-
-A source that needs the run window at wiring takes it as arguments
-(`start_nanos` / `duration_nanos` / `realtime`), which must match the eventual
-`graph.run(...)` — a Python `Graph` does not know its run mode until then.
-
-## Latency
-
-`wingfoil_next::latency` is bound too (`src/latency.rs`), unconditionally — it
-is not an adapter, so there is no feature to enable. A Rust caller names a stamp
-stage as a compile-time type; Python names it as a string, so a `Latency` record
-carries its stage list at runtime:
 
 ```python
-stages = ["ingest", "decode", "publish"]
-messages = source.map(lambda payload: wf.TracedBytes(payload, wf.Latency(stages)))
-
-stamped = wf.stamp(wf.stamp(wf.stamp(messages, "ingest"), "decode"), "publish")
-_sink, stats = wf.latency_report(stamped, stages, print_on_teardown=False)
-
-g.run(cycles=1000)
-print(stats["decode"]["p99_ns"], stats.report())
+# Write: the header is explicit — a dynamic row has no field names to derive
+# one from. The graph timestamp is written as a leading `time` column.
+g = wf.Graph()
+quotes = g.values(
+    [{"sym": "AAPL", "price": "101.0"}, {"sym": "AAPL", "price": "102.0"}],
+    period_nanos=100_000_000,
+)
+wf.csv_write(quotes, "out.csv", ["sym", "price"])
+g.run(cycles=2)
 ```
 
-`stamp_precise` reads a fresh clock per tick (intra-cycle resolution); every
-entry point has an `_if(…, enabled)` variant that wires nothing when disabled.
-`Latency.to_bytes()` / `Latency.from_bytes(data, stages)` are the little-endian
-header a Rust peer reads straight back as its `latency_stages!` record. An
-adapter can carry that header for you: `iceoryx2_sub` / `iceoryx2_pub` take an
-optional `stages=` list and then send `header ++ payload`, handing back
-`TracedBytes` instead of `bytes`.
+### KDB+
 
-## Documentation
+`kdb_read` (a time-sliced historical query), `kdb_sub` (the tickerplant tail —
+new against legacy) and `kdb_write`. Rows are `dict`s dispatched on each value's
+actual KDB type; temporal columns decode to their **raw `int`** (nanoseconds
+from the KDB epoch, 2000-01-01) rather than a `datetime` that would have to
+guess a timezone.
 
-`docs/` is the Sphinx source for the published module documentation — the API
-reference, and a **migration guide** for the legacy `wingfoil` package, which
-`wingfoil_next` supersedes (`import wingfoil` becomes `import wingfoil_next`,
-and a handful of entry points change shape). Build it with `maturin develop`
-followed by `make html` in `docs/`; see `docs/README.md`.
+Start a q process (`q -p 5000`) and create the table:
 
-## Build / test
+```
+test_trades:([]time:`timestamp$();sym:`symbol$();price:`float$();qty:`long$())
+```
+
+```python
+HOST, PORT, TABLE = "localhost", 5000, "test_trades"
+KDB_EPOCH_NANOS = 946_684_800_000_000_000
+DAY_NANOS = 86_400_000_000_000
+
+# Write: each dict is one row; `columns` names them in table order.
+g = wf.Graph()
+trades = g.values(
+    [{"sym": "AAPL", "price": 100.0, "qty": 10}], period_nanos=1_000_000_000
+)
+wf.kdb_write(
+    trades, HOST, PORT, TABLE,
+    [("sym", "symbol"), ("price", "float"), ("qty", "long")],
+)
+g.run(cycles=1, start_nanos=KDB_EPOCH_NANOS)
+
+# Read: a time-sliced query over the same window the run declares.
+g = wf.Graph()
+rows = wf.kdb_read(
+    g, HOST, PORT, f"select from {TABLE}", "time",
+    KDB_EPOCH_NANOS, DAY_NANOS, chunk_secs=3600,
+)
+rows.inspect(print)
+g.run(start_nanos=KDB_EPOCH_NANOS, duration_nanos=DAY_NANOS)
+```
+
+### ZeroMQ
+
+`zmq_sub` returns a **tuple** `(data, status)`; `status` ticks only on a
+transition, carrying `"connected"` / `"disconnected"`. Payloads cross as
+`bytes`. The `_etcd` pair adds service discovery and needs the `etcd` feature
+too.
+
+```python
+g = wf.Graph()
+
+counter = g.counter(period_nanos=20_000_000)
+wf.zmq_pub(counter.map(lambda n: str(n).encode()), 7779, bind_address="127.0.0.1")
+
+data, status = wf.zmq_sub(g, "tcp://127.0.0.1:7779")
+data.inspect(lambda messages: [print("msg:", m) for m in messages])
+status.inspect(lambda s: print("status:", s))
+
+g.run(realtime=True, duration_nanos=2_000_000_000)
+```
+
+A `SUB` socket is a slow joiner — messages published before it finishes
+connecting are simply lost — so assert on what arrived, never on the first
+message.
+
+With etcd discovery, publishers register under a service name and subscribers
+look it up; the lookup happens at wiring, so an unreachable registry raises
+there:
+
+```python
+wf.zmq_pub_etcd(payloads, 7779, "quotes", "http://127.0.0.1:2379",
+                bind_address="127.0.0.1")
+data, status = wf.zmq_sub_etcd(g, "quotes", "http://127.0.0.1:2379")
+```
+
+### FIX 4.4
+
+`fix_connect` (initiator), `fix_accept` (acceptor), `fix_connect_tls` (TLS
+initiator, handing back a `FixConnection`) and `fix_send`. Each source returns
+`(data, status)`. Messages are
+`{"msg_type": str, "seq_num": int, "fields": [(tag, value)]}` with **`str` tag
+values** — FIX is a text protocol, so spell a number `str(price)`. Session
+status is always a dict.
+
+```python
+g = wf.Graph()
+
+data, status = wf.fix_connect(g, "fix.example.com", 9876, "MYCOMP", "BROKER")
+data.inspect(lambda messages: [print("fix:", m) for m in messages])
+status.inspect(print)
+
+g.run(realtime=True, duration_nanos=10_000_000_000)
+```
+
+```python
+# TLS initiator (e.g. LMAX). This one hands back a single `FixConnection`
+# exposing `.data`, `.status`, `.send(msg)` and `.fix_sub(symbols)`.
+g = wf.Graph()
+connection = wf.fix_connect_tls(
+    g, "fix-marketdata.london-digital.lmax.com", 443, "USERNAME", "LMXBL",
+    password="secret",
+)
+connection.data.inspect(print)
+connection.send({"msg_type": "V", "fields": [(262, "req1"), (263, "1"), (264, "0")]})
+```
+
+### augurs
+
+Six on-graph time-series operators, no external service. `augurs_forecast`,
+`augurs_changepoint` and `augurs_seasons` analyse **one** series (a stream of
+floats); `augurs_outlier`, `augurs_dtw` and `augurs_cluster` compare **several**
+(a stream of lists of floats). Results are `dict`s carrying the full model
+output, not just the headline number, and `model` / `detector` / `metric` are
+strings.
+
+```python
+g = wf.Graph()
+prices = g.values([float(i) for i in range(1, 41)], period_nanos=1_000_000_000)
+
+wf.augurs_forecast(prices, window=32, horizon=3, level=0.95).inspect(
+    lambda f: print(f["point"], f["lower"], f["upper"])
+)
+wf.augurs_changepoint(prices, window=32).inspect(print)
+
+g.run(cycles=40)
+```
+
+### Prometheus
+
+A stateful handle exposing a gauge per stream on a scrape endpoint. Historical
+runs are a **no-op** — a backtest never publishes fast-forwarded values to a
+live endpoint.
+
+```python
+g = wf.Graph()
+
+exporter = wf.PrometheusExporter("0.0.0.0:9091")
+port = exporter.serve()                       # bind and start the HTTP server
+exporter.gauge("wingfoil_ticks", g.counter(period_nanos=1_000_000_000))
+
+g.run(realtime=True, duration_nanos=5_000_000_000)
+```
+
+Scrape with `curl http://localhost:9091/metrics`.
+
+### OpenTelemetry OTLP
+
+Push a stream's value to an OTLP HTTP collector as a gauge, stringified via
+Python's `str()`. Historical runs are a no-op, as above.
+
+```python
+g = wf.Graph()
+wf.otlp_push(
+    g.counter(period_nanos=1_000_000_000), "wingfoil_ticks",
+    "http://localhost:4318", "demo",
+)
+g.run(realtime=True, duration_nanos=10_000_000_000)
+```
+
+### web (WebSocket)
+
+A stateful `WebServer` handle. Publishing is a **server** method, not a stream
+method, because the handle owns the topic registry. Values marshal through the
+selected codec (`"bincode"` or `"json"`); `bytes` become an array of ints —
+wire-compatible with a Rust `Vec<u8>` peer, and therefore decoded back as a
+`list`, not `bytes`.
+
+```python
+g = wf.Graph()
+
+server = wf.WebServer("127.0.0.1:0", codec="json")
+print("listening on", server.port(), "codec", server.codec_name())
+
+server.pub(g.counter(period_nanos=50_000_000), "ticks")
+server.pub_bursts(g.constant([1.0, 2.0]), "book")   # a whole burst as one frame
+events = server.sub(g, "ui").accumulate()
+
+g.run(realtime=True, duration_nanos=5_000_000_000)
+server.stop()
+```
+
+`static_dir=` serves a directory alongside the socket, and `cert_path=` /
+`key_path=` (given together) switch it to TLS.
+
+### Aeron
+
+`aeron_sub`, `aeron_sub_with_status`, `aeron_pub`, `aeron_pub_with_status`.
+**Not in the default build** — `rusteron-client` builds the Aeron C library from
+source. Connecting is *eager*: an unreachable media driver raises at wiring.
+`mode` is `"spin"` or `"threaded"`.
+
+```python
+g = wf.Graph()
+messages = wf.aeron_sub(g, "aeron:ipc", 1001, mode="spin")
+wf.aeron_pub(messages, "aeron:ipc", 1002)
+g.run(realtime=True, duration_nanos=5_000_000_000)
+```
+
+### iceoryx2
+
+Zero-copy pub/sub over shared memory. **Not in the default build** —
+Linux/POSIX-only. Payloads cross as `bytes`; `variant` (`"ipc"` / `"local"`) and
+`mode` (`"spin"` / `"threaded"` / `"signaled"`) are strings.
+
+```python
+g = wf.Graph()
+
+received = wf.iceoryx2_sub(g, "wingfoil/demo", variant="local", mode="signaled")
+received.inspect(lambda messages: print("received:", messages))
+
+wf.iceoryx2_pub(
+    g.counter(period_nanos=100_000_000).map(lambda n: f"tick {n}".encode()),
+    "wingfoil/demo", variant="local",
+)
+
+g.run(realtime=True, duration_nanos=500_000_000)
+```
+
+Both entry points take an optional `stages=` list. With it, a sample is a
+`[u64; len(stages)]` little-endian stamp header followed by the payload, and the
+value is a `TracedBytes` rather than `bytes` — the same layout a Rust peer's
+`latency_stages!` record has, so a Python subscriber reads a Rust publisher's
+stamps.
+
+---
+
+## Authoring components in Rust
+
+The point of the binding is not just to expose the built-ins: you can author an
+op, a whole sub-graph, or an I/O adapter **in Rust** and call it from Python
+alongside the built-in vocabulary. Three macros do it, and a binding written in
+a third-party crate is indistinguishable from a built-in one:
+
+| Macro | Exposes |
+| --- | --- |
+| `#[pyop]` / `pyop_fn!` | An `Op` implementation as `module.my_op(stream, …)`. One to four inputs, tuple `Cfg` (each element its own named Python parameter), and stateful ops. |
+| `#[pygraph]` | A Rust wiring function (`fn(&Stream<T>) -> Stream<U>`) as one callable that splices its nodes into the caller's graph. Multi-input and tuple-returning forms supported. |
+| `#[pyadapter]` | A source or sink adapter trait on `GraphBuilder` or `Stream<T>`. A tuple return gives the `(data, status)` shape live sources use. |
+
+The interior of any of these stays **natively typed** — only the Python-facing
+edge erases to the boxed `PyElement`. Combined with `compiled_island`, that
+gives "compiled interiors, dynamic wiring": Python composes the graph at run
+time while the hot sub-graphs run as monomorphized straight-line code.
+
+This crate ships demo components proving the seam end to end — `scale`,
+`square`, `running_total`, `weighted_add`, `blend3`, `blend4`, `clamped_scale`,
+`doubled_running_total`, `spread_and_mid`, `ramp_source`, `pair_source`,
+`split_source`, `list_sink`, `burst_list_sink`, `compiled_island` and
+`interpreted_twin`:
+
+```python
+import wingfoil_next as wf
+
+g = wf.Graph()
+ramp = wf.ramp_source(g, 10.0, 2.0)     # a Rust source adapter
+squared = wf.square(ramp)               # a Rust op
+totals = wf.doubled_running_total(ramp) # a Rust sub-graph
+
+collected = []
+wf.list_sink(squared, collected)        # a Rust sink adapter
+g.run(cycles=3)
+print(collected)                        # [100.0, 144.0, 196.0]
+```
+
+See `docs/python-interop.md` at the repository root for the design, and
+`examples/plugin_sdk.py` for the runnable version.
+
+---
+
+## Build from source
 
 ```bash
-# from this directory
-maturin build --out dist          # build the wheel
+cd crates/wingfoil-next-python
+maturin develop                   # build + install into the active environment
+maturin build --out dist          # or build a wheel
 pip install --force-reinstall dist/*.whl
+```
+
+`maturin develop -F <feature>` **replaces** the wheel's feature list rather
+than adding to it, so a lone `-F aeron` build carries only that adapter.
+
+---
+
+## Testing
+
+```bash
 pytest                            # Python round-trip tests
 
 # the Rust object form and boundary type have their own unit tests
@@ -145,3 +921,39 @@ service that is not up. Opt in explicitly with a service running:
 docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine
 pytest -m requires_postgres tests/test_postgres.py
 ```
+
+Runnable examples live in [`examples/`](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-next-python/examples) and are smoke-tested by
+`tests/test_examples.py`, so they stay working as the binding evolves.
+
+---
+
+## Documentation
+
+- [`docs/`](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-next-python/docs) — the Sphinx source for the published module documentation:
+  this guide, the [API reference](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-next-python/docs/api.rst), and the
+  [migration guide](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-next-python/docs/migration.rst) for the legacy `wingfoil` package.
+  Build it with `maturin develop` followed by `make html` in `docs/`; see
+  [`docs/README.md`](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-next-python/docs/README.md).
+- Every adapter's module docs (`src/adapters/<name>.rs`) carry its entry-point
+  table, its argument semantics, and how its surface differs from the legacy
+  binding. Those doc comments *are* the Python docstrings — `help(wf.csv_read)`.
+- `docs/python-interop.md` at the repository root — the design of the boundary
+  and the plugin seam.
+
+---
+
+## Release status and feedback
+
+Wingfoil Next is pre-release: it is the engine that replaces the shipping
+`wingfoil`, and the Python binding tracks it. APIs are stabilising and we would
+love your input — especially if you:
+
+- are interested in contributing,
+- know of a project Wingfoil is a good fit for,
+- want to request a feature, or
+- have any feedback.
+
+Email us at [hello@wingfoil.io](mailto:hello@wingfoil.io), ping us on
+[discord](https://discord.gg/rfGqf3Ff), open a
+[GitHub discussion](https://github.com/wingfoil-io/wingfoil/discussions/), or
+browse the [issue tracker](https://github.com/wingfoil-io/wingfoil/issues).

--- a/crates/wingfoil-next-python/docs/api.rst
+++ b/crates/wingfoil-next-python/docs/api.rst
@@ -39,8 +39,10 @@ duration_nanos=None, realtime=False, start_nanos=0)``.
 ``difference``, ``not`` (a Python keyword — reach it with
 ``getattr(stream, "not")()``), ``split``.
 
-*Gate* — ``filter``, ``filter_value``, ``filter_none``, ``distinct``,
-``drop_small_change``, ``limit``, ``throttle``, ``sample``, ``delay``.
+*Gate* — ``filter`` (gates on another *stream*'s current value), ``filter_value``
+(gates on a *predicate* — this is legacy's ``filter``), ``filter_none``,
+``distinct``, ``drop_small_change``, ``limit``, ``throttle``, ``sample``,
+``delay``.
 
 *Combine* — ``merge``, ``merge_all``.
 

--- a/crates/wingfoil-next-python/docs/migration.rst
+++ b/crates/wingfoil-next-python/docs/migration.rst
@@ -85,9 +85,23 @@ Combinators
 -----------
 
 The combinator surface is a superset of legacy's. Names that carry over
-unchanged: ``map``, ``filter``, ``distinct``, ``difference``, ``delay``,
-``limit``, ``sample``, ``count``, ``buffer``, ``collect``, ``with_time``,
-``dataframe``, ``inspect``, ``fold``.
+unchanged: ``map``, ``distinct``, ``difference``, ``delay``, ``limit``,
+``sample``, ``count``, ``buffer``, ``collect``, ``with_time``, ``dataframe``,
+``inspect``, ``fold``.
+
+.. warning::
+
+   ``filter`` is the one name that carries over with a **different meaning**,
+   and it fails loudly rather than silently: next's
+   :meth:`~wingfoil_next.Stream.filter` gates on another *stream*'s current
+   value (matching the Rust engine), so passing legacy's predicate raises
+   ``TypeError: 'function' object is not an instance of 'Stream'``. The
+   predicate form is :meth:`~wingfoil_next.Stream.filter_value`.
+
+   .. code-block:: diff
+
+      - odds = counter.filter(lambda n: n % 2 == 1)
+      + odds = counter.filter_value(lambda n: n % 2 == 1)
 
 Changed or added:
 
@@ -99,6 +113,9 @@ Changed or added:
      - ``wingfoil_next``
    * - ``stream.peek_value()``
      - ``stream.value()``
+   * - ``stream.filter(predicate)``
+     - ``stream.filter_value(predicate)`` — ``filter`` now gates on another
+       stream's value (see the warning above)
    * - ``bimap(a, b, f)`` (free function)
      - ``a.bimap(b, f)`` (method)
    * - ``stream.average()``

--- a/crates/wingfoil-next-python/examples/README.md
+++ b/crates/wingfoil-next-python/examples/README.md
@@ -11,10 +11,11 @@ python examples/quick_start.py
 
 | Example | Shows |
 |---|---|
-| `quick_start.py`   | build a graph, chain combinators, run, read a value |
-| `custom_stream.py` | a Python object as a graph node (`Graph.custom_node`) |
-| `dataframe.py`     | collect a stream into a pandas DataFrame (needs `pandas`) |
-| `plugin_sdk.py`    | compose Rust-authored ops / sub-graphs / adapters from Python |
+| `quick_start.py`             | build a graph, chain combinators, run, read a value |
+| `custom_stream.py`           | a Python object as a graph node (`Graph.custom_node`) |
+| `custom_stream_subclass.py`  | the same thing by subclassing `CustomStream` — legacy wingfoil's shape |
+| `dataframe.py`               | collect a stream into a pandas DataFrame (needs `pandas`) |
+| `plugin_sdk.py`              | compose Rust-authored ops / sub-graphs / adapters from Python |
 
-All four are smoke-tested in `tests/test_examples.py`, so they stay working as
+All five are smoke-tested in `tests/test_examples.py`, so they stay working as
 the binding evolves.

--- a/crates/wingfoil-next-python/src/island.rs
+++ b/crates/wingfoil-next-python/src/island.rs
@@ -29,7 +29,12 @@ wingfoil_next::nitro! {
     }
 }
 
-/// The island as a Python callable: `compiled_island(graph, stream)`.
+/// A compiled sub-graph as one Python call: `compiled_island(graph, stream)`.
+///
+/// The interior (`x * 2`, `+ 1`, squared) is monomorphized straight-line code
+/// mounted as a single node of the caller's interpreted graph — "compiled
+/// interiors, dynamic wiring". `interpreted_twin` is the same wiring through
+/// the ordinary fluent layer, for comparison.
 #[pygraph(name = compiled_island)]
 fn build_compiled_island(g: &GraphBuilder, input: &Stream<f64>) -> Stream<f64> {
     hot_interior::nested(g, input)

--- a/crates/wingfoil-next-python/src/latency.rs
+++ b/crates/wingfoil-next-python/src/latency.rs
@@ -301,8 +301,11 @@ fn check_stages_py(stages: &[String]) -> PyResult<()> {
 /// follows legacy, whose only carrier was a `bytes` frame).
 #[pyclass(name = "TracedBytes")]
 pub struct PyTracedBytes {
+    /// The carried value — any Python object, not just `bytes`.
     #[pyo3(get)]
     pub payload: Py<PyAny>,
+    /// The `Latency` record travelling with the payload. Shared, so a stamp
+    /// anywhere downstream mutates this same record.
     #[pyo3(get)]
     pub latency: Py<PyLatency>,
 }

--- a/crates/wingfoil-next-python/src/python.rs
+++ b/crates/wingfoil-next-python/src/python.rs
@@ -336,6 +336,7 @@ crate::pyop_fn! {
 // `#[pyfunction]` `pyop_fn!` writes by hand.
 struct Square;
 
+/// Square each value: `square(stream)` yields `x * x` per tick.
 #[pyop(name = square)]
 impl Op for Square {
     type Cfg = ();
@@ -359,6 +360,8 @@ impl Op for Square {
 // the proc macro handles state, not just stateless transforms.
 struct RunningTotal;
 
+/// Cumulative sum: `running_total(stream)` yields the running total of every
+/// value seen so far. The accumulator is engine-owned state, re-seeded per run.
 #[pyop(name = running_total)]
 impl Op for RunningTotal {
     type Cfg = ();
@@ -383,6 +386,7 @@ impl Op for RunningTotal {
 // emits a `module.weighted_add(stream, other)` function.
 struct WeightedAdd;
 
+/// Add two streams: `weighted_add(stream, other)` yields `a + b` per tick.
 #[pyop(name = weighted_add)]
 impl Op for WeightedAdd {
     type Cfg = ();
@@ -406,6 +410,8 @@ impl Op for WeightedAdd {
 // `module.blend3(stream, second, third)` function over the `wire_op3` seam.
 struct Blend3;
 
+/// Combine three streams: `blend3(stream, second, third)` yields
+/// `a + b * 10 + c * 100` per tick.
 #[pyop(name = blend3)]
 impl Op for Blend3 {
     type Cfg = ();
@@ -428,6 +434,8 @@ impl Op for Blend3 {
 // over `wire_op4` / `Builder::register_op4`.
 struct Blend4;
 
+/// Combine four streams: `blend4(stream, second, third, fourth)` yields
+/// `a + b * 10 + c * 100 + d * 1000` per tick.
 #[pyop(name = blend4)]
 impl Op for Blend4 {
     type Cfg = ();
@@ -453,6 +461,8 @@ impl Op for Blend4 {
 // reads `clamped_scale(stream, factor, ceiling)` rather than passing a tuple.
 struct ClampedScale;
 
+/// Scale and cap: `clamped_scale(stream, factor, ceiling)` yields
+/// `min(x * factor, ceiling)` per tick.
 #[pyop(name = clamped_scale, arg = (factor, ceiling))]
 impl Op for ClampedScale {
     type Cfg = (f64, f64);
@@ -477,6 +487,9 @@ impl Op for ClampedScale {
 // splices its nodes into the caller's graph. The interior runs at native `f64`;
 // only the edge erases. The wiring fn names the fluent `Stream` fully-qualified
 // to avoid clashing with the `Stream` pyclass in this module.
+/// A Rust-authored sub-graph as one call: `doubled_running_total(stream)`
+/// doubles each value and then cumulatively sums it, splicing both nodes into
+/// the caller's graph.
 #[pygraph(name = doubled_running_total)]
 fn build_doubled_running_total(
     input: &::wingfoil_next::prelude::Stream<f64>,
@@ -489,6 +502,8 @@ fn build_doubled_running_total(
 // `spread_and_mid` — a **multi-input, multi-output `#[pygraph]`**: two streams
 // in, two out. The tuple return erases element-wise, so Python receives a tuple
 // of streams and can wire onward from each.
+/// Two streams in, two out: `spread_and_mid(bid, ask)` returns
+/// `(spread, mid)` — `ask - bid` and `(ask + bid) / 2`.
 #[pygraph(name = spread_and_mid)]
 fn build_spread_and_mid(
     bid: &::wingfoil_next::prelude::Stream<f64>,
@@ -515,6 +530,8 @@ trait RampSourceOps {
 
 #[pyadapter(name = ramp_source, source)]
 impl RampSourceOps for ::wingfoil_next::prelude::GraphBuilder {
+    /// A synthetic ramp source: `ramp_source(graph, start, step)` ticks
+    /// `start`, `start + step`, `start + 2 * step`, … as `float`.
     fn ramp_source(&self, start: f64, step: f64) -> ::wingfoil_next::prelude::Stream<f64> {
         use ::wingfoil_next::prelude::{SourceOps, StreamOps};
         self.ticker(Duration::from_nanos(100))
@@ -534,6 +551,9 @@ trait ListSinkOps {
 
 #[pyadapter(name = list_sink)]
 impl ListSinkOps for ::wingfoil_next::prelude::Stream<f64> {
+    /// Append each value to a Python list: `list_sink(stream, target)`.
+    /// Returns a terminal stream whose value is `None`; a raised `append`
+    /// aborts the run.
     fn list_sink(&self, target: Py<PyAny>) -> ::wingfoil_next::prelude::Stream<()> {
         use ::wingfoil_next::prelude::StreamOps;
         self.for_each(move |v: &f64| {
@@ -558,6 +578,8 @@ trait PairSourceOps {
 
 #[pyadapter(name = pair_source, source)]
 impl PairSourceOps for ::wingfoil_next::prelude::GraphBuilder {
+    /// A burst-shaped source: `pair_source(graph)` ticks a **list** of two
+    /// floats — `[n, n * 10]` — sharing one instant.
     fn pair_source(&self) -> ::wingfoil_next::prelude::Stream<::wingfoil_next::Burst<f64>> {
         use ::wingfoil_next::prelude::{SourceOps, StreamOps};
         let a = self
@@ -577,6 +599,9 @@ impl PairSourceOps for ::wingfoil_next::prelude::GraphBuilder {
 // Stream)`. This is the `(data, status)` shape a live source with a
 // connection-status stream has (`zmq_sub`), and the reason `#[pyadapter]`
 // accepts a tuple return at all.
+/// A tuple-returning source: `split_source(graph)` returns
+/// `(values, even)` — the tick count as a `float`, and whether it is even —
+/// the same shape a live source with a status stream has.
 #[pyadapter(name = split_source, source)]
 fn split_source_demo(
     g: &::wingfoil_next::prelude::GraphBuilder,
@@ -602,6 +627,9 @@ trait BurstListSinkOps {
 
 #[pyadapter(name = burst_list_sink)]
 impl BurstListSinkOps for ::wingfoil_next::prelude::Stream<::wingfoil_next::Burst<f64>> {
+    /// Append each **burst** to a Python list: `burst_list_sink(stream,
+    /// target)` appends one list per tick. A scalar stream arrives as
+    /// single-element bursts.
     fn burst_list_sink(&self, target: Py<PyAny>) -> ::wingfoil_next::prelude::Stream<()> {
         use ::wingfoil_next::prelude::StreamOps;
         self.for_each(move |burst: &::wingfoil_next::Burst<f64>| {


### PR DESCRIPTION
Generated both Sphinx doc sets — `crates/wingfoil-next-python/docs` and the legacy `legacy/wingfoil-python/docs` currently published on readthedocs — and compared what each actually renders.

| | Build | Notes |
|---|---|---|
| `crates/wingfoil-next-python/docs` | ✅ zero warnings | index, readme, migration, api + generated module page |
| `legacy/wingfoil-python/docs` | ✅ 24 warnings | all pre-existing: broken ToC anchors (legacy `conf.py` doesn't set `myst_heading_anchors`) |

Three content gaps, all of which would have shipped a thinner doc site at cutover than the one legacy publishes today.

## 1. Adapter entry points rendered with no documentation at all

`#[pyadapter]` / `#[pyop]` / `#[pygraph]` forwarded only `#[pyo3(..)]` attributes to the generated `#[pyfunction]`, dropping the `///` docs — so all 47 module-level functions (every adapter entry point, every plugin-seam demo) had an empty `__doc__`, and the reference's generated table was a list of bare names. The prose was already written, in Rust, right next to each function.

Forward `#[doc]` too, and fill in the demo components and the two `TracedBytes` getters that had none. Every module member is now documented; the generated module page is 144KB of real reference, and `help(wf.csv_read)` works. Legacy documented these, so this was a regression against the parity oracle, not a new gap.

## 2. The published User Guide was a fraction of legacy's

`readme.rst` includes the crate README as the guide: legacy's is 687 lines (features, install, quick start, core concepts, operator tables, statistics, composing, backtesting, pandas, per-adapter runnable examples); next's was 147.

Rewritten to cover the same ground on next's API, plus what next adds — bursts, the run window as an argument, latency tracing, all fifteen adapters, the plugin seam.

## 3. `crates/wingfoil-next/examples/` had no index

Legacy's is a 402-line guide with two tables and a snippet per adapter; next had nothing. The root README's tables listed 5 adapter examples out of 20 and described next's adapters as *"CSV, etcd, augurs, and line-oriented files"* — it has seventeen. Added the examples README and refreshed the root one.

## Also

- **A real doc bug:** `filter` is the one combinator that carries over from legacy with a *different meaning* (next gates on a stream; legacy's predicate form is `filter_value` now), and `migration.rst` listed it as unchanged. Corrected there and in `api.rst`.
- `/bind-adapter-next` gains the rule this surfaced: the `///` on an adapter fn *is* the published Python docstring, so write it for the Python caller.

## Verification

- `cargo fmt --all -- --check`, `cargo lint`, `cargo lint-all` — clean. `lint-all` also compiles the aeron/iceoryx2 bindings through the changed macro.
- `cargo test -p wingfoil-next-python --features all-adapters` — green.
- `cargo test -p wingfoil-next --all-features` — green except the eight Docker-backed `*_integration` suites, which fail on `Socket not found: /var/run/docker.sock`. No Docker in the sandbox; unrelated to these changes.
- `pytest` — 292 passed, 25 skipped, 47 deselected.
- Both doc sets rebuild; the next one with zero warnings.
- Every self-contained README snippet was executed against the built extension, and the adapter snippets needing no service (CSV, ZeroMQ, Prometheus, web) were run too — the outputs shown are the ones they produce. Two mistakes that caught: an example that would have hung a reader for hours (`accumulate()` over a day of ticks), and a `fix_connect_tls` call unpacking a 3-tuple it doesn't return.

## Left for a follow-up, deliberately out of scope here

- `wingfoil_next.__version__` is `None` — the extension doesn't set `__version__`, so the package's `getattr` fallback yields nothing.
- Legacy's `docs/README.md` (contributor notes) is published as a page on readthedocs, because legacy's `conf.py` lacks the `exclude_patterns` entry next's has. That is a legacy fix, which per `legacy/CLAUDE.md` branches from `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg9BgiuieHd85P7b6DSVVs)_