### PR TITLE
Bind the full statistics surface in next-python (cutover-plan 3.7)

### DIFF
--- a/.claude/commands/new-op-next.md
+++ b/.claude/commands/new-op-next.md
@@ -443,6 +443,45 @@ A post-run helper has no `nitro!`/compiled obligation (steps 5–6 do not apply)
 but it still owes a Rust unit test beside the other `graph.rs` tests and a
 pytest.
 
+**A *family* of ops binds as one dispatcher, not one function per op.** The
+op-per-binding assumption above breaks whenever the legacy Python contract
+parameterises a whole family with argument *objects*. The statistics surface is
+the worked example (`crates/wingfoil-next-python/src/statistics.rs`): the engine
+spells out ~40 methods on `StatisticsOps` (`rolling_mean`,
+`time_windowed_mean`, `cumulative_mean_time_weighted`, …) because Rust affords a
+wide statically-checked surface; legacy Python offered eight methods times two
+orthogonal knobs (`Window`, `Weighting`). Neither `#[pyop]` nor `pyop_fn!` can
+express that — **which op to wire is runtime data**, decided after the arguments
+are resolved — so the binding is a hand-written dispatcher over
+`Stream::wire`. Rules that fell out of it:
+
+- **The binding surface is the legacy binding's, not the engine's.** Do not
+  expose one Python function per engine method just because they exist; the
+  parity target is legacy's method list and its `int`/`str`/`float` shorthands.
+  Exhaustive `match` on the resolved knobs is the guard — a new engine
+  combination becomes a compile error in the dispatcher.
+- **A `#[pyclass]` used as an *argument* needs `from_py_object`.** On pyo3 0.29,
+  `#[pyclass(eq, frozen)]` alone leaves the `FromPyObject` derive deprecated, so
+  `arg.extract::<PyWindow>()` warns (and will stop compiling). Spell it
+  `#[pyclass(name = "Window", frozen, eq, from_py_object)]`, and register the
+  class in the `#[pymodule]` next to `Graph`/`Stream`.
+- **Validate at the boundary what the op only `debug_assert!`s.** `Ewma`
+  debug-asserts `alpha ∈ [0, 1]`; a release wheel would otherwise return a
+  silently diverging average, so `EwmaSpan.per_tick` raises `ValueError`. Any
+  `debug_assert!` in an op is a Python-visible hole until the binding closes it.
+- **Give a typed-edge family one labelled conversion seam.** Ops on
+  `Stream<f64>` need `PyElement → f64 → PyElement` at both ends;
+  `PyStream::wire_float_stat(op, |s| …)` does it once and names `op` in the
+  error, so a non-numeric value reports *which* operator demanded a number
+  (legacy's `as_floats` contract). Don't repeat `try_map(f64::try_from)` per
+  method.
+- **Reject an ambiguous shorthand rather than guessing.** `mean(10)` (ten
+  samples) and `mean(10.0)` (ten seconds?) cannot both be right, so a bare
+  `float` window is a `TypeError` pointing at `Window.seconds(...)`. Note that
+  `extract::<usize>` goes through `__index__`, so a `float` falls through to
+  that error instead of being silently truncated — the ordering of the
+  `extract` attempts is load-bearing.
+
 ## 8. Roadmap bookkeeping
 
 Update `docs/port-plan.md`: mark `$ARGUMENTS` in the Phase 2 inventory

--- a/crates/wingfoil-next-python/docs/api.rst
+++ b/crates/wingfoil-next-python/docs/api.rst
@@ -25,7 +25,8 @@ Quick index
 -----------
 
 **Core types**: :class:`~wingfoil_next.Graph`, :class:`~wingfoil_next.Stream`,
-:class:`~wingfoil_next.CustomStream`.
+:class:`~wingfoil_next.CustomStream`; plus the statistics argument objects
+``Window``, ``Weighting`` and ``EwmaSpan``.
 
 **Sources (methods on** :class:`~wingfoil_next.Graph` **)**:
 
@@ -46,17 +47,14 @@ duration_nanos=None, realtime=False, start_nanos=0)``.
 
 *Combine* — ``merge``, ``merge_all``.
 
-*Aggregate* — ``count``, ``sum``, ``mean`` (alias ``average``), ``accumulate``,
-``buffer``, ``window``, ``collect``, ``with_time``.
+*Aggregate* — ``count``, ``accumulate``, ``buffer``, ``window``, ``collect``,
+``with_time``; plus the statistics operators below.
 
 *Observe* — ``inspect``, ``print``, ``logged``, ``dataframe``, ``value``.
 
-**Statistics**: cumulative ``sum`` / ``mean`` are on
-:class:`~wingfoil_next.Stream`. The windowed moment surface (``variance``,
-``std``, ``median``, rolling windows, ``ewma``) lives in the Rust
-``wingfoil_next::stats`` layer and reaches Python through the plugin seam
-rather than as fixed :class:`~wingfoil_next.Stream` methods — see
-`Plugin seam`_.
+**Statistics** — ``mean``, ``variance``, ``std``, ``median``,
+``sum``, ``min``, ``max``, ``ewma``, parameterised by ``Window`` /
+``Weighting`` / ``EwmaSpan``; see `Statistics`_ below.
 
 **pandas** — ``stream.dataframe()`` frames a single stream; the free function
 ``build_dataframe({name: stream, ...})`` outer-joins several already-run streams
@@ -88,6 +86,82 @@ Core types
    :no-index:
 
 .. autoclass:: wingfoil_next.Stream
+   :members:
+   :undoc-members:
+   :no-index:
+
+.. _statistics:
+
+Statistics
+----------
+
+Every statistic is a method on :class:`~wingfoil_next.Stream` taking two
+orthogonal knobs — a **window** (how much history) and, for the moment
+operators, a **weighting** (how each sample counts). Values are read as ``float``
+at the edge, so a non-numeric value aborts the run naming the operator.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Method
+     - Meaning
+   * - ``mean(window=None, weighting=None)``
+     - Arithmetic mean. ``average()`` is a no-argument alias for the
+       cumulative form (the legacy method name).
+   * - ``variance(window=None, weighting=None)``
+     - ``Weighting.Count`` gives the sample variance (ddof = 1);
+       ``Weighting.Time`` the time-weighted population variance. ``0.0`` until
+       enough data is present.
+   * - ``std(window=None, weighting=None)``
+     - The square root of ``variance`` under the same weighting.
+   * - ``median(window=None, weighting=None)``
+     - An even sample count averages the two middle values. Over an unbounded
+       window this retains every sample, so memory grows with the stream.
+   * - ``sum(window=None)`` / ``min(window=None)`` / ``max(window=None)``
+     - Unweighted aggregates — window only.
+   * - ``ewma(span)``
+     - Exponentially weighted moving average; the first sample seeds it.
+
+**Window** — ``Window.count(n)`` (the most recent ``n`` samples),
+``Window.seconds(s)`` (everything seen in the last ``s`` of graph time; a
+sample exactly that old is still in the window), or ``Window.unbounded()``
+(cumulative). A plain ``int`` is shorthand for ``Window.count(n)`` and ``None``
+(the default) for ``Window.unbounded()``. A bare ``float`` is **rejected**:
+``mean(10)`` and ``mean(10.0)`` would mean wildly different things, so a time
+window must say so with ``Window.seconds(...)``.
+
+**Weighting** — ``Weighting.Count`` (the default; every sample counts equally)
+or ``Weighting.Time`` (each sample weighted by how long it was in effect, so
+the newest sample carries no weight until the clock advances). The strings
+``"count"`` and ``"time"`` work too.
+
+**EwmaSpan** — ``EwmaSpan.per_tick(alpha)`` for a fixed smoothing factor
+applied once per tick, or ``EwmaSpan.half_life(seconds)`` to decay by elapsed
+graph time independent of tick rate. A plain ``float`` is shorthand for
+``per_tick``; an ``alpha`` outside ``[0, 1]`` raises rather than producing a
+silently diverging average.
+
+.. code-block:: python
+
+   from wingfoil_next import EwmaSpan, Weighting, Window
+
+   prices.mean()                              # cumulative, count weighted
+   prices.mean(10)                            # last 10 samples
+   prices.std(Window.seconds(5.0), "time")    # 5s of graph time, time weighted
+   prices.ewma(EwmaSpan.half_life(30.0))
+
+.. autoclass:: wingfoil_next.Window
+   :members:
+   :undoc-members:
+   :no-index:
+
+.. autoclass:: wingfoil_next.Weighting
+   :members:
+   :undoc-members:
+   :no-index:
+
+.. autoclass:: wingfoil_next.EwmaSpan
    :members:
    :undoc-members:
    :no-index:

--- a/crates/wingfoil-next-python/docs/migration.rst
+++ b/crates/wingfoil-next-python/docs/migration.rst
@@ -154,12 +154,18 @@ Legacy exposed ``mean`` / ``variance`` / ``std`` / ``sum`` / ``min`` / ``max``
 / ``median`` / ``ewma`` as :class:`~wingfoil_next.Stream` methods parameterised
 by ``Window`` / ``Weighting`` / ``EwmaSpan`` ``#[pyclass]`` objects.
 
-In next, the cumulative forms (``sum``, ``mean``) are :class:`~wingfoil_next.Stream` methods,
-and the full windowed moment surface lives in the engine's ``stats`` layer,
-reached through the :ref:`plugin seam <plugin-seam>` — a Rust ``#[pyop]``
-exposing exactly the window you want, with no ``Window``/``Weighting`` classes
-to construct. That keeps the parameterisation where it can be checked (Rust
-types) instead of in three extra Python classes.
+**Nothing to change** — ``wingfoil_next`` binds the same eight methods with the
+same signatures and the same three argument classes, including the ``int`` /
+``str`` / ``float`` shorthands and the deliberate rejection of a bare ``float``
+window. See :ref:`Statistics <statistics>` for the full surface.
+
+The one thing that moved is *underneath*: next's engine spells each combination
+out as its own statically-checked method (``rolling_mean``,
+``time_windowed_mean``, ``cumulative_mean_time_weighted``, …), and the binding
+is a dispatcher from the two Python knobs onto them. If you would rather skip
+the dispatch and name the engine op directly, the :ref:`plugin seam
+<plugin-seam>` lets a Rust ``#[pyop]`` expose exactly the window you want with
+no ``Window``/``Weighting`` objects to construct.
 
 Custom nodes
 ------------
@@ -358,13 +364,6 @@ Not everything is a rename. Next adds, over the legacy binding:
 Known gaps
 ----------
 
-* **The statistics surface is smaller than legacy's.** Legacy bound
-  ``Window`` / ``Weighting`` / ``EwmaSpan`` over
-  ``mean``/``std``/``var``/``sum``/``min``/``max``/``median``/``ewma``;
-  ``wingfoil_next`` binds the cumulative ``sum``/``mean``/``average`` bridge
-  only. The *engine* has the full surface — it is the binding that stops short,
-  so this is expected to close without any API change to what is documented
-  here.
 * **``dataframe()`` materialises on the run's last cycle.** It assembles the
   frame when :meth:`~wingfoil_next.Stream.dataframe` is cycled *and* the kernel
   says this is the final cycle — so a stream that has already gone quiet by then

--- a/crates/wingfoil-next-python/src/graph.rs
+++ b/crates/wingfoil-next-python/src/graph.rs
@@ -25,16 +25,16 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use pyo3::IntoPyObject;
 use pyo3::prelude::*;
 use wingfoil_next::interp::{Builder, Handle, Runner, SlotRef};
 use wingfoil_next::op::{Activation, Ctx, Tick};
 use wingfoil_next::prelude::{Burst, GraphBuilder, SourceOps, Stream, StreamOps, Upstream};
-use wingfoil_next::stats::StatisticsOps;
 use wingfoil_next::{NanoTime, RunFor, RunMode};
 
 use crate::PyElement;
+use crate::statistics::{self, Aggregate, Moment, Weighting, Window};
 
 /// The runner produced by [`PyGraph::run`], shared by the graph and every
 /// [`PyStream`] wired from it so `value()` works on whichever you kept.
@@ -617,22 +617,39 @@ impl PyStream {
         })
     }
 
+    /// Wire a statistics op onto this stream: read each value as `f64` at the
+    /// edge, hand the typed stream to `wire`, and re-box its `f64` output as a
+    /// float [`PyElement`].
+    ///
+    /// The seam every [`crate::statistics`] binding goes through — the erased
+    /// surface only ever sees `PyElement`, while the engine's
+    /// [`StatisticsOps`](wingfoil_next::stats::StatisticsOps) run natively on
+    /// `f64`. `op` names the caller in the conversion error, so a non-numeric
+    /// value reports *which* operator demanded a number rather than a bare
+    /// conversion failure (the legacy `as_floats` contract).
+    pub fn wire_float_stat<F>(&self, op: &'static str, wire: F) -> PyStream
+    where
+        F: FnOnce(&Stream<f64>) -> Stream<f64>,
+    {
+        let as_f64 = self.stream.try_map(move |e: &PyElement| {
+            f64::try_from(e).with_context(|| format!("{op}: expected a float input value"))
+        });
+        self.wrap(wire(&as_f64).map(|v: &f64| PyElement::from(*v)))
+    }
+
     /// Cumulative running **sum** over the values (the legacy `sum`,
-    /// `Window::Unbounded`). Each value is read as `f64` at the edge — a
-    /// non-numeric value aborts the run with context — and the running total is
-    /// re-boxed as a float [`PyElement`].
+    /// `Window::Unbounded`). The windowed forms go through
+    /// [`crate::statistics::aggregate`]; this is the shorthand the erased
+    /// object form exposes directly.
     pub fn sum(&self) -> PyStream {
-        let as_f64 = self.stream.try_map(|e: &PyElement| f64::try_from(e));
-        self.wrap(as_f64.cumulative_sum().map(|v: &f64| PyElement::from(*v)))
+        statistics::aggregate(self, Aggregate::Sum, Window::Unbounded)
     }
 
     /// Cumulative running **mean** over the values (the legacy `mean` /
-    /// `average`, `Window::Unbounded`, count-weighted). Values are read as `f64`
-    /// at the edge (a non-numeric value aborts the run) and the running mean is
-    /// re-boxed as a float [`PyElement`].
+    /// `average`, `Window::Unbounded`, count-weighted). The windowed and
+    /// time-weighted forms go through [`crate::statistics::moment`].
     pub fn mean(&self) -> PyStream {
-        let as_f64 = self.stream.try_map(|e: &PyElement| f64::try_from(e));
-        self.wrap(as_f64.cumulative_mean().map(|v: &f64| PyElement::from(*v)))
+        statistics::moment(self, Moment::Mean, Window::Unbounded, Weighting::Count)
     }
 
     /// Combine this stream with `other` through a Python callable (the legacy

--- a/crates/wingfoil-next-python/src/lib.rs
+++ b/crates/wingfoil-next-python/src/lib.rs
@@ -31,6 +31,7 @@ pub mod latency;
 #[macro_use]
 mod macros;
 mod python;
+pub mod statistics;
 
 pub use element::PyElement;
 pub use graph::{PyGraph, PyStream};

--- a/crates/wingfoil-next-python/src/python.rs
+++ b/crates/wingfoil-next-python/src/python.rs
@@ -21,6 +21,10 @@ use pyo3::prelude::*;
 use wingfoil_next::{NanoTime, RunFor, RunMode};
 
 use crate::graph::{PyGraph, PyStream};
+use crate::statistics::{
+    Aggregate, Moment, PyEwmaSpan, PyWeighting, PyWindow, py_aggregate, py_ewma, py_median,
+    py_moment,
+};
 use crate::{Activation, Ctx, Op, PyElement, Tick, pyadapter, pygraph, pyop};
 
 /// Map an `anyhow::Error` to a Python exception, preserving the whole context
@@ -274,20 +278,111 @@ impl Stream {
         Stream(self.0.filter_none())
     }
 
-    /// Cumulative running sum over the numeric values.
-    fn sum(&self) -> Stream {
-        Stream(self.0.sum())
+    /// Sum of this stream of numbers over `window` (cumulative by default).
+    /// See `mean` for the accepted `window` forms.
+    #[pyo3(signature = (window=None))]
+    fn sum(&self, window: Option<&Bound<'_, PyAny>>) -> PyResult<Stream> {
+        Ok(Stream(py_aggregate(&self.0, Aggregate::Sum, window)?))
     }
 
-    /// Cumulative running mean over the numeric values.
-    fn mean(&self) -> Stream {
-        Stream(self.0.mean())
+    /// Minimum of this stream of numbers over `window` (cumulative by default).
+    /// See `mean` for the accepted `window` forms.
+    #[pyo3(signature = (window=None))]
+    fn min(&self, window: Option<&Bound<'_, PyAny>>) -> PyResult<Stream> {
+        Ok(Stream(py_aggregate(&self.0, Aggregate::Min, window)?))
     }
 
-    /// Cumulative running mean over the numeric values (alias for `mean`, the
+    /// Maximum of this stream of numbers over `window` (cumulative by default).
+    /// See `mean` for the accepted `window` forms.
+    #[pyo3(signature = (window=None))]
+    fn max(&self, window: Option<&Bound<'_, PyAny>>) -> PyResult<Stream> {
+        Ok(Stream(py_aggregate(&self.0, Aggregate::Max, window)?))
+    }
+
+    /// Mean of this stream of numbers over `window`.
+    ///
+    /// Args:
+    ///     window: `Window.count(n)`, `Window.seconds(s)`, `Window.unbounded()`,
+    ///         a plain `int` (shorthand for a count window), or `None`
+    ///         (cumulative — the default).
+    ///     weighting: `Weighting.Count` / `"count"` (default) for the ordinary
+    ///         arithmetic mean, or `Weighting.Time` / `"time"` to weight each
+    ///         sample by how long it was in effect.
+    ///
+    /// Returns:
+    ///     A Stream of floats.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn mean(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Stream> {
+        Ok(Stream(py_moment(&self.0, Moment::Mean, window, weighting)?))
+    }
+
+    /// Cumulative running mean over the numeric values (alias for `mean()`, the
     /// legacy method name).
     fn average(&self) -> Stream {
         Stream(self.0.mean())
+    }
+
+    /// Variance of this stream of numbers over `window`.
+    ///
+    /// `Weighting.Count` gives the sample variance (ddof = 1); `Weighting.Time`
+    /// gives the time-weighted population variance. Yields `0.0` until enough
+    /// data is present. See `mean` for the argument forms.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn variance(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Stream> {
+        Ok(Stream(py_moment(
+            &self.0,
+            Moment::Variance,
+            window,
+            weighting,
+        )?))
+    }
+
+    /// Standard deviation over `window` — the square root of `variance` under
+    /// the same weighting. See `mean` for the argument forms.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn std(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Stream> {
+        Ok(Stream(py_moment(&self.0, Moment::Std, window, weighting)?))
+    }
+
+    /// Median of this stream of numbers over `window`.
+    ///
+    /// `Weighting.Time` gives the time-weighted median (the value at which
+    /// cumulative in-effect time crosses one half). Over an unbounded window
+    /// this retains every sample, so memory grows with the stream. See `mean`
+    /// for the argument forms.
+    #[pyo3(signature = (window=None, weighting=None))]
+    fn median(
+        &self,
+        window: Option<&Bound<'_, PyAny>>,
+        weighting: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Stream> {
+        Ok(Stream(py_median(&self.0, window, weighting)?))
+    }
+
+    /// Exponentially weighted moving average of this stream of numbers.
+    ///
+    /// Args:
+    ///     span: `EwmaSpan.per_tick(alpha)` for a fixed smoothing factor
+    ///         applied once per tick, `EwmaSpan.half_life(seconds)` to decay by
+    ///         elapsed graph time, or a plain `float` (shorthand for
+    ///         `per_tick`). The first sample seeds the average.
+    ///
+    /// Returns:
+    ///     A Stream of floats.
+    fn ewma(&self, span: &Bound<'_, PyAny>) -> PyResult<Stream> {
+        Ok(Stream(py_ewma(&self.0, span)?))
     }
 
     /// Combine with `other` through `func(this_value, other_value)`, called
@@ -700,6 +795,11 @@ fn parse_log_level(level: &str) -> PyResult<log::Level> {
 fn _wingfoil(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Graph>()?;
     m.add_class::<Stream>()?;
+    // The statistics argument objects: `Window` / `Weighting` / `EwmaSpan`
+    // parameterise the `Stream` moment methods above.
+    m.add_class::<PyWindow>()?;
+    m.add_class::<PyWeighting>()?;
+    m.add_class::<PyEwmaSpan>()?;
     m.add_function(wrap_pyfunction!(scale, m)?)?;
     m.add_function(wrap_pyfunction!(square, m)?)?;
     m.add_function(wrap_pyfunction!(running_total, m)?)?;

--- a/crates/wingfoil-next-python/src/statistics.rs
+++ b/crates/wingfoil-next-python/src/statistics.rs
@@ -1,0 +1,522 @@
+//! Python bindings for the statistics ops (`wingfoil_next::stats`).
+//!
+//! The statistics layer is pure Rust with no external service, so — like the
+//! augurs bindings — every binding is a stream transform exposed as a method on
+//! [`Stream`](crate::Stream) rather than a source function. Each consumes a
+//! stream of numbers and emits a stream of floats:
+//!
+//! - `.mean(window, weighting)` / `.variance(...)` / `.std(...)`
+//! - `.sum(window)` / `.min(window)` / `.max(window)` / `.median(window, weighting)`
+//! - `.ewma(span)`
+//!
+//! **Why a `Window` object rather than one method per shape.** The engine's
+//! [`StatisticsOps`] spells every combination out as its own method
+//! (`rolling_mean`, `time_windowed_mean`, `cumulative_mean_time_weighted`, …)
+//! because Rust can afford a wide, statically-checked surface. Python cannot:
+//! the legacy binding settled on two orthogonal knobs — a [`Window`] and a
+//! [`Weighting`] — and that is the contract next must be a superset of. So this
+//! module is a **dispatcher**: it resolves the two knobs from Python, then picks
+//! the one engine method that implements that pair. Nothing here computes a
+//! statistic.
+//!
+//! Python gets the two knobs through the [`Window`](PyWindow) and
+//! [`Weighting`](PyWeighting) classes, with `int` and `str` shorthands so the
+//! common cases stay terse:
+//!
+//! ```python
+//! from wingfoil_next import Window, Weighting, EwmaSpan
+//!
+//! prices.mean()                                  # cumulative, count weighted
+//! prices.mean(10)                                # last 10 samples
+//! prices.mean(Window.seconds(5.0), "time")       # 5s of graph time, time weighted
+//! prices.ewma(EwmaSpan.half_life(30.0))
+//! ```
+//!
+//! A bare `float` is deliberately *not* accepted as a window: `mean(10)` and
+//! `mean(10.0)` would mean wildly different things (ten samples vs ten
+//! seconds), so a time window must say so via `Window.seconds(...)`.
+
+use std::time::Duration;
+
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use wingfoil_next::ops::EwmaDecay;
+use wingfoil_next::stats::StatisticsOps;
+
+use crate::graph::PyStream;
+
+/// The extent an operator aggregates over — the resolved form of
+/// [`Window`](PyWindow).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Window {
+    /// The most recent `n` samples. The engine clamps a zero-sample window to
+    /// one, so `Window.count(0)` behaves as `Window.count(1)`.
+    Count(usize),
+    /// Every sample seen in the last `Duration` of graph time (a sample exactly
+    /// that old is still in the window).
+    Time(Duration),
+    /// Every sample seen so far — a cumulative (expanding) window.
+    Unbounded,
+}
+
+/// How samples are weighted when aggregating — the resolved form of
+/// [`Weighting`](PyWeighting).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Weighting {
+    /// Every sample counts equally — the ordinary arithmetic statistic.
+    Count,
+    /// Each sample is weighted by how long it was in effect.
+    Time,
+}
+
+/// How samples are weighted when aggregating a stream.
+#[pyclass(eq, eq_int, name = "Weighting", from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PyWeighting {
+    /// Every sample counts equally — the ordinary arithmetic statistic.
+    Count,
+    /// Each sample is weighted by how long it was in effect (elapsed graph
+    /// time since the previous sample).
+    Time,
+}
+
+impl From<PyWeighting> for Weighting {
+    fn from(w: PyWeighting) -> Self {
+        match w {
+            PyWeighting::Count => Weighting::Count,
+            PyWeighting::Time => Weighting::Time,
+        }
+    }
+}
+
+/// The extent an operator aggregates over.
+///
+/// Build one with `Window.count(n)`, `Window.seconds(secs)` or
+/// `Window.unbounded()`. Operators also accept a plain `int` as shorthand for
+/// `Window.count(n)`, and `None` for `Window.unbounded()`.
+#[pyclass(name = "Window", frozen, eq, from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PyWindow(Window);
+
+#[pymethods]
+impl PyWindow {
+    /// The most recent `n` samples (clamped to at least one).
+    #[staticmethod]
+    fn count(n: usize) -> Self {
+        Self(Window::Count(n))
+    }
+
+    /// All samples seen in the last `seconds` of graph time.
+    #[staticmethod]
+    fn seconds(seconds: f64) -> PyResult<Self> {
+        Ok(Self(Window::Time(duration_from_secs(
+            "Window.seconds",
+            seconds,
+        )?)))
+    }
+
+    /// Every sample seen so far — a cumulative (expanding) window.
+    #[staticmethod]
+    fn unbounded() -> Self {
+        Self(Window::Unbounded)
+    }
+
+    fn __repr__(&self) -> String {
+        match self.0 {
+            Window::Count(n) => format!("Window.count({n})"),
+            Window::Time(d) => format!("Window.seconds({})", d.as_secs_f64()),
+            Window::Unbounded => "Window.unbounded()".to_string(),
+        }
+    }
+}
+
+/// How an `ewma` decays older observations — the resolved form of
+/// [`EwmaSpan`](PyEwmaSpan).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EwmaSpan {
+    /// Fixed smoothing factor applied once per tick.
+    PerTick(f64),
+    /// Time decay: a sample's weight halves every `Duration` of elapsed graph
+    /// time.
+    HalfLife(Duration),
+}
+
+impl From<EwmaSpan> for EwmaDecay {
+    fn from(span: EwmaSpan) -> Self {
+        match span {
+            EwmaSpan::PerTick(alpha) => EwmaDecay::PerTick(alpha),
+            EwmaSpan::HalfLife(half_life) => EwmaDecay::HalfLife(half_life.as_nanos() as f64),
+        }
+    }
+}
+
+/// How the `ewma` stream method decays older observations.
+///
+/// Build one with `EwmaSpan.per_tick(alpha)` or `EwmaSpan.half_life(seconds)`.
+/// `ewma` also accepts a plain `float` as shorthand for
+/// `EwmaSpan.per_tick(alpha)`.
+#[pyclass(name = "EwmaSpan", frozen, eq, from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PyEwmaSpan(EwmaSpan);
+
+#[pymethods]
+impl PyEwmaSpan {
+    /// Fixed smoothing factor applied once per tick
+    /// (`ewma_t = alpha * x_t + (1 - alpha) * ewma_{t-1}`).
+    #[staticmethod]
+    fn per_tick(alpha: f64) -> PyResult<Self> {
+        // The Rust op only `debug_assert!`s this, so a release build would
+        // silently produce a diverging (or frozen) average. Reject it at the
+        // boundary instead.
+        if !(0.0..=1.0).contains(&alpha) {
+            return Err(PyValueError::new_err(format!(
+                "ewma: per_tick alpha must be between 0 and 1, got {alpha}"
+            )));
+        }
+        Ok(Self(EwmaSpan::PerTick(alpha)))
+    }
+
+    /// Time decay: a sample's weight halves every `seconds` of elapsed graph
+    /// time, independent of tick rate.
+    #[staticmethod]
+    fn half_life(seconds: f64) -> PyResult<Self> {
+        let half_life = duration_from_secs("EwmaSpan.half_life", seconds)?;
+        if half_life.is_zero() {
+            return Err(PyValueError::new_err(
+                "EwmaSpan.half_life: seconds must be greater than 0",
+            ));
+        }
+        Ok(Self(EwmaSpan::HalfLife(half_life)))
+    }
+
+    fn __repr__(&self) -> String {
+        match self.0 {
+            EwmaSpan::PerTick(alpha) => format!("EwmaSpan.per_tick({alpha})"),
+            EwmaSpan::HalfLife(d) => format!("EwmaSpan.half_life({})", d.as_secs_f64()),
+        }
+    }
+}
+
+/// Convert a seconds `float` to a [`Duration`], rejecting the negative and
+/// non-finite values that [`Duration::from_secs_f64`] would panic on.
+fn duration_from_secs(op: &str, seconds: f64) -> PyResult<Duration> {
+    if !seconds.is_finite() || seconds < 0.0 {
+        return Err(PyValueError::new_err(format!(
+            "{op}: seconds must be a finite, non-negative number, got {seconds}"
+        )));
+    }
+    Ok(Duration::from_secs_f64(seconds))
+}
+
+/// Resolve the `window` argument shared by every statistics operator.
+///
+/// Accepts a [`Window`](PyWindow), a plain `int` (shorthand for a count
+/// window), or `None` (an unbounded/cumulative window).
+fn window_from_py(op: &str, window: Option<&Bound<'_, PyAny>>) -> PyResult<Window> {
+    let Some(window) = window else {
+        return Ok(Window::Unbounded);
+    };
+    if window.is_none() {
+        return Ok(Window::Unbounded);
+    }
+    if let Ok(window) = window.extract::<PyWindow>() {
+        return Ok(window.0);
+    }
+    // `extract::<usize>` goes through `__index__`, so a `float` lands in the
+    // error below rather than being silently truncated to a count window.
+    if let Ok(n) = window.extract::<usize>() {
+        return Ok(Window::Count(n));
+    }
+    Err(PyTypeError::new_err(format!(
+        "{op}: window must be a Window, an int (sample count), or None (unbounded) — \
+         pass Window.seconds(...) for a time window"
+    )))
+}
+
+/// Resolve the `weighting` argument of the moment operators.
+///
+/// Accepts a [`Weighting`](PyWeighting), the string `"count"` or `"time"`, or
+/// `None` (count weighting).
+fn weighting_from_py(op: &str, weighting: Option<&Bound<'_, PyAny>>) -> PyResult<Weighting> {
+    let Some(weighting) = weighting else {
+        return Ok(Weighting::Count);
+    };
+    if weighting.is_none() {
+        return Ok(Weighting::Count);
+    }
+    if let Ok(weighting) = weighting.extract::<PyWeighting>() {
+        return Ok(weighting.into());
+    }
+    if let Ok(name) = weighting.extract::<String>() {
+        return match name.to_ascii_lowercase().as_str() {
+            "count" => Ok(Weighting::Count),
+            "time" => Ok(Weighting::Time),
+            other => Err(PyValueError::new_err(format!(
+                "{op}: unknown weighting '{other}' (expected 'count' or 'time')"
+            ))),
+        };
+    }
+    Err(PyTypeError::new_err(format!(
+        "{op}: weighting must be a Weighting, 'count', 'time', or None"
+    )))
+}
+
+/// Resolve the `span` argument of [`py_ewma`].
+///
+/// Accepts an [`EwmaSpan`](PyEwmaSpan) or a plain `float` (shorthand for a
+/// per-tick smoothing factor).
+fn span_from_py(span: &Bound<'_, PyAny>) -> PyResult<EwmaSpan> {
+    if let Ok(span) = span.extract::<PyEwmaSpan>() {
+        return Ok(span.0);
+    }
+    if let Ok(alpha) = span.extract::<f64>() {
+        return Ok(PyEwmaSpan::per_tick(alpha)?.0);
+    }
+    Err(PyTypeError::new_err(
+        "ewma: span must be an EwmaSpan or a float (per-tick alpha)",
+    ))
+}
+
+/// A moment operator selected by the `.mean()` / `.variance()` / `.std()`
+/// stream methods, which differ only in which engine method they reach.
+#[derive(Clone, Copy)]
+pub enum Moment {
+    Mean,
+    Variance,
+    Std,
+}
+
+impl Moment {
+    fn name(self) -> &'static str {
+        match self {
+            Moment::Mean => "mean",
+            Moment::Variance => "variance",
+            Moment::Std => "std",
+        }
+    }
+}
+
+/// An unweighted window operator selected by the `.sum()` / `.min()` /
+/// `.max()` stream methods.
+#[derive(Clone, Copy)]
+pub enum Aggregate {
+    Sum,
+    Min,
+    Max,
+}
+
+impl Aggregate {
+    fn name(self) -> &'static str {
+        match self {
+            Aggregate::Sum => "sum",
+            Aggregate::Min => "min",
+            Aggregate::Max => "max",
+        }
+    }
+}
+
+/// Wire a moment operator: the (window, weighting) pair selects one engine
+/// method from [`StatisticsOps`].
+pub fn moment(stream: &PyStream, moment: Moment, window: Window, weighting: Weighting) -> PyStream {
+    stream.wire_float_stat(moment.name(), move |s| match (moment, window, weighting) {
+        (Moment::Mean, Window::Unbounded, Weighting::Count) => s.cumulative_mean(),
+        (Moment::Mean, Window::Count(n), Weighting::Count) => s.rolling_mean(n),
+        (Moment::Mean, Window::Time(d), Weighting::Count) => s.time_windowed_mean(d),
+        (Moment::Mean, Window::Unbounded, Weighting::Time) => s.cumulative_mean_time_weighted(),
+        (Moment::Mean, Window::Count(n), Weighting::Time) => s.rolling_mean_time_weighted(n),
+        (Moment::Mean, Window::Time(d), Weighting::Time) => s.time_windowed_mean_time_weighted(d),
+        (Moment::Variance, Window::Unbounded, Weighting::Count) => s.cumulative_var(),
+        (Moment::Variance, Window::Count(n), Weighting::Count) => s.rolling_var(n),
+        (Moment::Variance, Window::Time(d), Weighting::Count) => s.time_windowed_var(d),
+        (Moment::Variance, Window::Unbounded, Weighting::Time) => s.cumulative_var_time_weighted(),
+        (Moment::Variance, Window::Count(n), Weighting::Time) => s.rolling_var_time_weighted(n),
+        (Moment::Variance, Window::Time(d), Weighting::Time) => {
+            s.time_windowed_var_time_weighted(d)
+        }
+        (Moment::Std, Window::Unbounded, Weighting::Count) => s.cumulative_std(),
+        (Moment::Std, Window::Count(n), Weighting::Count) => s.rolling_std(n),
+        (Moment::Std, Window::Time(d), Weighting::Count) => s.time_windowed_std(d),
+        (Moment::Std, Window::Unbounded, Weighting::Time) => s.cumulative_std_time_weighted(),
+        (Moment::Std, Window::Count(n), Weighting::Time) => s.rolling_std_time_weighted(n),
+        (Moment::Std, Window::Time(d), Weighting::Time) => s.time_windowed_std_time_weighted(d),
+    })
+}
+
+/// Wire an unweighted aggregate: the window alone selects the engine method.
+pub fn aggregate(stream: &PyStream, aggregate: Aggregate, window: Window) -> PyStream {
+    stream.wire_float_stat(aggregate.name(), move |s| match (aggregate, window) {
+        (Aggregate::Sum, Window::Unbounded) => s.cumulative_sum(),
+        (Aggregate::Sum, Window::Count(n)) => s.rolling_sum(n),
+        (Aggregate::Sum, Window::Time(d)) => s.time_windowed_sum(d),
+        (Aggregate::Min, Window::Unbounded) => s.cumulative_min(),
+        (Aggregate::Min, Window::Count(n)) => s.rolling_min(n),
+        (Aggregate::Min, Window::Time(d)) => s.time_windowed_min(d),
+        (Aggregate::Max, Window::Unbounded) => s.cumulative_max(),
+        (Aggregate::Max, Window::Count(n)) => s.rolling_max(n),
+        (Aggregate::Max, Window::Time(d)) => s.time_windowed_max(d),
+    })
+}
+
+/// Wire a median: the (window, weighting) pair selects the engine method.
+pub fn median(stream: &PyStream, window: Window, weighting: Weighting) -> PyStream {
+    stream.wire_float_stat("median", move |s| match (window, weighting) {
+        (Window::Unbounded, Weighting::Count) => s.cumulative_median(),
+        (Window::Count(n), Weighting::Count) => s.rolling_median(n),
+        (Window::Time(d), Weighting::Count) => s.time_windowed_median(d),
+        (Window::Unbounded, Weighting::Time) => s.cumulative_median_time_weighted(),
+        (Window::Count(n), Weighting::Time) => s.rolling_median_time_weighted(n),
+        (Window::Time(d), Weighting::Time) => s.time_windowed_median_time_weighted(d),
+    })
+}
+
+/// Wire an exponentially weighted moving average.
+pub fn ewma(stream: &PyStream, span: EwmaSpan) -> PyStream {
+    let decay = EwmaDecay::from(span);
+    stream.wire_float_stat("ewma", move |s| s.ewma(decay))
+}
+
+/// The pyo3 entry point for `.mean()` / `.variance()` / `.std()`: resolve the
+/// Python arguments, then dispatch.
+pub fn py_moment(
+    stream: &PyStream,
+    kind: Moment,
+    window: Option<&Bound<'_, PyAny>>,
+    weighting: Option<&Bound<'_, PyAny>>,
+) -> PyResult<PyStream> {
+    let op = kind.name();
+    let window = window_from_py(op, window)?;
+    let weighting = weighting_from_py(op, weighting)?;
+    Ok(moment(stream, kind, window, weighting))
+}
+
+/// The pyo3 entry point for `.sum()` / `.min()` / `.max()`.
+pub fn py_aggregate(
+    stream: &PyStream,
+    kind: Aggregate,
+    window: Option<&Bound<'_, PyAny>>,
+) -> PyResult<PyStream> {
+    let window = window_from_py(kind.name(), window)?;
+    Ok(aggregate(stream, kind, window))
+}
+
+/// The pyo3 entry point for `.median()`.
+pub fn py_median(
+    stream: &PyStream,
+    window: Option<&Bound<'_, PyAny>>,
+    weighting: Option<&Bound<'_, PyAny>>,
+) -> PyResult<PyStream> {
+    let window = window_from_py("median", window)?;
+    let weighting = weighting_from_py("median", weighting)?;
+    Ok(median(stream, window, weighting))
+}
+
+/// The pyo3 entry point for `.ewma()`.
+pub fn py_ewma(stream: &PyStream, span: &Bound<'_, PyAny>) -> PyResult<PyStream> {
+    Ok(ewma(stream, span_from_py(span)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use wingfoil_next::{NanoTime, RunFor, RunMode};
+
+    use super::*;
+    use crate::PyGraph;
+
+    /// `1.0, 2.0, 3.0, …`, one per second of graph time (the legacy
+    /// `ticker(1.0).count().map(float)` fixture).
+    fn counts(g: &PyGraph) -> PyStream {
+        g.counter(Duration::from_secs(1))
+    }
+
+    fn run_cycles(g: &PyGraph, cycles: u32) {
+        g.run(
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Cycles(cycles),
+        )
+        .expect("invariant: the statistics fixture graph runs clean");
+    }
+
+    /// Every value `stream` emitted, read back after the run.
+    fn emitted(stream: &PyStream) -> Vec<f64> {
+        Python::attach(|py| {
+            stream
+                .value()
+                .value()
+                .extract::<Vec<f64>>(py)
+                .expect("invariant: accumulate() of a float stat is a list of floats")
+        })
+    }
+
+    #[test]
+    fn window_dispatch_covers_count_time_and_unbounded() {
+        let g = PyGraph::new();
+        let cumulative = aggregate(&counts(&g), Aggregate::Sum, Window::Unbounded).accumulate();
+        let rolling = aggregate(&counts(&g), Aggregate::Sum, Window::Count(3)).accumulate();
+        let timed = aggregate(
+            &counts(&g),
+            Aggregate::Sum,
+            Window::Time(Duration::from_secs(3)),
+        )
+        .accumulate();
+        run_cycles(&g, 5);
+        assert_eq!(vec![1.0, 3.0, 6.0, 10.0, 15.0], emitted(&cumulative));
+        assert_eq!(vec![1.0, 3.0, 6.0, 9.0, 12.0], emitted(&rolling));
+        assert_eq!(vec![1.0, 3.0, 6.0, 10.0, 14.0], emitted(&timed));
+    }
+
+    #[test]
+    fn weighting_dispatch_selects_the_time_weighted_twin() {
+        let g = PyGraph::new();
+        let counted = moment(
+            &counts(&g),
+            Moment::Mean,
+            Window::Unbounded,
+            Weighting::Count,
+        )
+        .accumulate();
+        let weighted = moment(
+            &counts(&g),
+            Moment::Mean,
+            Window::Unbounded,
+            Weighting::Time,
+        )
+        .accumulate();
+        run_cycles(&g, 5);
+        assert_eq!(vec![1.0, 1.5, 2.0, 2.5, 3.0], emitted(&counted));
+        assert_eq!(vec![1.0, 1.0, 1.5, 2.0, 2.5], emitted(&weighted));
+    }
+
+    #[test]
+    fn ewma_per_tick_matches_the_closed_form() {
+        let g = PyGraph::new();
+        let smoothed = ewma(&counts(&g), EwmaSpan::PerTick(0.5)).accumulate();
+        run_cycles(&g, 5);
+        assert_eq!(vec![1.0, 1.5, 2.25, 3.125, 4.0625], emitted(&smoothed));
+    }
+
+    #[test]
+    fn median_dispatch_reaches_the_windowed_engine_op() {
+        let g = PyGraph::new();
+        let rolling = median(&counts(&g), Window::Count(4), Weighting::Count).accumulate();
+        run_cycles(&g, 6);
+        // An even window averages its two middle samples.
+        assert_eq!(vec![1.0, 1.5, 2.0, 2.5, 3.5, 4.5], emitted(&rolling));
+    }
+
+    #[test]
+    fn non_numeric_input_names_the_operator() {
+        let lambda = Python::attach(|py| {
+            py.eval(c"lambda n: 'x'", None, None)
+                .expect("invariant: the test lambda compiles")
+                .unbind()
+        });
+        let g = PyGraph::new();
+        let _bad = median(&counts(&g).map(lambda), Window::Unbounded, Weighting::Count);
+        let err = g
+            .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(1))
+            .expect_err("a non-numeric value must abort the run");
+        assert!(format!("{err:#}").contains("median: expected a float input value"));
+    }
+}

--- a/crates/wingfoil-next-python/tests/test_statistics.py
+++ b/crates/wingfoil-next-python/tests/test_statistics.py
@@ -1,0 +1,277 @@
+"""Tests for the statistics Python bindings.
+
+Ported from `legacy/wingfoil-python/tests/test_statistics.py` — the parity
+oracle for this surface (cutover-plan row 3.7). Every legacy case has a twin
+here; the only edits are the wiring idiom (`wf.Graph()` + `counter` +
+`accumulate` instead of the legacy free `ticker` and `collect`) and the
+counter's period in nanoseconds.
+
+The statistics layer is pure Rust with no external service, so — like augurs —
+these tests run by default; there is no `requires_*` marker to gate. They pin
+the pyo3 argument-marshaling glue (`Window` / `Weighting` / `EwmaSpan` and their
+`int` / `str` / `float` shorthands) against deterministic historical-mode runs.
+
+Every helper builds a *fresh* graph: node state (counters, rolling windows)
+survives a run, so reusing one graph across runs would make later expectations
+depend on earlier tests.
+"""
+
+import math
+import unittest
+
+import wingfoil_next as wf
+from wingfoil_next import EwmaSpan, Weighting, Window
+
+SECOND_NANOS = 1_000_000_000
+
+
+def _counts(graph):
+    """A fresh stream of floats 1.0, 2.0, 3.0, ... one per second of graph time."""
+    return graph.counter(period_nanos=SECOND_NANOS).map(float)
+
+
+def _run(build, cycles):
+    """Build a stream with `build(counts)` on a fresh graph and run it.
+
+    Returns every value the built stream emitted. `build` receives the shared
+    `1.0, 2.0, 3.0, …` source so a test reads as one expression, the way the
+    legacy `_run(_counts().mean(), 5)` did.
+    """
+    graph = wf.Graph()
+    captured = build(_counts(graph)).accumulate()
+    graph.run(realtime=False, cycles=cycles)
+    return captured.value()
+
+
+class TestMean(unittest.TestCase):
+    def test_cumulative_default(self):
+        # No window argument is the cumulative (unbounded) window.
+        self.assertEqual([1.0, 1.5, 2.0, 2.5, 3.0], _run(lambda s: s.mean(), 5))
+
+    def test_explicit_unbounded_matches_default(self):
+        self.assertEqual(
+            _run(lambda s: s.mean(), 5),
+            _run(lambda s: s.mean(Window.unbounded()), 5),
+        )
+
+    def test_count_window(self):
+        # Rolling mean of the last three samples.
+        self.assertEqual([1.0, 1.5, 2.0, 3.0, 4.0, 5.0], _run(lambda s: s.mean(3), 6))
+
+    def test_int_shorthand_matches_window_count(self):
+        self.assertEqual(
+            _run(lambda s: s.mean(Window.count(3)), 6), _run(lambda s: s.mean(3), 6)
+        )
+
+    def test_time_window(self):
+        # Ticks land on whole seconds, and a sample exactly `seconds` old is
+        # still in the window, so a 3s window holds four samples once warm.
+        self.assertEqual(
+            [1.0, 1.5, 2.0, 2.5, 3.5, 4.5],
+            _run(lambda s: s.mean(Window.seconds(3.0)), 6),
+        )
+
+    def test_time_weighting_differs_from_count(self):
+        # Each sample is weighted by how long it was in effect, so the newest
+        # sample (in effect for zero time so far) carries no weight yet.
+        self.assertEqual(
+            [1.0, 1.0, 1.5, 2.0, 2.5],
+            _run(lambda s: s.mean(Window.unbounded(), Weighting.Time), 5),
+        )
+
+    def test_weighting_accepts_strings(self):
+        for name, weighting in (("count", Weighting.Count), ("time", Weighting.Time)):
+            with self.subTest(weighting=name):
+                self.assertEqual(
+                    _run(lambda s: s.mean(None, weighting), 5),
+                    _run(lambda s: s.mean(None, name), 5),
+                )
+
+    def test_average_is_cumulative_mean(self):
+        self.assertEqual(_run(lambda s: s.mean(), 5), _run(lambda s: s.average(), 5))
+
+
+class TestVarianceAndStd(unittest.TestCase):
+    def test_cumulative_sample_variance(self):
+        # ddof = 1, so the first tick yields 0.0 rather than a division by zero.
+        expected = [0.0, 0.5, 1.0, 5.0 / 3.0, 2.5]
+        for got, want in zip(_run(lambda s: s.variance(), 5), expected):
+            self.assertAlmostEqual(want, got)
+
+    def test_std_is_sqrt_of_variance(self):
+        variances = _run(lambda s: s.variance(4), 8)
+        stds = _run(lambda s: s.std(4), 8)
+        self.assertEqual(len(variances), len(stds))
+        for variance, std in zip(variances, stds):
+            self.assertAlmostEqual(math.sqrt(variance), std)
+
+    def test_std_time_weighted_is_non_negative(self):
+        # The time-weighted form is the population variance (no ddof), which is
+        # a different number from the count-weighted one but never negative.
+        stds = _run(lambda s: s.std(Window.unbounded(), "time"), 6)
+        self.assertTrue(all(std >= 0.0 for std in stds))
+        self.assertGreater(stds[-1], 0.0)
+
+
+class TestSumMinMax(unittest.TestCase):
+    def test_sum_no_args_is_cumulative(self):
+        # The pre-existing zero-argument `.sum()` keeps working unchanged.
+        self.assertEqual([1.0, 3.0, 6.0, 10.0, 15.0], _run(lambda s: s.sum(), 5))
+
+    def test_sum_count_window(self):
+        self.assertEqual(
+            [1.0, 3.0, 6.0, 9.0, 12.0, 15.0], _run(lambda s: s.sum(3), 6)
+        )
+
+    def test_sum_time_window(self):
+        self.assertEqual(
+            [1.0, 3.0, 6.0, 10.0, 14.0, 18.0],
+            _run(lambda s: s.sum(Window.seconds(3.0)), 6),
+        )
+
+    def test_cumulative_min_and_max(self):
+        self.assertEqual([1.0] * 5, _run(lambda s: s.min(), 5))
+        self.assertEqual([1.0, 2.0, 3.0, 4.0, 5.0], _run(lambda s: s.max(), 5))
+
+    def test_rolling_min_and_max(self):
+        self.assertEqual([1.0, 1.0, 1.0, 2.0, 3.0, 4.0], _run(lambda s: s.min(3), 6))
+        self.assertEqual([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], _run(lambda s: s.max(3), 6))
+
+    def test_time_windowed_min(self):
+        self.assertEqual(
+            [1.0, 1.0, 1.0, 1.0, 2.0, 3.0],
+            _run(lambda s: s.min(Window.seconds(3.0)), 6),
+        )
+
+
+class TestMedian(unittest.TestCase):
+    def test_count_window_even_and_odd(self):
+        # Even window sizes interpolate between the two middle samples.
+        self.assertEqual(
+            [1.0, 1.5, 2.0, 2.5, 3.5, 4.5], _run(lambda s: s.median(4), 6)
+        )
+        self.assertEqual(
+            [1.0, 1.5, 2.0, 3.0, 4.0, 5.0], _run(lambda s: s.median(3), 6)
+        )
+
+    def test_unbounded(self):
+        self.assertEqual([1.0, 1.5, 2.0, 2.5, 3.0], _run(lambda s: s.median(), 5))
+
+    def test_time_weighted_differs(self):
+        count_weighted = _run(lambda s: s.median(5, Weighting.Count), 6)
+        time_weighted = _run(lambda s: s.median(5, Weighting.Time), 6)
+        self.assertEqual(len(count_weighted), len(time_weighted))
+        self.assertNotEqual(count_weighted, time_weighted)
+
+
+class TestEwma(unittest.TestCase):
+    def test_per_tick_float_shorthand(self):
+        # The first sample seeds the average; thereafter
+        # ewma = alpha * x + (1 - alpha) * previous.
+        self.assertEqual(
+            [1.0, 1.5, 2.25, 3.125, 4.0625], _run(lambda s: s.ewma(0.5), 5)
+        )
+
+    def test_float_shorthand_matches_per_tick(self):
+        self.assertEqual(
+            _run(lambda s: s.ewma(EwmaSpan.per_tick(0.5)), 5),
+            _run(lambda s: s.ewma(0.5), 5),
+        )
+
+    def test_alpha_one_is_passthrough(self):
+        self.assertEqual([1.0, 2.0, 3.0, 4.0, 5.0], _run(lambda s: s.ewma(1.0), 5))
+
+    def test_half_life_seeds_then_lags(self):
+        values = _run(lambda s: s.ewma(EwmaSpan.half_life(2.0)), 5)
+        self.assertEqual(1.0, values[0])
+        # A decayed average trails a rising input but keeps rising with it.
+        for i in range(1, len(values)):
+            self.assertGreater(values[i], values[i - 1])
+            self.assertLess(values[i], float(i + 1))
+
+
+class TestArgumentTypes(unittest.TestCase):
+    """`Window` / `Weighting` / `EwmaSpan` behave as ordinary Python values."""
+
+    def test_window_repr(self):
+        self.assertEqual("Window.count(3)", repr(Window.count(3)))
+        self.assertEqual("Window.seconds(2.5)", repr(Window.seconds(2.5)))
+        self.assertEqual("Window.unbounded()", repr(Window.unbounded()))
+
+    def test_window_equality(self):
+        self.assertEqual(Window.count(3), Window.count(3))
+        self.assertNotEqual(Window.count(3), Window.count(4))
+        self.assertNotEqual(Window.count(3), Window.unbounded())
+
+    def test_ewma_span_repr_and_equality(self):
+        self.assertEqual("EwmaSpan.per_tick(0.25)", repr(EwmaSpan.per_tick(0.25)))
+        self.assertEqual(EwmaSpan.half_life(2.0), EwmaSpan.half_life(2.0))
+        self.assertNotEqual(EwmaSpan.per_tick(0.25), EwmaSpan.half_life(2.0))
+
+    def test_weighting_equality(self):
+        self.assertEqual(Weighting.Count, Weighting.Count)
+        self.assertNotEqual(Weighting.Count, Weighting.Time)
+
+
+class TestValidation(unittest.TestCase):
+    """Invalid arguments are rejected loudly rather than silently coerced."""
+
+    def test_float_window_raises(self):
+        # `mean(10)` (ten samples) and `mean(10.0)` (ten seconds?) would mean
+        # wildly different things, so a bare float is rejected in favour of
+        # Window.seconds(...).
+        for op in ("mean", "variance", "std", "sum", "min", "max", "median"):
+            with self.subTest(op=op):
+                with self.assertRaises(TypeError):
+                    getattr(_counts(wf.Graph()), op)(3.0)
+
+    def test_unknown_window_type_raises(self):
+        with self.assertRaises(TypeError):
+            _counts(wf.Graph()).mean("everything")
+
+    def test_unknown_weighting_raises(self):
+        with self.assertRaises(ValueError):
+            _counts(wf.Graph()).mean(None, "exponential")
+
+    def test_non_string_weighting_raises(self):
+        with self.assertRaises(TypeError):
+            _counts(wf.Graph()).mean(None, 1.5)
+
+    def test_negative_and_non_finite_seconds_raise(self):
+        for bad in (-1.0, float("nan"), float("inf")):
+            with self.subTest(seconds=bad):
+                with self.assertRaises(ValueError):
+                    Window.seconds(bad)
+                with self.assertRaises(ValueError):
+                    EwmaSpan.half_life(bad)
+
+    def test_zero_half_life_raises(self):
+        with self.assertRaises(ValueError):
+            EwmaSpan.half_life(0.0)
+
+    def test_out_of_range_alpha_raises(self):
+        # Rust only `debug_assert!`s this, so a release build would otherwise
+        # produce a silently diverging average.
+        for bad in (-0.1, 1.1, float("nan")):
+            with self.subTest(alpha=bad):
+                with self.assertRaises(ValueError):
+                    EwmaSpan.per_tick(bad)
+                with self.assertRaises(ValueError):
+                    _counts(wf.Graph()).ewma(bad)
+
+    def test_non_ewma_span_raises(self):
+        with self.assertRaises(TypeError):
+            _counts(wf.Graph()).ewma("fast")
+
+    def test_non_float_input_fails_fast(self):
+        # A non-numeric value is a hard error, not a silently substituted NaN
+        # that would poison every downstream aggregate.
+        graph = wf.Graph()
+        bad = graph.counter(period_nanos=SECOND_NANOS).map(lambda n: "not a float")
+        bad.mean(3)
+        with self.assertRaises(Exception):
+            graph.run(realtime=False, cycles=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/cutover-plan.md
+++ b/docs/cutover-plan.md
@@ -121,7 +121,7 @@ needs an explicit accept/fix ruling at cutover.** These are the open ones.
 
 | # | Item | Size |
 |:--:|---|:--:|
-| 3.7 | **The statistics Python binding stops short of legacy.** Legacy `legacy/wingfoil-python/src/py_statistics.rs` binds `Window` / `Weighting` / `EwmaSpan` over `mean`/`std`/`var`/`sum`/`min`/`max`/`median`/`ewma`; next-python binds only cumulative `sum`/`mean`/`average`. The engine already has the whole surface (`crates/wingfoil-next/src/stats.rs`, with parity tests), so this is binding work, not engine work. 37 legacy tests have nowhere to map. | M |
+| 3.7 | ✅ **The statistics Python binding — landed.** `crates/wingfoil-next-python/src/statistics.rs` binds `Window` / `Weighting` / `EwmaSpan` over `mean`/`variance`/`std`/`sum`/`min`/`max`/`median`/`ewma` as a **dispatcher** onto the engine's `StatisticsOps` — legacy's two orthogonal knobs resolved onto the engine's one-method-per-combination surface, matched exhaustively so a new engine combination is a compile error rather than a silent gap. No engine file touched. All 37 legacy tests ported to `crates/wingfoil-next-python/tests/test_statistics.py`. | M |
 | 3.8 | ✅ **Multi-stream `build_dataframe` in next-python — landed.** `wingfoil_next.build_dataframe({name: stream})` outer-joins several already-run streams on engine time, built in Rust beside the single-stream `dataframe()` rather than as a Python helper. Columns may be held as frames (`dataframe()`) or as `(time, value)` tuples (`collect()`, legacy's shape). All 4 legacy tests ported to `crates/wingfoil-next-python/tests/test_pandas.py`; the legacy `to_dataframe` tests have no counterpart by design (next builds the frame in the engine) — noted in `docs/migration.rst`. | S |
 
 Row **3.9** (sweep the legacy tree for drift since each phase was ticked) has
@@ -129,8 +129,8 @@ run; the findings are below, and it adds no rows.
 
 #### 3.9 — the legacy-drift sweep: ran, no new gaps
 
-**Ran 2026-08-02 against `next` @ `754514c`. Result: 3.7 is the only open
-case, so §3 gains no rows.**
+**Ran 2026-08-02 against `next` @ `754514c`. Result: 3.7 was the only open
+case, so §3 gained no rows — and 3.7 has since landed, closing the section.**
 
 **Window.** `docs/port-plan.md` was created at `6eb7940` (2026-07-19), so no ✅
 in it can predate that. The sweep therefore covers the whole life of the file:
@@ -176,7 +176,7 @@ equivalents.
 |---|---|---|---|
 | `d561c52` (#589) | 2026-07-27 | `wingfoil/src/nodes/drop_small_change.rs`, `PyStream.drop_small_change`, 3 pytest cases | **Drift** — landed 2 days after the Phase 2 catalog ✅ (`b774731`). **Already closed** by `991bfa7`: the op across all three engines, the fluent method, the Python binding and all three tests (`crates/wingfoil-next/src/ops.rs`, `src/fluent.rs`, `tests/catalog.rs`, `tests/op_completeness.rs`, `crates/wingfoil-next-python/src/graph.rs`, `tests/test_interop.py`) |
 | `f5b6915` (#590), `23fa547` (#591) | 2026-07-27 | `wingfoil-js/package.json` + `pnpm-lock.yaml` npm-audit patches | **Not a parity target** — `wingfoil-js` is now `js/` and survives the cutover |
-| `da919bb` (#611) | 2026-08-01 | `wingfoil-python/src/py_statistics.rs` (319 lines), 8 statistics methods on `PyStream`, `Window`/`Weighting`/`EwmaSpan` exports, `tests/test_statistics.py` (249 lines) | **Drift, still open** — this is row **3.7**, whose description matches the diff exactly (the `py_augurs.rs` hunk in the same commit is a pure refactor, hoisting `as_floats` into `py_stream.rs`) |
+| `da919bb` (#611) | 2026-08-01 | `wingfoil-python/src/py_statistics.rs` (319 lines), 8 statistics methods on `PyStream`, `Window`/`Weighting`/`EwmaSpan` exports, `tests/test_statistics.py` (249 lines) | **Drift** — this was row **3.7**, whose description matched the diff exactly; **since closed** (the full statistics binding, all 37 tests) (the `py_augurs.rs` hunk in the same commit is a pure refactor, hoisting `as_floats` into `py_stream.rs`) |
 
 **Everything else that touched legacy files in the window was next-originated,
 and none of it is a parity target.** `13ba842` / `6465d3d` / `bfbe24f` /
@@ -271,8 +271,9 @@ afterwards, since it repoints the names 1.2 creates.
 
 Everything else parallelises. Section 2's rulings need no code — 2.1 and 1.4
 should land early because 4.2 depends on both. Sections 3 and 4 are
-independent of each other and of 1.2. 3.9 has now run and added nothing, so
-section 3 is just 3.7 and 3.8; its standing replacement is gate 6.5.
+independent of each other and of 1.2. **Section 3 is now closed**: 3.9 ran and
+added nothing, and 3.7 and 3.8 have both landed. Its standing replacement is
+gate 6.5, which re-checks the sweep immediately before the swap.
 
 One sequencing hazard, learned the hard way: a branch cut before an
 invariant lands will happily reintroduce what that invariant removed, and CI

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -1526,12 +1526,16 @@ tests covered — not "legacy pytest passes unchanged."
   state has no engine reset hook); next-python *regular* graphs re-run.
 - **Surface build-out** ✅ *landed*: `PyStream`/`PyGraph` cover the legacy
   combinator surface — `fold`/`sample`/`count`/`limit`/`difference`/
-  `with_time`/`collect`/`buffer`/`window`/`not_`, the `sum`/`mean` statistics
-  bridge, plus `filter_map`/`filter_value`/`filter_none`/`reduce`/`bimap`/
-  `split`/`dataframe` (all in `graph.rs`, each with a unit test), and the free
-  `build_dataframe` that outer-joins several run streams on time (legacy's
-  `pandas_helpers.build_dataframe`, likewise built in Rust). The per-adapter
-  bindings that followed are the next bullet.
+  `with_time`/`collect`/`buffer`/`window`/`not_`, plus
+  `filter_map`/`filter_value`/`filter_none`/`reduce`/`bimap`/`split`/`dataframe`
+  (all in `graph.rs`, each with a unit test), and the free `build_dataframe`
+  that outer-joins several run streams on time (legacy's
+  `pandas_helpers.build_dataframe`, likewise built in Rust). The **statistics**
+  surface — `mean`/`variance`/`std`/`sum`/`min`/`max`/`median`/`ewma`
+  parameterised by `Window`/`Weighting`/`EwmaSpan` — lives in `statistics.rs`, a
+  dispatcher onto the engine's `StatisticsOps`, with `tests/test_statistics.py`
+  as the legacy parity twin. The per-adapter bindings that followed are the next
+  bullet.
 - **Per-adapter Python bindings** 🟡 *mechanical + stream-transform tiers landed (9 of 15)*: the `#[pyadapter]`
   exposure of the real `adapters::*` I/O adapters, each behind a
   `wingfoil-next-python` cargo feature of the same name (`crate::adapters::*`,
@@ -1827,14 +1831,16 @@ tests covered — not "legacy pytest passes unchanged."
     `test_build_dataframe_skips_empty_streams`) are ported one for one. The
     remaining 7 cover `to_dataframe`, a pure-Python list-to-frame converter with
     no next counterpart by design (next builds the frame in the engine).
-  - `test_statistics.py` (37) → **not ported**. Legacy `py_statistics.rs` binds
-    the whole statistics adapter (`Window` / `Weighting` / `EwmaSpan` and their
-    int/str/float shorthands over `mean`/`std`/`var`/`sum`/`min`/`max`/`median`/
-    `ewma`); next-python binds only the cumulative `sum`/`mean`/`average` bridge
-    named in the "Surface build-out" bullet above. The engine has the full
-    surface (`stats.rs`, ported in Phase 2) — it is the *binding* that stops
-    short. Legacy grew this binding after that bullet was written, so the parity
-    target moved.
+  - `test_statistics.py` (37) → `crates/wingfoil-next-python/tests/test_statistics.py`,
+    one for one (cutover-plan row 3.7). `src/statistics.rs` binds the same
+    `Window` / `Weighting` / `EwmaSpan` classes and their int/str/float
+    shorthands over `mean`/`variance`/`std`/`sum`/`min`/`max`/`median`/`ewma`.
+    The binding is a **dispatcher**: legacy's two orthogonal knobs resolve onto
+    the engine's one-method-per-combination `StatisticsOps` surface (`stats.rs`,
+    ported in Phase 2), so no engine work was involved. Legacy grew this binding
+    after the "Surface build-out" bullet above was written, which is how the
+    parity target moved under an already-ticked bullet — the case row 3.9
+    generalises.
 
   **Gaps found and closed in the audit's own PR** (next had the capability, and
   nothing exercised it): `delay` and 2-ary `merge`; `run(duration_nanos=…)`,
@@ -1853,10 +1859,10 @@ tests covered — not "legacy pytest passes unchanged."
   only the *ran but never ticked* case. Legacy `peek_value` answers `None`
   there, so `value()` now returns the empty element in both.
 
-  **Remaining** — missing *binding surface*, not missing tests, so it belongs to
-  "Surface build-out" rather than here: the statistics adapter binding.
-  (`build_dataframe` was the other one; it landed — see the `test_pandas.py`
-  entry above.)
+  **Remaining** — nothing. The two outstanding items were both missing *binding
+  surface* rather than missing tests: the statistics adapter binding and
+  `build_dataframe`. Both have landed (cutover-plan rows 3.7 and 3.8) — see the
+  `test_statistics.py` and `test_pandas.py` entries above.
 - **`wingfoil_next::compat` (`Signal<T>`)** stays a *Rust-side* legacy-idiom
   ergonomic (free `ticker`/`constant`, `stream.run`/`peek_value`; `tests/
   compat.rs`) — it is **not** the Python-binding path (that is the object-form


### PR DESCRIPTION
Closes cutover-plan row **3.7** — *"The statistics Python binding stops short of legacy."*

Legacy `legacy/wingfoil-python/src/py_statistics.rs` binds `Window` / `Weighting` / `EwmaSpan` over `mean`/`variance`/`std`/`sum`/`min`/`max`/`median`/`ewma`; next-python bound only cumulative `sum`/`mean`/`average`, and legacy's 37 statistics tests had nowhere to map. This is **binding work only** — the engine surface (`crates/wingfoil-next/src/stats.rs`) already had every combination, with parity tests. No engine file is touched.

## What changed

**`crates/wingfoil-next-python/src/statistics.rs`** (new) — the binding, and deliberately a **dispatcher**. The engine spells each combination out as its own statically-checked method on `StatisticsOps` (`rolling_mean`, `time_windowed_mean`, `cumulative_mean_time_weighted`, …) because Rust can afford a wide surface; legacy Python settled on two orthogonal knobs, and that is the contract next must be a superset of. So the module resolves a `Window` and a `Weighting` from Python and `match`es the pair onto the one engine method that implements it. Nothing here computes a statistic. The `match`es are exhaustive, so a new engine combination shows up as a compile error rather than a silent gap.

Ported verbatim from the legacy binding: the `Window` / `Weighting` / `EwmaSpan` pyclasses with their `__repr__`/equality, the `int` (count window) / `None` (unbounded) / `"count"` / `"time"` / bare-`float` (per-tick alpha) shorthands, the rejection of a bare `float` window (`mean(10)` and `mean(10.0)` cannot both be right), and the boundary validation of things the Rust op only `debug_assert!`s — an `alpha` outside `[0, 1]`, a non-finite or negative `seconds`, a zero half-life.

**`src/python.rs`** — `Stream` grows `min` / `max` / `variance` / `std` / `median` / `ewma`; `sum` gains `window=None` and `mean` gains `window=None, weighting=None`. Both keep working unchanged when called with no arguments, and `average()` is untouched. The three argument classes are registered in the `#[pymodule]`.

**`src/graph.rs`** — one new seam, `PyStream::wire_float_stat(op, |s| …)`: `PyElement → f64 → PyElement` in one place, with `op` named in the conversion error so a non-numeric value reports *which* operator demanded a number (the legacy `as_floats` contract). `PyStream::sum`/`mean` now route through the dispatcher rather than carrying their own edge conversion, so there is exactly one code path per statistic.

## Parity evidence

`crates/wingfoil-next-python/tests/test_statistics.py` — **all 37 legacy cases ported, none dropped, none skipped**, with the legacy expected values unchanged. The only edits are the wiring idiom (`wf.Graph()` + `counter` + `accumulate` for legacy's free `ticker` + `collect`) and the counter's period in nanoseconds. Plus five Rust unit tests in `statistics.rs` covering the dispatch itself (each window kind, the time-weighted twin, the median window, the ewma closed form, and the labelled conversion error).

## Docs

* `docs/api.rst` — a new **Statistics** section: the method table, the three argument objects, and a worked example. The old "lives in the Rust `wingfoil_next::stats` layer and reaches Python through the plugin seam" paragraph is gone.
* `docs/migration.rst` — the "Windowed statistics" section now reads *nothing to change*, and the "statistics surface is smaller than legacy's" known-gap bullet is removed.
* `docs/port-plan.md` — `test_statistics.py` moves from "not ported" to its next twin; the Phase 6 "Surface build-out" bullet names the real statistics surface.
* `docs/cutover-plan.md` — row 3.7 removed; row 3.9 reworded (it cited 3.7 as its motivating example).

## Skill update

`/new-op-next` grew a subsection under step 7: **"A *family* of ops binds as one dispatcher, not one function per op."** The skill's existing guidance assumes a 1:1 op↔binding mapping, which breaks whenever the legacy Python contract parameterises a family with argument objects — neither `#[pyop]` nor `pyop_fn!` can express "which op to wire is runtime data". It records the five rules this work produced: bind the legacy surface not the engine's; a `#[pyclass]` used as an *argument* needs `from_py_object` on pyo3 0.29; validate at the boundary what the op only `debug_assert!`s; give a typed-edge family one labelled conversion seam; and reject an ambiguous shorthand rather than guessing (including why the order of the `extract` attempts is load-bearing).

## Gates

| Gate | Result |
|---|---|
| `cargo fmt --all` | ✅ |
| `cargo lint` | ✅ |
| `cargo lint-all` | ✅ |
| `cargo test -p wingfoil-next` (all features) | ✅ 71 test binaries |
| `cargo test -p wingfoil-next-python --features all-adapters` (CI's leg) | ✅ 207 + 23 |
| `maturin develop -F all-adapters && pytest` | ✅ 344 passed, 10 skipped |

`aeron_integration` is excluded from the local all-features test run: it is `#[cfg(feature = "aeron-integration-test")]` and needs a Docker-hosted Aeron media driver, which this sandbox has no way to start. Everything else in the all-features set runs and passes. (`cargo lint-all` and the linking legs also needed CMake ≥ 3.30 and `libbsd-dev` installed locally, per the repo's documented system deps.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4RtmWkPKk5Zj4E67d2PmG)_