### PR TITLE
Multi-stream `build_dataframe` in next-python (cutover-plan 3.8)

### DIFF
--- a/.claude/commands/new-op-next.md
+++ b/.claude/commands/new-op-next.md
@@ -152,6 +152,16 @@ see step 4). Everything else is generated.
 **without** ticking (what `delay` needs so a passive reader never sees
 `T::default()`); `Tick::Quiet` emits nothing (warm-up, suppressed duplicate).
 
+**`ctx.is_last_cycle()` only fires if the op is *cycled* on that cycle.** An op
+that flushes on the final cycle (`buffer`, `window`, the Python `dataframe`
+binding) but is `Activation::NONE` is only cycled when an active input ticks —
+so a stream that has gone quiet before the run ends (a slower ticker, anything
+behind `limit`) never reaches the flush and its value stays at the default. That
+is a real, observable outcome, not a theoretical one: `dataframe()` on the slow
+half of two tickers at different rates yields Python `None`. If the flush must
+happen regardless, the op needs `Activation::ALWAYS`; if not, say so in the op
+docs and name the alternative (`collect` for `dataframe`) so callers can pick.
+
 ## 3. Implement the `Op`
 
 In `ops.rs` (or `stats.rs`), add a zero-sized witness type and its `impl Op`:
@@ -403,6 +413,35 @@ validates the callable's return. `drop_small_change` extracts a strict `bool`
 convention its neighbours in `graph.rs` use, precisely because the legacy
 binding does and has a test pinning it. Port those binding tests alongside the
 node's.
+
+**…and the legacy oracle is not only Rust.** Legacy surface also lives in the
+pure-Python package at `legacy/wingfoil-python/python/wingfoil/` (e.g.
+`pandas_helpers.build_dataframe`, re-exported from its `__init__.py`). A grep of
+`py_stream.rs` misses those entirely, so check the Python package and its
+`__all__` too when establishing what a binding must cover.
+
+**Not every Python surface is an op.** Some legacy vocabulary is a *post-run
+helper* over already-run streams rather than a node — `build_dataframe`
+outer-joins several streams' recorded histories after the run and touches no
+graph. Do not force it through `#[pyop]` / `pyop_fn!`: write it as a plain free
+`#[pyfunction]` that reads `Stream::value()` and register it in the
+`#[pymodule]` like any other. Two conventions still apply, and they are what
+makes it feel native rather than bolted on:
+
+- **Put the logic in `graph.rs` and the glue in `python.rs`,** the same split
+  the pyclass methods use — `graph.rs` owns the erased object form and the real
+  work (returning `anyhow::Result`), `python.rs` owns `#[pyclass]`/`#[pyfunction]`
+  argument extraction and the `to_pyerr` mapping.
+- **Prefer Rust over a new pure-Python module.** `python/wingfoil_next/` exists
+  only for what genuinely needs Python (subclassing, in `CustomStream`), and its
+  `__init__.py` re-export is *derived* from the extension — so a Rust
+  `#[pyfunction]` appears in `wingfoil_next.*` with nothing to keep in sync,
+  while a Python helper is a second hand-maintained surface. Even helpers that
+  are "just pandas calls" belong in Rust for that reason.
+
+A post-run helper has no `nitro!`/compiled obligation (steps 5–6 do not apply),
+but it still owes a Rust unit test beside the other `graph.rs` tests and a
+pytest.
 
 ## 8. Roadmap bookkeeping
 

--- a/crates/wingfoil-next-python/docs/api.rst
+++ b/crates/wingfoil-next-python/docs/api.rst
@@ -58,6 +58,11 @@ duration_nanos=None, realtime=False, start_nanos=0)``.
 rather than as fixed :class:`~wingfoil_next.Stream` methods — see
 `Plugin seam`_.
 
+**pandas** — ``stream.dataframe()`` frames a single stream; the free function
+``build_dataframe({name: stream, ...})`` outer-joins several already-run streams
+on their engine time into one frame, one column per key. Columns may be held as
+frames (``dataframe()``) or as ``(time, value)`` tuples (``collect()``).
+
 **Rust-authored demo components** (the plugin seam, proven end to end):
 ``scale``, ``square``, ``running_total``, ``weighted_add``, ``blend3``,
 ``blend4``, ``clamped_scale``, ``doubled_running_total``, ``spread_and_mid``,

--- a/crates/wingfoil-next-python/docs/migration.rst
+++ b/crates/wingfoil-next-python/docs/migration.rst
@@ -127,9 +127,18 @@ Changed or added:
      - ``stream.inspect(f)`` for the pass-through tap. Legacy needed the
        ``Node``-returning terminals because ``run`` hung off a node; next runs
        the graph, so a tap that keeps flowing is the only shape needed.
-   * - ``to_dataframe`` / ``build_dataframe`` (free functions)
-     - ``stream.dataframe()`` — the same pandas frame (columns ``time`` /
-       ``value``), read back with ``.value()`` after the run
+   * - ``stream.dataframe()`` (a list of ``(time, value)`` tuples)
+     - ``stream.collect()`` — the same growing list of pairs, with the time in
+       nanoseconds as an int rather than seconds as a float. ``dataframe()`` in
+       next is the upgrade: a real ``pandas.DataFrame`` (columns ``time`` /
+       ``value``) assembled in Rust, read back with ``.value()`` after the run
+   * - ``to_dataframe`` (free function)
+     - ``stream.dataframe()`` — next builds the frame in the engine, so there is
+       no list-to-frame converter to call
+   * - ``build_dataframe({name: stream})`` (free function)
+     - ``wingfoil_next.build_dataframe({name: stream})`` — same call, same outer
+       join on time. Columns may be held either as frames (``dataframe()``) or
+       as ``(time, value)`` tuples (``collect()``, the legacy shape)
    * - *(new)*
      - ``merge``, ``merge_all``, ``throttle``, ``window``, ``accumulate``,
        ``reduce``, ``filter_map``, ``filter_value``, ``filter_none``,
@@ -356,11 +365,15 @@ Known gaps
   only. The *engine* has the full surface — it is the binding that stops short,
   so this is expected to close without any API change to what is documented
   here.
-* **No multi-stream ``build_dataframe``.** Legacy's ``pandas_helpers.build_dataframe``
-  outer-joined several streams on time. :meth:`~wingfoil_next.Stream.dataframe`
-  frames a single stream — and does it better, building a real
-  ``pandas.DataFrame`` in Rust where legacy returned ``(time, value)`` tuples
-  for a Python helper to assemble. Only the multi-stream join is missing.
+* **``dataframe()`` materialises on the run's last cycle.** It assembles the
+  frame when :meth:`~wingfoil_next.Stream.dataframe` is cycled *and* the kernel
+  says this is the final cycle — so a stream that has already gone quiet by then
+  (a slower ticker, a stream behind ``limit``) never reaches the build step and
+  its value stays ``None``. Legacy's ``dataframe()`` re-emitted its rows on every
+  tick and had no such edge; next's equivalent of that shape is
+  :meth:`~wingfoil_next.Stream.collect`, so nothing is lost — reach for
+  ``collect()`` when a stream may be silent at the end, including as a column of
+  ``build_dataframe``.
 * **ZeroMQ cross-language interop** with a *legacy* Rust/Python peer is not
   guaranteed: next's ``bincode`` envelope is its own. Two next peers
   interoperate, and so does a next Python peer with a next Rust peer publishing

--- a/crates/wingfoil-next-python/examples/README.md
+++ b/crates/wingfoil-next-python/examples/README.md
@@ -14,7 +14,7 @@ python examples/quick_start.py
 | `quick_start.py`             | build a graph, chain combinators, run, read a value |
 | `custom_stream.py`           | a Python object as a graph node (`Graph.custom_node`) |
 | `custom_stream_subclass.py`  | the same thing by subclassing `CustomStream` — legacy wingfoil's shape |
-| `dataframe.py`               | collect a stream into a pandas DataFrame (needs `pandas`) |
+| `dataframe.py`               | collect a stream into a pandas DataFrame, and outer-join several with `build_dataframe` (needs `pandas`) |
 | `plugin_sdk.py`              | compose Rust-authored ops / sub-graphs / adapters from Python |
 
 All five are smoke-tested in `tests/test_examples.py`, so they stay working as

--- a/crates/wingfoil-next-python/examples/dataframe.py
+++ b/crates/wingfoil-next-python/examples/dataframe.py
@@ -1,16 +1,57 @@
 #!/usr/bin/env python3
-"""DataFrame — collect a stream into a pandas DataFrame.
+"""DataFrame — collect one stream into a pandas DataFrame, and join several.
 
 `stream.dataframe()` accumulates each value with its engine time and, on the
 last cycle, produces a pandas DataFrame (columns `time`, `value`) as the
-stream's final value. Requires pandas (`pip install pandas`).
+stream's final value.
+
+`build_dataframe({name: stream, ...})` is the multi-stream half: it outer-joins
+several already-run streams on their engine time into one frame, one column per
+key. A stream holds its history either as a frame (`dataframe()`) or as
+`(time, value)` tuples (`collect()`); both are accepted.
+
+Requires pandas (`pip install pandas`).
 """
 
 import wingfoil_next as wf
 
-g = wf.Graph()
+print("~~~ Single stream (primitives) ~~~")
 
+g = wf.Graph()
 df = g.counter(period_nanos=100).map(lambda n: n * n).dataframe()  # squares
 g.run(cycles=5)
 
 print(df.value())
+
+print("\n~~~ Single stream (dictionaries) ~~~")
+
+g = wf.Graph()
+quotes = (
+    g.counter(period_nanos=100)
+    .map(lambda i: {"price": 100 + i, "qty": 10})
+    .dataframe()
+)
+g.run(cycles=5)
+
+print(quotes.value())
+
+print("\n~~~ Multiple streams (build_dataframe) ~~~")
+
+g = wf.Graph()
+source = g.counter(period_nanos=100)
+price = source.map(lambda i: 100 + i).dataframe()
+qty = source.map(lambda _: 10).dataframe()
+g.run(cycles=5)
+
+print(wf.build_dataframe({"price": price, "qty": qty}))
+
+print("\n~~~ Streams at different rates (outer join fills NaN) ~~~")
+
+# A slower stream is quiet on the run's last cycle, so it never reaches
+# `dataframe()`'s build step — `collect()` is the shape to join on here.
+g = wf.Graph()
+fast = g.counter(period_nanos=100).map(lambda n: n * 10).collect()
+slow = g.counter(period_nanos=200).map(lambda n: n * 100).collect()
+g.run(cycles=4)
+
+print(wf.build_dataframe({"fast": fast, "slow": slow}))

--- a/crates/wingfoil-next-python/src/graph.rs
+++ b/crates/wingfoil-next-python/src/graph.rs
@@ -1150,6 +1150,143 @@ impl PyStream {
     }
 }
 
+/// Normalise one already-run column into a `time`-indexed single-column pandas
+/// `DataFrame`, or `None` when the stream has nothing to contribute.
+///
+/// Two input shapes are accepted, because next has two ways to hold a stream's
+/// history and both are legitimate inputs to the join:
+///
+/// - a pandas `DataFrame` with `time` / `value` columns — what
+///   [`PyStream::dataframe`] produces;
+/// - an iterable of `(time, value)` pairs — what [`PyStream::collect`] produces,
+///   and the *only* shape legacy had (legacy's `dataframe()` was next's
+///   `collect()`; see `docs/migration.rst`).
+///
+/// An empty column contributes nothing, mirroring legacy's `if not val:
+/// continue`. Emptiness is tested by length rather than truthiness because a
+/// `DataFrame` raises on `bool()`.
+fn column_frame<'py>(
+    py: Python<'py>,
+    pandas: &Bound<'py, PyAny>,
+    name: &str,
+    element: &PyElement,
+) -> Result<Option<Bound<'py, PyAny>>> {
+    if element.is_none() {
+        return Ok(None);
+    }
+    let value = element.object().bind(py);
+    let frame_type = pandas
+        .getattr("DataFrame")
+        .map_err(|err| anyhow::anyhow!("pandas.DataFrame lookup failed: {err}"))?;
+    let (times, values) = if value
+        .is_instance(&frame_type)
+        .map_err(|err| anyhow::anyhow!("build_dataframe() column {name:?}: {err}"))?
+    {
+        let column = |key: &str| -> Result<Bound<'py, PyAny>> {
+            value
+                .get_item(key)
+                .and_then(|series| series.call_method0("tolist"))
+                .map_err(|err| {
+                    anyhow::anyhow!(
+                        "build_dataframe() column {name:?}: frame has no usable {key:?} column: {err}"
+                    )
+                })
+        };
+        (column("time")?, column("value")?)
+    } else {
+        let rows = value.try_iter().map_err(|err| {
+            anyhow::anyhow!(
+                "build_dataframe() column {name:?}: expected a DataFrame or an iterable of \
+                 (time, value) pairs: {err}"
+            )
+        })?;
+        let mut times = Vec::new();
+        let mut values = Vec::new();
+        for row in rows {
+            let row =
+                row.map_err(|err| anyhow::anyhow!("build_dataframe() column {name:?}: {err}"))?;
+            let pair = |i: usize| -> Result<Bound<'py, PyAny>> {
+                row.get_item(i).map_err(|err| {
+                    anyhow::anyhow!(
+                        "build_dataframe() column {name:?}: row is not a (time, value) pair: {err}"
+                    )
+                })
+            };
+            times.push(pair(0)?);
+            values.push(pair(1)?);
+        }
+        let to_list = |items: Vec<Bound<'py, PyAny>>| -> Result<Bound<'py, PyAny>> {
+            Ok(pyo3::types::PyList::new(py, items)
+                .map_err(|err| anyhow::anyhow!("build_dataframe() column {name:?}: {err}"))?
+                .into_any())
+        };
+        (to_list(times)?, to_list(values)?)
+    };
+    let len = times
+        .len()
+        .map_err(|err| anyhow::anyhow!("build_dataframe() column {name:?}: {err}"))?;
+    if len == 0 {
+        return Ok(None);
+    }
+    let columns = pyo3::types::PyDict::new(py);
+    columns
+        .set_item("time", times)
+        .and_then(|()| columns.set_item(name, values))
+        .map_err(|err| anyhow::anyhow!("build_dataframe() column {name:?} build: {err}"))?;
+    pandas
+        .call_method1("DataFrame", (columns,))
+        .and_then(|frame| frame.call_method1("set_index", ("time",)))
+        .map(Some)
+        .map_err(|err| anyhow::anyhow!("build_dataframe() column {name:?}: {err}"))
+}
+
+/// Outer-join several already-run streams on their engine time into one pandas
+/// `DataFrame` — the legacy `pandas_helpers.build_dataframe`.
+///
+/// Each `(name, value)` pair becomes one column named `name`, indexed by the
+/// stream's tick times; the columns are concatenated with an **outer** join, so
+/// a time at which one stream ticked and another did not yields `NaN` for the
+/// quiet one. Column order follows the order the pairs are supplied in. The
+/// `time` index is restored as the leading column, so the result reads
+/// `time, <name>, <name>, …` exactly as legacy's did.
+///
+/// Streams that produced nothing are skipped (legacy's `if not val: continue`);
+/// if that leaves no columns at all the result is an empty `DataFrame`.
+///
+/// `pandas` is imported lazily here, for the same reason
+/// [`PyStream::dataframe`] does it: only a caller that actually joins frames
+/// needs it, and a missing pandas aborts with context rather than at import.
+pub fn build_dataframe(columns: &[(String, PyElement)]) -> Result<Py<PyAny>> {
+    Python::attach(|py| {
+        let pandas = py
+            .import("pandas")
+            .map_err(|err| anyhow::anyhow!("build_dataframe() needs pandas: {err}"))?;
+        let pandas = pandas.as_any();
+        let mut frames = Vec::with_capacity(columns.len());
+        for (name, element) in columns {
+            if let Some(frame) = column_frame(py, pandas, name, element)? {
+                frames.push(frame);
+            }
+        }
+        if frames.is_empty() {
+            return pandas
+                .call_method0("DataFrame")
+                .map(|frame| frame.unbind())
+                .map_err(|err| anyhow::anyhow!("pandas.DataFrame raised: {err}"));
+        }
+        let kwargs = pyo3::types::PyDict::new(py);
+        kwargs
+            .set_item("axis", 1)
+            .and_then(|()| kwargs.set_item("join", "outer"))
+            .map_err(|err| anyhow::anyhow!("build_dataframe() concat arguments: {err}"))?;
+        pandas
+            .call_method("concat", (frames,), Some(&kwargs))
+            .and_then(|joined| joined.call_method0("reset_index"))
+            .map(|joined| joined.unbind())
+            .map_err(|err| anyhow::anyhow!("pandas.concat raised: {err}"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1380,6 +1517,120 @@ mod tests {
         });
         assert_eq!(vec![0, 100, 200], times);
         assert_eq!(vec![1, 2, 3], values);
+    }
+
+    /// Read one column of a pandas frame as a `Vec<T>`.
+    fn frame_column<T>(frame: &Py<PyAny>, name: &str) -> Vec<T>
+    where
+        T: for<'a, 'py> pyo3::FromPyObject<'a, 'py>,
+    {
+        Python::attach(|py| {
+            frame
+                .bind(py)
+                .call_method1("__getitem__", (name,))
+                .unwrap()
+                .call_method0("tolist")
+                .unwrap()
+                .extract()
+                .unwrap()
+        })
+    }
+
+    #[test]
+    fn build_dataframe_joins_synchronous_columns() {
+        if Python::attach(|py| py.import("pandas").is_err()) {
+            return;
+        }
+        let g = PyGraph::new();
+        let source = g.counter(Duration::from_nanos(100));
+        let a = source.map(lambda("lambda i: i - 1")).dataframe();
+        let b = source.map(lambda("lambda i: (i - 1) * 2")).dataframe();
+        run_cycles(&g, 3);
+        let joined = build_dataframe(&[
+            ("col_a".to_string(), a.value()),
+            ("col_b".to_string(), b.value()),
+        ])
+        .unwrap();
+        assert_eq!(vec![0, 100, 200], frame_column::<i64>(&joined, "time"));
+        assert_eq!(vec![0, 1, 2], frame_column::<i64>(&joined, "col_a"));
+        assert_eq!(vec![0, 2, 4], frame_column::<i64>(&joined, "col_b"));
+    }
+
+    #[test]
+    fn build_dataframe_outer_joins_asynchronous_columns() {
+        if Python::attach(|py| py.import("pandas").is_err()) {
+            return;
+        }
+        // Two independent tickers at different rates. `collect()` (legacy's
+        // `dataframe()`) is the shape that survives a stream being quiet on the
+        // last cycle, which is exactly what a slower ticker does.
+        let g = PyGraph::new();
+        let fast = g
+            .counter(Duration::from_nanos(100))
+            .map(lambda("lambda x: x * 10"))
+            .collect();
+        let slow = g
+            .counter(Duration::from_nanos(200))
+            .map(lambda("lambda x: x * 100"))
+            .collect();
+        run_cycles(&g, 4);
+        let joined = build_dataframe(&[
+            ("fast".to_string(), fast.value()),
+            ("slow".to_string(), slow.value()),
+        ])
+        .unwrap();
+        assert_eq!(vec![0, 100, 200, 300], frame_column::<i64>(&joined, "time"));
+        assert_eq!(
+            vec![10.0, 20.0, 30.0, 40.0],
+            frame_column::<f64>(&joined, "fast")
+        );
+        // The slow ticker is silent at t=100 and t=300 — outer join fills NaN.
+        let slow_column = frame_column::<f64>(&joined, "slow");
+        assert_eq!(100.0, slow_column[0]);
+        assert!(slow_column[1].is_nan());
+        assert_eq!(200.0, slow_column[2]);
+        assert!(slow_column[3].is_nan());
+    }
+
+    #[test]
+    fn build_dataframe_skips_columns_that_produced_nothing() {
+        if Python::attach(|py| py.import("pandas").is_err()) {
+            return;
+        }
+        let never_run = PyGraph::new()
+            .counter(Duration::from_nanos(100))
+            .dataframe();
+        let g = PyGraph::new();
+        let live = g.counter(Duration::from_nanos(100)).dataframe();
+        run_cycles(&g, 3);
+        let joined = build_dataframe(&[
+            ("empty".to_string(), never_run.value()),
+            ("live".to_string(), live.value()),
+        ])
+        .unwrap();
+        let columns: Vec<String> = Python::attach(|py| {
+            joined
+                .bind(py)
+                .getattr("columns")
+                .unwrap()
+                .call_method0("tolist")
+                .unwrap()
+                .extract()
+                .unwrap()
+        });
+        assert_eq!(vec!["time".to_string(), "live".to_string()], columns);
+        assert_eq!(vec![1, 2, 3], frame_column::<i64>(&joined, "live"));
+    }
+
+    #[test]
+    fn build_dataframe_with_nothing_to_join_is_empty() {
+        if Python::attach(|py| py.import("pandas").is_err()) {
+            return;
+        }
+        let empty = build_dataframe(&[]).unwrap();
+        let is_empty: bool =
+            Python::attach(|py| empty.bind(py).getattr("empty").unwrap().extract().unwrap());
+        assert!(is_empty);
     }
 
     #[test]

--- a/crates/wingfoil-next-python/src/python.rs
+++ b/crates/wingfoil-next-python/src/python.rs
@@ -645,6 +645,38 @@ impl BurstListSinkOps for ::wingfoil_next::prelude::Stream<::wingfoil_next::Burs
     }
 }
 
+/// Outer-join several already-run streams on engine time into a single pandas
+/// `DataFrame` — the multi-stream counterpart of [`Stream::dataframe`], and the
+/// replacement for legacy's `wingfoil.pandas_helpers.build_dataframe`.
+///
+/// `streams` maps a column name to a stream that has already been run. Each
+/// stream contributes one column named by its key, indexed by the times it
+/// ticked; times where a stream was quiet come back as `NaN`. Column order
+/// follows the dict's insertion order and the joined `time` is the leading
+/// column.
+///
+/// A stream holds its history either as a frame (`stream.dataframe()`) or as
+/// `(time, value)` tuples (`stream.collect()`) — both are accepted, so the join
+/// composes with whichever half of the pair the caller already had. Streams that
+/// produced nothing are skipped; if none produced anything the result is an
+/// empty `DataFrame`. Requires pandas at call time.
+#[pyfunction]
+fn build_dataframe(streams: &Bound<'_, pyo3::types::PyDict>) -> PyResult<Py<PyAny>> {
+    use pyo3::types::PyDictMethods;
+
+    let mut columns = Vec::with_capacity(streams.len());
+    for (key, value) in streams.iter() {
+        let name: String = key.extract()?;
+        let stream: PyRef<'_, Stream> = value.extract().map_err(|_| {
+            PyValueError::new_err(format!(
+                "build_dataframe() value for {name:?} is not a wingfoil_next Stream"
+            ))
+        })?;
+        columns.push((name, stream.0.value()));
+    }
+    crate::graph::build_dataframe(&columns).map_err(to_pyerr)
+}
+
 /// Parse a case-insensitive level name into a [`log::Level`] for
 /// [`Stream::logged`]. A ValueError names the accepted set on a bad input.
 fn parse_log_level(level: &str) -> PyResult<log::Level> {
@@ -684,6 +716,7 @@ fn _wingfoil(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pair_source, m)?)?;
     m.add_function(wrap_pyfunction!(burst_list_sink, m)?)?;
     m.add_function(wrap_pyfunction!(split_source, m)?)?;
+    m.add_function(wrap_pyfunction!(build_dataframe, m)?)?;
     register_latency(m)?;
     register_adapters(m)?;
     Ok(())

--- a/crates/wingfoil-next-python/tests/test_pandas.py
+++ b/crates/wingfoil-next-python/tests/test_pandas.py
@@ -1,0 +1,171 @@
+"""pandas interop — the multi-stream ``build_dataframe`` join.
+
+The parity oracle is ``legacy/wingfoil-python/tests/test_pandas.py``. Its four
+stream-level tests (``test_dict_of_streams``, ``test_async_frequencies``,
+``test_massive_fan_out``, ``test_build_dataframe_skips_empty_streams``) are
+ported here one for one.
+
+Two mapping notes:
+
+* legacy's ``stream.dataframe()`` accumulated ``(time, value)`` tuples — that is
+  next's ``stream.collect()``. Next's ``stream.dataframe()`` is the *upgraded*
+  half: a real ``pandas.DataFrame`` assembled in Rust. ``build_dataframe``
+  accepts either shape, so both are exercised below.
+* legacy timestamps were seconds as floats; next's are nanoseconds as ints (the
+  established ``with_time`` convention). Tick *times* are asserted, tick
+  *values* are unchanged from legacy.
+
+The legacy file's other seven tests cover ``to_dataframe``, a pure-Python
+list-to-frame converter with no next counterpart by design — next builds the
+frame in the engine (``stream.dataframe()``), so there is no free function to
+test. See ``docs/migration.rst``.
+"""
+
+import pytest
+
+import wingfoil_next as wf
+
+pd = pytest.importorskip("pandas")
+
+
+def test_dict_of_streams():
+    """Legacy ``test_dict_of_streams`` — two branches of one source, joined."""
+    g = wf.Graph()
+    source = g.counter(period_nanos=100)  # 1, 2, 3 at t = 0, 100, 200
+
+    stream_a = source.map(lambda i: i - 1).dataframe()
+    stream_b = source.map(lambda i: (i - 1) * 2).dataframe()
+
+    g.run(cycles=3)
+
+    df = wf.build_dataframe({"col_a": stream_a, "col_b": stream_b})
+
+    assert len(df) == 3
+    assert "time" in df.columns
+    assert "col_a" in df.columns
+    assert "col_b" in df.columns
+
+    assert list(df["time"]) == [0, 100, 200]
+    assert df.iloc[0]["col_a"] == 0
+    assert df.iloc[0]["col_b"] == 0
+    assert df.iloc[2]["col_a"] == 2
+    assert df.iloc[2]["col_b"] == 4
+
+
+def test_async_frequencies():
+    """Legacy ``test_async_frequencies`` — two independent tickers at different
+    speeds, outer-joined with NaNs where the slow one was silent.
+
+    Collected with ``collect()`` rather than ``dataframe()``: ``dataframe()``
+    materialises the frame on the run's *last cycle*, which a stream that has
+    gone quiet by then never sees. ``collect()`` re-emits its rows on every tick
+    and is what legacy's ``dataframe()` actually was.
+    """
+    g = wf.Graph()
+    fast_stream = g.counter(period_nanos=100).map(lambda x: x * 10).collect()
+    slow_stream = g.counter(period_nanos=200).map(lambda x: x * 100).collect()
+
+    g.run(cycles=4)  # t = 0, 100, 200, 300 — slow ticks only at 0 and 200
+
+    df = wf.build_dataframe({"fast": fast_stream, "slow": slow_stream})
+
+    assert len(df) == 4
+    assert "fast" in df.columns
+    assert "slow" in df.columns
+
+    assert pd.isna(df.iloc[1]["slow"])
+    assert pd.isna(df.iloc[3]["slow"])
+    # But it should have values where they align.
+    assert not pd.isna(df.iloc[0]["slow"])
+    assert df.iloc[0]["slow"] == 100
+    assert df.iloc[2]["slow"] == 200
+    assert list(df["fast"]) == [10, 20, 30, 40]
+
+
+def test_massive_fan_out():
+    """Legacy ``test_massive_fan_out`` — one source, three branches, all aligned."""
+    g = wf.Graph()
+    source = g.counter(period_nanos=100)  # 1, 2, 3
+
+    s_add = source.map(lambda x: x + 5).dataframe()
+    s_sub = source.map(lambda x: x - 5).dataframe()
+    s_mult = source.map(lambda x: x * 5).dataframe()
+
+    g.run(cycles=3)
+
+    df = wf.build_dataframe({"add": s_add, "sub": s_sub, "mult": s_mult})
+
+    assert len(df) == 3
+    assert all(col in df.columns for col in ["time", "add", "sub", "mult"])
+
+    assert df.iloc[2]["add"] == 8
+    assert df.iloc[2]["sub"] == -2
+    assert df.iloc[2]["mult"] == 15
+
+
+def test_build_dataframe_skips_empty_streams():
+    """Legacy ``test_build_dataframe_skips_empty_streams`` — a stream that never
+    ran contributes no column.
+
+    Legacy ran a single stream's own sub-graph; next runs a whole ``Graph``, so
+    the never-run stream lives on a second graph that is simply left alone.
+    """
+    empty_graph = wf.Graph()
+    empty_stream = empty_graph.counter(period_nanos=100).dataframe()
+
+    live_graph = wf.Graph()
+    live_stream = live_graph.counter(period_nanos=100).dataframe()
+    live_graph.run(cycles=3)
+
+    df = wf.build_dataframe({"empty": empty_stream, "live": live_stream})
+
+    assert "live" in df.columns
+    assert "empty" not in df.columns
+    assert len(df) == 3
+
+
+# Beyond the legacy four: contract details the legacy helper had but never
+# pinned with a test, plus the shapes next adds.
+
+
+def test_build_dataframe_with_no_columns_is_empty():
+    """Every stream empty (or none supplied at all) yields an empty frame."""
+    empty_stream = wf.Graph().counter(period_nanos=100).dataframe()
+
+    assert wf.build_dataframe({}).empty
+    assert wf.build_dataframe({"empty": empty_stream}).empty
+
+
+def test_build_dataframe_preserves_column_order():
+    """Columns follow the dict's insertion order, after the joined `time`."""
+    g = wf.Graph()
+    source = g.counter(period_nanos=100)
+    third = source.map(lambda i: i * 3).dataframe()
+    first = source.map(lambda i: i).dataframe()
+    second = source.map(lambda i: i * 2).dataframe()
+    g.run(cycles=2)
+
+    df = wf.build_dataframe({"c": third, "a": first, "b": second})
+
+    assert list(df.columns) == ["time", "c", "a", "b"]
+
+
+def test_build_dataframe_mixes_frame_and_tuple_columns():
+    """A `dataframe()` column and a `collect()` column join interchangeably."""
+    g = wf.Graph()
+    source = g.counter(period_nanos=100)
+    framed = source.map(lambda i: i * 10).dataframe()
+    collected = source.map(lambda i: i * 100).collect()
+    g.run(cycles=3)
+
+    df = wf.build_dataframe({"framed": framed, "collected": collected})
+
+    assert list(df["time"]) == [0, 100, 200]
+    assert list(df["framed"]) == [10, 20, 30]
+    assert list(df["collected"]) == [100, 200, 300]
+
+
+def test_build_dataframe_rejects_non_stream_values():
+    """A dict value that is not a Stream is a clear error, not a crash."""
+    with pytest.raises(ValueError, match="not a wingfoil_next Stream"):
+        wf.build_dataframe({"nope": [(0, 1)]})

--- a/docs/cutover-plan.md
+++ b/docs/cutover-plan.md
@@ -122,7 +122,7 @@ needs an explicit accept/fix ruling at cutover.** These are the open ones.
 | # | Item | Size |
 |:--:|---|:--:|
 | 3.7 | **The statistics Python binding stops short of legacy.** Legacy `legacy/wingfoil-python/src/py_statistics.rs` binds `Window` / `Weighting` / `EwmaSpan` over `mean`/`std`/`var`/`sum`/`min`/`max`/`median`/`ewma`; next-python binds only cumulative `sum`/`mean`/`average`. The engine already has the whole surface (`crates/wingfoil-next/src/stats.rs`, with parity tests), so this is binding work, not engine work. 37 legacy tests have nowhere to map. | M |
-| 3.8 | **No multi-stream `build_dataframe` in next-python.** Legacy `pandas_helpers.build_dataframe` outer-joins several streams on time; next's `dataframe()` frames a single stream. 4 legacy tests have nowhere to map. The single-stream half is already ahead of legacy (a real `pandas.DataFrame` built in Rust), so only the multi-stream join is missing. | S |
+| 3.8 | ✅ **Multi-stream `build_dataframe` in next-python — landed.** `wingfoil_next.build_dataframe({name: stream})` outer-joins several already-run streams on engine time, built in Rust beside the single-stream `dataframe()` rather than as a Python helper. Columns may be held as frames (`dataframe()`) or as `(time, value)` tuples (`collect()`, legacy's shape). All 4 legacy tests ported to `crates/wingfoil-next-python/tests/test_pandas.py`; the legacy `to_dataframe` tests have no counterpart by design (next builds the frame in the engine) — noted in `docs/migration.rst`. | S |
 
 Row **3.9** (sweep the legacy tree for drift since each phase was ticked) has
 run; the findings are below, and it adds no rows.

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -1528,8 +1528,10 @@ tests covered — not "legacy pytest passes unchanged."
   combinator surface — `fold`/`sample`/`count`/`limit`/`difference`/
   `with_time`/`collect`/`buffer`/`window`/`not_`, the `sum`/`mean` statistics
   bridge, plus `filter_map`/`filter_value`/`filter_none`/`reduce`/`bimap`/
-  `split`/`dataframe` (all in `graph.rs`, each with a unit test). The
-  per-adapter bindings that followed are the next bullet.
+  `split`/`dataframe` (all in `graph.rs`, each with a unit test), and the free
+  `build_dataframe` that outer-joins several run streams on time (legacy's
+  `pandas_helpers.build_dataframe`, likewise built in Rust). The per-adapter
+  bindings that followed are the next bullet.
 - **Per-adapter Python bindings** 🟡 *mechanical + stream-transform tiers landed (9 of 15)*: the `#[pyadapter]`
   exposure of the real `adapters::*` I/O adapters, each behind a
   `wingfoil-next-python` cargo feature of the same name (`crate::adapters::*`,
@@ -1814,12 +1816,17 @@ tests covered — not "legacy pytest passes unchanged."
     inside `adapters/web.rs` (`bytes_marshal_as_an_array_of_ints`, the i64/u64/
     beyond-u64 ladder). Legacy's "silently becomes null" cases invert: next
     fails loudly, and `test_web.py` asserts the errors.
-  - `test_pandas.py` (12) → partially. `stream.dataframe()` builds the frame in
-    Rust (`test_interop.py::test_dataframe_from_stream`, `examples/dataframe.py`)
-    where legacy returned `(time, value)` tuples for a Python helper to assemble.
-    The **multi-stream** half — `pandas_helpers.build_dataframe`, which
-    outer-joins several streams on time (`test_dict_of_streams`,
-    `test_async_frequencies`, `test_massive_fan_out`) — has no next equivalent.
+  - `test_pandas.py` (12) → `test_pandas.py`. `stream.dataframe()` builds the
+    frame in Rust (`test_interop.py::test_dataframe_from_stream`,
+    `examples/dataframe.py`) where legacy returned `(time, value)` tuples for a
+    Python helper to assemble — legacy's tuple shape is next's `collect()`. The
+    **multi-stream** half — `pandas_helpers.build_dataframe`, which outer-joins
+    several streams on time — is now `wingfoil_next.build_dataframe`, also built
+    in Rust; its 4 legacy tests (`test_dict_of_streams`,
+    `test_async_frequencies`, `test_massive_fan_out`,
+    `test_build_dataframe_skips_empty_streams`) are ported one for one. The
+    remaining 7 cover `to_dataframe`, a pure-Python list-to-frame converter with
+    no next counterpart by design (next builds the frame in the engine).
   - `test_statistics.py` (37) → **not ported**. Legacy `py_statistics.rs` binds
     the whole statistics adapter (`Window` / `Weighting` / `EwmaSpan` and their
     int/str/float shorthands over `mean`/`std`/`var`/`sum`/`min`/`max`/`median`/
@@ -1846,9 +1853,10 @@ tests covered — not "legacy pytest passes unchanged."
   only the *ran but never ticked* case. Legacy `peek_value` answers `None`
   there, so `value()` now returns the empty element in both.
 
-  **Remaining** — both are missing *binding surface*, not missing tests, so they
-  belong to "Surface build-out" rather than here: the statistics adapter
-  binding, and a multi-stream `build_dataframe` equivalent.
+  **Remaining** — missing *binding surface*, not missing tests, so it belongs to
+  "Surface build-out" rather than here: the statistics adapter binding.
+  (`build_dataframe` was the other one; it landed — see the `test_pandas.py`
+  entry above.)
 - **`wingfoil_next::compat` (`Signal<T>`)** stays a *Rust-side* legacy-idiom
   ergonomic (free `ticker`/`constant`, `stream.run`/`peek_value`; `tests/
   compat.rs`) — it is **not** the Python-binding path (that is the object-form


### PR DESCRIPTION
Closes **row 3.8** of `docs/cutover-plan.md` — the last legacy pandas gap.

`wingfoil_next.build_dataframe({name: stream})` outer-joins several already-run
streams on their engine time into one frame: one column per key, `NaN` where a
stream was quiet, `time` restored as the leading column — the same contract as
legacy `wingfoil.pandas_helpers.build_dataframe`.

```python
g = wf.Graph()
source = g.counter(period_nanos=100)
a = source.map(lambda i: i - 1).dataframe()
b = source.map(lambda i: (i - 1) * 2).dataframe()
g.run(cycles=3)

wf.build_dataframe({"col_a": a, "col_b": b})
#    time  col_a  col_b
# 0     0      0      0
# 1   100      1      2
# 2   200      2      4
```

## Rust, not a Python helper — and why

Legacy's `build_dataframe` was a pure-Python module (`python/wingfoil/pandas_helpers.py`).
Next builds it in Rust, in `graph.rs` beside the single-stream `dataframe()`, with
the `#[pyfunction]` glue in `python.rs`. Three reasons:

1. **No second hand-maintained surface.** `python/wingfoil_next/__init__.py`
   derives its re-export from the extension (`dir(_ext)`), precisely so a new
   Rust-side function appears in `wingfoil_next.*` with nothing to keep in sync.
   Its own docstring scopes the pure-Python package to "what is more naturally
   written in Python than through pyo3" — currently only `CustomStream`, which
   needs Python subclassing. A join over pandas objects needs nothing Python-only.
2. **It keeps the single-stream advantage's provenance.** `dataframe()` is
   already ahead of legacy because the frame is assembled in Rust; assembling
   the join in Python would have put the two halves of the same feature on
   different sides of the boundary.
3. **One error-handling policy.** The join returns `anyhow::Result` with
   `.context`-style messages naming the offending column, mapped through the
   existing `to_pyerr` at the seam — the same shape as every other binding here.
   No `.unwrap()` in production code.

## Both column shapes are accepted, deliberately

A stream holds its history either as a real frame (`dataframe()`) or as
`(time, value)` tuples (`collect()`). `build_dataframe` takes either.

That is not convenience — it is the parity mapping. Legacy's `dataframe()` was
*exactly* next's `collect()` (a growing list of `(time, value)` pairs; see
`legacy/wingfoil-python/src/py_stream.rs`), so accepting the tuple shape is what
makes the legacy call sites port verbatim. Next's `dataframe()` is the upgraded
half, and it joins just as well.

It also matters for correctness. Next's `dataframe()` materialises the frame on
the run's **last cycle**, and it is `Activation::NONE` — so a stream that has
already gone quiet by then (a slower ticker, anything behind `limit`) is never
cycled, never reaches the build step, and its value stays `None`. Legacy's
tuple-accumulating `dataframe()` had no such edge. Nothing is lost, because
`collect()` *is* that shape — but callers need to know which to reach for, so
it is documented in `migration.rst` (under Known gaps, replacing the
now-closed `build_dataframe` bullet) and in the example.

## Legacy tests — where each one landed

New file `crates/wingfoil-next-python/tests/test_pandas.py`. All four
stream-level legacy tests map one for one:

| Legacy `test_pandas.py` | Ported as | Notes |
|---|---|---|
| `test_dict_of_streams` | same name | two branches of one source; identical values (`0,1,2` / `0,2,4`) |
| `test_async_frequencies` | same name | two tickers at 100ns/200ns; NaN where the slow one is silent. Uses `collect()` — the literal legacy shape, and the one that survives a stream being quiet at the end |
| `test_massive_fan_out` | same name | one source, three branches; identical values (`8`, `-2`, `15`) |
| `test_build_dataframe_skips_empty_streams` | same name | legacy ran one stream's own sub-graph; next runs a `Graph`, so the never-run stream lives on a second graph that is simply left alone |

Legacy's timestamps were seconds as floats; next's are nanoseconds as ints (the
established `with_time` convention). Values are unchanged from legacy; tick
times are asserted too.

**The other seven legacy tests cover `to_dataframe`** — a pure-Python
list-to-frame converter. They have no counterpart *by design*, not by omission:
next builds the frame in the engine (`stream.dataframe()`), so there is no free
converter function to test. Recorded in the new test module's docstring, in
`migration.rst`, and in `port-plan.md`'s twin-less-files audit rather than
deleted silently.

Beyond the legacy four, four more pytest cases pin contract details legacy had
but never tested (empty result, column order, mixed frame/tuple columns,
non-Stream rejection), plus four Rust unit tests in `graph.rs` alongside
`dataframe_builds_on_last_cycle`.

## Examples

`legacy/wingfoil-python/examples/dataframe.py` had three sections; next's had
one. It now carries all three (single-stream primitives, single-stream dicts,
multi-stream join) plus a fourth showing the different-rate outer join — the
superset obligation names examples explicitly. Smoke-tested by the existing
`tests/test_examples.py`.

## Skill update

`/new-op-next` gained two rules this work surfaced:

- **`ctx.is_last_cycle()` only fires if the op is cycled on that cycle.** An
  `Activation::NONE` op that flushes on the final cycle silently produces
  nothing for an input that has gone quiet. Real and observable, not
  theoretical.
- **Not every Python surface is an op**, and **the legacy oracle is not only
  Rust**. A post-run helper over already-run streams is a plain free
  `#[pyfunction]` — don't force it through `#[pyop]`; and legacy surface also
  lives in `legacy/wingfoil-python/python/wingfoil/`, which a grep of
  `py_stream.rs` misses entirely (exactly how this gap arose). Includes the
  `graph.rs`-logic / `python.rs`-glue split and the prefer-Rust rule above.

## Docs

`cutover-plan.md` row 3.8 marked landed; `port-plan.md` twin-less-files audit
and "Surface build-out" bullet updated; `docs/api.rst` gained a pandas
paragraph; `docs/migration.rst` mapping table now distinguishes legacy
`dataframe()` → `collect()`, `to_dataframe` → `stream.dataframe()`, and
`build_dataframe` → `build_dataframe`.

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --all` / `--check` | pass |
| `cargo lint` | pass |
| `cargo lint-all` | pass |
| `cargo test -p wingfoil-next --all-features` | pass except the service-backed `*_integration` suites (`failed to initialize a docker client: Socket not found: /var/run/docker.sock`, and aeron's missing media driver) — environmental, untouched by this change, which is confined to `wingfoil-next-python` and docs |
| `cargo test -p wingfoil-next-python` | pass (72 + 23) |
| `maturin develop && pytest` | 300 passed, 25 skipped, 47 deselected |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V4RtmWkPKk5Zj4E67d2PmG)_