### PR TITLE
docs: the four the cutover owes (cutover-plan 4.1–4.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,10 @@ crates/                     # every Cargo crate in the tree
   wingfoil-wasm/            # Browser-side WASM codec (excluded from the default
                             #   workspace) — survives cutover
 
-docs/                       # port-plan.md (the port roadmap), cutover-plan.md,
-                            #   design reviews and decisions
+docs/                       # wingfoil-next-architecture.md (read this first),
+                            #   migration.md (#[node] -> Op), port-plan.md
+                            #   (the port roadmap), cutover-plan.md,
+                            #   deviation-register.md, design decisions
 
 js/                         # TypeScript client for the web adapter — an npm
                             #   package, not a crate (@wingfoil/client).
@@ -52,6 +54,14 @@ legacy/                     # The legacy MutableNode engine — deleted at cutov
 scripts/                    # Dev helpers (setup-dev.sh, ci-logs.sh, disk.sh,
                             #   bench-report.sh)
 ```
+
+## Start here
+
+New to the engine? Read
+[`docs/wingfoil-next-architecture.md`](docs/wingfoil-next-architecture.md)
+before your first non-trivial change — the shape of the thing, the one
+decision everything else follows from, and the rules that bite. Porting code
+off the legacy engine is [`docs/migration.md`](docs/migration.md).
 
 ## The one design objective that governs everything
 

--- a/crates/wingfoil-next/src/lib.rs
+++ b/crates/wingfoil-next/src/lib.rs
@@ -1,42 +1,52 @@
-//! **Design prototype**: what wingfoil's core abstractions look like if
-//! designed from scratch to support dual execution — interpreted *and*
-//! compiled — from one definition of node semantics.
+//! A Rust stream-processing library: build a directed acyclic graph of data
+//! transformations once, then run it against live data or replay it over
+//! history with identical semantics.
 //!
-//! The retrofit on the main crate (`wingfoil::codegen`) hit three walls, all
-//! caused by `MutableNode` fusing three concerns into one object:
+//! ```
+//! use std::time::Duration;
+//! use wingfoil_next::prelude::*;
+//! use wingfoil_next::{NanoTime, RunFor, RunMode};
 //!
-//! 1. **Semantics trapped in objects** — `cycle(&mut self, &mut GraphState)`
-//!    couples the computation to its storage (fields behind `RefCell`) and
-//!    its feeding (peeking upstream `Rc<dyn Stream>`s), so compiled runners
-//!    had to *re-implement* node semantics as emitted source.
-//! 2. **Types and closures erased at wiring time** — codegen had to
-//!    reverse-engineer types from name strings and could never recover
-//!    closures (hence the `Inputs` re-supply and its drift risk).
-//! 3. **Activation invisible** — nothing declared "this node schedules
-//!    callbacks", forcing name-based allowlists.
+//! let g = GraphBuilder::new();
+//! let count = g.ticker(Duration::from_millis(10)).count();
+//! let is_even = count.map(|n: &u64| n.is_multiple_of(2));
+//! let total = count.filter(&is_even).fold(0u64, |acc, v| *acc += v);
 //!
-//! This crate inverts all three:
+//! let mut runner = g.build();
+//! runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(10)).unwrap();
+//! assert_eq!(runner.value(&total), 2 + 4 + 6 + 8 + 10);
+//! ```
 //!
-//! - [`Op`](op::Op) defines node semantics as a pure, monomorphizable
-//!   associated function over **external** state and **typed inputs passed
-//!   in** by the engine, with a `const ACTIVATION` declaration.
-//! - [`interp::Builder`] is the interpreted engine: it owns the value slots
-//!   and the state, adapts each `Op` behind one dyn boundary, and drives the
-//!   shared [`Kernel`](runtime::kernel::Kernel). [`fluent`] layers the
-//!   legacy chaining style (`ticker(d).count().map(f)`) on top — wiring
-//!   sugar only, identical execution.
-//! - A compiled runner is a plain function with state in locals that calls
-//!   **the same `Op::cycle` functions**, monomorphized — see
-//!   `tests/compiled_parity.rs` for the hand-expanded odds/evens graph. (In
-//!   the full design this expansion is produced by a `nitro!` proc macro so
-//!   wiring is written once; the macro is mechanical once this shape works.)
+//! Swap `RunMode::HistoricalFrom` for `RunMode::RealTime` and the same graph
+//! runs against the wall clock — that is the point of the two run modes.
 //!
-//! The load-bearing property demonstrated here: **both engines execute the
-//! identical semantics code**. There is no duplicated cycle logic anywhere —
-//! not per-kind emitter strings, not `cycle_inline` twins — so the engines
-//! cannot drift.
+//! # The idea: node semantics as a function, not an object
 //!
-//! Built out from that prototype, and what each module now holds:
+//! An [`Op`](op::Op) defines what a node *does* as a pure associated
+//! function — `cycle(cfg, state, input, ctx)` — over engine-owned state and
+//! typed inputs the engine passes in, with a `const ACTIVATION` declaring how
+//! it is scheduled. Nothing about a node's computation is tied to how its
+//! storage is allocated or how its inputs are fetched.
+//!
+//! That separation is what lets **one** definition drive several execution
+//! strategies, and it is the property the whole design is arranged around:
+//!
+//! - the **interpreted** engine ([`interp::Builder`]) owns the value slots and
+//!   the state, adapts each `Op` behind a single dyn boundary, and drives the
+//!   [`Kernel`];
+//! - a **compiled** runner is a plain function with node state in local
+//!   variables, calling the same `Op::cycle` functions monomorphized, with
+//!   tick propagation as `bool`s the optimiser can see through;
+//! - a **nested island** packs a whole sub-graph into one node of an
+//!   interpreted graph, running that same compiled code inside it.
+//!
+//! Every one of those executes the *identical* semantics code. There is no
+//! duplicated cycle logic anywhere — no per-kind emitter strings, no
+//! `cycle_inline` twins — so the strategies cannot drift from each other.
+//! [`nitro!`](macro@nitro) is the front door: one wiring function in, all
+//! three out.
+//!
+//! # The tour
 //!
 //! - **[`nitro!`](macro@nitro)** — one wiring function, three execution paths
 //!   from the same tokens: `interpreted()`, fully-monomorphized `compiled()`,
@@ -52,14 +62,19 @@
 //!   `Op` impl generates the interpreted `Builder` method *and* the `nitro!`
 //!   forwarder functions every compiled/nested emission dispatches through,
 //!   both derived from the op's declared shape — there is no per-op table in
-//!   the macro, so built-in and user ops take the identical path — see
-//!   `docs/port-plan.md` "Adding an op".
+//!   the macro, so built-in and user ops take the identical path.
 //! - **Sources in every activation mode**: `Activation::THREADED`
 //!   [`external`](fluent::SourceOps::external), busy-spin `Activation::ALWAYS`
 //!   [`poll`](fluent::SourceOps::poll), the both-modes
 //!   [`channel`](fluent::SourceOps::channel), and
 //!   [`feedback`](fluent::SourceOps::feedback) edges. All
 //!   non-coalescing: same-instant values ride one [`Burst`], never latest-wins.
+//! - **[`adapters`]** — the I/O surface (CSV, Kafka, ZeroMQ, KDB+, Redis,
+//!   Postgres, etcd, FIX, web, Aeron, iceoryx2, Fluvio, augurs, Prometheus,
+//!   OTLP), each behind its own feature and kept out of the prelude — opt in
+//!   with `use wingfoil_next::adapters::<name>::…`.
+//! - **[`latency`]** — stamp wall-clock timestamps onto messages as they hop
+//!   through ops and across processes, then aggregate per-stage deltas.
 //! - **[`channel`]** — the `Message` envelope and senders; **`async_source`**
 //!   (the `async` feature) wraps it as `produce_async`, an async producer of
 //!   timestamped values that replays deterministically in historical mode.
@@ -68,12 +83,15 @@
 //!   `start`/`cycle`/`stop`/`teardown` error with node context and still runs
 //!   cleanup. **[`compat`]** offers a legacy-style `Signal` facade over it.
 //!
+//! For how the pieces fit together, and why, see
+//! `docs/wingfoil-next-architecture.md`.
+//!
 //! # Tracing and instrumentation
 //!
-//! The engine can emit `tracing` spans around its own execution, ported
-//! feature-for-feature from legacy wingfoil. Every span site is behind its own
-//! feature, and the `tracing` dependency itself is optional, so a default build
-//! carries neither the dependency nor a single span:
+//! The engine can emit `tracing` spans around its own execution. Every span
+//! site is behind its own feature, and the `tracing` dependency itself is
+//! optional, so a default build carries neither the dependency nor a single
+//! span:
 //!
 //! | feature | what it adds |
 //! |---|---|
@@ -81,7 +99,7 @@
 //! | `instrument-run` | A span around [`Runner::run`](interp::Runner::run) (and `run_dynamic`, under `dynamic-graph`) — the whole start→cycles→stop→teardown lifecycle. |
 //! | `instrument-cycle` | A span around each engine cycle (one per dirty-node batch). |
 //! | `instrument-apply-nodes` | A span around each lifecycle phase (start / stop / teardown) applied over all nodes, recording the phase in `desc`. |
-//! | `instrument-initialise` | A span around graph initialisation ([`Builder::build`](interp::Builder::build)), named `initialise` after legacy's. |
+//! | `instrument-initialise` | A span around graph initialisation ([`Builder::build`](interp::Builder::build)). |
 //! | `instrument-cycle-node` | A span per node execution, recording the node index and label. High frequency — opt in deliberately. |
 //! | `instrument-default` | `instrument-run` + `instrument-cycle` + `instrument-apply-nodes` + `instrument-initialise`. |
 //! | `instrument-all` | `instrument-default` plus `instrument-cycle-node`. |
@@ -93,10 +111,14 @@
 //! [`StreamOps::logged`](fluent::StreamOps::logged) for the per-value debug tap
 //! (which emits through the `log` crate, independently of these features).
 //!
-//! Still out of scope for the prototype (documented, not forgotten):
-//! variadic-input ops (merge/join are fixed at two inputs), an arena/SoA value
-//! store and topologically-ordered dirty-list scheduling for the interpreted engine
-//! (see `docs/port-plan.md` "Phase 4.5"), and dynamic (runtime-mutated) graphs.
+//! # Known limits
+//!
+//! Documented, not forgotten: `merge`/`join` are fixed at two inputs on the
+//! compiled path (the interpreted side has variadic `merge_n`); the
+//! interpreted value store is per-node slots rather than an arena/SoA, and its
+//! dirty list is drained rather than topologically ordered; and `compiled()`
+//! is a closed box — static topology, outputs only, no I/O or live inputs, by
+//! design. See `docs/port-plan.md` "Deferred / post-v1 work".
 
 // Lets this crate refer to itself as `wingfoil_next`, so the paths that
 // `nitro!`-generated code emits (`::wingfoil_next::...`) resolve when the

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,183 @@
+# Migrating Rust code from the legacy engine
+
+Wingfoil's engine was rewritten. This page is the complete list of what
+changes for Rust callers, and why. The Python half is
+[`crates/wingfoil-next-python/docs/migration.rst`](../crates/wingfoil-next-python/docs/migration.rst)
+— it stands on its own; this page does not repeat it.
+
+> **Status: the facade question is not yet ratified.** This guide is written on
+> the assumption recorded as cutover-plan row **1.4** — that the new engine
+> replaces the old one outright, with **no compatibility facade** over the
+> `MutableNode` API. That matches what the Python binding already committed to.
+> If 1.4 lands the other way, the "what breaks" sections below narrow; nothing
+> else here changes.
+
+## The shape of the change
+
+The old engine fused three concerns into one object. A node was its
+computation *and* its storage (`RefCell` fields) *and* its input plumbing
+(peeking upstream `Rc<dyn Stream>`s). The new engine separates them: an `Op`
+says only what a node *computes*, and the engine owns the rest.
+
+That is a real break, not a rename. In exchange, one definition of a node's
+semantics now drives the interpreted engine, a fully-monomorphized compiled
+runner, and compiled islands nested inside interpreted graphs — with no
+duplicated cycle logic to drift. See
+[`wingfoil-next-architecture.md`](wingfoil-next-architecture.md).
+
+Everything the legacy tree could do, the new engine can do. The **one**
+exception is listed under [What is gone](#what-is-gone).
+
+## Writing a node: `#[node]` → `Op`
+
+Before — state in fields, inputs peeked from stored upstreams:
+
+```rust
+#[node(active = [upstream], output = value: f64)]
+impl MutableNode for ScaleStream {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.value = self.upstream.peek_value() * self.factor;
+        Ok(true)
+    }
+}
+```
+
+After — config, state and inputs are parameters; the return says what to do:
+
+```rust
+pub struct Scale;
+
+#[op(build = scale, fluent)]
+impl Op for Scale {
+    type Cfg = f64;              // construction-time config
+    type State = ();             // engine-owned mutable state
+    type In<'a> = (&'a f64,);    // typed inputs, passed in per cycle
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(cfg: &mut f64, _state: &mut (), input: (&f64,), _ctx: &mut Ctx<'_>)
+        -> Result<Tick<f64>>
+    {
+        Ok(Tick::Value(input.0 * *cfg))
+    }
+}
+```
+
+The mapping, item by item:
+
+| Legacy | Now | Note |
+|---|---|---|
+| `&mut self` fields for scratch state | `type State` | Engine-owned; `Default`-seeded unless the op declares otherwise |
+| `&mut self` fields for config | `type Cfg` | Closures live here |
+| `self.upstream.peek_value()` | `input.0` | Typed and passed in; no stored upstream handles |
+| `#[node(active = [a, b])]` | `type In<'a> = (&'a A, &'a B)` | Position is the edge order |
+| `#[node(passive = [x])]` | `#[op(build = …, passive = [0])]` | A bitmask; positions index `In` |
+| `Ok(true)` / `Ok(false)` | `Tick::Value(v)` / `Tick::Quiet` | **Plus `Tick::Silent(v)` — see below** |
+| no declaration | `const ACTIVATION` | Scheduling is declared, not inferred from names |
+| `fn setup/start/stop` | `fn start/stop/teardown` on `Op` | All return `anyhow::Result` |
+
+### `Tick` has three states, not two
+
+`Ok(true)`/`Ok(false)` could not express "update my value but do not tick
+downstream" — the thing `delay` needs. That is `Tick::Silent(v)`. If you ported
+a node mechanically to `Value`/`Quiet` and its downstream now fires when it
+should not, `Silent` is what you want.
+
+### Ops are generic; there is no per-op table
+
+`#[op(build = name)]` generates the interpreted builder method **and** the
+`nitro!` forwarders the compiled paths dispatch through, both derived from the
+declared shape. Your op and a built-in op take the identical path. If you are
+looking for a match arm to register a node in, there isn't one — that is the
+design, not an omission.
+
+An op generic over a type nothing in `Cfg`/`In`/`Out` mentions (a marker, a
+unit, a latency stage) declares it `#[op(build = name, explicit = S)]` and is
+called `.name::<S>()`.
+
+## Wiring: the graph is explicit
+
+Legacy sources were free functions returning `Rc<dyn Stream<T>>`, with the
+graph assembled implicitly from whatever you passed to `run`. Now you hold a
+`GraphBuilder` and build sources **on** it:
+
+```rust
+// before
+let count = ticker(Duration::from_millis(10)).count();
+count.run(RunMode::RealTime, RunFor::Cycles(100))?;
+
+// after
+let g = GraphBuilder::new();
+let count = g.ticker(Duration::from_millis(10)).count();
+let mut runner = g.build();
+runner.run(RunMode::RealTime, RunFor::Cycles(100))?;
+```
+
+| Legacy | Now |
+|---|---|
+| `ticker(d)`, `constant(v)` — free fns | `g.ticker(d)`, `g.constant(v)` — on the builder |
+| `Rc<dyn Stream<T>>` | `Stream<T>` (a cheap handle, `Clone`) |
+| `node.peek_value()` | `runner.value(&handle)` |
+| `node.run(mode, for)` | `g.build()` then `runner.run(mode, for)` |
+| operator traits (`StreamOperators`) | extension traits (`StreamOps`, `SourceOps`) |
+
+`RunMode`, `RunFor` and `NanoTime` are **unchanged** — literally the same
+types, since both engines share one runtime core.
+
+### Adapters: one trait method, not a free-fn/operator pair
+
+Legacy exposed most adapters twice — a free function *and* an operator-trait
+method. Now sinks are extension-trait methods on `Stream<T>` and sources are
+free functions taking `&GraphBuilder` first:
+
+```rust
+use wingfoil_next::adapters::zmq::{ZeroMqPub, zmq_sub};
+
+let (data, status) = zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, "tcp://host:5556")?;
+let sink = stream.zmq_pub(5556, ());
+```
+
+Adapters stay **out of the prelude** — opt in per adapter with
+`use wingfoil_next::adapters::<name>::…;`.
+
+Two behavioural differences worth knowing before you port an I/O graph:
+
+- **Connections are established at `start()`, not at wiring.** Wiring is pure,
+  so a connection error now surfaces during the run (with node context) rather
+  than during graph construction.
+- **Live sources reject `RunMode::HistoricalFrom` at wiring.** A historical run
+  block-collects its input up front, so an unbounded live tail would deadlock
+  at `start`. You get an error naming the bounded reader instead of a hang.
+
+The full list of behavioural deltas, adapter by adapter, is
+[`deviation-register.md`](deviation-register.md).
+
+## Errors
+
+Every lifecycle function returns `anyhow::Result`. Propagate with `?` and add
+`.context("…")` at I/O boundaries. A producer thread pushes an error into the
+graph with `sender.send_error(e)`, which aborts the run with context.
+
+Production code does not call `.unwrap()`; use `.expect("invariant: WHY")` only
+where a precondition makes the branch unreachable.
+
+## What is gone
+
+**`Graph::export`** — the GML topology dump. It is the only public legacy API
+with no replacement, and the drop is deliberate (cutover-plan row **2.1**,
+register **C6**): we want a designed introspection and visualisation story
+rather than a same-shape port of a debug-only helper. Nothing in the engine
+blocks reintroducing it — the builder holds the full topology plus debug
+labels — so if you depend on it, say so and it can come back as part of that
+work.
+
+If you find anything else the legacy tree did that the new engine cannot, that
+is a bug in the port, not an intended break — please report it.
+
+## Interoperating during the transition
+
+You do not have to move every process at once. The **ZeroMQ wire format is
+byte-compatible between the two engines**, so a publisher on one can feed a
+subscriber on the other, in either direction, including through the Python
+bindings. That is covered by tests specifically so a staged rollout stays safe
+(register **C2**).

--- a/docs/wingfoil-next-architecture.md
+++ b/docs/wingfoil-next-architecture.md
@@ -1,0 +1,187 @@
+# Wingfoil architecture
+
+Orientation for someone about to change the engine. Not an API reference —
+that is the rustdoc — but the shape of the thing and the reasons behind the
+handful of decisions that everything else follows from.
+
+Read this before your first non-trivial change. It is roughly 20 minutes, and
+it will save you from the two or three "why on earth is it like *that*"
+moments that the code cannot explain on its own.
+
+## What the library does
+
+You describe a directed acyclic graph of data transformations once, and run it
+either against live data or replayed over history, with identical semantics.
+Nodes are pure computations; the engine owns their state, their scheduling and
+their wiring.
+
+```rust
+let g = GraphBuilder::new();
+let count = g.ticker(Duration::from_millis(10)).count();
+let is_even = count.map(|n: &u64| n.is_multiple_of(2));
+let total = count.filter(&is_even).fold(0u64, |acc, v| *acc += v);
+
+let mut runner = g.build();
+runner.run(RunMode::RealTime, RunFor::Cycles(100))?;
+```
+
+## The one decision everything follows from
+
+**Node semantics are an associated function, not a method on an object.**
+
+```rust
+trait Op {
+    type Cfg;              // construction-time config; closures live here
+    type State;            // engine-owned mutable state
+    type In<'a>;           // typed inputs, passed in per cycle
+    type Out;              // the produced value
+    const ACTIVATION: Activation;
+
+    fn cycle(cfg: &mut Self::Cfg, state: &mut Self::State,
+             input: Self::In<'_>, ctx: &mut Ctx<'_>) -> Result<Tick<Self::Out>>;
+}
+```
+
+Nothing here says how state is stored, how inputs are fetched, or who calls
+it. That is the whole trick. Because `cycle` is a free function over explicit
+arguments, the *same* function can be driven by:
+
+| Strategy | Who owns state | Dispatch | Where |
+|---|---|---|---|
+| **Interpreted** | the `Builder`'s slots | one dyn call per node | `interp.rs` |
+| **Compiled** | local variables in a generated fn | monomorphized, inlinable | `nitro!` |
+| **Nested island** | locals inside one composite node | monomorphized inside, one dyn call outside | `nitro!` |
+
+There is no duplicated cycle logic anywhere — no per-kind emitter strings, no
+`cycle_inline` twins. **The strategies cannot drift, because there is only one
+copy of the semantics.** If you find yourself writing a second implementation
+of what a node does, stop: that is the invariant being broken.
+
+### Why this matters more than it looks
+
+The predecessor engine fused three concerns into one object — a node was its
+computation *and* its storage (`RefCell` fields) *and* its input plumbing
+(peeking upstream `Rc<dyn Stream>`s). A compiled backend then had no choice but
+to **re-implement** every node's semantics as emitted source, which drifts the
+moment anyone touches either copy. Types and closures were erased at wiring
+time, so codegen reverse-engineered types from name strings and could never
+recover a closure at all. And nothing declared "this node schedules
+callbacks", so scheduling relied on name-based allowlists.
+
+`Op` inverts all three: semantics are separable from storage, types and
+closures survive into the generated code because they are ordinary generic
+parameters, and `const ACTIVATION` states scheduling behaviour where a machine
+can read it.
+
+## The pieces
+
+```
+op.rs         The Op trait, Activation, Tick, Ctx — the vocabulary
+interp.rs     The interpreted engine: slots, dirty list, dispatch, Runner
+fluent.rs     GraphBuilder + Stream<T>; combinators as extension traits
+ops.rs        The op catalog (map/filter/fold/join/delay/window, sources)
+stats.rs      EWMA and rolling-window statistics (opt-in trait)
+latency.rs    Stamping and per-stage latency aggregation
+channel.rs    The Message envelope and senders — the thread boundary
+async_source  produce_async: async producers, deterministic historical replay
+adapters/     I/O: csv, kafka, zmq, kdb, redis, postgres, etcd, fix, web,
+              aeron, iceoryx2, fluvio, augurs, prometheus, otlp, lines
+runtime/      Shared core: NanoTime, RunMode/RunFor, TimeQueue, Kernel,
+              Burst, the latency data layer
+compat.rs     A legacy-style Signal facade over the fallible lifecycle
+```
+
+Plus `wingfoil-next-macros` (`nitro!` and `#[op]`), `wingfoil-next-python`
+(PyO3 bindings), `wingfoil-wire-types` + `wingfoil-wasm` + `js/` (the browser
+side of the web adapter).
+
+### `Tick<T>` — three outcomes, not two
+
+```rust
+enum Tick<T> { Value(T), Silent(T), Quiet }
+```
+
+`Value` updates the slot and ticks downstream. `Quiet` does neither. `Silent`
+updates the value slot **without** ticking — which is exactly what `delay`
+needs, and the reason a two-state "did it fire?" boolean is not enough.
+
+### `Activation` — scheduling declared, not inferred
+
+`NONE` (fires when an upstream ticks), `SCHEDULES` (also wakes itself via the
+`TimeQueue` — tickers, delays), `THREADED` (fed from another thread through
+the channel layer), `ALWAYS` (busy-spun every cycle — socket polling). It is a
+`const`, so the interpreted engine reads it at wiring time and the compiled
+emission folds it into a dispatch condition after monomorphization.
+
+### Wiring is open, `Stream` is closed
+
+Combinators are **extension traits** (`SourceOps`, `StreamOps`,
+`StatisticsOps`, one per adapter), never inherent methods on `Stream<T>`. New
+vocabulary is added through exactly two public primitives —
+`GraphBuilder::source` and `Stream::wire` — so a downstream crate can add ops
+that feel native without this crate knowing about them. `#[op(build = name)]`
+generates the interpreted builder method *and* the `nitro!` forwarders from
+the op's declared shape, so **built-in and user ops take the identical path**.
+There is no per-op table in the macro. If you are editing a match arm to add
+an op, you are on the wrong road.
+
+## The rules that bite
+
+These are the ones that cost someone real time. Each is written up where it
+lives; this is the index.
+
+**`TimeQueue` deduplicates by design.** Pushing a `(value, time)` pair already
+queued is a no-op. A node scheduled twice for the same instant, or the same
+feedback value sent twice in a cycle, must collapse to one event. It is
+bounded on `PartialEq`, not `Hash + Eq`, specifically so `f64` payloads can
+flow through `delay` and `feedback`. Do not "fix" either.
+
+**Bursts, never latest-wins.** Same-instant values ride one `Burst<T>` and are
+delivered atomically. A source that coalesces same-instant values is a bug —
+the strictly-monotonic clock means a split same-time group cannot be
+reassembled.
+
+**No locks on the graph execution path.** `RefCell` for graph-thread-local
+state; the channel layer to talk to background threads; `ArcSwap` where a
+background thread needs an occasional read. A mutex in `cycle` is a
+correctness problem, not just a performance one.
+
+**I/O is established at `start()`, not at wiring.** Wiring stays pure — parse,
+validate, reject the wrong run mode — so it is testable without a live
+service, and connection errors surface during the run with node context.
+
+**Live sources reject `RunMode::HistoricalFrom` at wiring.** A historical run
+block-collects its whole input up front, so an unbounded live tail would
+deadlock at `start`. Rejecting at wiring turns a hang into an error message.
+
+**Production code does not `.unwrap()`.** `?` first, `.expect("invariant: WHY")`
+where a precondition makes the branch unreachable. Mutex poisoning is
+deliberately not recovered.
+
+## Testing shape
+
+Determinism comes from `RunMode::HistoricalFrom(NanoTime::ZERO)`: assert exact
+values **and** exact tick times (`with_time()` + `accumulate()`). A test that
+only checks values will not catch a scheduling regression.
+
+Three tiers for anything with I/O:
+
+1. `tests/<name>_adapter.rs` — no service required, runs in normal CI.
+2. `tests/<name>_integration.rs` — needs a container or real sockets; compiled
+   always, run in a per-adapter workflow.
+3. `crates/wingfoil-next-python/tests/test_<name>.py` — the binding surface.
+
+An op that reaches the compiled tiers should be asserted across all three
+strategies in one test, comparing them against each other — that is how the
+"cannot drift" property stays true rather than merely intended.
+
+## Where to look next
+
+| You want to… | Read |
+|---|---|
+| Add an op | `.claude/commands/new-op-next.md` |
+| Add an I/O adapter | `.claude/commands/new-adapter-next.md` |
+| Add Python bindings for one | `.claude/commands/bind-adapter-next.md` |
+| Understand a deviation from the legacy engine | `docs/deviation-register.md` |
+| Know what is deferred and why | `docs/port-plan.md` |
+| Port code off the legacy engine | `docs/migration.md` |


### PR DESCRIPTION
All four §4 rows in one PR, as agreed — they are one editorial pass over the same story, and 4.2 and 4.4 overlap enough that splitting them would mean writing the architecture prose twice.

## 4.1 — the crate front page

`lib.rs` opened with *"**Design prototype**: what wingfoil's core abstractions look like if designed from scratch"* and spent its first forty lines on a post-mortem of the abandoned `wingfoil::codegen` retrofit. That becomes the first thing a user sees the moment this crate is `wingfoil`.

Rewritten to lead with **what the library does**, then the one decision everything follows from (node semantics as a function, not an object), then the tour. The retrofit post-mortem moves to the architecture doc, where the historical "why" belongs and is still useful.

The opening example is now a **real doctest** rather than ` ```ignore `. Worth knowing why: the version I first drafted used a `filter_by` method that does not exist — an unchecked example on a front page rots, and this one was born rotten. It now runs in CI.

## 4.4 — `docs/wingfoil-next-architecture.md` (new)

Orientation for someone about to change the engine: the `Op` decision and why it is load-bearing (one copy of the semantics, so the interpreted/compiled/nested strategies *cannot* drift), the module map, `Tick`'s three states and why two is not enough, `Activation`, the open-vocabulary wiring rule — and an index of the rules that actually cost people time: `TimeQueue` dedup, bursts never latest-wins, no locks on the graph path, I/O at `start()` not wiring, live sources rejecting historical.

## 4.2 — `docs/migration.md` (new)

`#[node]` → `Op` for Rust callers: a field-by-field mapping table, the wiring change (ambient graph → explicit `GraphBuilder`), the adapter free-fn/operator-pair collapse, and the two behavioural deltas that bite when porting an I/O graph.

`Graph::export` is named as the one public API with no replacement, per row 2.1's ruling in #670.

**It carries a stated assumption, marked as such.** Row 1.4 — whether the legacy facade API survives — is still owed, and 4.2 depends on it. The guide is written assuming *no facade*, which is what the Python binding already committed to, with a call-out box saying so. If 1.4 rules the other way, the "what breaks" sections narrow and nothing else changes. I flagged it rather than quietly deciding it for you.

The Python half already exists (`wingfoil-next-python/docs/migration.rst`) and is linked, not duplicated.

## 4.3 — root `CLAUDE.md`

A "Start here" pointer to both new docs, and an accurate `docs/` line in the layout block.

The legacy branching section **stays** — legacy is still on disk and still cut from `main`, so stripping it now would be wrong. Deleting the `legacy/` copies of README/CONTRIBUTING/CLAUDE.md rides with the tree at the deletion step.

## Not included, on purpose

`docs/cutover-plan.md` is untouched. Its §4 rows are edited by #670, and having two of my own open PRs conflict on the same table helps nobody — the rows get ticked there.

## Verification

`fmt --check` clean, `clippy --all-targets -D warnings` clean, the new front-page doctest passes, `scripts/check-example-docs.sh` green, and every relative link in the new and edited docs resolves (checked programmatically, not by eye).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfX6mGysUNvGGfMZjKPQLb)_