### PR TITLE
feat: add fluent GraphBuilder and use it throughout

### DIFF
--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -293,7 +293,10 @@ Add `//!` module-level doc at the top of `mod.rs` covering:
 //! $ARGUMENTS_sub(conn, "prefix")
 //!     .collapse()
 //!     .for_each(|event, _| println!("{:?}", event))
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -301,7 +304,10 @@ Add `//!` module-level doc at the top of `mod.rs` covering:
 //! ```ignore
 //! constant(burst![<Name>Entry { key: "k".into(), value: b"v".to_vec() }])
 //!     .$ARGUMENTS_pub(conn)
-//!     .run(RunMode::RealTime, RunFor::Cycles(1))
+//!     .graph()
+//!     .real_time()
+//!     .cycles(1)
+//!     .run()
 //!     .unwrap();
 //! ```
 ```
@@ -692,7 +698,7 @@ fn test_sub_snapshot() -> anyhow::Result<()> {
 
     let conn = <Name>Connection::new(&endpoint);
     let collected = $ARGUMENTS_sub(conn, "/prefix/").collapse().collect();
-    collected.clone().run(RunMode::RealTime, RunFor::Cycles(1))?;
+    collected.clone().graph().real_time().cycles(1).run()?;
 
     assert_eq!(collected.peek_value().len(), 1);
     Ok(())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,26 @@ See `wingfoil/examples/dynamic/dynamic-manual/main.rs` for a fully manual custom
 - Nodes are wrapped in `Rc<RefCell<...>>` for interior mutability
 - Factory functions return `Rc<dyn Stream<T>>` or `Rc<dyn Node>`
 - Fluent API: `ticker(duration).map(f).filter(g).fold(init, h)`
+- Prefer a single chain from wiring to execution.  [`Graph::builder()`] and
+  [`NodeOperators::graph()`] both return a `GraphBuilder`, so a graph is
+  configured and run without breaking out of the chain:
+  ```rust
+  // single root
+  ticker(period).count().print().graph().historical().cycles(5).run().unwrap();
+
+  // several roots — `add` takes a Node, a Stream, or a Vec of either
+  Graph::builder()
+      .add(prices.csv_write("prices.csv"))
+      .add(fills.csv_write("fills.csv"))
+      .historical()
+      .forever()
+      .run()
+      .unwrap();
+  ```
+  Run mode shorthands: `real_time()` (default), `historical()`,
+  `historical_from(t)`, or `run_mode(m)`.  Duration shorthands: `forever()`
+  (default), `cycles(n)`, `duration(d)`, or `run_for(f)`.  `build()` returns the
+  `Graph` itself when a handle is needed instead of an immediate `run()`.
 
 ### Error Handling
 
@@ -194,6 +214,8 @@ thread panicked while holding it, and we propagate that panic deliberately.
 
 Tests use historical mode for determinism:
 ```rust
-stream.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10)).unwrap();
+stream.graph().historical().cycles(10).run().unwrap();
 assert_eq!(expected, stream.peek_value());
 ```
+`stream.run(run_mode, run_for)` remains available as a two-argument shorthand
+and is still used widely in the existing unit tests.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ fn main() {
         .count()
         .map(|i| format!("hello, world {:}", i))
         .print()
-        .run(RunMode::RealTime, RunFor::Duration(period*3)
-    );
+        .graph()
+        .real_time()
+        .duration(period * 3)
+        .run()
+        .unwrap();
 }
 ```
 This output is produced:
@@ -63,12 +66,11 @@ let get_time = |msg: &Message| NanoTime::new((msg.seconds * 1e9) as u64);
 let (fills, prices) = csv_read("aapl.csv", get_time, true)
     .map(move |chunk| process_orders(chunk, &book))
     .split();
-let prices_export = prices
-    .filter_none()
-    .distinct()
-    .csv_write("prices.csv");
-let fills_export = fills.csv_write("fills.csv");
-Graph::new(vec![prices_export, fills_export], RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+Graph::builder()
+    .add(prices.filter_none().distinct().csv_write("prices.csv"))
+    .add(fills.csv_write("fills.csv"))
+    .historical()
+    .forever()
     .print()
     .run()
     .unwrap();

--- a/wingfoil-python/src/lib.rs
+++ b/wingfoil-python/src/lib.rs
@@ -180,8 +180,11 @@ impl PyGraph {
                 std::mem::forget(node);
             }
 
-            let mut graph = ::wingfoil::Graph::new(roots, run_mode, run_for);
-            graph.run()
+            ::wingfoil::Graph::builder()
+                .add(roots)
+                .run_mode(run_mode)
+                .run_for(run_for)
+                .run()
         });
         result.to_pyresult()?;
         Ok(())

--- a/wingfoil/benches/iceoryx2_modes.rs
+++ b/wingfoil/benches/iceoryx2_modes.rs
@@ -10,7 +10,7 @@ use iceoryx2::prelude::ZeroCopySend;
 use wingfoil::adapters::iceoryx2::{
     Iceoryx2Mode, Iceoryx2ServiceVariant, Iceoryx2SubOpts, iceoryx2_pub_with, iceoryx2_sub_opts,
 };
-use wingfoil::{Burst, Graph, NodeOperators, RunFor, RunMode, StreamOperators, ticker};
+use wingfoil::{Burst, Graph, NodeOperators, StreamOperators, ticker};
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, ZeroCopySend)]
@@ -45,12 +45,13 @@ fn bench_mode(c: &mut Criterion, mode: Iceoryx2Mode, mode_name: &str) {
             let pub_node =
                 iceoryx2_pub_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-            let mut graph = Graph::new(
-                vec![pub_node, collected.clone().as_node()],
-                RunMode::RealTime,
-                RunFor::Cycles(100),
-            );
-            graph.run().unwrap();
+            Graph::builder()
+                .add(pub_node)
+                .add(collected.clone())
+                .real_time()
+                .cycles(100)
+                .run()
+                .unwrap();
         })
     });
 }

--- a/wingfoil/examples/README.md
+++ b/wingfoil/examples/README.md
@@ -90,7 +90,7 @@ let round_trip = etcd_sub(conn.clone(), "/source/")
     })
     .etcd_pub(conn, None, true);
 
-round_trip.run(RunMode::RealTime, RunFor::Cycles(3)).unwrap();
+round_trip.graph().real_time().cycles(3).run().unwrap();
 ```
 
 [Full example.](etcd/)
@@ -115,7 +115,7 @@ let round_trip = fluvio_sub(conn.clone(), "source", 0, None)
     })
     .fluvio_pub(conn, "dest");
 
-round_trip.run(RunMode::RealTime, RunFor::Cycles(10)).unwrap();
+round_trip.graph().real_time().cycles(10).run().unwrap();
 ```
 
 [Full example.](fluvio/)
@@ -140,7 +140,7 @@ let round_trip = kafka_sub(conn.clone(), "source", "example-group")
     })
     .kafka_pub(conn);
 
-round_trip.run(RunMode::RealTime, RunFor::Cycles(10)).unwrap();
+round_trip.graph().real_time().cycles(10).run().unwrap();
 ```
 
 [Full example.](kafka/)
@@ -165,7 +165,7 @@ let processor = redis_sub(conn.clone(), "source")
     })
     .redis_pub(conn);
 
-processor.run(RunMode::RealTime, RunFor::Forever).unwrap();
+processor.graph().real_time().forever().run().unwrap();
 ```
 
 The adapter also supports Redis **Streams** for a persistent, replayable log:
@@ -229,7 +229,10 @@ ticker(Duration::from_millis(100))
     .count()
     .map(|n: u64| format!("{n}").into_bytes())
     .zmq_pub(7779, ())
-    .run(RunMode::RealTime, RunFor::Forever)?;
+    .graph()
+    .real_time()
+    .forever()
+    .run()?;
 ```
 
 ```rust,ignore
@@ -240,7 +243,10 @@ use wingfoil::*;
 let (data, _status) = zmq_sub::<Vec<u8>>("tcp://127.0.0.1:7779")?;
 // See wingfoil-python/examples/zmq/ for a Python subscriber
 data.print()
-    .run(RunMode::RealTime, RunFor::Forever)?;
+    .graph()
+    .real_time()
+    .forever()
+    .run()?;
 ```
 
 Service discovery via etcd is also supported — see [`zmq/etcd`](zmq/etcd/) for details.
@@ -271,12 +277,12 @@ let received = aeron_sub_fragment(
 );
 let publisher = received.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-Graph::new(
-    vec![received.print().as_node(), publisher],
-    RunMode::RealTime,
-    RunFor::Cycles(10),
-)
-.run()?;
+Graph::builder()
+    .add(received.print())
+    .add(publisher)
+    .real_time()
+    .cycles(10)
+    .run()?;
 ```
 
 Use `AeronMode::Threaded` to poll on a background thread instead. The pure-Rust
@@ -301,16 +307,14 @@ let fix = fix_connect_tls(
 // Subscribe to EUR/USD — waits for LoggedIn, then sends the request.
 let sub = fix.fix_sub(constant(vec!["4001".into()]));
 
-let data_node = fix.data.logged("fix-data", Info).as_node();
-let status_node = fix.status.logged("fix-status", Info).as_node();
-
-Graph::new(
-    vec![data_node, status_node, sub],
-    RunMode::RealTime,
-    RunFor::Duration(Duration::from_secs(60)),
-)
-.run()
-.unwrap();
+Graph::builder()
+    .add(fix.data.logged("fix-data", Info))
+    .add(fix.status.logged("fix-status", Info))
+    .add(sub)
+    .real_time()
+    .duration(Duration::from_secs(60))
+    .run()
+    .unwrap();
 ```
 
 Run the self-contained loopback example (no external FIX engine needed):
@@ -339,10 +343,13 @@ let config = OtlpConfig {
 };
 
 let counter = ticker(Duration::from_secs(1)).count();
-let prometheus_node = exporter.register("wingfoil_ticks_total", counter.clone());
-let otlp_node = counter.otlp_push("wingfoil_ticks_total", config);
 
-Graph::new(vec![prometheus_node, otlp_node], RunMode::RealTime, RunFor::Forever).run()?;
+Graph::builder()
+    .add(exporter.register("wingfoil_ticks_total", counter.clone()))
+    .add(counter.otlp_push("wingfoil_ticks_total", config))
+    .real_time()
+    .forever()
+    .run()?;
 ```
 
 [Full example.](telemetry/)
@@ -362,13 +369,19 @@ ticker(Duration::from_secs(1))
     .map(|n| n as f64 + (n as f64 * 0.5).sin())
     .augurs_forecast(AugursForecastConfig::new(48, 5).with_level(0.90))
     .for_each(|f, _| println!("next 5: {:?}", f.point))
-    .run(RunMode::RealTime, RunFor::Forever)?;
+    .graph()
+    .real_time()
+    .forever()
+    .run()?;
 
 // Flag the series that diverges from the group (one Vec<f64> per tick).
 readings // Rc<dyn Stream<Vec<f64>>>
     .augurs_outlier(AugursOutlierConfig::mad(40, 0.5))
     .for_each(|o, _| println!("outlying: {:?}", o.outlying))
-    .run(RunMode::RealTime, RunFor::Forever)?;
+    .graph()
+    .real_time()
+    .forever()
+    .run()?;
 
 // Detect regime changes and seasonal periods in a single series.
 prices.augurs_changepoint(AugursChangepointConfig::new(120));

--- a/wingfoil/examples/aeron/main.rs
+++ b/wingfoil/examples/aeron/main.rs
@@ -47,19 +47,17 @@ fn main() -> anyhow::Result<()> {
     // Publisher runs in its own graph on the same thread.
     let publisher_node = subscriber.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    // A downstream node that prints received values.
-    let printer = subscriber.inspect(|burst| {
-        for v in burst.iter() {
-            println!("spin received: {v}");
-        }
-    });
-
-    Graph::new(
-        vec![printer.as_node(), publisher_node],
-        RunMode::RealTime,
-        RunFor::Cycles(10),
-    )
-    .run()?;
+    Graph::builder()
+        // A downstream node that prints received values.
+        .add(subscriber.inspect(|burst| {
+            for v in burst.iter() {
+                println!("spin received: {v}");
+            }
+        }))
+        .add(publisher_node)
+        .real_time()
+        .cycles(10)
+        .run()?;
 
     // -----------------------------------------------------------------------
     // Threaded subscriber (secondary pattern)
@@ -85,8 +83,10 @@ fn main() -> anyhow::Result<()> {
                 println!("threaded received: {v}");
             }
         })
-        .as_node()
-        .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(3)))?;
+        .graph()
+        .real_time()
+        .duration(Duration::from_secs(3))
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/aeron/status_circuit_breaker.rs
+++ b/wingfoil/examples/aeron/status_circuit_breaker.rs
@@ -121,12 +121,12 @@ fn main() -> anyhow::Result<()> {
     let breaker = CircuitBreakerNode::new(data_stream, status_stream);
     let breaker_node: Rc<dyn Node> = RefCell::new(breaker).into_node();
 
-    wingfoil::Graph::new(
-        vec![breaker_node, publisher_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(3)),
-    )
-    .run()?;
+    wingfoil::Graph::builder()
+        .add(breaker_node)
+        .add(publisher_node)
+        .real_time()
+        .duration(Duration::from_secs(3))
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/async/README.md
+++ b/wingfoil/examples/async/README.md
@@ -59,6 +59,9 @@ produce_async(producer, None)
     .logged("on-graph", log::Level::Info)
     .collapse()
     .consume_async(Box::new(consumer))
-    .run(run_mode, run_for);
+    .graph()
+    .run_mode(run_mode)
+    .run_for(run_for)
+    .run();
 ```
 

--- a/wingfoil/examples/async/main.rs
+++ b/wingfoil/examples/async/main.rs
@@ -32,6 +32,9 @@ fn main() {
         .logged("on-graph", log::Level::Info)
         .collapse()
         .consume_async(Box::new(consumer))
-        .run(run_mode, run_for)
+        .graph()
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()
         .unwrap();
 }

--- a/wingfoil/examples/augurs/main.rs
+++ b/wingfoil/examples/augurs/main.rs
@@ -37,7 +37,10 @@ fn forecasting() {
             let point: Vec<String> = forecast.point.iter().map(|v| format!("{v:.1}")).collect();
             println!("  {time}  next 5: [{}]", point.join(", "));
         })
-        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(36))
+        .graph()
+        .historical()
+        .cycles(36)
+        .run()
         .unwrap();
 }
 
@@ -58,7 +61,10 @@ fn outlier_detection() {
                 println!("  {time}  outlying series: {:?}", outliers.outlying);
             }
         })
-        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(36))
+        .graph()
+        .historical()
+        .cycles(36)
+        .run()
         .unwrap();
 }
 
@@ -76,7 +82,10 @@ fn seasonality() {
                 println!("  {time}  seasonal period ~= {period} samples (true 24)");
             }
         })
-        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(120))
+        .graph()
+        .historical()
+        .cycles(120)
+        .run()
         .unwrap();
 }
 
@@ -96,7 +105,10 @@ fn changepoints() {
                 );
             }
         })
-        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(50))
+        .graph()
+        .historical()
+        .cycles(50)
+        .run()
         .unwrap();
 }
 

--- a/wingfoil/examples/breadth_first/README.md
+++ b/wingfoil/examples/breadth_first/README.md
@@ -21,9 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for _ in 1..128 {
         source = add(&source, &source);
     }
-    source
-        .timed()
-        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+    source.timed().graph().historical().forever().run()?;
     println!("value {:?}", source.peek_value());
     Ok(())
 }

--- a/wingfoil/examples/breadth_first/main.rs
+++ b/wingfoil/examples/breadth_first/main.rs
@@ -8,9 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for _ in 1..128 {
         source = add(&source, &source);
     }
-    source
-        .timed()
-        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
+    source.timed().graph().historical().forever().run()?;
     println!("value {:?}", source.peek_value());
     Ok(())
 }

--- a/wingfoil/examples/dynamic/demux/main.rs
+++ b/wingfoil/examples/dynamic/demux/main.rs
@@ -100,15 +100,12 @@ fn main() -> anyhow::Result<()> {
 
 pub fn run(period: Duration, cycles: u32) -> anyhow::Result<()> {
     let (price_book, overflow_node) = build(period);
-    Graph::new(
-        vec![
-            price_book.logged("price book (demux)", Info).as_node(),
-            overflow_node,
-        ],
-        RunMode::HistoricalFrom(NanoTime::ZERO),
-        RunFor::Cycles(cycles),
-    )
-    .run()
+    Graph::builder()
+        .add(price_book.logged("price book (demux)", Info))
+        .add(overflow_node)
+        .historical()
+        .cycles(cycles)
+        .run()
 }
 
 #[cfg(test)]
@@ -163,12 +160,12 @@ mod tests {
             assert_eq!(states, expected_book_states());
             Ok(())
         });
-        Graph::new(
-            vec![assertion, overflow_node],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Cycles(20),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(assertion)
+            .add(overflow_node)
+            .historical()
+            .cycles(20)
+            .run()
+            .unwrap();
     }
 }

--- a/wingfoil/examples/dynamic/dynamic-group/main.rs
+++ b/wingfoil/examples/dynamic/dynamic-group/main.rs
@@ -56,12 +56,12 @@ fn main() -> anyhow::Result<()> {
     env_logger::init();
     let period = Duration::from_secs(1);
     let (aggregator, inst_price) = build(period);
-    Graph::new(
-        vec![aggregator.logged(">", Info).as_node(), inst_price],
-        RunMode::HistoricalFrom(NanoTime::ZERO),
-        RunFor::Cycles(20),
-    )
-    .run()
+    Graph::builder()
+        .add(aggregator.logged(">", Info))
+        .add(inst_price)
+        .historical()
+        .cycles(20)
+        .run()
 }
 
 #[cfg(test)]

--- a/wingfoil/examples/dynamic/dynamic-manual/main.rs
+++ b/wingfoil/examples/dynamic/dynamic-manual/main.rs
@@ -114,12 +114,12 @@ fn main() -> anyhow::Result<()> {
     env_logger::init();
     let period = Duration::from_secs(1);
     let (aggregator, inst_price) = build(period);
-    Graph::new(
-        vec![aggregator.logged(">", Info).as_node(), inst_price],
-        RunMode::HistoricalFrom(NanoTime::ZERO),
-        RunFor::Cycles(20),
-    )
-    .run()
+    Graph::builder()
+        .add(aggregator.logged(">", Info))
+        .add(inst_price)
+        .historical()
+        .cycles(20)
+        .run()
 }
 
 #[cfg(test)]

--- a/wingfoil/examples/dynamic/market_data.rs
+++ b/wingfoil/examples/dynamic/market_data.rs
@@ -145,12 +145,13 @@ mod tests {
             Ok(())
         });
 
-        Graph::new(
-            vec![new_insts, del_insts, prices],
-            wingfoil::RunMode::HistoricalFrom(wingfoil::NanoTime::ZERO),
-            wingfoil::RunFor::Cycles(9),
-        )
-        .run()
-        .unwrap();
+        wingfoil::Graph::builder()
+            .add(new_insts)
+            .add(del_insts)
+            .add(prices)
+            .historical()
+            .cycles(9)
+            .run()
+            .unwrap();
     }
 }

--- a/wingfoil/examples/dynamic/tests.rs
+++ b/wingfoil/examples/dynamic/tests.rs
@@ -55,11 +55,11 @@ fn price_book_accumulation() {
         assert_eq!(states, expected_book_states());
         Ok(())
     });
-    Graph::new(
-        vec![assertion, overflow_node],
-        RunMode::HistoricalFrom(NanoTime::ZERO),
-        RunFor::Duration(period * 19),
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(assertion)
+        .add(overflow_node)
+        .historical()
+        .duration(period * 19)
+        .run()
+        .unwrap();
 }

--- a/wingfoil/examples/etcd/README.md
+++ b/wingfoil/examples/etcd/README.md
@@ -116,7 +116,12 @@ fn main() -> anyhow::Result<()> {
         })
         .etcd_pub(conn, None, true);
 
-    Graph::new(vec![seed, round_trip], RunMode::RealTime, RunFor::Cycles(3)).run()?;
+    Graph::builder()
+        .add(seed)
+        .add(round_trip)
+        .real_time()
+        .cycles(3)
+        .run()?;
     Ok(())
 }
 ```

--- a/wingfoil/examples/etcd/main.rs
+++ b/wingfoil/examples/etcd/main.rs
@@ -68,7 +68,12 @@ fn main() -> anyhow::Result<()> {
         })
         .etcd_pub(conn, None, true);
 
-    Graph::new(vec![seed, round_trip], RunMode::RealTime, RunFor::Cycles(3)).run()?;
+    Graph::builder()
+        .add(seed)
+        .add(round_trip)
+        .real_time()
+        .cycles(3)
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/feedback/README.md
+++ b/wingfoil/examples/feedback/README.md
@@ -63,7 +63,10 @@ let plant = bimap(Dep::Active(heater), Dep::Passive(temp_rx), |power, temp| temp
 plant
     .feedback(temp_tx)
     .for_each(|t, _| println!("temperature: {t:.3}"))
-    .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Duration(period * 7))?;
+    .graph()
+    .historical()
+    .duration(period * 7)
+    .run()?;
 ```
 
 Run it:

--- a/wingfoil/examples/feedback/main.rs
+++ b/wingfoil/examples/feedback/main.rs
@@ -37,14 +37,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Close the loop: feed each new temperature back so the next step's
     // `error` can read it. plant -> heater -> error -> plant is a genuine
     // cycle; the feedback channel is the only edge that can express it.
-    let temperature = plant.feedback(temp_tx);
-
-    temperature
+    plant
+        .feedback(temp_tx)
         .for_each(|t, _| println!("temperature: {t:.3}"))
-        .run(
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Duration(period * 7),
-        )?;
+        .graph()
+        .historical()
+        .duration(period * 7)
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/fix/fix_client.rs
+++ b/wingfoil/examples/fix/fix_client.rs
@@ -16,11 +16,11 @@ fn main() {
     let data_node = data.logged("fix", Info).as_node();
     let status_node = status.logged("fix-status", Info).as_node();
 
-    Graph::new(
-        vec![data_node, status_node],
-        RunMode::RealTime,
-        RunFor::Forever,
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(data_node)
+        .add(status_node)
+        .real_time()
+        .forever()
+        .run()
+        .unwrap();
 }

--- a/wingfoil/examples/fix/fix_echo_server.rs
+++ b/wingfoil/examples/fix/fix_echo_server.rs
@@ -20,11 +20,11 @@ fn main() {
     let data_node = data.logged("fix-data", Info).as_node();
     let status_node = status.logged("fix-status", Info).as_node();
 
-    Graph::new(
-        vec![data_node, status_node],
-        RunMode::RealTime,
-        RunFor::Forever,
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(data_node)
+        .add(status_node)
+        .real_time()
+        .forever()
+        .run()
+        .unwrap();
 }

--- a/wingfoil/examples/fix/fix_loopback.rs
+++ b/wingfoil/examples/fix/fix_loopback.rs
@@ -48,24 +48,17 @@ fn main() {
         .filter_value(|burst| burst.contains(&FixSessionStatus::LoggedIn))
         .logged("initiator-logon", Info);
 
-    // Log acceptor status events.
-    let acc_status_node = acc_status.logged("acceptor-status", Info).as_node();
-
-    // Print the running message count.
-    let count_node = acc_msg_count.logged("acceptor-msg-count", Info).as_node();
-
-    Graph::new(
-        vec![
-            init_data.as_node(),
-            init_logged_in.as_node(),
-            acc_status_node,
-            count_node,
-        ],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(5)),
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(init_data)
+        .add(init_logged_in)
+        // Log acceptor status events.
+        .add(acc_status.logged("acceptor-status", Info))
+        // Print the running message count.
+        .add(acc_msg_count.logged("acceptor-msg-count", Info))
+        .real_time()
+        .duration(Duration::from_secs(5))
+        .run()
+        .unwrap();
 
     info!("Done.");
 }

--- a/wingfoil/examples/fix/lmax_demo.rs
+++ b/wingfoil/examples/fix/lmax_demo.rs
@@ -69,13 +69,14 @@ fn main() {
     let data_node = fix.data.logged("fix-data", Info).as_node();
     let status_node = fix.status.logged("fix-status", Info).as_node();
 
-    Graph::new(
-        vec![data_node, status_node, sub],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(60)),
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(data_node)
+        .add(status_node)
+        .add(sub)
+        .real_time()
+        .duration(Duration::from_secs(60))
+        .run()
+        .unwrap();
 
     info!("Done.");
 }

--- a/wingfoil/examples/fix/lmax_instruments.rs
+++ b/wingfoil/examples/fix/lmax_instruments.rs
@@ -107,11 +107,11 @@ fn main() {
         })
         .as_node();
 
-    Graph::new(
-        vec![data_node, status_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(60)),
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(data_node)
+        .add(status_node)
+        .real_time()
+        .duration(Duration::from_secs(60))
+        .run()
+        .unwrap();
 }

--- a/wingfoil/examples/fluvio/README.md
+++ b/wingfoil/examples/fluvio/README.md
@@ -56,7 +56,12 @@ fn main() -> anyhow::Result<()> {
         })
         .fluvio_pub(conn, DEST_TOPIC);
 
-    Graph::new(vec![seed, transform], RunMode::RealTime, RunFor::Cycles(3)).run()?;
+    Graph::builder()
+        .add(seed)
+        .add(transform)
+        .real_time()
+        .cycles(3)
+        .run()?;
     Ok(())
 }
 ```

--- a/wingfoil/examples/fluvio/main.rs
+++ b/wingfoil/examples/fluvio/main.rs
@@ -61,7 +61,12 @@ fn main() -> anyhow::Result<()> {
         })
         .fluvio_pub(conn, DEST_TOPIC);
 
-    Graph::new(vec![seed, transform], RunMode::RealTime, RunFor::Cycles(3)).run()?;
+    Graph::builder()
+        .add(seed)
+        .add(transform)
+        .real_time()
+        .cycles(3)
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/iceoryx2/README.md
+++ b/wingfoil/examples/iceoryx2/README.md
@@ -65,9 +65,10 @@ let upstream = ticker(period)
     })
     .logged("pub", Info);
 
-let pub_node = iceoryx2_pub(upstream, "wingfoil/examples/counter");
-
-Graph::new(vec![pub_node], RunMode::RealTime, RunFor::Forever)
+iceoryx2_pub(upstream, "wingfoil/examples/counter")
+    .graph()
+    .real_time()
+    .forever()
     .run()
     .unwrap();
 ```
@@ -82,11 +83,14 @@ let opts = Iceoryx2SubOpts {
     ..Default::default()
 };
 
-let sub = iceoryx2_sub_opts::<Counter>("wingfoil/examples/counter", opts);
-sub.collapse()
+iceoryx2_sub_opts::<Counter>("wingfoil/examples/counter", opts)
+    .collapse()
     .inspect(|c: &Counter| println!("received seq={}", c.seq))
     .logged("sub", Info)
-    .run(RunMode::RealTime, RunFor::Forever)
+    .graph()
+    .real_time()
+    .forever()
+    .run()
     .unwrap();
 ```
 

--- a/wingfoil/examples/iceoryx2/pub.rs
+++ b/wingfoil/examples/iceoryx2/pub.rs
@@ -30,10 +30,11 @@ fn main() {
         })
         .logged("pub", Info);
 
-    let pub_node = iceoryx2_pub(upstream, service_name);
-
     println!("Publishing Counter on \"{service_name}\" every {period:?} — press Ctrl-C to stop");
-    Graph::new(vec![pub_node], RunMode::RealTime, RunFor::Forever)
+    iceoryx2_pub(upstream, service_name)
+        .graph()
+        .real_time()
+        .forever()
         .run()
         .unwrap();
 }

--- a/wingfoil/examples/iceoryx2/sub.rs
+++ b/wingfoil/examples/iceoryx2/sub.rs
@@ -52,10 +52,13 @@ fn main() {
 
     println!("Subscribing to \"{service_name}\" in {mode:?} mode — waiting for publisher...");
 
-    let sub = iceoryx2_sub_opts::<Counter>(service_name, opts);
-    sub.collapse()
+    iceoryx2_sub_opts::<Counter>(service_name, opts)
+        .collapse()
         .inspect(|c: &Counter| println!("received seq={}", c.seq))
         .logged("sub", Info)
-        .run(RunMode::RealTime, RunFor::Forever)
+        .graph()
+        .real_time()
+        .forever()
+        .run()
         .unwrap();
 }

--- a/wingfoil/examples/kafka/main.rs
+++ b/wingfoil/examples/kafka/main.rs
@@ -65,7 +65,12 @@ fn main() -> anyhow::Result<()> {
         })
         .kafka_pub(conn);
 
-    Graph::new(vec![seed, round_trip], RunMode::RealTime, RunFor::Cycles(3)).run()?;
+    Graph::builder()
+        .add(seed)
+        .add(round_trip)
+        .real_time()
+        .cycles(3)
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/kdb/read/main.rs
+++ b/wingfoil/examples/kdb/read/main.rs
@@ -48,10 +48,10 @@ fn main() -> Result<()> {
         None,
     )
     .logged("prices", Info)
-    .run(
-        RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
-        RunFor::Duration(Duration::from_secs(100)),
-    )?;
+    .graph()
+    .historical_from(NanoTime::from_kdb_timestamp(0))
+    .duration(Duration::from_secs(100))
+    .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/kdb/read_cached/main.rs
+++ b/wingfoil/examples/kdb/read_cached/main.rs
@@ -46,10 +46,10 @@ fn run(conn: KdbConnection, config: CacheConfig) -> Result<()> {
         },
     )
     .logged("prices", Info)
-    .run(
-        RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
-        RunFor::Duration(Duration::from_secs(100)),
-    )?;
+    .graph()
+    .historical_from(NanoTime::from_kdb_timestamp(0))
+    .duration(Duration::from_secs(100))
+    .run()?;
     Ok(())
 }
 

--- a/wingfoil/examples/kdb/round_trip/README.md
+++ b/wingfoil/examples/kdb/round_trip/README.md
@@ -101,7 +101,10 @@ fn main() -> Result<()> {
     // Write
     generate(num_rows)
         .kdb_write(conn.clone(), table)
-        .run(run_mode, run_for)?;
+        .graph()
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()?;
     let baseline = generate(num_rows);
     // Read
     let read = kdb_read::<Trade>(
@@ -117,8 +120,11 @@ fn main() -> Result<()> {
         },
     );
     // Validate
-    let check = validate(baseline, read);
-    Graph::new(check, run_mode, run_for).run()?;
+    Graph::builder()
+        .add(validate(baseline, read))
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()?;
     println!("✓ {num_rows} written, read and validated");
     Ok(())
 }

--- a/wingfoil/examples/kdb/round_trip/main.rs
+++ b/wingfoil/examples/kdb/round_trip/main.rs
@@ -103,8 +103,11 @@ fn main() -> Result<()> {
         None,
     );
     // tie-out
-    let check = validate(baseline, read);
-    Graph::new(check, run_mode, run_for).run()?;
+    Graph::builder()
+        .add(validate(baseline, read))
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()?;
     println!("✓ {num_rows} written, read and validated");
     Ok(())
 }

--- a/wingfoil/examples/latency/pub.rs
+++ b/wingfoil/examples/latency/pub.rs
@@ -46,13 +46,14 @@ fn main() {
         b
     });
 
-    let pub_node = iceoryx2_pub(burst_stream, SERVICE_NAME);
-
     println!(
         "Publishing Traced<Quote, QuoteLatency> on \"{SERVICE_NAME}\" every {period:?} \
          — press Ctrl-C to stop"
     );
-    Graph::new(vec![pub_node], RunMode::RealTime, RunFor::Forever)
+    iceoryx2_pub(burst_stream, SERVICE_NAME)
+        .graph()
+        .real_time()
+        .forever()
         .run()
         .unwrap();
 }

--- a/wingfoil/examples/latency/sub.rs
+++ b/wingfoil/examples/latency/sub.rs
@@ -43,5 +43,5 @@ fn main() {
     // LatencyReport sink prints the per-stage delta histogram on shutdown.
     let (sink, _stats) = pipeline.latency_report(true);
 
-    sink.run(RunMode::RealTime, RunFor::Forever).unwrap();
+    sink.graph().real_time().forever().run().unwrap();
 }

--- a/wingfoil/examples/latency_e2e/fix_gw.rs
+++ b/wingfoil/examples/latency_e2e/fix_gw.rs
@@ -333,7 +333,7 @@ fn main() -> anyhow::Result<()> {
     // applies only to the graph cycle thread (this one).
     pin_current_from_env("WINGFOIL_PIN_GRAPH");
 
-    Graph::new(nodes, RunMode::RealTime, RunFor::Forever).run()?;
+    Graph::builder().add(nodes).real_time().forever().run()?;
     Ok(())
 }
 

--- a/wingfoil/examples/latency_e2e/ws_server.rs
+++ b/wingfoil/examples/latency_e2e/ws_server.rs
@@ -327,7 +327,7 @@ fn main() -> anyhow::Result<()> {
     // cycle thread (this one).
     pin_current_from_env("WINGFOIL_PIN_GRAPH");
 
-    Graph::new(nodes, RunMode::RealTime, RunFor::Forever).run()?;
+    Graph::builder().add(nodes).real_time().forever().run()?;
     Ok(())
 }
 

--- a/wingfoil/examples/order_book/README.md
+++ b/wingfoil/examples/order_book/README.md
@@ -48,14 +48,11 @@ let get_time = |msg: &Message| NanoTime::new((msg.seconds * 1e9) as u64);
 let (fills, prices) = csv_read_vec(source_path, get_time, true)
     .map(move |chunk| process_orders(chunk, &book))
     .split();
-let prices_export = prices
-    .filter_none()
-    .distinct()
-    .csv_write(prices_path);
-let fills_export = fills.csv_write_vec(fills_path);
-let run_mode = RunMode::HistoricalFrom(NanoTime::ZERO);
-let run_for = RunFor::Forever;
-Graph::new(vec![prices_export, fills_export], run_mode, run_for)
+Graph::builder()
+    .add(prices.filter_none().distinct().csv_write(prices_path))
+    .add(fills.csv_write_vec(fills_path))
+    .historical()
+    .forever()
     .print()
     .run()
     .unwrap();

--- a/wingfoil/examples/order_book/main.rs
+++ b/wingfoil/examples/order_book/main.rs
@@ -2,8 +2,7 @@
 
 use wingfoil::adapters::csv::*;
 use wingfoil::{
-    Burst, Graph, NanoTime, OptionStreamOperators, RunFor, RunMode, StreamOperators,
-    TupleStreamOperators,
+    Burst, Graph, NanoTime, OptionStreamOperators, StreamOperators, TupleStreamOperators,
 };
 
 use serde::{Deserialize, Serialize};
@@ -31,11 +30,11 @@ pub fn main() {
         .expect("failed to open aapl.csv")
         .map(move |chunk| process_orders(chunk, &book))
         .split();
-    let prices_export = prices.filter_none().distinct().csv_write("prices.csv");
-    let fills_export = fills.csv_write("fills.csv");
-    let run_mode = RunMode::HistoricalFrom(NanoTime::ZERO);
-    let run_for = RunFor::Forever;
-    Graph::new(vec![prices_export, fills_export], run_mode, run_for)
+    Graph::builder()
+        .add(prices.filter_none().distinct().csv_write("prices.csv"))
+        .add(fills.csv_write("fills.csv"))
+        .historical()
+        .forever()
         .print()
         .run()
         .unwrap();

--- a/wingfoil/examples/postgres/README.md
+++ b/wingfoil/examples/postgres/README.md
@@ -68,7 +68,10 @@ fn main() -> Result<()> {
     // ... create the table, then:
     generate(10)
         .postgres_write(conn.clone(), "example_trades")
-        .run(run_mode, run_for)?;
+        .graph()
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()?;
 
     let read = postgres_read::<Trade>(
         conn,

--- a/wingfoil/examples/postgres/main.rs
+++ b/wingfoil/examples/postgres/main.rs
@@ -117,8 +117,11 @@ fn main() -> Result<()> {
     );
 
     // tie-out
-    let check = validate(baseline, read);
-    Graph::new(check, run_mode, run_for).run()?;
+    Graph::builder()
+        .add(validate(baseline, read))
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()?;
     println!("✓ {num_rows} written, read and validated");
     Ok(())
 }

--- a/wingfoil/examples/redis/main.rs
+++ b/wingfoil/examples/redis/main.rs
@@ -54,7 +54,10 @@ fn main() -> anyhow::Result<()> {
                     .collect::<Burst<RedisEntry>>()
             })
             .redis_pub(processor_conn)
-            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+            .graph()
+            .real_time()
+            .duration(Duration::from_secs(2))
+            .run()?;
         Ok(())
     });
 
@@ -70,7 +73,10 @@ fn main() -> anyhow::Result<()> {
                     event.payload_str().unwrap_or("?")
                 );
             })
-            .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+            .graph()
+            .real_time()
+            .duration(Duration::from_secs(2))
+            .run()?;
         Ok(())
     });
 
@@ -88,7 +94,10 @@ fn main() -> anyhow::Result<()> {
         },
     ])
     .redis_pub(conn)
-    .run(RunMode::RealTime, RunFor::Cycles(1))?;
+    .graph()
+    .real_time()
+    .cycles(1)
+    .run()?;
 
     processor.join().expect("processor thread panicked")?;
     verifier.join().expect("verifier thread panicked")?;

--- a/wingfoil/examples/run_mode/README.md
+++ b/wingfoil/examples/run_mode/README.md
@@ -37,7 +37,7 @@ fn run(run_mode: RunMode) {
     // Build the graph — add business logic here.
     let prices = builder.price();
 
-    prices.run(run_mode, RunFor::Cycles(5)).unwrap();
+    prices.graph().run_mode(run_mode).cycles(5).run().unwrap();
     println!("last price: {}", prices.peek_value());
 }
 ```

--- a/wingfoil/examples/run_mode/main.rs
+++ b/wingfoil/examples/run_mode/main.rs
@@ -45,7 +45,7 @@ fn run(run_mode: RunMode) {
     // Build the graph — add business logic here.
     let prices = builder.price();
 
-    prices.run(run_mode, RunFor::Cycles(5)).unwrap();
+    prices.graph().run_mode(run_mode).cycles(5).run().unwrap();
     println!("last price: {}", prices.peek_value());
 }
 

--- a/wingfoil/examples/statistics/README.md
+++ b/wingfoil/examples/statistics/README.md
@@ -55,15 +55,18 @@ fn main() {
     println!();
 
     let trigger = ticker(Duration::from_millis(500));
-    let table = combine(columns).sample(trigger).for_each(|row, time| {
-        print!("{:>5.1}s", f64::from(time) / 1e9);
-        for value in &row {
-            print!(" {value:>7.2}");
-        }
-        println!();
-    });
-
-    Graph::new(vec![table], RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Duration(Duration::from_secs(5)))
+    combine(columns)
+        .sample(trigger)
+        .for_each(|row, time| {
+            print!("{:>5.1}s", f64::from(time) / 1e9);
+            for value in &row {
+                print!(" {value:>7.2}");
+            }
+            println!();
+        })
+        .graph()
+        .historical()
+        .duration(Duration::from_secs(5))
         .run()
         .unwrap();
 }

--- a/wingfoil/examples/statistics/main.rs
+++ b/wingfoil/examples/statistics/main.rs
@@ -47,20 +47,18 @@ fn main() {
     }
     println!();
 
-    let trigger = ticker(Duration::from_millis(500));
-    let table = combine(columns).sample(trigger).for_each(|row, time| {
-        print!("{:>5.1}s", f64::from(time) / 1e9);
-        for value in &row {
-            print!(" {value:>7.2}");
-        }
-        println!();
-    });
-
-    Graph::new(
-        vec![table],
-        RunMode::HistoricalFrom(NanoTime::ZERO),
-        RunFor::Duration(Duration::from_secs(5)),
-    )
-    .run()
-    .unwrap();
+    combine(columns)
+        .sample(ticker(Duration::from_millis(500)))
+        .for_each(|row, time| {
+            print!("{:>5.1}s", f64::from(time) / 1e9);
+            for value in &row {
+                print!(" {value:>7.2}");
+            }
+            println!();
+        })
+        .graph()
+        .historical()
+        .duration(Duration::from_secs(5))
+        .run()
+        .unwrap();
 }

--- a/wingfoil/examples/telemetry/otlp/README.md
+++ b/wingfoil/examples/telemetry/otlp/README.md
@@ -28,10 +28,13 @@ let config = OtlpConfig {
 };
 
 let counter = ticker(Duration::from_secs(1)).count();
-let metric_node = exporter.register("wingfoil_ticks_total", counter.clone());
-let otlp_node = counter.otlp_push("wingfoil_ticks_total", config);
 
-Graph::new(vec![metric_node, otlp_node], RunMode::RealTime, RunFor::Forever).run()?;
+Graph::builder()
+    .add(exporter.register("wingfoil_ticks_total", counter.clone()))
+    .add(counter.otlp_push("wingfoil_ticks_total", config))
+    .real_time()
+    .forever()
+    .run()?;
 ```
 
 ## Output

--- a/wingfoil/examples/telemetry/otlp/main.rs
+++ b/wingfoil/examples/telemetry/otlp/main.rs
@@ -36,16 +36,14 @@ fn main() -> anyhow::Result<()> {
     };
 
     let counter = ticker(Duration::from_secs(1)).count();
-    let metric_node = exporter.register("wingfoil_ticks_total", counter.clone());
-    let otlp_node = counter.otlp_push("wingfoil_ticks_total", config);
 
     println!("Pushing OTLP metrics to {endpoint}");
 
-    Graph::new(
-        vec![metric_node, otlp_node],
-        RunMode::RealTime,
-        RunFor::Forever,
-    )
-    .run()?;
+    Graph::builder()
+        .add(exporter.register("wingfoil_ticks_total", counter.clone()))
+        .add(counter.otlp_push("wingfoil_ticks_total", config))
+        .real_time()
+        .forever()
+        .run()?;
     Ok(())
 }

--- a/wingfoil/examples/telemetry/prometheus/README.md
+++ b/wingfoil/examples/telemetry/prometheus/README.md
@@ -32,9 +32,13 @@ let exporter = PrometheusExporter::new("0.0.0.0:9091");
 let port = exporter.serve()?;
 
 let counter = ticker(Duration::from_secs(1)).count();
-let node = exporter.register("wingfoil_ticks_total", counter);
 
-node.run(RunMode::RealTime, RunFor::Forever)?;
+exporter
+    .register("wingfoil_ticks_total", counter)
+    .graph()
+    .real_time()
+    .forever()
+    .run()?;
 ```
 
 ## Output

--- a/wingfoil/examples/telemetry/prometheus/main.rs
+++ b/wingfoil/examples/telemetry/prometheus/main.rs
@@ -13,10 +13,14 @@ fn main() -> anyhow::Result<()> {
     println!("Prometheus metrics available at http://localhost:{port}/metrics");
 
     let counter = ticker(Duration::from_secs(1)).count();
-    let metric_node = exporter.register("wingfoil_ticks_total", counter.clone());
 
     // ── Run ────────────────────────────────────────────────────────────────
     // For OTLP push support, see the `otlp_metrics` example.
-    Graph::new(vec![metric_node], RunMode::RealTime, RunFor::Forever).run()?;
+    exporter
+        .register("wingfoil_ticks_total", counter)
+        .graph()
+        .real_time()
+        .forever()
+        .run()?;
     Ok(())
 }

--- a/wingfoil/examples/threading/README.md
+++ b/wingfoil/examples/threading/README.md
@@ -50,7 +50,10 @@ fn main() {
         .mapper(map_graph)
         .collapse()
         .logged(&label("main-post"), Info)
-        .run(run_mode, run_for)
+        .graph()
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()
         .unwrap();
 }
 ```

--- a/wingfoil/examples/threading/main.rs
+++ b/wingfoil/examples/threading/main.rs
@@ -30,6 +30,9 @@ fn main() {
         .mapper(map_graph)
         .collapse()
         .logged(&label("main-post"), Info)
-        .run(run_mode, run_for)
+        .graph()
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()
         .unwrap();
 }

--- a/wingfoil/examples/tracing/main.rs
+++ b/wingfoil/examples/tracing/main.rs
@@ -64,8 +64,5 @@ fn main() {
         }
     }
 
-    let stream = build_graph();
-    stream
-        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
-        .unwrap();
+    build_graph().graph().historical().cycles(3).run().unwrap();
 }

--- a/wingfoil/examples/web/README.md
+++ b/wingfoil/examples/web/README.md
@@ -75,11 +75,15 @@ let price_stream = ticker(Duration::from_millis(10))
 
 // Receive UI events from any connected browser.
 let ui_events: Rc<dyn Stream<Burst<UiEvent>>> = web_sub(&server, "ui");
-let ui_log = ui_events
-    .collapse()
-    .for_each(|event, time| println!("{} ui-event: {:?}", time.pretty(), event));
 
-Graph::new(vec![price_stream, ui_log], RunMode::RealTime, RunFor::Forever).run()?;
+Graph::builder()
+    .add(price_stream)
+    .add(ui_events.collapse().for_each(|event, time| {
+        println!("{} ui-event: {:?}", time.pretty(), event)
+    }))
+    .real_time()
+    .forever()
+    .run()?;
 ```
 
 ## Expected output

--- a/wingfoil/examples/web/main.rs
+++ b/wingfoil/examples/web/main.rs
@@ -88,9 +88,6 @@ fn main() -> anyhow::Result<()> {
 
     // Receive browser UI events and log them.
     let ui_events: std::rc::Rc<dyn Stream<Burst<UiEvent>>> = web_sub(&server, "ui");
-    let ui_log = ui_events.collapse().for_each(|event, time| {
-        println!("{} ui-event: {:?}", time.pretty(), event);
-    });
 
     // Real time runs forever (Ctrl-C to stop); historical replays a finite
     // series and then ends, at which point clients receive `Complete`.
@@ -100,7 +97,14 @@ fn main() -> anyhow::Result<()> {
         (RunMode::RealTime, RunFor::Forever)
     };
 
-    Graph::new(vec![price_stream, ui_log], run_mode, run_for).run()?;
+    Graph::builder()
+        .add(price_stream)
+        .add(ui_events.collapse().for_each(|event, time| {
+            println!("{} ui-event: {:?}", time.pretty(), event);
+        }))
+        .run_mode(run_mode)
+        .run_for(run_for)
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/zmq/direct/zmq_pub.rs
+++ b/wingfoil/examples/zmq/direct/zmq_pub.rs
@@ -21,7 +21,10 @@ fn main() -> anyhow::Result<()> {
         .map(|n: u64| format!("{n}").into_bytes())
         .logged("pub", Info)
         .zmq_pub(7779, ())
-        .run(RunMode::RealTime, RunFor::Forever)?;
+        .graph()
+        .real_time()
+        .forever()
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/zmq/direct/zmq_sub.rs
+++ b/wingfoil/examples/zmq/direct/zmq_sub.rs
@@ -23,7 +23,10 @@ fn main() -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     })
     .logged("sub", Info)
-    .run(RunMode::RealTime, RunFor::Forever)?;
+    .graph()
+    .real_time()
+    .forever()
+    .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/zmq/etcd/zmq_pub.rs
+++ b/wingfoil/examples/zmq/etcd/zmq_pub.rs
@@ -34,7 +34,10 @@ fn main() -> anyhow::Result<()> {
                 EtcdRegistry::new("http://127.0.0.1:2379"),
             ),
         )
-        .run(RunMode::RealTime, RunFor::Forever)?;
+        .graph()
+        .real_time()
+        .forever()
+        .run()?;
 
     Ok(())
 }

--- a/wingfoil/examples/zmq/etcd/zmq_sub.rs
+++ b/wingfoil/examples/zmq/etcd/zmq_sub.rs
@@ -33,7 +33,10 @@ fn main() -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     })
     .logged("sub", Info)
-    .run(RunMode::RealTime, RunFor::Forever)?;
+    .graph()
+    .real_time()
+    .forever()
+    .run()?;
 
     Ok(())
 }

--- a/wingfoil/src/adapters/aeron/integration_tests.rs
+++ b/wingfoil/src/adapters/aeron/integration_tests.rs
@@ -13,7 +13,7 @@
 
 use super::*;
 use crate::nodes::{NodeOperators, StreamOperators};
-use crate::{Burst, Graph, RunFor, RunMode};
+use crate::{Burst, Graph};
 use std::time::Duration;
 use testcontainers::{
     GenericImage, ImageExt,
@@ -262,13 +262,13 @@ fn test_aeron_rs_spin_roundtrip() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let values: Vec<i64> = collected
         .peek_value()
@@ -380,13 +380,13 @@ fn test_spin_sub_burst_single_message_roundtrip() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let values: Vec<i64> = collected
         .peek_value()
@@ -438,13 +438,13 @@ fn test_spin_sub_burst_typed_accumulation() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let total: usize = collected.peek_value().iter().map(|b| b.value.len()).sum();
     assert!(
@@ -489,13 +489,13 @@ fn test_threaded_sub_burst_accumulates_across_channel_drain() -> anyhow::Result<
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let values: Vec<i64> = collected
         .peek_value()
@@ -542,13 +542,13 @@ fn test_collapse_yields_latest_value() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(1)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(1))
+        .run()
+        .ok();
 
     let values: Vec<i64> = collected
         .peek_value()
@@ -609,13 +609,13 @@ fn test_burst_parser_sees_fragment_header_with_real_position() -> anyhow::Result
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let observed = captured_position.load(Ordering::SeqCst);
     assert!(
@@ -674,13 +674,14 @@ fn test_status_stream_emits_on_connect() -> anyhow::Result<()> {
     // The subscriber data node must be in the graph: it polls Aeron and records
     // the connection transition into the (shared) status stream. Without it the
     // subscriber never polls and the status stream stays empty.
-    Graph::new(
-        vec![data.as_node(), inspected.as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(data)
+        .add(inspected)
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let observed = observed.borrow();
     assert!(
@@ -730,13 +731,13 @@ fn test_status_stream_no_emission_when_steady() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![inspected.as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(inspected)
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     // Expect at most one transition during the entire run (the initial
     // Disconnected → Connected). Re-emission would manifest as ≥2 entries.
@@ -801,13 +802,14 @@ fn test_threaded_status_stream_emits_on_connect() -> anyhow::Result<()> {
 
     // The subscriber data node demuxes data + status from its background poll
     // thread; without it in the graph the status stream is never driven.
-    Graph::new(
-        vec![data.as_node(), inspected.as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(data)
+        .add(inspected)
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let observed = observed.borrow();
     assert!(
@@ -865,13 +867,13 @@ fn test_publisher_status_emits_back_pressure() -> anyhow::Result<()> {
         }
     });
 
-    Graph::new(
-        vec![inspected.as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(3)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(inspected)
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(3))
+        .run()
+        .ok();
 
     let observed = observed.borrow();
     assert!(
@@ -909,13 +911,13 @@ fn test_publisher_no_dedup_publishes_every_burst_item() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let values: Vec<i64> = collected
         .peek_value()
@@ -964,13 +966,13 @@ fn test_channel_uri_ipc_roundtrip() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let values: Vec<i64> = collected
         .peek_value()
@@ -1021,13 +1023,13 @@ fn test_channel_uri_mdc_roundtrip() -> anyhow::Result<()> {
         });
     let pub_node = source.aeron_pub(pub_, |v: &i64| v.to_le_bytes().to_vec());
 
-    Graph::new(
-        vec![collected.clone().as_node(), pub_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(2)),
-    )
-    .run()
-    .ok();
+    Graph::builder()
+        .add(collected.clone())
+        .add(pub_node)
+        .real_time()
+        .duration(Duration::from_secs(2))
+        .run()
+        .ok();
 
     let values: Vec<i64> = collected
         .peek_value()

--- a/wingfoil/src/adapters/aeron/mod.rs
+++ b/wingfoil/src/adapters/aeron/mod.rs
@@ -82,7 +82,10 @@
 //! )
 //!     .map(|burst| burst.into_iter().sum::<i64>())
 //!     .print()
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -100,7 +103,10 @@
 //!     .count()
 //!     .map(|n: u64| burst![n])
 //!     .aeron_pub(pub_, |v: &u64| v.to_le_bytes().to_vec())
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 
@@ -433,7 +439,7 @@ mod tests {
         use crate::adapters::aeron::buffer::FragmentBuffer;
         use crate::adapters::aeron::error::TransportError;
         use crate::adapters::aeron::transport::MockSubscriber;
-        use crate::{NodeOperators, RunFor, RunMode, StreamOperators};
+        use crate::{NodeOperators, StreamOperators};
         use std::time::Duration;
 
         // The default MockSubscriber is never connected, so the threaded poll
@@ -455,10 +461,10 @@ mod tests {
         let collected = status_stream.collect();
         collected
             .clone()
-            .run(
-                RunMode::RealTime,
-                RunFor::Duration(Duration::from_millis(100)),
-            )
+            .graph()
+            .real_time()
+            .duration(Duration::from_millis(100))
+            .run()
             .unwrap();
         assert!(
             collected

--- a/wingfoil/src/adapters/aeron/pub_node.rs
+++ b/wingfoil/src/adapters/aeron/pub_node.rs
@@ -171,7 +171,10 @@ where
 ///     .count()
 ///     .map(|n: u64| burst![n])
 ///     .aeron_pub(pub_, |v: &u64| v.to_le_bytes().to_vec())
-///     .run(RunMode::RealTime, RunFor::Forever)
+///     .graph()
+///     .real_time()
+///     .forever()
+///     .run()
 ///     .unwrap();
 /// ```
 pub trait AeronPub<T: Element> {
@@ -222,7 +225,7 @@ impl<T: Element> AeronPub<T> for dyn Stream<Burst<T>> {
 mod tests {
     use super::*;
     use crate::adapters::aeron::transport::MockPublisher;
-    use crate::{Graph, IntoStream, NanoTime, RunFor, RunMode};
+    use crate::{Graph, IntoStream};
     use std::cell::RefCell;
 
     fn make_spin_stream(values: Vec<i64>) -> Rc<dyn Stream<Burst<i64>>> {
@@ -360,13 +363,13 @@ mod tests {
             SharedMockPublisher(shared.clone()),
         );
         // Publisher only supports RealTime; use Cycles(2) so it exits quickly.
-        Graph::new(
-            vec![upstream.as_node(), pub_node],
-            RunMode::RealTime,
-            RunFor::Cycles(2),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(upstream)
+            .add(pub_node)
+            .real_time()
+            .cycles(2)
+            .run()
+            .unwrap();
         let values: Vec<i64> = shared
             .borrow()
             .published
@@ -384,12 +387,12 @@ mod tests {
             |v: &i64| v.to_le_bytes().to_vec(),
             MockPublisher::new(),
         );
-        let result = Graph::new(
-            vec![upstream.as_node(), pub_node],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Cycles(1),
-        )
-        .run();
+        let result = Graph::builder()
+            .add(upstream)
+            .add(pub_node)
+            .historical()
+            .cycles(1)
+            .run();
         assert!(result.is_err());
         let msg = format!("{:?}", result.unwrap_err());
         assert!(
@@ -405,13 +408,13 @@ mod tests {
         let pub_node = stream.aeron_pub(SharedMockPublisher(shared.clone()), |v: &i64| {
             v.to_le_bytes().to_vec()
         });
-        Graph::new(
-            vec![stream.as_node(), pub_node],
-            RunMode::RealTime,
-            RunFor::Cycles(1),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(stream)
+            .add(pub_node)
+            .real_time()
+            .cycles(1)
+            .run()
+            .unwrap();
         let values: Vec<i64> = shared
             .borrow()
             .published
@@ -432,13 +435,13 @@ mod tests {
         let pub_node = upstream.aeron_pub(SharedRichPublisher(shared.clone()), |v: &i64| {
             v.to_le_bytes().to_vec()
         });
-        Graph::new(
-            vec![upstream.as_node(), pub_node],
-            RunMode::RealTime,
-            RunFor::Cycles(3),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(upstream)
+            .add(pub_node)
+            .real_time()
+            .cycles(3)
+            .run()
+            .unwrap();
         assert_eq!(
             shared.borrow().offered.len(),
             3,
@@ -454,13 +457,13 @@ mod tests {
             .aeron_pub_with_status(SharedRichPublisher(shared.clone()), |v: &i64| {
                 v.to_le_bytes().to_vec()
             });
-        Graph::new(
-            vec![upstream.as_node(), pub_node],
-            RunMode::RealTime,
-            RunFor::Cycles(1),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(upstream)
+            .add(pub_node)
+            .real_time()
+            .cycles(1)
+            .run()
+            .unwrap();
         assert_eq!(
             status_stream.peek_value().last(),
             Some(&AeronStatus::Connected),
@@ -475,13 +478,13 @@ mod tests {
             .aeron_pub_with_status(SharedRichPublisher(shared.clone()), |v: &i64| {
                 v.to_le_bytes().to_vec()
             });
-        Graph::new(
-            vec![upstream.as_node(), pub_node],
-            RunMode::RealTime,
-            RunFor::Cycles(1),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(upstream)
+            .add(pub_node)
+            .real_time()
+            .cycles(1)
+            .run()
+            .unwrap();
         assert_eq!(
             status_stream.peek_value().last(),
             Some(&AeronStatus::BackPressured),
@@ -496,13 +499,13 @@ mod tests {
             .aeron_pub_with_status(SharedRichPublisher(shared.clone()), |v: &i64| {
                 v.to_le_bytes().to_vec()
             });
-        Graph::new(
-            vec![upstream.as_node(), pub_node],
-            RunMode::RealTime,
-            RunFor::Cycles(1),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(upstream)
+            .add(pub_node)
+            .real_time()
+            .cycles(1)
+            .run()
+            .unwrap();
         assert_eq!(
             status_stream.peek_value().last(),
             Some(&AeronStatus::Closed),
@@ -519,13 +522,13 @@ mod tests {
             .aeron_pub_with_status(SharedRichPublisher(shared.clone()), |v: &i64| {
                 v.to_le_bytes().to_vec()
             });
-        Graph::new(
-            vec![upstream.as_node(), pub_node],
-            RunMode::RealTime,
-            RunFor::Cycles(2),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(upstream)
+            .add(pub_node)
+            .real_time()
+            .cycles(2)
+            .run()
+            .unwrap();
         // After cycle 1 the transition Disconnected→Connected emitted; the
         // status burst held one element. After cycle 2 the producer cleared
         // the burst at cycle start and the re-recorded Connected was

--- a/wingfoil/src/adapters/augurs/mod.rs
+++ b/wingfoil/src/adapters/augurs/mod.rs
@@ -47,7 +47,10 @@
 //!     .map(|n| n as f64 + (n as f64 * 0.3).sin())
 //!     .augurs_forecast(AugursForecastConfig::new(64, 5).with_level(0.95))
 //!     .for_each(|f, _| println!("next 5: {:?}", f.point))
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //!
 //! // Seasonal data: fit MSTL with a period-24 season instead of plain ETS.
@@ -67,7 +70,10 @@
 //! some_stream_of_readings // Rc<dyn Stream<Vec<f64>>>
 //!     .augurs_outlier(AugursOutlierConfig::mad(32, 0.5))
 //!     .for_each(|o, _| println!("outlying series: {:?}", o.outlying))
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 

--- a/wingfoil/src/adapters/csv/mod.rs
+++ b/wingfoil/src/adapters/csv/mod.rs
@@ -24,7 +24,10 @@
 //!     .unwrap()
 //!     .collapse()
 //!     .for_each(|row, _| println!("{:?}", row))
-//!     .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+//!     .graph()
+//!     .historical()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -37,7 +40,10 @@
 //! csv_read("input.csv", get_time, true)
 //!     .unwrap()
 //!     .csv_write("output.csv")
-//!     .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)
+//!     .graph()
+//!     .historical()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 

--- a/wingfoil/src/adapters/etcd/mod.rs
+++ b/wingfoil/src/adapters/etcd/mod.rs
@@ -92,7 +92,10 @@
 //!     .for_each(|event, _| {
 //!         println!("{:?} {} = {:?}", event.kind, event.entry.key, event.entry.value_str())
 //!     })
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -113,7 +116,10 @@
 //!     EtcdEntry { key: "/config/port".into(), value: b"8080".to_vec() },
 //! ])
 //! .etcd_pub(conn, None, true)
-//! .run(RunMode::RealTime, RunFor::Cycles(1))
+//! .graph()
+//! .real_time()
+//! .cycles(1)
+//! .run()
 //! .unwrap();
 //! ```
 //!
@@ -133,7 +139,10 @@
 //! ticker(Duration::from_secs(10))
 //!     .map(|_| burst![EtcdEntry { key: "/heartbeat".into(), value: b"ok".to_vec() }])
 //!     .etcd_pub(conn, Some(Duration::from_secs(30)), true)
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -168,7 +177,13 @@
 //!     })
 //!     .etcd_pub(conn, None, true);
 //!
-//! Graph::new(vec![seed, round_trip], RunMode::RealTime, RunFor::Cycles(3)).run().unwrap();
+//! Graph::builder()
+//!     .add(seed)
+//!     .add(round_trip)
+//!     .real_time()
+//!     .cycles(3)
+//!     .run()
+//!     .unwrap();
 //! ```
 
 mod read;

--- a/wingfoil/src/adapters/fix/integration_tests.rs
+++ b/wingfoil/src/adapters/fix/integration_tests.rs
@@ -8,7 +8,7 @@
 //       -- lmax --nocapture --test-threads=1
 
 use super::*;
-use crate::{Graph, RunFor, RunMode, StreamOperators, constant};
+use crate::{Graph, StreamOperators, constant};
 use std::time::Duration;
 
 const LMAX_MD_HOST: &str = "fix-marketdata.london-demo.lmax.com";
@@ -48,12 +48,11 @@ fn lmax_logon() -> anyhow::Result<()> {
         Ok(())
     });
 
-    Graph::new(
-        vec![status_node],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(10)),
-    )
-    .run()
+    Graph::builder()
+        .add(status_node)
+        .real_time()
+        .duration(Duration::from_secs(10))
+        .run()
 }
 
 /// Verify we can subscribe to AVAX/USD market data and receive at least one snapshot
@@ -99,10 +98,11 @@ fn lmax_market_data() -> anyhow::Result<()> {
         Ok(())
     });
 
-    Graph::new(
-        vec![data_node, status_node, sub],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_secs(20)),
-    )
-    .run()
+    Graph::builder()
+        .add(data_node)
+        .add(status_node)
+        .add(sub)
+        .real_time()
+        .duration(Duration::from_secs(20))
+        .run()
 }

--- a/wingfoil/src/adapters/fix/mod.rs
+++ b/wingfoil/src/adapters/fix/mod.rs
@@ -297,10 +297,14 @@ impl FixConnection {
     /// ```ignore
     /// let fix = fix_connect_tls(host, port, sender, target, Some(&pw));
     /// let sub = fix.fix_sub(constant(vec!["4001".into(), "4002".into()]));
-    /// Graph::new(
-    ///     vec![fix.data.as_node(), fix.status.as_node(), sub],
-    ///     RunMode::RealTime, RunFor::Duration(Duration::from_secs(60)),
-    /// ).run().unwrap();
+    /// Graph::builder()
+    ///     .add(fix.data)
+    ///     .add(fix.status)
+    ///     .add(sub)
+    ///     .real_time()
+    ///     .duration(Duration::from_secs(60))
+    ///     .run()
+    ///     .unwrap();
     /// ```
     pub fn fix_sub(&self, symbols: Rc<dyn Stream<Vec<String>>>) -> Rc<dyn Node> {
         FixSubNode {
@@ -1778,12 +1782,12 @@ mod tests {
         // test load — the Error status usually arrives within tens of ms
         // but the background thread may be starved when 250+ tests run
         // concurrently.
-        let _result = Graph::new(
-            vec![data.as_node(), status_collected.clone().as_node()],
-            RunMode::RealTime,
-            RunFor::Duration(Duration::from_secs(5)),
-        )
-        .run();
+        let _result = Graph::builder()
+            .add(data)
+            .add(status_collected.clone())
+            .real_time()
+            .duration(Duration::from_secs(5))
+            .run();
         // The graph should complete without panicking. The status stream should
         // contain an Error event from the failed connection attempt.
         let statuses: Vec<FixSessionStatus> = status_collected
@@ -1837,13 +1841,13 @@ mod tests {
 
         let (data, status) = fix_connect("127.0.0.1", port, "INIT", "ACC", FixPollMode::Threaded);
         let status_collected = status.collect();
-        Graph::new(
-            vec![data.as_node(), status_collected.clone().as_node()],
-            RunMode::RealTime,
-            RunFor::Duration(Duration::from_secs(3)),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(data)
+            .add(status_collected.clone())
+            .real_time()
+            .duration(Duration::from_secs(3))
+            .run()
+            .unwrap();
 
         stop.store(true, Ordering::Relaxed);
         server.join().unwrap();
@@ -1900,13 +1904,15 @@ mod tests {
             Ok(())
         });
 
-        Graph::new(
-            vec![acc_data.as_node(), acc_node, init_data.as_node(), init_node],
-            RunMode::RealTime,
-            run_for,
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(acc_data)
+            .add(acc_node)
+            .add(init_data)
+            .add(init_node)
+            .real_time()
+            .run_for(run_for)
+            .run()
+            .unwrap();
     }
 
     #[test]
@@ -1942,13 +1948,15 @@ mod tests {
             Ok(())
         });
 
-        Graph::new(
-            vec![acc_data.as_node(), acc_node, init_data.as_node(), init_node],
-            RunMode::RealTime,
-            run_for,
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(acc_data)
+            .add(acc_node)
+            .add(init_data)
+            .add(init_node)
+            .real_time()
+            .run_for(run_for)
+            .run()
+            .unwrap();
     }
 
     /// Fills the inject channel to capacity with no draining receiver and

--- a/wingfoil/src/adapters/fluvio/mod.rs
+++ b/wingfoil/src/adapters/fluvio/mod.rs
@@ -40,7 +40,10 @@
 //!     .for_each(|event, _| {
 //!         println!("offset={} value={:?}", event.offset, event.value_str())
 //!     })
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -60,7 +63,10 @@
 //!     FluvioRecord::new(b"world".to_vec()),
 //! ])
 //! .fluvio_pub(conn, "my-topic")
-//! .run(RunMode::RealTime, RunFor::Cycles(1))
+//! .graph()
+//! .real_time()
+//! .cycles(1)
+//! .run()
 //! .unwrap();
 //! ```
 //!

--- a/wingfoil/src/adapters/iceoryx2/integration_tests.rs
+++ b/wingfoil/src/adapters/iceoryx2/integration_tests.rs
@@ -19,7 +19,7 @@
 use super::*;
 use crate::nodes::{NodeOperators, StreamOperators};
 use crate::types::{Burst, IntoNode};
-use crate::{Graph, RunFor, RunMode, ticker};
+use crate::{Graph, ticker};
 use iceoryx2::port::update_connections::UpdateConnections;
 use iceoryx2::prelude::ZeroCopySend;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -103,12 +103,12 @@ fn test_late_joiner_with_history() -> anyhow::Result<()> {
     }
     .into_node();
 
-    Graph::new(
-        vec![publisher_update, collected.clone().as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(300)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(publisher_update)
+        .add(collected.clone())
+        .real_time()
+        .duration(Duration::from_millis(300))
+        .run()?;
 
     let values = collected.peek_value();
     assert_eq!(values.len(), 3, "expected 3 samples from history");
@@ -132,12 +132,12 @@ fn test_ipc_round_trip() -> anyhow::Result<()> {
     });
     let pub_node = iceoryx2_pub(upstream, &service_name);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(200)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .duration(Duration::from_millis(200))
+        .run()?;
 
     let values = collected.peek_value();
     assert!(!values.is_empty());

--- a/wingfoil/src/adapters/iceoryx2/local_tests.rs
+++ b/wingfoil/src/adapters/iceoryx2/local_tests.rs
@@ -11,7 +11,7 @@ use super::*;
 use crate::latency::*;
 use crate::nodes::{NodeOperators, StreamOperators};
 use crate::types::Burst;
-use crate::{Graph, RunFor, RunMode, latency_stages, ticker};
+use crate::{Graph, RunFor, latency_stages, ticker};
 use iceoryx2::prelude::ZeroCopySend;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -47,12 +47,12 @@ fn test_local_spin_round_trip() -> anyhow::Result<()> {
     });
     let pub_node = iceoryx2_pub_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(100)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .duration(Duration::from_millis(100))
+        .run()?;
 
     let values = collected.peek_value();
     assert!(!values.is_empty(), "expected to receive samples");
@@ -79,13 +79,15 @@ fn test_local_threaded_round_trip() -> anyhow::Result<()> {
     });
     let pub_node = iceoryx2_pub_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        // Background threads + connection establishment can be slow on loaded CI runners.
-        RunFor::Duration(Duration::from_millis(500)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .run_for(
+            // Background threads + connection establishment can be slow on loaded CI runners.
+            RunFor::Duration(Duration::from_millis(500)),
+        )
+        .run()?;
 
     // Threaded mode might take a cycle or two to deliver
     let values = collected.peek_value();
@@ -116,13 +118,15 @@ fn test_local_signaled_round_trip() -> anyhow::Result<()> {
     });
     let pub_node = iceoryx2_pub_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        // Signaled mode depends on the Event service and can require a few retries on startup.
-        RunFor::Duration(Duration::from_millis(500)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .run_for(
+            // Signaled mode depends on the Event service and can require a few retries on startup.
+            RunFor::Duration(Duration::from_millis(500)),
+        )
+        .run()?;
 
     let values = collected.peek_value();
     assert!(
@@ -164,12 +168,12 @@ fn test_local_service_config_mismatch_fails() {
     );
 
     let collected = sub.collapse().collect();
-    let res = Graph::new(
-        vec![pub_node, collected.as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(100)),
-    )
-    .run();
+    let res = Graph::builder()
+        .add(pub_node)
+        .add(collected)
+        .real_time()
+        .duration(Duration::from_millis(100))
+        .run();
 
     assert!(res.is_err(), "expected mismatch to fail");
     let err = res.unwrap_err();
@@ -224,12 +228,12 @@ fn test_local_slice_spin_round_trip() -> anyhow::Result<()> {
     });
     let pub_node = iceoryx2_pub_slice_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(150)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .duration(Duration::from_millis(150))
+        .run()?;
 
     let values: Vec<Vec<u8>> = collected
         .peek_value()
@@ -260,12 +264,12 @@ fn test_local_slice_threaded_round_trip() -> anyhow::Result<()> {
     });
     let pub_node = iceoryx2_pub_slice_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(500)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .duration(Duration::from_millis(500))
+        .run()?;
 
     let values: Vec<Vec<u8>> = collected
         .peek_value()
@@ -299,12 +303,12 @@ fn test_local_slice_signaled_round_trip() -> anyhow::Result<()> {
     });
     let pub_node = iceoryx2_pub_slice_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(500)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .duration(Duration::from_millis(500))
+        .run()?;
 
     let values: Vec<Vec<u8>> = collected
         .peek_value()
@@ -369,12 +373,12 @@ fn test_local_latency_round_trip() -> anyhow::Result<()> {
         });
     let pub_node = iceoryx2_pub_with(upstream, &service_name, Iceoryx2ServiceVariant::Local);
 
-    Graph::new(
-        vec![pub_node, collected.clone().as_node()],
-        RunMode::RealTime,
-        RunFor::Duration(Duration::from_millis(150)),
-    )
-    .run()?;
+    Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .real_time()
+        .duration(Duration::from_millis(150))
+        .run()?;
 
     let values = collected.peek_value();
     assert!(!values.is_empty(), "expected to receive at least one quote");

--- a/wingfoil/src/adapters/iceoryx2/mod.rs
+++ b/wingfoil/src/adapters/iceoryx2/mod.rs
@@ -299,7 +299,7 @@ mod integration_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Burst, Graph, RunFor, RunMode};
+    use crate::{Burst, Graph};
     use iceoryx2::prelude::ZeroCopySend;
 
     #[test]
@@ -323,7 +323,7 @@ mod tests {
         let invalid_name = "";
         let sub = iceoryx2_sub::<TestData>(invalid_name);
 
-        let graph_res = Graph::new(vec![sub.as_node()], RunMode::RealTime, RunFor::Cycles(1)).run();
+        let graph_res = Graph::builder().add(sub).real_time().cycles(1).run();
         assert!(graph_res.is_err(), "expected invalid service name to error");
     }
 

--- a/wingfoil/src/adapters/kafka/mod.rs
+++ b/wingfoil/src/adapters/kafka/mod.rs
@@ -35,7 +35,10 @@
 //!     .for_each(|event, _| {
 //!         println!("{}: {:?}", event.topic, event.value_str())
 //!     })
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -54,7 +57,10 @@
 //!     KafkaRecord { topic: "my-topic".into(), key: Some(b"key1".to_vec()), value: b"hello".to_vec() },
 //! ])
 //! .kafka_pub(conn)
-//! .run(RunMode::RealTime, RunFor::Cycles(1))
+//! .graph()
+//! .real_time()
+//! .cycles(1)
+//! .run()
 //! .unwrap();
 //! ```
 //!
@@ -86,7 +92,13 @@
 //!     })
 //!     .kafka_pub(conn);
 //!
-//! Graph::new(vec![seed, round_trip], RunMode::RealTime, RunFor::Cycles(3)).run().unwrap();
+//! Graph::builder()
+//!     .add(seed)
+//!     .add(round_trip)
+//!     .real_time()
+//!     .cycles(3)
+//!     .run()
+//!     .unwrap();
 //! ```
 
 mod read;

--- a/wingfoil/src/adapters/kdb/mod.rs
+++ b/wingfoil/src/adapters/kdb/mod.rs
@@ -52,10 +52,10 @@
 //!             println!("{}", trade.price);
 //!         }
 //!     })
-//!     .run(
-//!         RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
-//!         RunFor::Duration(std::time::Duration::from_secs(86400)),
-//!     )
+//!     .graph()
+//!     .historical_from(NanoTime::from_kdb_timestamp(0))
+//!     .duration(std::time::Duration::from_secs(86400))
+//!     .run()
 //!     .unwrap();
 //! ```
 

--- a/wingfoil/src/adapters/kdb/write.rs
+++ b/wingfoil/src/adapters/kdb/write.rs
@@ -79,7 +79,10 @@ pub trait KdbSerialize: Sized {
 /// #       panic!("example code");
 ///     // Time from graph tuples will be prepended when writing to KDB
 ///     kdb_write(conn, "trades", &trades)
-///         .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(10)))
+///         .graph()
+///         .real_time()
+///         .duration(Duration::from_secs(10))
+///         .run()
 ///         .unwrap();
 /// }
 /// ```

--- a/wingfoil/src/adapters/postgres/mod.rs
+++ b/wingfoil/src/adapters/postgres/mod.rs
@@ -52,10 +52,10 @@
 //! })
 //!     .collapse()
 //!     .print()
-//!     .run(
-//!         RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)),
-//!         RunFor::Duration(std::time::Duration::from_secs(86400)),
-//!     )
+//!     .graph()
+//!     .historical_from(NanoTime::from_kdb_timestamp(0))
+//!     .duration(std::time::Duration::from_secs(86400))
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -82,7 +82,10 @@
 //!     )
 //! })
 //!     .print() // prints each burst; several rows can arrive per real-time cycle
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -112,7 +115,10 @@
 //! let conn = PostgresConnection::new("host=localhost user=postgres password=postgres dbname=postgres");
 //! constant(burst![Trade { sym: "AAPL".into(), price: 1.0, qty: 1 }])
 //!     .postgres_write(conn, "trades")
-//!     .run(RunMode::HistoricalFrom(NanoTime::from_kdb_timestamp(0)), RunFor::Cycles(1))
+//!     .graph()
+//!     .historical_from(NanoTime::from_kdb_timestamp(0))
+//!     .cycles(1)
+//!     .run()
 //!     .unwrap();
 //! ```
 

--- a/wingfoil/src/adapters/prometheus/integration_tests.rs
+++ b/wingfoil/src/adapters/prometheus/integration_tests.rs
@@ -71,7 +71,11 @@ fn multiple_metrics_all_appear_in_scrape() {
     let node_a = exporter.register("multi_counter_a", counter);
     let node_b = exporter.register("multi_counter_b", doubled);
 
-    Graph::new(vec![node_a, node_b], RunMode::RealTime, RunFor::Cycles(3))
+    Graph::builder()
+        .add(node_a)
+        .add(node_b)
+        .real_time()
+        .cycles(3)
         .run()
         .unwrap();
 

--- a/wingfoil/src/adapters/prometheus/mod.rs
+++ b/wingfoil/src/adapters/prometheus/mod.rs
@@ -14,7 +14,7 @@
 //! let counter = ticker(Duration::from_secs(1)).count();
 //! let node = exporter.register("wingfoil_counter_total", counter.clone());
 //!
-//! node.run(RunMode::RealTime, RunFor::Forever).unwrap();
+//! node.graph().real_time().forever().run().unwrap();
 //! ```
 //!
 //! For push-based metrics export see the `otlp` adapter.

--- a/wingfoil/src/adapters/redis/mod.rs
+++ b/wingfoil/src/adapters/redis/mod.rs
@@ -41,7 +41,10 @@
 //!     .for_each(|event, _| {
 //!         println!("{}: {:?}", event.channel, event.payload_str())
 //!     })
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -60,7 +63,10 @@
 //!     RedisEntry { channel: "prices".into(), payload: b"42".to_vec() },
 //! ])
 //! .redis_pub(conn)
-//! .run(RunMode::RealTime, RunFor::Cycles(1))
+//! .graph()
+//! .real_time()
+//! .cycles(1)
+//! .run()
 //! .unwrap();
 //! ```
 //!
@@ -79,14 +85,20 @@
 //! // Append an entry.
 //! constant(burst![RedisStreamRecord::single("events", "kind", b"login".to_vec())])
 //!     .redis_stream_write(conn.clone())
-//!     .run(RunMode::RealTime, RunFor::Cycles(1))
+//!     .graph()
+//!     .real_time()
+//!     .cycles(1)
+//!     .run()
 //!     .unwrap();
 //!
 //! // Replay history, then tail live entries.
 //! redis_stream_read(conn, "events")
 //!     .collapse()
 //!     .for_each(|event, _| println!("{} {:?}", event.id, event.fields))
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!

--- a/wingfoil/src/adapters/web/integration_tests.rs
+++ b/wingfoil/src/adapters/web/integration_tests.rs
@@ -449,11 +449,12 @@ fn test_historical_web_sub_does_not_block() -> anyhow::Result<()> {
 
     // If `web_sub` blocked on its listener this would hang; a bounded
     // `RunFor` plus a wall-clock guard turns a regression into a failure.
-    let mut graph = crate::Graph::new(
-        vec![pub_node, collected.clone()],
-        RunMode::HistoricalFrom(NanoTime::ZERO),
-        RunFor::Cycles(20),
-    );
+    let mut graph = crate::Graph::builder()
+        .add(pub_node)
+        .add(collected.clone())
+        .historical()
+        .cycles(20)
+        .build();
     let start = Instant::now();
     graph.run()?;
     assert!(

--- a/wingfoil/src/adapters/web/mod.rs
+++ b/wingfoil/src/adapters/web/mod.rs
@@ -31,7 +31,10 @@
 //! ticker(Duration::from_millis(10))
 //!     .count()
 //!     .web_pub(&server, "tick")
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! ```
 //!
@@ -43,7 +46,7 @@
 //!
 //! let server = WebServer::bind("127.0.0.1:0").start().unwrap();
 //! let clicks: std::rc::Rc<dyn Stream<Burst<u32>>> = web_sub(&server, "ui_events");
-//! clicks.collapse().print().run(RunMode::RealTime, RunFor::Forever).unwrap();
+//! clicks.collapse().print().graph().real_time().forever().run().unwrap();
 //! ```
 //!
 //! # Serving a static UI bundle

--- a/wingfoil/src/adapters/zmq/integration_tests.rs
+++ b/wingfoil/src/adapters/zmq/integration_tests.rs
@@ -70,14 +70,15 @@ fn zmq_same_thread() {
     let port = 5556;
     let address = format!("tcp://127.0.0.1:{port}");
     let run_for = RunFor::Duration(period * 10);
-    Graph::new(
-        vec![sender(period, port), receiver(&address)],
-        RunMode::RealTime,
-        run_for,
-    )
-    .print()
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(sender(period, port))
+        .add(receiver(&address))
+        .real_time()
+        .run_for(run_for)
+        .build()
+        .print()
+        .run()
+        .unwrap();
 }
 
 #[test]
@@ -143,13 +144,13 @@ fn zmq_first_message_not_dropped() {
         assert_eq!(values[0], 1, "first message dropped: got {}", values[0]);
         Ok(())
     });
-    Graph::new(
-        vec![sender_with_delay(period, port), recv_node],
-        RunMode::RealTime,
-        run_for,
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(sender_with_delay(period, port))
+        .add(recv_node)
+        .real_time()
+        .run_for(run_for)
+        .run()
+        .unwrap();
 }
 
 #[test]
@@ -173,13 +174,13 @@ fn zmq_first_message_not_dropped_no_delay() {
     // Uses sender() with NO delay — publisher sends immediately after bind.
     // Verifies the publisher's buffering mechanism prevents the ZMQ slow-joiner
     // problem even without an artificial startup delay.
-    Graph::new(
-        vec![sender(period, port), recv_node],
-        RunMode::RealTime,
-        run_for,
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(sender(period, port))
+        .add(recv_node)
+        .real_time()
+        .run_for(run_for)
+        .run()
+        .unwrap();
 }
 
 #[test]
@@ -203,13 +204,14 @@ fn zmq_reports_connected_status() {
         );
         Ok(())
     });
-    Graph::new(
-        vec![sender(period, port), data_node, status_node],
-        RunMode::RealTime,
-        run_for,
-    )
-    .run()
-    .unwrap();
+    Graph::builder()
+        .add(sender(period, port))
+        .add(data_node)
+        .add(status_node)
+        .real_time()
+        .run_for(run_for)
+        .run()
+        .unwrap();
 }
 
 #[test]

--- a/wingfoil/src/adapters/zmq/mod.rs
+++ b/wingfoil/src/adapters/zmq/mod.rs
@@ -28,7 +28,10 @@
 //! ticker(Duration::from_millis(100))
 //!     .count()
 //!     .zmq_pub(5556, ())
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //!
 //! // Subscriber — direct address
@@ -36,7 +39,10 @@
 //! data.for_each(|burst, _| {
 //!     for msg in burst { println!("{msg:?}"); }
 //! })
-//! .run(RunMode::RealTime, RunFor::Forever)
+//! .graph()
+//! .real_time()
+//! .forever()
+//! .run()
 //! .unwrap();
 //! # Ok::<(), anyhow::Error>(())
 //! ```
@@ -53,14 +59,20 @@
 //!     ticker(Duration::from_millis(100))
 //!         .count()
 //!         .zmq_pub(5556, ("quotes", EtcdRegistry::new("http://etcd:2379")))
-//!         .run(RunMode::RealTime, RunFor::Forever)
+//!         .graph()
+//!         .real_time()
+//!         .forever()
+//!         .run()
 //!         .unwrap();
 //! });
 //!
 //! // Subscriber looks up the publisher address from etcd.
 //! let (data, _status) = zmq_sub::<u64>(("quotes", EtcdRegistry::new("http://etcd:2379")))?;
 //! data.for_each(|burst, _| println!("{burst:?}"))
-//!     .run(RunMode::RealTime, RunFor::Forever)
+//!     .graph()
+//!     .real_time()
+//!     .forever()
+//!     .run()
 //!     .unwrap();
 //! # Ok::<(), anyhow::Error>(())
 //! ```

--- a/wingfoil/src/bencher.rs
+++ b/wingfoil/src/bencher.rs
@@ -1,6 +1,4 @@
-use crate::{
-    Graph, GraphState, IntoNode, MutableNode, Node, NodeOperators, RunFor, RunMode, UpStreams,
-};
+use crate::{GraphState, IntoNode, MutableNode, Node, NodeOperators, RunMode, UpStreams};
 
 use criterion::Criterion;
 use derive_new::new;
@@ -78,7 +76,7 @@ impl Bencher {
             let node = builder(trigger).produce(move || {
                 signal_for_end.store(Signal::End.into(), Ordering::SeqCst);
             });
-            if let Err(e) = Graph::new(vec![node], run_mode, RunFor::Forever).run() {
+            if let Err(e) = node.graph().run_mode(run_mode).forever().run() {
                 log::error!("bencher worker thread terminated: {e:#}");
                 // Wake the bencher loop so step() doesn't spin forever.
                 signal.store(Signal::End.into(), Ordering::SeqCst);

--- a/wingfoil/src/graph.rs
+++ b/wingfoil/src/graph.rs
@@ -1,5 +1,5 @@
 use crate::queue::TimeQueue;
-use crate::types::{NanoTime, Node};
+use crate::types::{AsUpstreamNodes, NanoTime, Node};
 use by_address::ByThinAddress;
 
 use crossbeam::channel::{Receiver, SendError, Sender, select};
@@ -81,8 +81,11 @@ impl WiringFrame {
 }
 
 /// Whether the [Graph] should run RealTime or Historical mode.
-#[derive(Clone, Copy, Debug, PartialEq)]
+///
+/// Defaults to [`RunMode::RealTime`], the production deployment mode.
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum RunMode {
+    #[default]
     RealTime,
     HistoricalFrom(NanoTime),
 }
@@ -98,10 +101,13 @@ impl RunMode {
 
 /// Defines how long the graph should run for.  Can be a
 /// Duration, number of cycles or forever.
-#[derive(Clone, Copy, Debug)]
+///
+/// Defaults to [`RunFor::Forever`].
+#[derive(Clone, Copy, Debug, Default)]
 pub enum RunFor {
     Duration(Duration),
     Cycles(u32),
+    #[default]
     Forever,
 }
 
@@ -490,18 +496,194 @@ impl GraphState {
     }
 }
 
+/// Fluent builder for a [`Graph`].
+///
+/// Lets a graph be wired, configured and executed as a single expression,
+/// rather than collecting root nodes into a `Vec` up front:
+///
+/// ```
+/// # use wingfoil::*;
+/// # use std::time::Duration;
+/// Graph::builder()
+///     .add(ticker(Duration::from_millis(10)).count().print())
+///     .historical()
+///     .cycles(3)
+///     .run()
+///     .unwrap();
+/// ```
+///
+/// [`add`](GraphBuilder::add) takes anything that can be viewed as root nodes —
+/// an `Rc<dyn Node>`, an `Rc<dyn Stream<T>>`, or a `Vec` of either — and can be
+/// called repeatedly to attach several roots:
+///
+/// ```
+/// # use wingfoil::*;
+/// # use std::time::Duration;
+/// let prices = ticker(Duration::from_millis(10)).count();
+/// Graph::builder()
+///     .add(prices.map(|p| p * 2).print())
+///     .add(prices.map(|p| p + 1).print())
+///     .historical()
+///     .cycles(3)
+///     .run()
+///     .unwrap();
+/// ```
+///
+/// The run mode defaults to [`RunMode::RealTime`] and the duration to
+/// [`RunFor::Forever`], so a production graph need only name its roots.
+#[derive(Default)]
+pub struct GraphBuilder {
+    root_nodes: Vec<Rc<dyn Node>>,
+    run_mode: RunMode,
+    run_for: RunFor,
+    start_time: Option<NanoTime>,
+    print: bool,
+    #[cfg(feature = "async")]
+    tokio_runtime: Option<Arc<tokio::runtime::Runtime>>,
+}
+
+impl GraphBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attaches root nodes to the graph.  Accepts an `Rc<dyn Node>`, an
+    /// `Rc<dyn Stream<T>>` or a `Vec` of either, and may be called repeatedly.
+    // `add` is the natural builder verb here; the `should_implement_trait` lint's
+    // suggestion (`std::ops::Add`) makes no sense for accumulating graph roots.
+    #[allow(clippy::should_implement_trait)]
+    #[must_use]
+    pub fn add(mut self, roots: impl AsUpstreamNodes) -> Self {
+        self.root_nodes.extend(roots.as_upstream_nodes());
+        self
+    }
+
+    /// Sets the [RunMode].  See also [`real_time`](Self::real_time),
+    /// [`historical`](Self::historical) and
+    /// [`historical_from`](Self::historical_from).
+    #[must_use]
+    pub fn run_mode(mut self, run_mode: RunMode) -> Self {
+        self.run_mode = run_mode;
+        self
+    }
+
+    /// Runs against the wall clock — [`RunMode::RealTime`].  This is the default.
+    #[must_use]
+    pub fn real_time(self) -> Self {
+        self.run_mode(RunMode::RealTime)
+    }
+
+    /// Replays from [`NanoTime::ZERO`] — [`RunMode::HistoricalFrom`].
+    #[must_use]
+    pub fn historical(self) -> Self {
+        self.historical_from(NanoTime::ZERO)
+    }
+
+    /// Replays from `start_time` — [`RunMode::HistoricalFrom`].
+    #[must_use]
+    pub fn historical_from(self, start_time: NanoTime) -> Self {
+        self.run_mode(RunMode::HistoricalFrom(start_time))
+    }
+
+    /// Sets the [RunFor].  See also [`cycles`](Self::cycles),
+    /// [`duration`](Self::duration) and [`forever`](Self::forever).
+    #[must_use]
+    pub fn run_for(mut self, run_for: RunFor) -> Self {
+        self.run_for = run_for;
+        self
+    }
+
+    /// Stops after `cycles` engine cycles — [`RunFor::Cycles`].
+    #[must_use]
+    pub fn cycles(self, cycles: u32) -> Self {
+        self.run_for(RunFor::Cycles(cycles))
+    }
+
+    /// Stops after `duration` of engine time — [`RunFor::Duration`].
+    #[must_use]
+    pub fn duration(self, duration: Duration) -> Self {
+        self.run_for(RunFor::Duration(duration))
+    }
+
+    /// Never stops — [`RunFor::Forever`].  This is the default.
+    #[must_use]
+    pub fn forever(self) -> Self {
+        self.run_for(RunFor::Forever)
+    }
+
+    /// Overrides the engine start time.  Defaults to
+    /// [`RunMode::start_time`], i.e. the wall clock in
+    /// [`RunMode::RealTime`] and the replay start in
+    /// [`RunMode::HistoricalFrom`].
+    #[must_use]
+    pub fn start_time(mut self, start_time: NanoTime) -> Self {
+        self.start_time = Some(start_time);
+        self
+    }
+
+    /// Supplies the tokio runtime used by async nodes.  Defaults to a runtime
+    /// created on demand by the graph.
+    #[cfg(feature = "async")]
+    #[must_use]
+    pub fn tokio_runtime(mut self, tokio_runtime: Arc<tokio::runtime::Runtime>) -> Self {
+        self.tokio_runtime = Some(tokio_runtime);
+        self
+    }
+
+    /// Prints the wired graph — see [`Graph::print`] — once it has been built.
+    /// A debugging aid that keeps [`Graph::print`] reachable from a chain.
+    #[must_use]
+    pub fn print(mut self) -> Self {
+        self.print = true;
+        self
+    }
+
+    /// Wires the graph, ready to [`Graph::run`].  Use [`run`](Self::run) unless
+    /// you need to hold on to the [Graph] itself.
+    #[must_use]
+    pub fn build(self) -> Graph {
+        let start_time = self
+            .start_time
+            .unwrap_or_else(|| self.run_mode.start_time());
+        let state = GraphState::new(self.run_mode, self.run_for, start_time);
+        #[cfg(feature = "async")]
+        if let Some(tokio_runtime) = self.tokio_runtime {
+            state.run_time.set(tokio_runtime).ok();
+        }
+        let mut graph = Graph { state };
+        graph.initialise(self.root_nodes);
+        if self.print {
+            graph.print();
+        }
+        graph
+    }
+
+    /// Wires and executes the graph — [`build`](Self::build) then
+    /// [`Graph::run`].
+    pub fn run(self) -> anyhow::Result<()> {
+        self.build().run()
+    }
+}
+
 /// Engine for co-ordinating execution of [Node]s
 pub struct Graph {
     pub(crate) state: GraphState,
 }
 
 impl Graph {
+    /// Returns a fluent [GraphBuilder].
+    #[must_use]
+    pub fn builder() -> GraphBuilder {
+        GraphBuilder::new()
+    }
+
     pub fn new(root_nodes: Vec<Rc<dyn Node>>, run_mode: RunMode, run_for: RunFor) -> Graph {
-        let start_time = run_mode.start_time();
-        let state = GraphState::new(run_mode, run_for, start_time);
-        let mut graph = Graph { state };
-        graph.initialise(root_nodes);
-        graph
+        Graph::builder()
+            .add(root_nodes)
+            .run_mode(run_mode)
+            .run_for(run_for)
+            .build()
     }
 
     #[cfg(feature = "async")]
@@ -512,11 +694,13 @@ impl Graph {
         run_for: RunFor,
         start_time: NanoTime,
     ) -> Graph {
-        let state = GraphState::new(run_mode, run_for, start_time);
-        state.run_time.set(tokio_runtime).ok();
-        let mut graph = Graph { state };
-        graph.initialise(root_nodes);
-        graph
+        Graph::builder()
+            .add(root_nodes)
+            .tokio_runtime(tokio_runtime)
+            .run_mode(run_mode)
+            .run_for(run_for)
+            .start_time(start_time)
+            .build()
     }
 
     pub(crate) fn setup_nodes(&mut self) -> anyhow::Result<()> {
@@ -1218,6 +1402,96 @@ mod tests {
     use std::cell::RefCell;
 
     use itertools::Itertools;
+
+    // ── GraphBuilder ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn builder_defaults_to_realtime_forever() {
+        let builder = Graph::builder();
+        assert_eq!(builder.run_mode, RunMode::RealTime);
+        assert!(matches!(builder.run_for, RunFor::Forever));
+    }
+
+    #[test]
+    fn builder_run_mode_shorthands() {
+        assert_eq!(Graph::builder().real_time().run_mode, RunMode::RealTime);
+        assert_eq!(
+            Graph::builder().historical().run_mode,
+            RunMode::HistoricalFrom(NanoTime::ZERO)
+        );
+        assert_eq!(
+            Graph::builder().historical_from(NanoTime::new(7)).run_mode,
+            RunMode::HistoricalFrom(NanoTime::new(7))
+        );
+    }
+
+    #[test]
+    fn builder_run_for_shorthands() {
+        assert!(matches!(
+            Graph::builder().cycles(4).run_for,
+            RunFor::Cycles(4)
+        ));
+        assert!(matches!(
+            Graph::builder().duration(Duration::from_secs(2)).run_for,
+            RunFor::Duration(d) if d == Duration::from_secs(2)
+        ));
+        assert!(matches!(
+            Graph::builder().cycles(4).forever().run_for,
+            RunFor::Forever
+        ));
+    }
+
+    #[test]
+    fn builder_add_accepts_nodes_streams_and_vecs() {
+        let count = ticker(Duration::from_secs(1)).count();
+        let graph = Graph::builder()
+            // Rc<dyn Stream<T>>
+            .add(count.clone())
+            // Rc<dyn Node>
+            .add(count.clone().as_node())
+            // Vec<Rc<dyn Node>>
+            .add(vec![ticker(Duration::from_secs(2))])
+            .historical()
+            .cycles(1)
+            .build();
+        // Two distinct tickers, `count` (constant + sample + reduce) — every
+        // root and its upstreams get wired exactly once.
+        assert!(graph.state.nodes.len() > 2);
+    }
+
+    #[test]
+    fn builder_runs_the_same_graph_as_graph_new() {
+        let via_builder = ticker(Duration::from_secs(1))
+            .count()
+            .graph()
+            .historical()
+            .cycles(3)
+            .build();
+        let via_new = Graph::new(
+            vec![ticker(Duration::from_secs(1)).count().as_node()],
+            RunMode::HistoricalFrom(NanoTime::ZERO),
+            RunFor::Cycles(3),
+        );
+        assert_eq!(via_builder.state.nodes.len(), via_new.state.nodes.len());
+    }
+
+    #[test]
+    fn builder_run_executes_the_graph() {
+        let count = ticker(Duration::from_secs(1)).count();
+        count.graph().historical().cycles(3).run().unwrap();
+        assert_eq!(3, count.peek_value());
+    }
+
+    #[test]
+    fn builder_start_time_overrides_run_mode_start() {
+        let graph = Graph::builder()
+            .add(ticker(Duration::from_secs(1)))
+            .historical_from(NanoTime::new(10))
+            .start_time(NanoTime::new(99))
+            .cycles(1)
+            .build();
+        assert_eq!(NanoTime::new(99), graph.state.start_time());
+    }
 
     // ── RunFor::done ─────────────────────────────────────────────────────────
 

--- a/wingfoil/src/lib.rs
+++ b/wingfoil/src/lib.rs
@@ -25,10 +25,10 @@
 //!         .map(|i| format!("{:} is even", i));
 //!     merge(vec![odds, evens])
 //!         .print()
-//!         .run(
-//!             RunMode::HistoricalFrom(NanoTime::ZERO),
-//!             RunFor::Duration(period * 5),
-//!         );
+//!         .graph()
+//!         .historical()
+//!         .duration(period * 5)
+//!         .run();
 //! }
 //! ```
 //! This output is produced:  
@@ -69,7 +69,10 @@
 //!         ticker(Duration::from_secs(1))
 //!             .count()
 //!             .logged("tick", Info)
-//!             .run(run_mode, RunFor::Cycles(3));
+//!             .graph()
+//!             .run_mode(run_mode)
+//!             .cycles(3)
+//!             .run();
 //!     }
 //! }
 //! ```
@@ -162,7 +165,10 @@
 //! ticker(Duration::from_secs(1))
 //!     .count()
 //!     .logged("tick", Info)  // emits a tracing event per tick when feature = "tracing"
-//!     .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+//!     .graph()
+//!     .historical()
+//!     .cycles(3)
+//!     .run()
 //!     .unwrap();
 //! ```
 //!

--- a/wingfoil/src/nodes/delay.rs
+++ b/wingfoil/src/nodes/delay.rs
@@ -76,14 +76,12 @@ mod tests {
         let captured_delayed = delayed.collect();
         let run_mode = RunMode::HistoricalFrom(NanoTime::ZERO);
         let run_for = RunFor::Cycles(6);
-        let mut graph = Graph::new(
-            vec![
-                captured_source.clone().as_node(),
-                captured_delayed.clone().as_node(),
-            ],
-            run_mode,
-            run_for,
-        );
+        let mut graph = Graph::builder()
+            .add(captured_source.clone())
+            .add(captured_delayed.clone())
+            .run_mode(run_mode)
+            .run_for(run_for)
+            .build();
         let expected_source = vec![
             ValueAt {
                 value: 1,

--- a/wingfoil/src/nodes/demux.rs
+++ b/wingfoil/src/nodes/demux.rs
@@ -639,7 +639,12 @@ mod tests {
             let muxed = combine(streams);
             let (demuxed, overflow) = muxed.demux_it_with_map(map, parse_message);
             let (results, nodes) = build_results(demuxed, overflow, with_overflow);
-            Graph::new(nodes, *run_mode, *RUN_FOR).run().unwrap();
+            Graph::builder()
+                .add(nodes)
+                .run_mode(*run_mode)
+                .run_for(*RUN_FOR)
+                .run()
+                .unwrap();
             let parse_topic = |msgs: &Burst<Message>| {
                 assert!(msgs.len() == 1);
                 msgs[0].topic
@@ -658,7 +663,12 @@ mod tests {
             let muxed = merge(streams);
             let (demuxed, overflow) = muxed.demux(capacity, parse_message);
             let (results, nodes) = build_results(demuxed, overflow, with_overflow);
-            Graph::new(nodes, *run_mode, *RUN_FOR).run().unwrap();
+            Graph::builder()
+                .add(nodes)
+                .run_mode(*run_mode)
+                .run_for(*RUN_FOR)
+                .run()
+                .unwrap();
             validate_results(results, |msg| msg.topic);
         }
     }

--- a/wingfoil/src/nodes/feedback.rs
+++ b/wingfoil/src/nodes/feedback.rs
@@ -153,13 +153,13 @@ mod tests {
             Ok(())
         });
 
-        Graph::new(
-            vec![fb.as_node(), res],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Duration(period * 5),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(fb)
+            .add(res)
+            .historical()
+            .duration(period * 5)
+            .run()
+            .unwrap();
     }
 
     #[test]
@@ -183,13 +183,13 @@ mod tests {
             Ok(())
         });
 
-        Graph::new(
-            vec![fb.as_node(), res],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Cycles(5),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(fb)
+            .add(res)
+            .historical()
+            .cycles(5)
+            .run()
+            .unwrap();
     }
     #[test]
     fn feedback_works() {
@@ -220,13 +220,13 @@ mod tests {
             Ok(())
         });
 
-        Graph::new(
-            vec![trigger, res],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Duration(period * 14),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(trigger)
+            .add(res)
+            .historical()
+            .duration(period * 14)
+            .run()
+            .unwrap();
     }
 
     #[test]

--- a/wingfoil/src/nodes/graph_node.rs
+++ b/wingfoil/src/nodes/graph_node.rs
@@ -83,9 +83,14 @@ where
                 let run_mode = graph_state.run_mode();
                 let task = move || {
                     let node = func().send(sender, None);
-                    let mut graph =
-                        Graph::new_with(vec![node], tokio_runtime, run_mode, run_for, start_time);
-                    if let Err(e) = graph.run() {
+                    let result = Graph::builder()
+                        .add(node)
+                        .tokio_runtime(tokio_runtime)
+                        .run_mode(run_mode)
+                        .run_for(run_for)
+                        .start_time(start_time)
+                        .run();
+                    if let Err(e) = result {
                         log::error!("graph producer worker thread terminated: {e:#}");
                     }
                 };
@@ -232,9 +237,14 @@ where
                 let task = move || {
                     let src = ChannelReceiverStream::new(receiver_in, None, tx_notif).into_stream();
                     let node = func(src.clone()).send(sender_out, Some(src.as_node()));
-                    let mut graph =
-                        Graph::new_with(vec![node], tokio_runtime, run_mode, run_for, start_time);
-                    if let Err(e) = graph.run() {
+                    let result = Graph::builder()
+                        .add(node)
+                        .tokio_runtime(tokio_runtime)
+                        .run_mode(run_mode)
+                        .run_for(run_for)
+                        .start_time(start_time)
+                        .run();
+                    if let Err(e) = result {
                         log::error!("graph map worker thread terminated: {e:#}");
                     }
                 };

--- a/wingfoil/src/nodes/mod.rs
+++ b/wingfoil/src/nodes/mod.rs
@@ -268,6 +268,22 @@ pub trait NodeOperators {
     /// ```
     fn run(self: &Rc<Self>, run_mode: RunMode, run_to: RunFor) -> anyhow::Result<()>;
     fn into_graph(self: &Rc<Self>, run_mode: RunMode, run_for: RunFor) -> Graph;
+
+    /// Returns a [GraphBuilder] rooted at this node, so a chain can be
+    /// configured and executed without breaking out of the chain.
+    /// ```
+    /// # use wingfoil::*;
+    /// # use std::time::Duration;
+    /// ticker(Duration::from_millis(1))
+    ///     .count()
+    ///     .graph()
+    ///     .historical()
+    ///     .cycles(3)
+    ///     .run()
+    ///     .unwrap();
+    /// ```
+    #[must_use]
+    fn graph(self: &Rc<Self>) -> GraphBuilder;
 }
 
 impl NodeOperators for dyn Node {
@@ -289,10 +305,13 @@ impl NodeOperators for dyn Node {
         ProducerStream::new(self.clone(), Box::new(func)).into_stream()
     }
     fn run(self: &Rc<Self>, run_mode: RunMode, run_for: RunFor) -> anyhow::Result<()> {
-        Graph::new(vec![self.clone()], run_mode, run_for).run()
+        self.graph().run_mode(run_mode).run_for(run_for).run()
     }
     fn into_graph(self: &Rc<Self>, run_mode: RunMode, run_for: RunFor) -> Graph {
-        Graph::new(vec![self.clone()], run_mode, run_for)
+        self.graph().run_mode(run_mode).run_for(run_for).build()
+    }
+    fn graph(self: &Rc<Self>) -> GraphBuilder {
+        Graph::builder().add(self.clone())
     }
 }
 
@@ -317,6 +336,9 @@ impl<T> NodeOperators for dyn Stream<T> {
     }
     fn into_graph(self: &Rc<Self>, run_mode: RunMode, run_for: RunFor) -> Graph {
         self.clone().as_node().into_graph(run_mode, run_for)
+    }
+    fn graph(self: &Rc<Self>) -> GraphBuilder {
+        self.clone().as_node().graph()
     }
 }
 
@@ -1035,13 +1057,12 @@ mod tests {
         let overflow_node = overflow.stream().for_each(|_, _| {});
         let mut nodes: Vec<Rc<dyn Node>> = collected.iter().map(|c| c.clone().as_node()).collect();
         nodes.push(overflow_node);
-        Graph::new(
-            nodes,
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Forever,
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(nodes)
+            .historical()
+            .forever()
+            .run()
+            .unwrap();
     }
 
     #[test]
@@ -1111,13 +1132,13 @@ mod tests {
         let (a, b) = stream.split();
         let ca = a.collect();
         let cb2 = b.collect();
-        Graph::new(
-            vec![ca.clone().as_node(), cb2.clone().as_node()],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Forever,
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(ca.clone())
+            .add(cb2.clone())
+            .historical()
+            .forever()
+            .run()
+            .unwrap();
         assert_eq!(ca.peek_value()[0].value, 10u64);
         assert_eq!(cb2.peek_value()[0].value, 20u64);
     }

--- a/wingfoil/src/nodes/node_flow.rs
+++ b/wingfoil/src/nodes/node_flow.rs
@@ -307,12 +307,12 @@ mod tests {
             Ok(())
         });
 
-        Graph::new(
-            vec![fb, res],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Duration(period * 2),
-        )
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(fb)
+            .add(res)
+            .historical()
+            .duration(period * 2)
+            .run()
+            .unwrap();
     }
 }

--- a/wingfoil/src/nodes/sample.rs
+++ b/wingfoil/src/nodes/sample.rs
@@ -39,13 +39,13 @@ mod tests {
             .logged("a", log::Level::Info)
             .sample(ticker2)
             .logged("b", log::Level::Info);
-        Graph::new(
-            vec![node.as_node()],
-            RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Duration(Duration::from_millis(1000)),
-        )
-        .print()
-        .run()
-        .unwrap();
+        Graph::builder()
+            .add(node)
+            .historical()
+            .duration(Duration::from_millis(1000))
+            .build()
+            .print()
+            .run()
+            .unwrap();
     }
 }


### PR DESCRIPTION
Graphs previously had to be collected into a `Vec` of roots and passed
positionally to `Graph::new(roots, run_mode, run_for)`, which broke the
fluent chain that the rest of the API encourages.

Add `GraphBuilder`, reachable two ways:

- `Graph::builder()` — for graphs with several roots
- `NodeOperators::graph()` — continues an existing stream/node chain

Both support named run-mode and duration shorthands (`real_time`,
`historical`, `historical_from`, `cycles`, `duration`, `forever`, plus
`run_mode`/`run_for` for held values), `start_time`, `tokio_runtime`,
`print`, and terminate in `run()` or `build()`. `add()` accepts an
`Rc<dyn Node>`, an `Rc<dyn Stream<T>>`, or a `Vec` of either via
`AsUpstreamNodes`, so a graph now reads as a single expression:

    Graph::builder()
        .add(prices.csv_write("prices.csv"))
        .add(fills.csv_write("fills.csv"))
        .historical()
        .forever()
        .run()?;

`RunMode` and `RunFor` gain `Default` impls (`RealTime` / `Forever`) to
back the builder's defaults. `Graph::new` and `Graph::new_with` remain,
now as thin wrappers over the builder, and `run(mode, for)` is unchanged.

Converted every `Graph::new` call site outside the graph engine's own
unit tests — examples, benches, adapters, node tests, the Python
bindings — plus the rustdoc, README and adapter docs that mirror them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YECdFysgsNJduRei5urTHt