### PR TITLE
Stop charging every cycle for timers that are not due

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,18 @@ Because dedup only needs equality (not hashing), the bound is `T: PartialEq`,
 payloads, which implement `PartialEq` but neither `Hash` nor `Eq`) flow
 through `delay` and `feedback`. Keep the bound at `PartialEq`.
 
+Dedup is **scoped to the instant being pushed to**, and must stay that way.
+Entries live in a `BTreeMap` keyed by time, so a push compares only against
+that time's bucket. A flat scan of every pending entry — which is what this
+queue used to do — is `O(pending)` per schedule, and *pending* here is not
+small: the scheduler holds one entry per timer at all times, because a ticker
+re-arms itself the moment it fires. That put every timer in the graph on the
+cost of every other timer's tick (22 ns per schedule at one pending entry,
+686 ns at 1024), and `delay` paid the same shape with every value still in
+flight. The earliest instant is additionally held *out* of the map and
+refilled lazily, so a single-timer graph — and a fast timer among slow ones —
+never touches the map at all.
+
 ## Branching: next work merges into `next`, not `main`
 
 Everything at the root is built up on the long-lived **`next` branch** to

--- a/crates/wingfoil/benches/README.md
+++ b/crates/wingfoil/benches/README.md
@@ -347,8 +347,8 @@ Both bars predate the scheduler-cost fix ([above](#results)), and this is the
 bench it moves most: the padding is 256 cold branches with **256 separate
 tickers**, so the `Sparse` bar was mostly paying for timers that never fired
 rather than for the ~8 nodes that did. A paired re-run on the same machine puts
-it at **19.4 ms → 6.65 ms**, i.e. ~330 ns per cycle rather than ~984, which
-widens the sparse-vs-oracle gap from 6.2× to ~17×. The table above is left as
+it at **19.4 ms → 5.88 ms**, i.e. ~294 ns per cycle rather than ~984, which
+widens the sparse-vs-oracle gap from 6.2× to ~19×. The table above is left as
 captured, matching how the other superseded readings here are handled.
 [Violin plot](images/ops/store_sparse_dispatch.svg).
 

--- a/crates/wingfoil/benches/README.md
+++ b/crates/wingfoil/benches/README.md
@@ -152,6 +152,18 @@ Those sections are left as captured rather than adjusted by hand; they need a
 run on machine A. The two machine-B sections have been re-captured since the
 change and do not carry this caveat.
 
+**Every section here also predates the scheduler-cost fix** — dedup in
+`TimeQueue::push` scoped to one instant instead of scanning the whole pending
+set, dispatch seeding from `Kernel::due()` instead of walking every
+callback-activated node, and `end_cycle` clearing only the flags it set (see
+`docs/port-plan.md`, "The `O(timers)` seed term"). What it moves is any graph
+holding **more than a handful of timers**, which in this suite means
+[`sparse_dispatch`](#store-baseline) above all: each of its 256 cold branches
+has its own ticker. Sections whose graphs have one or two timers — the tiers,
+the topological sweep — are affected only by the `end_cycle` term and move
+little. Paired figures are in the port-plan section above; the tables below are
+the pre-fix capture and want a re-run.
+
 ## Graph overhead
 
 The [`graph`](graph.rs) bench wires a trivial DAG `width` × `depth`, with every
@@ -330,6 +342,14 @@ size.
 | `FullSweep` (the `O(N)` oracle) | 121.08 ms | 6.05 µs |
 
 **6.2× apart** — the dirty list is doing its job.
+
+Both bars predate the scheduler-cost fix ([above](#results)), and this is the
+bench it moves most: the padding is 256 cold branches with **256 separate
+tickers**, so the `Sparse` bar was mostly paying for timers that never fired
+rather than for the ~8 nodes that did. A paired re-run on the same machine puts
+it at **19.4 ms → 6.65 ms**, i.e. ~330 ns per cycle rather than ~984, which
+widens the sparse-vs-oracle gap from 6.2× to ~17×. The table above is left as
+captured, matching how the other superseded readings here are handled.
 [Violin plot](images/ops/store_sparse_dispatch.svg).
 
 **Payload clone tax** (a large payload forwarded through a chain of `filter`

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -2238,9 +2238,9 @@ impl Builder {
         // Honour the `always` activation the same way [`poll`](Self::poll) does:
         // a busy-poll custom node must keep the realtime kernel from parking
         // between cycles, else its `cycle` only fires on unrelated wakeups (a
-        // socket-polling `ALWAYS` node would never advance). `seed_nodes` already
-        // includes it via `push_node`; this flips the engine into the busy-spin
-        // loop so it is actually driven every cycle.
+        // socket-polling `ALWAYS` node would never advance). `build` already puts it
+        // in `always_nodes` from its activation; this flips the engine into the
+        // busy-spin loop so it is actually driven every cycle.
         if activation.always {
             self.has_always = true;
         }
@@ -2287,10 +2287,13 @@ impl Builder {
         //     ticking `u` marks dirty. Dispatch propagates the tick frontier
         //     forward through these edges (passive edges are absent — read but
         //     not triggering).
-        //   * `seed_nodes` — the frontier dispatch seeds each cycle: `always`
-        //     (busy-poll) and callback-activated nodes (tickers, feedback
-        //     source, channel/external, `delay`'s scheduled pop, …).
-        //     Precomputed so seeding is O(#sources), not O(N).
+        //   * `always_nodes` / `is_seed` — the frontier dispatch may seed each
+        //     cycle: `always` (busy-poll) nodes, which fire unconditionally and
+        //     so are kept as a list, and callback-activated ones (tickers,
+        //     feedback source, channel/external, `delay`'s scheduled pop, …),
+        //     which fire only when the kernel marks them and so are kept as a
+        //     membership bitmap tested against `Kernel::due`. Seeding is
+        //     therefore O(#fired), not O(#sources) and not O(N).
         //
         // Dispatch orders the per-cycle work set by ascending node **index**
         // (see `Runner::run`). Wiring order is a valid topological order over
@@ -2314,7 +2317,8 @@ impl Builder {
         let n = self.nodes.len();
         let mut active_downs: Vec<Vec<usize>> = vec![Vec::new(); n];
         let mut passive_downs: Vec<Vec<usize>> = vec![Vec::new(); n];
-        let mut seed_nodes: Vec<usize> = Vec::new();
+        let mut always_nodes: Vec<usize> = Vec::new();
+        let mut is_seed: Vec<bool> = vec![false; n];
         let mut layer: Vec<usize> = vec![0; n];
         for i in 0..n {
             let mut lyr = 0usize;
@@ -2334,9 +2338,10 @@ impl Builder {
             }
             layer[i] = lyr;
             let act = self.nodes[i].activation;
-            if act.always || act.callback_activated() {
-                seed_nodes.push(i);
+            if act.always {
+                always_nodes.push(i);
             }
+            is_seed[i] = act.always || act.callback_activated();
         }
         Runner {
             nodes: self.nodes,
@@ -2354,7 +2359,8 @@ impl Builder {
             pending: self.pending,
             marks: self.marks,
             has_marks: self.has_marks,
-            seed_nodes,
+            always_nodes,
+            is_seed,
             layer,
             dispatch: Dispatch::default(),
             re_runnable: self.re_runnable,
@@ -2427,8 +2433,8 @@ pub enum Dispatch {
 /// Executes a wired graph. Dispatch is a sparse dirty-list — legacy wingfoil's
 /// `dirty_nodes_by_layer` model — so per-cycle work is proportional to the
 /// nodes that actually fire, not the graph size `N`. Each cycle seeds a work
-/// set from the frontier ([`seed_nodes`](Runner::seed_nodes): `always`
-/// busy-poll ops and kernel-marked callback-activated ops), then propagates the
+/// set from the frontier ([`always_nodes`](Runner::always_nodes) busy-poll ops
+/// plus the kernel's [`due`](Kernel::due) list), then propagates the
 /// tick frontier forward: a node that ticks marks its active downstream
 /// neighbours ([`active_downs`](Runner::active_downs)) dirty. The work set is
 /// drained in ascending **`(layer, index)`** order ([`layer`](Runner::layer) =
@@ -2458,8 +2464,8 @@ pub struct Runner {
     #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
     passive_downs: Vec<Vec<usize>>,
     /// `removed[i]` — a tombstone set when a node is deleted at runtime
-    /// (`Extension::remove`). Its edges are unlinked and it is dropped from
-    /// `seed_nodes` so it never cycles again; the flag additionally stops the
+    /// (`Extension::remove`). Its edges are unlinked and its `is_seed` flag is
+    /// cleared so it never cycles again; the flag additionally stops the
     /// end-of-run cleanup from calling its `stop`/`teardown` a second time
     /// (they already ran at removal — legacy parity, `graph.rs:1015-1028`).
     /// Slots are tombstoned, never freed, so a `Handle` stays valid. Always
@@ -2477,9 +2483,23 @@ pub struct Runner {
     marks: Rc<RefCell<Vec<usize>>>,
     /// Whether any routing node exists; gates the `marks` drain off the hot path.
     has_marks: bool,
-    /// Frontier sources seeded each cycle: `always` ops and callback-activated
-    /// ops (the latter only fire when the kernel marks them dirty).
-    seed_nodes: Vec<usize>,
+    /// Busy-poll (`always`) ops, seeded unconditionally every cycle. Empty for
+    /// every historical graph and for most realtime ones — an `always` op is a
+    /// socket/ring-buffer poller.
+    ///
+    /// Its callback-activated counterpart is **not** a list to walk: those ops
+    /// fire only when the kernel marks them, and the kernel already knows which
+    /// ones it marked ([`Kernel::due`]), so dispatch reads the frontier from
+    /// there and checks membership through [`is_seed`](Self::is_seed). Walking
+    /// a list of every callback-activated node instead made a cycle cost
+    /// `O(timers in the graph)`: 1024 idle tickers took the per-cycle cost of an
+    /// 8-node hot path from 247 ns to 2.99 µs, none of it work the graph asked
+    /// for.
+    always_nodes: Vec<usize>,
+    /// `is_seed[i]` — whether `i` may be seeded from the kernel's frontier
+    /// (`always` or callback-activated). A dynamically removed node's flag is
+    /// cleared, so a stale schedule left in the kernel cannot resurrect it.
+    is_seed: Vec<bool>,
     /// `layer[i]` = longest path to `i` over all upstream edges (active and
     /// passive); the primary sparse-dispatch sort key. `(layer, index)` is a
     /// valid topological order that survives dynamic edge splices (which index
@@ -2704,7 +2724,6 @@ impl Runner {
         while !self.finished.get() && kernel.begin_cycle(&mut dirty) {
             if let Some(e) = self.drain_cycle(
                 kernel,
-                &dirty,
                 &mut buckets,
                 &mut occupied,
                 &mut node_dirty,
@@ -2729,7 +2748,6 @@ impl Runner {
     fn drain_cycle(
         &mut self,
         kernel: &mut Kernel,
-        dirty: &[bool],
         buckets: &mut [Vec<usize>],
         occupied: &mut [u64],
         node_dirty: &mut [bool],
@@ -2739,12 +2757,23 @@ impl Runner {
         // Seed the frontier into per-layer buckets: `always` ops fire
         // unconditionally; callback-activated ops (tickers, `delay` pops,
         // feedback source, channel replay) fire only when the kernel marked them
-        // dirty this cycle. Everything else reaches a bucket by downstream
+        // dirty this cycle — and the kernel hands those over directly, so this
+        // costs the size of the frontier rather than a walk of every node that
+        // *could* be on it. Everything else reaches a bucket by downstream
         // propagation below. `max_layer` tracks the deepest active layer so the
         // drain scans only `0..=max_layer`, not all `N` buckets.
         let mut max_layer = 0usize;
-        for &i in &self.seed_nodes {
-            if (self.nodes[i].activation.always || dirty[i]) && !node_dirty[i] {
+        // `is_seed` is the membership test the old walk got for free from its
+        // seed list: it rejects a node the kernel marked but that dispatch must
+        // not seed — a dynamically removed node whose stale schedule is still
+        // queued.
+        let frontier = self
+            .always_nodes
+            .iter()
+            .copied()
+            .chain(kernel.due().iter().copied().filter(|&i| self.is_seed[i]));
+        for i in frontier {
+            if !node_dirty[i] {
                 node_dirty[i] = true;
                 let l = self.layer[i];
                 buckets[l].push(i);
@@ -2844,7 +2873,7 @@ impl Runner {
         // nodes actually drained. Both terms are the sparse engine's real
         // per-cycle cost drivers — neither mentions `N`, which is exactly the
         // property `sparse_work_is_independent_of_graph_size` pins.
-        self.node_visits += (self.seed_nodes.len() + fired.len()) as u64;
+        self.node_visits += (self.always_nodes.len() + kernel.due().len() + fired.len()) as u64;
         self.layer_visits += scan_steps;
         // Reset only the nodes we touched (all buckets are empty again),
         // keeping the per-cycle reset sparse.
@@ -3082,11 +3111,19 @@ impl Runner {
             let mut occupied: Vec<u64> = Vec::new();
             let mut node_dirty: Vec<bool> = Vec::new();
             let mut fired: Vec<usize> = Vec::new();
+            // The kernel's dirty flags. Grown (never reallocated per cycle) as
+            // nodes are appended, and left all-false by every `end_cycle`, so a
+            // long dynamic run does not allocate and zero a graph-sized array on
+            // every one of its cycles.
+            let mut dirty: Vec<bool> = Vec::new();
             let mut cycles: u32 = 0;
             loop {
                 let n = self.nodes.len();
                 if node_dirty.len() < n {
                     node_dirty.resize(n, false);
+                }
+                if dirty.len() < n {
+                    dirty.resize(n, false);
                 }
                 // `layer[i] < n`, so `n` buckets always suffice; regrow as nodes
                 // are appended (splices only add layers at the top).
@@ -3098,13 +3135,11 @@ impl Runner {
                 if occupied.len() < n.div_ceil(64) {
                     occupied.resize(n.div_ceil(64), 0);
                 }
-                let mut dirty = vec![false; n];
                 if self.finished.get() || !kernel.begin_cycle(&mut dirty) {
                     break;
                 }
                 if let Some(e) = self.drain_cycle(
                     &mut kernel,
-                    &dirty,
                     &mut buckets,
                     &mut occupied,
                     &mut node_dirty,
@@ -3207,7 +3242,7 @@ impl Runner {
 
     /// Append a node to the *live* graph, growing every parallel structure the
     /// sparse engine keeps (`nodes`, `ticked`, `active_downs`, `passive_downs`,
-    /// `layer`, and `seed_nodes` if the node self-activates) and wiring its
+    /// `layer`, `is_seed`, and `always_nodes` if it busy-polls) and wiring its
     /// reverse edges + layer. `active_ups`/`passive_ups` reference existing
     /// (lower-index) nodes, so no existing node's order changes — pure append.
     fn rt_append_node(
@@ -3248,9 +3283,11 @@ impl Runner {
         self.passive_downs.push(Vec::new());
         self.removed.push(false);
         self.layer.push(lyr);
-        if activation.always || activation.callback_activated() {
-            self.seed_nodes.push(idx);
+        if activation.always {
+            self.always_nodes.push(idx);
         }
+        self.is_seed
+            .push(activation.always || activation.callback_activated());
         idx
     }
 
@@ -3304,7 +3341,7 @@ impl Runner {
 
     /// Unlink node `idx` from the live graph and run its lifecycle teardown.
     /// Removes it from every upstream's down-list and every downstream's
-    /// up-list (both active and passive), drops it from `seed_nodes`, runs
+    /// up-list (both active and passive), drops it from the dispatch frontier, runs
     /// `stop` then `teardown` once, and tombstones it (`removed[idx] = true`).
     /// Because it no longer appears in any frontier or reverse-edge list it can
     /// never be enqueued again. Port of legacy's `process_pending_removals`
@@ -3331,8 +3368,10 @@ impl Runner {
         for &d in &passive_downs {
             self.nodes[d].passive_ups.retain(|&x| x != idx);
         }
-        // Drop from the dispatch frontier so it is never seeded again.
-        self.seed_nodes.retain(|&x| x != idx);
+        // Drop from the dispatch frontier so it is never seeded again — including
+        // via a schedule the kernel is still holding for it.
+        self.always_nodes.retain(|&x| x != idx);
+        self.is_seed[idx] = false;
         self.removed[idx] = true;
         // Lifecycle teardown, once, with node context — stop then teardown.
         let label = self.nodes[idx].label;
@@ -3348,8 +3387,8 @@ impl Runner {
     /// Walks `new`'s upstream cone, bounded to nodes in `appended` (this
     /// boundary's new nodes); a node is an *attachment point* if it reads a
     /// pre-existing (non-`appended`) upstream or is a source. Each attachment
-    /// point is scheduled and, if not already a dispatch seed, added to
-    /// `seed_nodes` so the scheduled dirty flag actually fires it (a plain
+    /// point is scheduled and marked in `is_seed` so the scheduled dirty flag
+    /// actually fires it (a plain
     /// `map`/`fold` is otherwise reached only by upstream propagation).
     /// Downstream appended nodes then fire by normal tick propagation, so the
     /// region evaluates in order and reads real values, not `Default`. Mirrors
@@ -3371,9 +3410,7 @@ impl Runner {
                 self.nodes[ix].active_ups.is_empty() && self.nodes[ix].passive_ups.is_empty();
             if has_preexisting || is_source {
                 kernel.schedule(ix, time);
-                if !self.seed_nodes.contains(&ix) {
-                    self.seed_nodes.push(ix);
-                }
+                self.is_seed[ix] = true;
             }
             for &u in self.nodes[ix]
                 .active_ups

--- a/crates/wingfoil/src/runtime/kernel.rs
+++ b/crates/wingfoil/src/runtime/kernel.rs
@@ -92,6 +92,20 @@ pub struct Kernel {
     is_last_cycle: bool,
     cycles: u32,
     scheduled: TimeQueue<usize>,
+    /// Indices this kernel marked dirty in the current cycle, in the order it
+    /// marked them. Two jobs, both of which take an `O(N)` term off the
+    /// per-cycle cost of a graph that is mostly quiet:
+    ///
+    /// * [`end_cycle`](Kernel::end_cycle) clears exactly these flags instead of
+    ///   memsetting the whole `dirty` array — the array is as long as the graph,
+    ///   so the clear used to scale with graph size on every cycle;
+    /// * [`due`](Kernel::due) hands an engine the frontier directly, so it can
+    ///   seed its work set from the nodes that actually came due rather than
+    ///   scanning every callback-activated node in the graph to ask.
+    ///
+    /// Entries are unique: a marker only records an index whose flag it
+    /// actually flipped.
+    due: Vec<usize>,
     /// External wake-ups from [`KernelWaker`]s, realtime mode only. Mirrors
     /// the interpreted engine's ready-callback channel.
     ready: Option<Receiver<usize>>,
@@ -138,8 +152,30 @@ impl Kernel {
             is_last_cycle: false,
             cycles: 0,
             scheduled: TimeQueue::new(),
+            due: Vec::new(),
             ready,
             spin: false,
+        }
+    }
+
+    /// Mark `index` dirty, recording it in [`due`](Self::due) if this is the
+    /// call that flipped the flag. Out-of-range indices (a misbehaving waker)
+    /// are ignored.
+    ///
+    /// Returns whether `index` was **in range** — deliberately not whether the
+    /// flag changed. It is the caller's `progressed` signal, and a node marked
+    /// twice in one cycle (woken twice, or scheduled at two times that both
+    /// come due) is still progress: the cycle must run.
+    fn mark(&mut self, index: usize, dirty: &mut [bool]) -> bool {
+        match dirty.get_mut(index) {
+            Some(d) => {
+                if !*d {
+                    *d = true;
+                    self.due.push(index);
+                }
+                true
+            }
+            None => false,
         }
     }
 
@@ -153,15 +189,14 @@ impl Kernel {
     /// Drain pending external wake-ups into `dirty`. Out-of-range indices
     /// (a misbehaving waker) are ignored.
     fn drain_ready(&mut self, dirty: &mut [bool]) -> bool {
-        let Some(rx) = &self.ready else {
+        if self.ready.is_none() {
             return false;
-        };
+        }
         let mut any = false;
-        while let Ok(ix) = rx.try_recv() {
-            if let Some(d) = dirty.get_mut(ix) {
-                *d = true;
-                any = true;
-            }
+        // Collected first so `mark` can take `&mut self` while the receiver
+        // borrow is released.
+        while let Some(ix) = self.ready.as_ref().and_then(|rx| rx.try_recv().ok()) {
+            any |= self.mark(ix, dirty);
         }
         any
     }
@@ -269,8 +304,7 @@ impl Kernel {
                     };
                     let mut progressed = false;
                     while let Some(ix) = self.scheduled.pop_if_pending(self.time) {
-                        dirty[ix] = true;
-                        progressed = true;
+                        progressed |= self.mark(ix, dirty);
                     }
                     if !progressed {
                         return false;
@@ -287,7 +321,7 @@ impl Kernel {
                         // always-active ops need it even with nothing due.
                         self.time = NanoTime::now().max(self.time + 1);
                         while let Some(ix) = self.scheduled.pop_if_pending(self.time) {
-                            dirty[ix] = true;
+                            self.mark(ix, dirty);
                         }
                         self.wall_time.set(None);
                         return true;
@@ -301,18 +335,19 @@ impl Kernel {
                                 let now = NanoTime::now();
                                 if target > now {
                                     let timeout = Duration::from_nanos(u64::from(target - now));
-                                    match &self.ready {
+                                    let woken = match &self.ready {
                                         Some(rx) => match rx.recv_timeout(timeout) {
-                                            Ok(ix) => {
-                                                if let Some(d) = dirty.get_mut(ix) {
-                                                    *d = true;
-                                                    progressed = true;
-                                                }
-                                            }
+                                            Ok(ix) => Some(ix),
                                             Err(RecvTimeoutError::Timeout)
-                                            | Err(RecvTimeoutError::Disconnected) => {}
+                                            | Err(RecvTimeoutError::Disconnected) => None,
                                         },
-                                        None => std::thread::sleep(timeout),
+                                        None => {
+                                            std::thread::sleep(timeout);
+                                            None
+                                        }
+                                    };
+                                    if let Some(ix) = woken {
+                                        progressed |= self.mark(ix, dirty);
                                     }
                                 }
                             }
@@ -346,10 +381,7 @@ impl Kernel {
                                 };
                                 match woken {
                                     Some(ix) => {
-                                        if let Some(d) = dirty.get_mut(ix) {
-                                            *d = true;
-                                            progressed = true;
-                                        }
+                                        progressed |= self.mark(ix, dirty);
                                     }
                                     // All wakers dropped (recv Err) or the
                                     // end bound passed with nothing queued.
@@ -361,8 +393,7 @@ impl Kernel {
                     }
                     self.time = NanoTime::now().max(self.time + 1);
                     while let Some(ix) = self.scheduled.pop_if_pending(self.time) {
-                        dirty[ix] = true;
-                        progressed = true;
+                        progressed |= self.mark(ix, dirty);
                     }
                     if progressed {
                         self.wall_time.set(None);
@@ -375,11 +406,36 @@ impl Kernel {
         }
     }
 
+    /// The nodes this kernel marked dirty in the cycle
+    /// [`begin_cycle`](Self::begin_cycle) just opened — the activation frontier,
+    /// in the order it was marked, with no duplicates.
+    ///
+    /// This is the same information as the `true` entries of the `dirty` slice,
+    /// handed over as a list so an engine need not go looking for them. The
+    /// interpreted engine seeds its work set from here; the alternative is to
+    /// walk every callback-activated node in the graph asking "were you marked?",
+    /// which costs a cycle in proportion to how many timers the graph *has*
+    /// rather than how many just fired.
+    ///
+    /// Valid until the matching [`end_cycle`](Self::end_cycle), which clears it.
+    pub fn due(&self) -> &[usize] {
+        &self.due
+    }
+
     /// Finish the current cycle: clear the dirty flags.
+    ///
+    /// Clears exactly the flags this kernel set (see [`due`](Self::due)) rather
+    /// than sweeping the whole slice, so a quiet graph does not pay a memset of
+    /// its own size on every cycle. `dirty` must therefore be the same slice
+    /// `begin_cycle` marked — which it is for every engine in the tree, all of
+    /// which keep one long-lived array per run.
     pub fn end_cycle(&mut self, dirty: &mut [bool]) {
-        for d in dirty.iter_mut() {
-            *d = false;
+        for &ix in &self.due {
+            if let Some(d) = dirty.get_mut(ix) {
+                *d = false;
+            }
         }
+        self.due.clear();
         self.cycles += 1;
     }
 }

--- a/crates/wingfoil/src/runtime/time_queue.rs
+++ b/crates/wingfoil/src/runtime/time_queue.rs
@@ -1,41 +1,78 @@
-use std::cmp::{Ordering, Reverse};
-use std::collections::BinaryHeap;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, VecDeque};
 
 use crate::runtime::time::NanoTime;
 
-/// An entry in a [`TimeQueue`], ordered by `(time, seq)` alone.
-///
-/// The ordering deliberately ignores the payload `T` so the heap needs no
-/// `Ord`/`Hash`/`Eq` bound on `T`. `seq` is a per-queue monotonic counter that
-/// makes the order *total* (no two entries compare equal) and gives a stable
-/// FIFO order among entries sharing a `time`.
+/// The entries queued at one instant. Overwhelmingly there is exactly one — two
+/// nodes scheduled for the very same nanosecond is the exception — so the
+/// single-entry case is held inline. A `Vec`-per-instant instead put a heap
+/// allocation and a free on the path of every schedule, which is most of what
+/// one costs.
 #[derive(Debug)]
-struct Entry<T> {
-    time: NanoTime,
-    seq: u64,
-    value: T,
+enum Bucket<T> {
+    One(T),
+    /// Two or more distinct values at this instant, in FIFO order. Never empty
+    /// and never of length one: `pop` collapses it back to `One` at two.
+    Many(VecDeque<T>),
 }
 
-impl<T> Entry<T> {
-    fn key(&self) -> (NanoTime, u64) {
-        (self.time, self.seq)
+impl<T> Bucket<T> {
+    /// Append `value` behind everything already queued at this instant.
+    fn push_back(&mut self, value: T) {
+        match self {
+            Bucket::Many(q) => q.push_back(value),
+            Bucket::One(_) => {
+                let Bucket::One(first) = std::mem::replace(self, Bucket::Many(VecDeque::new()))
+                else {
+                    unreachable!("invariant: matched Bucket::One immediately above")
+                };
+                let Bucket::Many(q) = self else {
+                    unreachable!("invariant: just replaced with Bucket::Many")
+                };
+                q.push_back(first);
+                q.push_back(value);
+            }
+        }
+    }
+
+    /// Take the front (earliest-pushed) value, and report whether anything is
+    /// still queued at this instant. `false` means the bucket is spent and its
+    /// instant should retire — the no-empty-bucket invariant.
+    fn pop_front(&mut self) -> (T, bool) {
+        match self {
+            Bucket::Many(q) => {
+                let value = q
+                    .pop_front()
+                    .expect("invariant: Bucket::Many is never empty");
+                if q.len() == 1 {
+                    // Collapse back to the inline form so a long-lived queue
+                    // does not keep a `VecDeque` per instant alive.
+                    let last = q.pop_front().expect("invariant: len checked as 1");
+                    *self = Bucket::One(last);
+                }
+                (value, true)
+            }
+            Bucket::One(_) => {
+                // The empty `Many` left behind is transient: the caller drops
+                // the whole bucket on the `false`.
+                let Bucket::One(value) = std::mem::replace(self, Bucket::Many(VecDeque::new()))
+                else {
+                    unreachable!("invariant: matched Bucket::One immediately above")
+                };
+                (value, false)
+            }
+        }
     }
 }
 
-impl<T> PartialEq for Entry<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.key() == other.key()
-    }
-}
-impl<T> Eq for Entry<T> {}
-impl<T> PartialOrd for Entry<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-impl<T> Ord for Entry<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.key().cmp(&other.key())
+impl<T: PartialEq> Bucket<T> {
+    /// Whether `value` is already queued at this instant — the dedup test,
+    /// scoped to one bucket.
+    fn contains(&self, value: &T) -> bool {
+        match self {
+            Bucket::One(queued) => queued == value,
+            Bucket::Many(queued) => queued.iter().any(|q| q == value),
+        }
     }
 }
 
@@ -63,22 +100,57 @@ impl<T> Ord for Entry<T> {
 /// float semantics: `NaN != NaN`, so two `NaN` entries at the same time are not
 /// deduplicated — which is the correct behaviour for `NaN`.)
 ///
-/// Dedup is a linear scan of the pending entries on push; the queues this backs
-/// hold only a handful of not-yet-due items at a time, so this is not a hot-path
-/// concern in practice.
+/// ## Why the entries are bucketed by time
+///
+/// Dedup only ever compares against entries sharing the *same* `time`, so the
+/// queue keys entries by time rather than holding one flat heap: a push scans
+/// its own instant's bucket (almost always empty or a single entry) instead of
+/// every pending item.
+///
+/// That distinction is on the hot path, not a micro-optimisation. This queue
+/// backs the graph scheduler, where **every scheduling node holds a pending
+/// entry at all times** — a ticker re-arms itself the moment it fires — so the
+/// pending set is the size of the graph's timer population, not "a handful".
+/// A flat scan made one `Ctx::schedule` cost `O(pending)`: measured at 22 ns
+/// with one entry queued and 686 ns with 1024, i.e. every timer in the graph
+/// taxing every other timer's tick. `delay` pays the same shape, its pending
+/// set being every value still in flight.
+///
+/// The earliest instant is then held *out* of the map, in `front`, and refilled
+/// **lazily** — `pop` leaves `front` empty rather than promoting the map's next
+/// instant, and a later `push` earlier than that instant claims the empty
+/// `front` directly. A `BTreeMap` insert and remove costs ~30 ns together, and
+/// allocates and frees a root node every time the map empties and refills, so
+/// the two shapes that matter must not touch it at all:
+///
+/// * **one timer** — the map stays empty for the whole run; `front` alone
+///   absorbs every fire-and-re-arm;
+/// * **one fast timer among slow ones** — the fast timer's next fire is earlier
+///   than everything in the map, so it lands in the vacated `front` while the
+///   slow instants sit undisturbed. Eager promotion made this the *worst* case
+///   instead: the map thrashed between one entry and none on every cycle.
+///
+/// None of this is observable: earliest time first, FIFO within a time
+/// (insertion order), and `(value, time)` dedup — all exactly as before.
 #[derive(Debug)]
 pub struct TimeQueue<T> {
-    // `BinaryHeap` is a max-heap; `Reverse` turns it into a min-heap on
-    // `(time, seq)`, i.e. earliest time first, ties broken by insertion order.
-    heap: BinaryHeap<Reverse<Entry<T>>>,
-    next_seq: u64,
+    /// The earliest pending instant and its entries, held out of `buckets`.
+    /// **Invariant: when occupied, `front.0` is strictly less than every key in
+    /// `buckets`** — so entries sharing an instant are never split across the
+    /// two, and an occupied `front` answers `next_time` outright. `None` does
+    /// *not* mean the queue is empty: the earliest instant may still be sitting
+    /// in `buckets`, waiting for a `pop` or an earlier `push` to claim the slot.
+    front: Option<(NanoTime, Bucket<T>)>,
+    /// Every later instant, earliest key first; within a bucket, insertion
+    /// (FIFO) order. **Invariant: no bucket is ever empty.**
+    buckets: BTreeMap<NanoTime, Bucket<T>>,
 }
 
 impl<T> Default for TimeQueue<T> {
     fn default() -> Self {
         Self {
-            heap: BinaryHeap::new(),
-            next_seq: 0,
+            front: None,
+            buckets: BTreeMap::new(),
         }
     }
 }
@@ -90,30 +162,51 @@ impl<T> TimeQueue<T> {
 
     /// Time of the next item, or `None` if the queue is empty.
     pub fn next_time(&self) -> Option<NanoTime> {
-        self.heap.peek().map(|Reverse(e)| e.time)
+        match self.front {
+            Some((time, _)) => Some(time),
+            // `front` vacated but the map still holds instants — see the field's
+            // invariant. Reading the minimum here (rather than promoting it)
+            // keeps the map untouched.
+            None => self.buckets.first_key_value().map(|(&time, _)| time),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.heap.is_empty()
+        self.front.is_none() && self.buckets.is_empty()
     }
 
     /// Pop the earliest item, or `None` if the queue is empty.
     pub fn pop(&mut self) -> Option<T> {
-        self.heap.pop().map(|Reverse(e)| e.value)
+        if self.front.is_none() {
+            // Only now is promoting worth a map operation: something is being
+            // taken out, so the instant is about to be consumed anyway.
+            self.front = self.buckets.pop_first();
+        }
+        let (_, bucket) = self.front.as_mut()?;
+        let (value, instant_still_occupied) = bucket.pop_front();
+        if !instant_still_occupied {
+            self.front = None;
+        }
+        Some(value)
     }
 
     /// Pop the earliest item iff its time is `<= current_time`. Designed for the
     /// `while let Some(v) = q.pop_if_pending(now) { ... }` idiom that drains all
     /// callbacks due at or before the current engine tick.
+    ///
+    /// The common call is the one that finds *nothing* due — the drain loop's
+    /// last iteration, every cycle — so the not-due answer must not touch the
+    /// map beyond reading its minimum key.
     pub fn pop_if_pending(&mut self, current_time: NanoTime) -> Option<T> {
         match self.next_time() {
-            Some(t) if t <= current_time => self.pop(),
+            Some(time) if time <= current_time => self.pop(),
             _ => None,
         }
     }
 
     pub fn clear(&mut self) {
-        self.heap.clear();
+        self.front = None;
+        self.buckets.clear();
     }
 }
 
@@ -121,16 +214,53 @@ impl<T: PartialEq> TimeQueue<T> {
     /// Push `value` at `time`. A `(value, time)` pair already present in the
     /// queue is suppressed (see the type-level docs — dedup is intentional).
     pub fn push(&mut self, value: T, time: NanoTime) {
-        if self
-            .heap
-            .iter()
-            .any(|Reverse(e)| e.time == time && e.value == value)
-        {
-            return;
+        // Only entries at the *same* time can be duplicates, so the scan is
+        // confined to this instant's bucket.
+        match self.front.as_mut() {
+            // Same instant as the held-out front: the whole operation stays out
+            // of the map. This is the single-timer graph's every push.
+            Some((front_time, bucket)) if *front_time == time => {
+                if bucket.contains(&value) {
+                    return;
+                }
+                bucket.push_back(value);
+            }
+            // Earlier than the front: it becomes the new front, and the old one
+            // moves into the map (whose keys are all later still, so the
+            // strictly-less-than invariant is preserved).
+            Some((front_time, _)) if time < *front_time => {
+                let Some((old_time, old_bucket)) = self.front.replace((time, Bucket::One(value)))
+                else {
+                    unreachable!("invariant: matched Some immediately above")
+                };
+                self.buckets.insert(old_time, old_bucket);
+            }
+            // A later instant, with the front occupied: it belongs in the map.
+            Some(_) => self.push_into_map(value, time),
+            // `front` is vacant. Claim it if this instant is earlier than
+            // everything in the map — the fast-timer-among-slow-ones case, which
+            // must not cost a map mutation.
+            None => match self.buckets.first_key_value() {
+                Some((&earliest, _)) if time >= earliest => self.push_into_map(value, time),
+                _ => self.front = Some((time, Bucket::One(value))),
+            },
         }
-        let seq = self.next_seq;
-        self.next_seq += 1;
-        self.heap.push(Reverse(Entry { time, seq, value }));
+    }
+
+    /// Push into `buckets`, deduplicating within the instant's bucket. One
+    /// descent of the map, not a `get_mut` followed by an `insert`.
+    fn push_into_map(&mut self, value: T, time: NanoTime) {
+        match self.buckets.entry(time) {
+            Entry::Occupied(mut bucket) => {
+                if bucket.get().contains(&value) {
+                    return;
+                }
+                bucket.get_mut().push_back(value);
+            }
+            Entry::Vacant(slot) => {
+                slot.insert(Bucket::One(value));
+            }
+        }
     }
 }
 
@@ -209,6 +339,94 @@ mod tests {
         queue.push(1, NanoTime::new(100));
         assert_eq!(queue.pop_if_pending(NanoTime::new(99)), None);
         assert_eq!(queue.pop_if_pending(NanoTime::new(100)), Some(1));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn draining_a_time_lets_it_be_pushed_again() {
+        // The no-empty-bucket invariant: popping the last entry at a time must
+        // retire that time entirely, so a later push at the same time is a
+        // fresh entry rather than a dedup hit against a drained ghost.
+        let mut queue: TimeQueue<u32> = TimeQueue::new();
+        queue.push(1, NanoTime::new(100));
+        assert_eq!(queue.pop(), Some(1));
+        assert!(queue.is_empty());
+        assert_eq!(queue.next_time(), None);
+        queue.push(1, NanoTime::new(100));
+        assert_eq!(queue.next_time(), Some(NanoTime::new(100)));
+        assert_eq!(queue.pop(), Some(1));
+    }
+
+    #[test]
+    fn dedup_is_scoped_to_the_pushed_time_only() {
+        // Two entries at t=100 and one at t=200. Re-pushing `1` at 200 must be
+        // suppressed (it is queued there) while `2` at 200 is accepted, even
+        // though `2` is already queued at 100.
+        let mut queue: TimeQueue<u32> = TimeQueue::new();
+        queue.push(1, NanoTime::new(100));
+        queue.push(2, NanoTime::new(100));
+        queue.push(1, NanoTime::new(200));
+        queue.push(1, NanoTime::new(200)); // duplicate → suppressed
+        queue.push(2, NanoTime::new(200));
+        assert_eq!(queue.pop(), Some(1));
+        assert_eq!(queue.pop(), Some(2));
+        assert_eq!(queue.pop(), Some(1));
+        assert_eq!(queue.pop(), Some(2));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn a_fast_repeat_interleaves_correctly_with_a_distant_entry() {
+        // The lazy-refill shape: one distant entry parked in the map while a
+        // fast one is popped and re-pushed ahead of it, over and over. The
+        // vacated front must be reclaimed by each re-push (never letting the
+        // distant entry jump the queue), and the distant entry must still come
+        // out last, exactly once.
+        let mut queue: TimeQueue<u32> = TimeQueue::new();
+        queue.push(99, NanoTime::new(1_000_000));
+        queue.push(1, NanoTime::new(10));
+        for step in 1..=5 {
+            assert_eq!(queue.next_time(), Some(NanoTime::new(step * 10)));
+            assert_eq!(queue.pop(), Some(1));
+            // Front is vacant and the map still holds the distant entry; this
+            // push must claim the front rather than land behind it.
+            queue.push(1, NanoTime::new((step + 1) * 10));
+            assert_eq!(queue.next_time(), Some(NanoTime::new((step + 1) * 10)));
+        }
+        assert_eq!(queue.pop(), Some(1));
+        assert_eq!(queue.next_time(), Some(NanoTime::new(1_000_000)));
+        assert_eq!(queue.pop(), Some(99));
+        assert!(queue.is_empty());
+        assert_eq!(queue.pop(), None);
+    }
+
+    #[test]
+    fn is_empty_is_false_while_only_the_map_holds_entries() {
+        // A vacated `front` is not an empty queue: `pop` and `next_time` must
+        // still see what is parked in the map behind it.
+        let mut queue: TimeQueue<u32> = TimeQueue::new();
+        queue.push(1, NanoTime::new(100));
+        queue.push(2, NanoTime::new(200));
+        assert_eq!(queue.pop(), Some(1)); // vacates `front`; 2 stays in the map
+        assert!(!queue.is_empty());
+        assert_eq!(queue.next_time(), Some(NanoTime::new(200)));
+        assert_eq!(queue.pop_if_pending(NanoTime::new(199)), None);
+        assert_eq!(queue.pop_if_pending(NanoTime::new(200)), Some(2));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn dedup_holds_against_an_entry_parked_in_the_map() {
+        // Dedup must not depend on where an entry happens to live. `3` is in the
+        // map (behind the front), so re-pushing it at the same time is still a
+        // duplicate — and stays one after the front is vacated.
+        let mut queue: TimeQueue<u32> = TimeQueue::new();
+        queue.push(1, NanoTime::new(100));
+        queue.push(3, NanoTime::new(300));
+        queue.push(3, NanoTime::new(300)); // duplicate, front occupied
+        assert_eq!(queue.pop(), Some(1)); // vacates `front`
+        queue.push(3, NanoTime::new(300)); // duplicate, front vacant
+        assert_eq!(queue.pop(), Some(3));
         assert!(queue.is_empty());
     }
 

--- a/crates/wingfoil/tests/sparse_graph.rs
+++ b/crates/wingfoil/tests/sparse_graph.rs
@@ -228,6 +228,70 @@ fn sparse_work_is_independent_of_graph_size() {
     );
 }
 
+/// **The timer-population half of the perf gate.**
+/// `sparse_work_is_independent_of_graph_size` hangs all of its padding off *one*
+/// shared cold driver, so every graph it builds has two timers no matter how
+/// wide it gets. That leaves a whole axis unpinned, and the engine was losing on
+/// it: dispatch seeded each cycle by walking a list of every callback-activated
+/// node in the graph and asking each whether the kernel had marked it, which
+/// costs `O(timers)` per cycle whether or not any of them is due. A graph of
+/// per-instrument tickers, throttles or delays is exactly that shape, and it is
+/// an ordinary shape, not a pathological one. Measured: 1024 idle tickers took
+/// an 8-node hot path from 247 ns to 2.99 µs per cycle.
+///
+/// So this test gives every cold branch **its own ticker**, and pins the same
+/// property the width gate pins, by the same method: what the padding adds must
+/// be a one-off (every ticker really is due at `t = 0`), not a per-cycle tax.
+/// Dispatch now seeds from [`Kernel::due`] — the frontier the kernel already
+/// knows — so a timer that is not due costs nothing to have.
+#[test]
+fn sparse_work_is_independent_of_timer_count() {
+    const HOT: Duration = Duration::from_nanos(10);
+    /// Far beyond the simulated time these runs cover: due at `t = 0`, never again.
+    const NEVER: Duration = Duration::from_millis(1);
+    const FEW: usize = 8;
+    const MANY: usize = 512;
+    const SHORT: u32 = 200;
+    const LONG: u32 = 2_000;
+
+    /// One hot chain plus `timers` cold branches, each with its **own** ticker.
+    fn run_padded(timers: usize, cycles: u32) -> (u64, Vec<u64>) {
+        let g = GraphBuilder::new();
+
+        let mut hot = g.ticker(HOT).count();
+        for _ in 0..4 {
+            hot = hot.map(|v| v.wrapping_add(1));
+        }
+        let out = hot.accumulate();
+
+        let _padding: Vec<_> = (0..timers)
+            .map(|_| g.ticker(NEVER).count().map(|v| v.wrapping_mul(3)))
+            .collect();
+
+        let mut r = g.build();
+        r.run(HISTORICAL, RunFor::Cycles(cycles)).unwrap();
+        (r.node_visits(), r.value(&out))
+    }
+
+    fn padding_cost(cycles: u32) -> u64 {
+        let (few, out_few) = run_padded(FEW, cycles);
+        let (many, out_many) = run_padded(MANY, cycles);
+        assert_eq!(out_few, out_many, "cold timers changed the hot output");
+        assert!(!out_few.is_empty(), "hot chain produces a series");
+        many - few
+    }
+
+    let short = padding_cost(SHORT);
+    let long = padding_cost(LONG);
+    assert_eq!(
+        short, long,
+        "{MANY} vs {FEW} idle tickers cost {short} extra node visits over \
+         {SHORT} cycles but {long} over {LONG} — an idle timer is being charged \
+         per cycle, so per-cycle work tracks the graph's timer population rather \
+         than the set that is actually due"
+    );
+}
+
 /// **The depth half of the perf gate.** `sparse_work_is_independent_of_graph_size`
 /// pins independence from the node *count*; this pins independence from graph
 /// *depth*, which was a real cost until the drain stopped walking empty buckets.

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -1161,6 +1161,11 @@ a 200-cycle run. The oracle is asserted on too, so the gate cannot degrade into
 a tautology: if `node_visits` ever stopped being sensitive to graph size, the
 oracle half of the test fails first.
 
+Two companion gates pin the axes this one does not: `quiet_depth_does_not_cost_per_cycle`
+for graph *depth*, and `sparse_work_is_independent_of_timer_count` for the
+graph's *timer* population — see the two sections below, both of which were
+real per-cycle costs this gate's graph shape could not express.
+
 ### The `O(depth)` drain term — ✅ fixed
 
 Measuring the tiers on sparse workloads (`benches/tiers.rs`, groups `sparse` /
@@ -1196,6 +1201,58 @@ cycle to 10**, and the benchmark's depth slope from **+63%** (2.70ms → 4.39ms
 across the two padding widths) to **+8%** (2.94ms → 3.18ms). Gated by
 `quiet_depth_does_not_cost_per_cycle` (`tests/sparse_graph.rs`), which fails at
 636 against a bound of 39 if the walk returns.
+
+### The `O(timers)` seed term — ✅ fixed
+
+The width gate above builds all of its padding off **one shared cold driver**,
+so every graph it measures has two timers no matter how wide it gets. That
+left a third axis unpinned — the *timer* population — and the engine was
+losing badly on it. Three per-cycle terms scaled with what a graph merely
+*has* rather than with what just fired:
+
+- **`TimeQueue::push` deduplicated by scanning the whole pending heap.** The
+  scheduler holds one pending entry per timer at all times (a ticker re-arms
+  the moment it fires), so that scan is the graph's timer population, not the
+  "handful" the type's docs assumed: **22 ns per schedule with one entry
+  queued, 686 ns with 1024**. `delay` pays the same shape, its pending set
+  being every value still in flight.
+- **Dispatch seeded by walking every callback-activated node** and asking each
+  whether the kernel had marked it — `O(timers)` per cycle, each iteration
+  touching a ~150-byte `NodeRt` it otherwise never reads. This was the largest
+  of the three.
+- **`Kernel::end_cycle` memset the whole dirty array** — `O(N)` in graph size,
+  on the "sparse" path.
+
+**Fixed**: `TimeQueue` buckets entries by time (dedup compares only against
+the instant being pushed to) and holds the earliest instant out of the map,
+refilled *lazily* — an eagerly-promoted front thrashes the `BTreeMap` once per
+cycle on the very common "one fast timer among slow ones" shape, which is
+worse than what it replaced. The kernel records what it marks, so `end_cycle`
+clears only that and dispatch seeds straight from `Kernel::due()` rather than
+going looking. `run_dynamic` also stops allocating a graph-sized `dirty` array
+every cycle.
+
+Nothing observable moves: earliest-first order, FIFO within an instant and
+`(value, time)` dedup are all preserved, and dispatch still drains by
+`(layer, index)`, so per-cycle results stay byte-identical.
+
+Results, on an 8-node hot path padded with idle tickers (ns per cycle):
+
+| Idle tickers | 0 | 64 | 256 | 1024 |
+|---|---|---|---|---|
+| before | 247 | 421 | 943 | 2994 |
+| after | 247 | 300 | 327 | 459 |
+
+`store_baseline`'s `sparse_dispatch` bar — an ~8-node hot path among 256 cold
+branches, each with its own ticker — went **19.4 ms → 6.65 ms**. Graphs with a
+single timer are unchanged to within noise, which is the constraint that
+shaped the fix.
+
+Gated by **`sparse_work_is_independent_of_timer_count`**
+(`tests/sparse_graph.rs`), which gives every cold branch its own ticker and
+applies the same one-off-versus-per-cycle method as the width gate. It fails
+on the pre-fix engine, charging 504 extra visits per cycle for 504 timers that
+never fire.
 
 ### The missing n-ary merge — a Phase 6 gate violation, ✅ now closed
 

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -1241,10 +1241,10 @@ Results, on an 8-node hot path padded with idle tickers (ns per cycle):
 | Idle tickers | 0 | 64 | 256 | 1024 |
 |---|---|---|---|---|
 | before | 247 | 421 | 943 | 2994 |
-| after | 247 | 300 | 327 | 459 |
+| after | 247 | 266 | 287 | 442 |
 
 `store_baseline`'s `sparse_dispatch` bar — an ~8-node hot path among 256 cold
-branches, each with its own ticker — went **19.4 ms → 6.65 ms**. Graphs with a
+branches, each with its own ticker — went **19.4 ms → 5.88 ms**. Graphs with a
 single timer are unchanged to within noise, which is the constraint that
 shaped the fix.
 


### PR DESCRIPTION
The sparse dispatcher's claim is that per-cycle work tracks the *active* node
count. Three per-cycle terms did not honour it, and all three scale with what a
graph merely **has** rather than with what just fired.

## What was wrong

**`TimeQueue::push` deduplicated by scanning the whole pending heap.** The
type's own docs said the queues it backs "hold only a handful of not-yet-due
items at a time, so this is not a hot-path concern in practice." That is not
true of the graph scheduler: every scheduling node holds a pending entry *at all
times*, because a ticker re-arms itself the moment it fires. So the scan is the
size of the graph's timer population, and every timer taxes every other timer's
tick. Measured directly:

| pending entries | 1 | 8 | 64 | 256 | 1024 |
|---|---|---|---|---|---|
| ns per `push` | 22 | 31 | 75 | 219 | 686 |

`delay` pays the same shape, its pending set being every value still in flight.

**Dispatch seeded by walking every callback-activated node** and asking each
whether the kernel had marked it — `O(timers)` per cycle whether or not any of
them was due, each iteration touching a ~150-byte `NodeRt` it otherwise never
reads. This was the largest of the three.

**`Kernel::end_cycle` memset the whole dirty array** — `O(N)` in graph size, on
the path whose whole point is not to be.

## What changed

`TimeQueue` buckets entries by time, so dedup compares only against the instant
being pushed to, and holds the earliest instant *out* of the map, refilled
**lazily**. The laziness is the load-bearing part: an eagerly-promoted front
thrashes the `BTreeMap` between one entry and none on every cycle of the very
common "one fast timer among slow ones" shape. Lazy refill keeps both shapes
that matter — a single timer, and a fast timer among slow ones — from touching
the map at all.

The kernel records the indices it marks, so `end_cycle` clears only those and
dispatch seeds straight from `Kernel::due()` instead of going looking.
`run_dynamic` also stops allocating a graph-sized `dirty` array every cycle.

**Nothing observable changes.** The queue keeps earliest-first order, FIFO
within an instant, and `(value, time)` dedup — the `CLAUDE.md` invariant is
intact, just scoped. Dispatch still drains by `(layer, index)`, so per-cycle
results stay byte-identical; the seed order shift is erased by the existing
per-layer `sort_unstable`. The randomised `sparse_matches_full_sweep_across_random_graphs`
differential oracle is what backs that claim.

Three non-perf differences a reviewer should know about, none intended to change
behaviour:

1. In historical mode `begin_cycle` used to do `dirty[ix] = true`, which
   **panics** on an out-of-range index. It now goes through `mark()`, which
   ignores out-of-range and reports no progress, so the run ends rather than
   panicking. Unreachable in practice; the realtime paths already used
   `get_mut` and are unchanged.
2. **`Kernel::end_cycle` gained a precondition**: it clears only the flags it
   recorded, so the caller must pass the same array `begin_cycle` marked. All
   in-tree callers comply (`run_dynamic`'s per-cycle allocation was hoisted
   partly to guarantee it), but `Kernel` is public and re-exported as
   `wingfoil::codegen`, so a hand-rolled kernel driver relying on the old
   wholesale clear would need updating.
3. **`Runner::node_visits()` returns different numbers** — the term it used to
   count no longer exists. It is `#[doc(hidden)]` and both gates assert on
   deltas, which still hold, but an assertion on absolute counts would move.

## Results

The claim that depends on no timing at all — `node_visits`, an exact count of
nodes the dispatch loop had to look at, on an 8-node hot path among 1024 idle
tickers:

| | baseline | this branch |
|---|---|---|
| `node_visits` over 20 000 cycles | 20,685,120 | **206,144** |

That is 1034 nodes examined per cycle to run 8, versus ~10. It is what
`sparse_work_is_independent_of_timer_count` asserts on, and it is reproducible
on any machine.

Wall clock, same graph, ns per cycle:

| idle tickers | 0 | 64 | 256 | 1024 |
|---|---|---|---|---|
| baseline | 236 | 414 | 952 | 2895 |
| this branch | 247 | 266 | 287 | 442 |

`store_baseline`'s `sparse_dispatch` bar — an ~8-node hot path among 256 cold
branches, each with its own ticker — went **19.4 ms → 5.88 ms**, widening the
sparse-vs-oracle gap from 6.2× to ~19×. Graphs with a single timer are unchanged,
which is the constraint that shaped the fix rather than an afterthought: a
`BTreeMap`-only version regressed them ~20 ns/cycle and was discarded.

Two caveats on reading the wall-clock figures:

- On this shared 4-core VM the *unchanged* `legacy` control column in
  `benches/tiers.rs` drifted **+1.4% to +20.4%** between two back-to-back
  passes. Anything under ~20% there is not resolvable. The figures above are
  well outside that band; the `graph` bench's `10x10`/`100x100` bars moved
  −4% and are not claimed either way.
- An earlier revision of this description carried figures (`6.65 ms`, and a
  `459 ns` tail) taken from a paired run whose baseline lived in a git worktree
  sharing one `CARGO_TARGET_DIR` with the main tree. Two packages of the same
  name in one target directory left three `libwingfoil_next` rlibs and cargo
  served stale ones, so those readings did not describe the code under test.
  Everything above is from a wiped target directory. The corrected numbers are
  *better*, because the originals also predated the lazy refill.

## The gate that could not have caught it

`sparse_work_is_independent_of_graph_size` hangs all of its padding off **one
shared cold driver**, so every graph it builds has two timers however wide it
gets — the timer axis was never expressed. `sparse_work_is_independent_of_timer_count`
gives every cold branch its own ticker and applies the same
one-off-versus-per-cycle method. It fails on the pre-fix engine, charging 504
extra visits per cycle for 504 timers that never fire.

`TimeQueue` gains tests for the lazy-refill invariant specifically: a vacated
front is not an empty queue, a fast repeat must reclaim the slot without letting
a parked distant entry jump the queue, and dedup must hold against an entry
sitting in the map rather than in the front.

## Docs

`docs/port-plan.md` gains an `O(timers)` section beside the `O(depth)` one it
rhymes with. `CLAUDE.md`'s TimeQueue rule keeps its "dedup is a feature" framing
and gains the reason dedup must stay scoped to one instant, so a flat scan is
not reintroduced as a simplification later. The benches README marks its tables
as pre-fix rather than editing numbers it did not measure — the same treatment
the lazy wall-clock snap already gets there.

## Testing

Rebased across the crate rename (#679); all paths moved to `crates/wingfoil/`.
`cargo fmt --all --check`, the full-feature next suite, the 8 `sparse_graph`
gates and the 13 `TimeQueue` tests all pass on the renamed tree, plus the legacy
suite (legacy shares this `TimeQueue` through `CallBackStream`). `cargo lint` and
`cargo lint-all` passed pre-rename; `lint-all` needed CMake ≥ 3.30 for the Aeron
C build, so 3.31 was installed per `CLAUDE.md` to make it build the
aeron/iceoryx2 features for real rather than skip them.

## Not addressed here

Three things this review surfaced that are separate changes:

- `Accumulate` is **O(n²)** — it clones the entire growing `Vec` every tick, and
  it is the standard test-assertion helper, so it is everywhere.
- `NodeRt` is ~150 bytes (three cache lines) but the drain loop reads only its
  16-byte `cycle` field. Splitting hot/cold arrays is the direct lever on the
  benches README's own observation that `100x100` costs 2.3× per node vs `10x10`.
- `ticked` is an `Rc<RefCell<Vec<bool>>>` and pays a borrow-flag round trip per
  node per cycle in the drain loop; a slice of `Cell<bool>` removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011n8TUfyC93PNHzqZLrHbJt