### PR TITLE
Add Stream::build so a whole graph can be one chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ streaming data across your entire stack.
 ## Quick Start
 
 In this example we build a simple, linear pipeline with all nodes ticking in
-lock-step.
+lock-step — wired, built and run as a single chain.
 
 ```rust
 use std::time::Duration;
@@ -52,16 +52,21 @@ use wingfoil_next::{RunFor, RunMode};
 use wingfoil_next::prelude::*;
 
 fn main() {
-    let g = GraphBuilder::new();
-    g.ticker(Duration::from_secs(1))
+    GraphBuilder::new()
+        .ticker(Duration::from_secs(1))
         .count()
         .map(|i| format!("hello, world {i}"))
-        .print();
-
-    let mut runner = g.build();
-    runner.run(RunMode::RealTime, RunFor::Cycles(3)).unwrap();
+        .print()
+        .build()
+        .run(RunMode::RealTime, RunFor::Cycles(3))
+        .unwrap();
 }
 ```
+
+`build()` is available at the end of a chain as well as on the `GraphBuilder`,
+and builds the whole graph either way. Keep the builder and the streams in
+bindings when you branch, or when you want to read values back after the run
+(`runner.value(&stream)`) — as the worked example below does.
 
 This output is produced:
 

--- a/crates/wingfoil-next/README.md
+++ b/crates/wingfoil-next/README.md
@@ -13,15 +13,19 @@ use std::time::Duration;
 use wingfoil_next::prelude::*;
 use wingfoil_next::{RunFor, RunMode};
 
-let g = GraphBuilder::new();
-g.ticker(Duration::from_secs(1))
+GraphBuilder::new()
+    .ticker(Duration::from_secs(1))
     .count()
     .map(|i| format!("hello, world {i}"))
-    .print();
-
-let mut runner = g.build();
-runner.run(RunMode::RealTime, RunFor::Cycles(3)).unwrap();
+    .print()
+    .build()
+    .run(RunMode::RealTime, RunFor::Cycles(3))
+    .unwrap();
 ```
+
+`build()` sits on `Stream<T>` as well as on `GraphBuilder`, so a whole program
+can be one chain; it builds the graph either way. Hold the builder and the
+streams in bindings when you branch or want to read values back after the run.
 
 ## Execution tiers
 

--- a/crates/wingfoil-next/src/fluent.rs
+++ b/crates/wingfoil-next/src/fluent.rs
@@ -158,6 +158,10 @@ impl GraphBuilder {
     /// Consume the wired graph into a [`Runner`]. Streams stay usable as
     /// value handles (`runner.value(&stream)`).
     ///
+    /// Also available at the end of a chain as [`Stream::build`], which builds
+    /// this same graph — use it when nothing needs reading back and the whole
+    /// program can be one expression.
+    ///
     /// # Precondition
     ///
     /// May be called **once**: it takes the underlying [`Builder`], leaving the
@@ -553,7 +557,8 @@ impl SourceOps for GraphBuilder {
 
 /// A typed stream in a graph under construction. Combinators live in the
 /// [`StreamOps`] extension trait (and others), so `use`ing the trait enables
-/// chaining: `g.ticker(p).count().map(|i| i * 2)`.
+/// chaining: `g.ticker(p).count().map(|i| i * 2)`. [`build`](Stream::build)
+/// closes the chain, so wiring, building and running can be one expression.
 pub struct Stream<T> {
     inner: Rc<RefCell<Builder>>,
     /// Shared with the owning [`GraphBuilder`]: set once the graph is built, so
@@ -652,6 +657,37 @@ impl<T> Stream<T> {
         T: 'static,
     {
         self.inner.borrow().slot(self.handle)
+    }
+
+    /// Consume the wired graph this stream belongs to into a [`Runner`] —
+    /// [`GraphBuilder::build`] reached from the end of a chain, so a whole
+    /// program can be one expression:
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use wingfoil_next::prelude::*;
+    /// use wingfoil_next::{RunFor, RunMode};
+    ///
+    /// GraphBuilder::new()
+    ///     .ticker(Duration::from_secs(1))
+    ///     .count()
+    ///     .map(|i| format!("hello, world {i}"))
+    ///     .print()
+    ///     .build()
+    ///     .run(RunMode::RealTime, RunFor::Cycles(3))
+    ///     .unwrap();
+    /// ```
+    ///
+    /// It builds the *graph*, not this stream: which stream you call it on
+    /// makes no difference, and every other stream wired from the same
+    /// [`GraphBuilder`] stays usable as a value handle
+    /// (`runner.value(&stream)`). Carries the same **call-once** precondition
+    /// as [`GraphBuilder::build`] — a second `build()`, from any stream or the
+    /// builder itself, panics rather than returning an empty [`Runner`]. When
+    /// you need to read values back, keep the builder and the streams in
+    /// bindings instead of chaining.
+    pub fn build(&self) -> Runner {
+        self.graph().build()
     }
 
     /// Erase this stream to an [`Upstream`] edge for

--- a/crates/wingfoil-next/tests/fluent_primitives.rs
+++ b/crates/wingfoil-next/tests/fluent_primitives.rs
@@ -4,7 +4,8 @@
 //! behind their file sinks), and `SourceOps::source_at_start` (the
 //! deferred-connection source behind live adapters like `zmq_sub`). The adapter
 //! tests cover them end-to-end through files/sockets; these exercise the
-//! primitives directly.
+//! primitives directly. Also `Stream::build` — `GraphBuilder::build` reached
+//! from the end of a chain.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -367,4 +368,58 @@ fn register_op4_reads_four_actives() {
         ],
         runner.value(&out)
     );
+}
+
+/// `Stream::build` builds the whole graph from the end of a chain, so a program
+/// is one expression: wire, build and run without ever naming the builder.
+#[test]
+fn stream_build_runs_the_whole_graph_from_the_end_of_a_chain() {
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let sink = seen.clone();
+
+    GraphBuilder::new()
+        .ticker(std::time::Duration::from_nanos(100))
+        .count()
+        .map(|i: &u64| format!("hello, world {i}"))
+        .for_each(move |s: &String| {
+            sink.borrow_mut().push(s.clone());
+            Ok(())
+        })
+        .build()
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+
+    assert_eq!(
+        vec!["hello, world 1", "hello, world 2", "hello, world 3"],
+        *seen.borrow(),
+    );
+}
+
+/// It builds the *graph*, not the stream it is called on: a sibling branch wired
+/// from the same builder still runs, and every stream stays readable as a value
+/// handle afterwards.
+#[test]
+fn stream_build_builds_the_graph_not_the_stream() {
+    let g = GraphBuilder::new();
+    let counter = g.ticker(std::time::Duration::from_nanos(100)).count();
+    let doubled = counter.map(|n: &u64| *n * 2).accumulate();
+    // Built from one branch; the sibling branch above must still be in the graph.
+    let mut runner = counter.map(|n: &u64| *n + 100).accumulate().build();
+    runner
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+
+    assert_eq!(vec![2, 4, 6], runner.value(&doubled));
+}
+
+/// `Stream::build` shares the builder's call-once guard: a second build — from
+/// the builder or any other stream — panics with the explanatory message rather
+/// than handing back an empty `Runner`.
+#[test]
+#[should_panic(expected = "GraphBuilder::build() called twice")]
+fn stream_build_shares_the_builders_call_once_guard() {
+    let g = GraphBuilder::new();
+    let s = g.ticker(std::time::Duration::from_nanos(100)).count();
+    let _first = s.build();
+    let _second = g.build();
 }


### PR DESCRIPTION
`build()` lived only on `GraphBuilder`, so even the smallest program had to break the chain to name the builder:

```rust
let g = GraphBuilder::new();
g.ticker(Duration::from_secs(1))
    .count()
    .map(|i| format!("hello, world {i}"))
    .print();

let mut runner = g.build();
runner.run(RunMode::RealTime, RunFor::Cycles(3)).unwrap();
```

## What's here

**`Stream::build() -> Runner`** (`crates/wingfoil-next/src/fluent.rs`) — `GraphBuilder::build` reached from the end of a chain, a one-liner over `self.graph().build()`. It builds the *graph*, not the stream it is called on: which stream you call it on makes no difference, sibling branches still run, and every stream stays usable as a value handle. It shares the builder's call-once poison flag, so a second `build()` — from any stream or the builder itself — still panics with the existing explanatory message rather than returning an empty `Runner`.

Docs on `GraphBuilder::build` and the `Stream` struct cross-reference it, with the caveat that you keep the builder and streams in bindings when you branch or want to read values back via `runner.value(&stream)`.

**Quick start** in both `README.md` and `crates/wingfoil-next/README.md` is now a single chain:

```rust
GraphBuilder::new()
    .ticker(Duration::from_secs(1))
    .count()
    .map(|i| format!("hello, world {i}"))
    .print()
    .build()
    .run(RunMode::RealTime, RunFor::Cycles(3))
    .unwrap();
```

**Tests** (`crates/wingfoil-next/tests/fluent_primitives.rs`) — three: the one-chain wire→build→run produces the expected values; building from one branch still runs a sibling branch and leaves streams readable as value handles; and a second build panics with the call-once message.

Purely additive — no existing API changes shape, and the wiring layer still adds nothing to execution.

## Verification

`cargo fmt --all`, `cargo lint` and `cargo lint-all` are clean. `cargo test -p wingfoil-next --all-features --no-fail-fast` passes everything except the `*_integration` suites (aeron, etcd, fluvio, kafka, otlp, postgres, redis, zmq_etcd), which fail on `Socket not found: /var/run/docker.sock` — testcontainers, no Docker in the dev sandbox, unrelated to this change. All 7 doctests pass, including the new one on `Stream::build`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvGcgpbiwAvsUPjjoUhGcx)_