### PR TITLE
build: record legacy's zmq deps in the root lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7553,6 +7553,7 @@ version = "8.0.0"
 dependencies = [
  "anyhow",
  "async-stream",
+ "bincode",
  "by_address",
  "chrono",
  "crossbeam",
@@ -7581,6 +7582,7 @@ dependencies = [
  "tynm",
  "wingfoil-derive",
  "wingfoil-next",
+ "zmq",
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up fix to #672, which I merged without the regenerated lockfile.

`zmq-cross-engine-test = ["zmq", "wingfoil/zmq"]` turns on the legacy crate's zmq adapter, which pulls `bincode` and `zmq` into that package's entry in the root `Cargo.lock`. The feature landed without the lock update, so `cargo` with `--locked` currently fails on `next`:

```
error: cannot update the lock file /home/user/wingfoil/Cargo.lock because --locked was passed to prevent this
```

Two lines, no version changes — the `wingfoil` entry gains the two optional deps the feature enables.

I caught it because the change showed up as local drift while merging the branches, and confirmed it by running `cargo metadata --locked` with and without: 101 before, 0 after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfX6mGysUNvGGfMZjKPQLb)_