### PR TITLE
docs: reconcile the plan docs with what has actually landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ crates/                     # every Cargo crate in the tree
 
 docs/                       # wingfoil-architecture.md (read this first),
                             #   migration.md (#[node] -> Op), port-plan.md
-                            #   (the port roadmap), cutover-plan.md,
+                            #   (the port roadmap), cutover-plan.md +
+                            #   cutover-runbook.md (the remaining swap),
                             #   deviation-register.md, design decisions
 
 js/                         # TypeScript client for the web adapter — an npm

--- a/docs/cutover-plan.md
+++ b/docs/cutover-plan.md
@@ -78,7 +78,15 @@ execution model, the infrastructure, and the Python binding surface. The
 shared runtime core has moved to `wingfoil` and the dependency edge is
 inverted, so nothing under `crates/` points at the legacy crates.
 
-What is left is the Phase 7 cutover itself, plus the prerequisites below.
+**Every prerequisite below has now landed**, including the two rulings that
+were owed code (2.2, 2.3), all four docs rows (§4), the release plumbing (§5.3–
+5.6) and the first of the two swap steps — the crate and module rename (1.2),
+which went in over a workspace that legacy had already left (5.0).
+
+What is left is the second swap step: deleting `legacy/` and the scaffolding
+that existed only to let the two engines coexist (1.3, 5.2, the 4.3 deletions),
+then the verification gates (§6) and the `next` → `main` merge. That sequence
+is [`cutover-runbook.md`](cutover-runbook.md).
 
 ## The swap is sequenced in two steps, not one
 
@@ -121,9 +129,13 @@ consequences that reach outside the repo — is
 
 ## Prerequisite work before cutover starts
 
-Everything still outstanding before the directory promotion can begin,
-grouped by kind. "Blocking" means the swap cannot ship without it; "gating"
-means it needs an explicit decision, which may be to accept a deviation.
+What had to be true before the swap could begin, grouped by kind. "Blocking"
+meant the swap cannot ship without it; "gating" meant it needs an explicit
+decision, which may be to accept a deviation.
+
+**This section is now a record rather than a queue** — every row is either ✅
+landed/ruled or ⏸️ deliberately sequenced with the deletion (1.3, 5.2, the 4.3
+deletions), which is [`cutover-runbook.md`](cutover-runbook.md)'s subject.
 
 Completed rows are removed as they land. **Row IDs are stable** — they are
 referenced from commits, PRs and `port-plan.md` — so gaps in the numbering
@@ -262,16 +274,16 @@ gate **6.5**, run immediately before the swap.
 
 ### 4. Docs the cutover owes
 
-**All four land in one PR** (decided 2026-08-03) — they are one editorial pass
-over the same story, and 4.2 and 4.4 overlap enough that splitting them would
-mean writing the architecture prose twice.
+**All four landed in one PR** (#675, as decided 2026-08-03) — they were one
+editorial pass over the same story, and 4.2 and 4.4 overlapped enough that
+splitting them would have meant writing the architecture prose twice.
 
 | # | Item | Size |
 |:--:|---|:--:|
-| 4.1 | **Rewrite the crate-level docs.** `crates/wingfoil/src/lib.rs` still opens *"**Design prototype**: what wingfoil's core abstractions look like if designed from scratch…"* and spends its first 40 lines on a post-mortem of the abandoned `codegen` retrofit. That becomes the crate's front page the moment it is `wingfoil`. | M |
-| 4.2 | **Migration guide `#[node]` → `Op`.** Does not exist. Carries the Rust facade decision (1.4) and 2.1's ruling — `Graph::export` is the one removed public API. The Python half is largely written — `wingfoil-python/docs/migration.rst` — and can be referenced rather than duplicated. | M |
-| 4.3 | **Retire the `legacy/` copies of `README` / `CONTRIBUTING` / `CLAUDE.md`.** The promotion itself is done — next's copies *are* the root copies and the originals moved to `legacy/`. Deleting them rides with the legacy deletion, so what this PR owes is the root `CLAUDE.md` edits: the legacy branching section survives (legacy is still on disk and still cut from `main`) but must now say legacy is out of the workspace and how to build it. The strip happens at deletion. | S |
-| 4.4 | **Architecture / orientation doc** (`docs/wingfoil-architecture.md`, was #507). Deferred until the refactor settled; it has, and cutover is exactly when a new contributor needs it. | M |
+| 4.1 | ✅ **Crate-level docs rewritten.** `crates/wingfoil/src/lib.rs` used to open *"**Design prototype**: what wingfoil's core abstractions look like if designed from scratch…"* and spend its first 40 lines on a post-mortem of the abandoned `codegen` retrofit. It now opens on what the library *is*, with a runnable graph in the first screenful. | M |
+| 4.2 | ✅ **Migration guide `#[node]` → `Op` — written** ([`migration.md`](migration.md)). Carries the Rust facade decision (1.4 — there is no facade) and 2.1's ruling: `Graph::export` is named as the one removed public API. The Python half stays where it was and is referenced, not duplicated — `crates/wingfoil-python/docs/migration.rst`. | M |
+| 4.3 | 🟢 **Root `CLAUDE.md` edits done; the `legacy/` copies retire at deletion.** The promotion itself was already done — next's copies *are* the root copies and the originals moved to `legacy/`. What this PR owed was the root `CLAUDE.md`: the legacy branching section survives (legacy is still on disk and still cut from `main`) and now says legacy is out of the workspace and how to build it. Deleting `legacy/README` / `CONTRIBUTING` / `CLAUDE.md` and stripping that section rides with the deletion — runbook step 1 and step 5. | S |
+| 4.4 | ✅ **Architecture / orientation doc written** — [`wingfoil-architecture.md`](wingfoil-architecture.md) (was #507). Deferred until the refactor settled; it had, and this is what a new contributor reads first. | M |
 
 ### 5. Repo, CI and release plumbing — Goal 2's "directory promotion"
 
@@ -300,43 +312,45 @@ is left, and it is deliberately sequenced with the deletion** — see its row.
 
 ### Open issues to route
 
-Only **#602** (aeron: fragment assembly, sub ergonomics, publisher
-back-pressure) carries the `next` label. Most issues under the `classic`
-label — still named that on GitHub, and a candidate for renaming with the
-rest — die with the legacy tree, but these survive the swap and want
-re-labelling rather than closing: **#367** (wheel excludes aeron/iceoryx2 —
-see 5.4), **#450**
-(no manylinux/aarch64/sdist wheels, trusted publishing), **#452** (Dependabot
-alerts, wasm lockfile), **#449 / #451 / #359** (CI blind spots, workflow
-dedup, stale actions), **#461** (supply-chain hardening), **#457**
-(wingfoil-js), and **#437** (web historical streaming is lossy — confirm
-whether next's web adapter already fixes it).
+**The re-labelling has happened.** When this section was written only **#602**
+(aeron: fragment assembly, sub ergonomics, publisher back-pressure) carried the
+`next` label and the survivors were still under `classic`. All **26** open
+issues now carry `next`, so the routing question is closed and what is left is
+per-issue triage, not a sweep. Named here because the runbook's step 8 acts on
+them: **#367** (wheel excludes aeron/iceoryx2) is **resolved by 5.4** and should
+be closed rather than kept; **#450** (no manylinux/aarch64/sdist wheels, trusted
+publishing), **#452** (Dependabot alerts, wasm lockfile), **#449 / #451 / #359**
+(CI blind spots, workflow dedup, stale actions), **#461** (supply-chain
+hardening), **#457** (wingfoil-js) and **#437** (web historical streaming is
+lossy — confirm whether next's web adapter already fixes it) all survive the
+swap and stay open.
 
 ### Order
 
-Five PRs, in this order (agreed 2026-08-03):
+Five PRs, in this order (agreed 2026-08-03). **All five have landed:**
 
-| | PR | Depends on |
-|:--:|---|---|
-| 1 | **5.0** — legacy out of the workspace | — |
-| 2 | **2.3** — zmq cross-language interop | — |
-| 3 | **2.2** — latency ops in `nitro!` / `compiled()` / `nested()` | — |
-| 4 | **§4** — all four docs rows, one PR | 2.1 (ruled), 1.4 |
-| 5 | **1.2** — the crate + module rename | 5.0 |
+| | PR | Depends on | Landed |
+|:--:|---|---|---|
+| 1 | **5.0** — legacy out of the workspace | — | ✅ #671 |
+| 2 | **2.3** — zmq cross-language interop | — | ✅ #672 |
+| 3 | **2.2** — latency ops in `nitro!` / `compiled()` / `nested()` | — | ✅ #674 |
+| 4 | **§4** — all four docs rows, one PR | 2.1 (ruled), 1.4 (ruled) | ✅ #675 |
+| 5 | **1.2** — the crate + module rename | 5.0 | ✅ #679 |
 
-2, 3 and 4 are mutually independent and independent of 1; they only need to be
+2, 3 and 4 were mutually independent and independent of 1; they only had to be
 in before 1.2, because **1.2 touches every `use wingfoil::` in the tree**
-and conflicts with anything open across it. Land it with the tree quiet. The
-rest of section 5 follows it, and `rm -rf legacy/` (with 1.3, the 4.3
-deletions and the legacy workflow/publish retirement) is the separate second
-step.
+and conflicts with anything open across it. It was landed with the tree quiet.
+The rest of section 5 followed it (§5.3–5.6, #680), leaving `rm -rf legacy/` —
+with 1.3, the 4.3 deletions and the legacy workflow/publish retirement — as the
+separate second step, now written up as [`cutover-runbook.md`](cutover-runbook.md).
 
 **Section 3 is closed**: 3.9 ran and added nothing, and 3.7 and 3.8 have both
 landed. Its standing replacement is gate 6.5, which re-checks the sweep
 immediately before the swap.
 
-1.4 is the one ruling still owed that anything else waits on — 4.2 cannot be
-written without knowing whether the legacy facade API survives.
+**Every ruling owed by §2 has been given** (2026-08-03) — 1.4 was the last one
+anything waited on, since 4.2 could not be written without knowing whether the
+legacy facade API survived. It does not.
 
 One sequencing hazard, learned the hard way: a branch cut before an
 invariant lands will happily reintroduce what that invariant removed, and CI

--- a/docs/cutover-runbook.md
+++ b/docs/cutover-runbook.md
@@ -194,13 +194,20 @@ on `next`. `main` still carries the pre-cutover world.
 
 ## Step 8 — issues
 
-Re-label the survivors from `classic` (itself a name worth retiring): **#450**
-wheels, **#452** dependabot, **#449 / #451 / #359** CI, **#461** supply chain,
-**#457** wingfoil-js, **#437** web historical streaming. **#367 is resolved** by
-the wheel change — close it.
+**The re-labelling is already done** — all 26 open issues carry `next`, and
+nothing is left under `classic`. What this step still owes:
 
-Everything else under `classic` describes the deleted engine and can be closed
-with a note pointing at this runbook.
+- **Close #367** (iceoryx2/aeron missing from the wheel) — resolved by the
+  5.4 wheel change.
+- Re-check the survivors against the deleted tree: **#450** wheels, **#452**
+  dependabot, **#449 / #451 / #359** CI, **#461** supply chain, **#457**
+  wingfoil-js, **#437** web historical streaming. All describe the surviving
+  engine or its packaging, so they stay open — but **#437** in particular
+  should be confirmed against next's web adapter rather than assumed to carry
+  over, and the CI issues (#449 / #451) are partly answered by step 4's
+  workflow collapse.
+- Anything that still describes the *deleted* engine can be closed with a note
+  pointing at this runbook.
 
 ## Order
 

--- a/docs/deviation-register.md
+++ b/docs/deviation-register.md
@@ -1,9 +1,11 @@
 # wingfoil → legacy: deviation register
 
-Status: **living checklist** for the eventual Phase-7 cutover audit. Every place
-wingfoil's behaviour or surface deviates from the legacy `wingfoil` tree,
-collected in one place and classified so each can be given an explicit
-accept/fix ruling before cutover.
+Status: **the cutover audit has run — every 🔴 and 🟡 was ruled on 2026-08-03**
+(reasoning in [`cutover-plan.md`](./cutover-plan.md) §2). This stays a living
+checklist: every place wingfoil's behaviour or surface deviates from the legacy
+`wingfoil` tree, collected in one place and classified, so a *new* deviation
+arriving after that audit is still caught and still gets an explicit accept/fix
+ruling.
 
 **Sources:** (1) each ported adapter's `# Deviations from legacy` module-doc
 block — regenerate with
@@ -178,18 +180,34 @@ motivated the reject only ever required two *mechanisms*, not two public
 
 ---
 
-## Recommended priorities
+## Where this stands — nothing open
 
-1. **B4** — decide whether the csv whole-file memory deviation matters for the
-   "strict superset" claim, or is an acceptable documented trade-off.
-1. **C6** — `Graph::export` is a *public legacy API* we have chosen not to
-   port. That choice needs ratifying against the superset objective (accept
-   the drop and document it in the migration guide, or port `export` before
-   the swap); it is the only legacy public function next has no answer for.
-2. **A6 is closed** (pinned to A3); **A2 is closed** (parity — legacy is
-   single-run for I/O sources too, verified against legacy source). The
-   defer-to-start plan (A1) is complete. What's left is the non-code rulings
-   (B4, and the cutover-audit sweep of any remaining 🟡).
+This section used to list what to do next. Every entry on it has since been
+closed, and it is kept as the record of how:
+
+1. **B4** — *was* "decide whether the csv whole-file memory deviation is
+   acceptable". Not a ruling in the end: it was **fixed**. `csv_read` (and
+   `lines`) moved off `replay_results` to a lazy `produce_async` producer with
+   a `buffer_size` bound, so rows deserialize on demand and a malformed row
+   aborts mid-stream, closer to legacy than the up-front read ever was.
+2. **C6** — `Graph::export` is a *public legacy API* next chose not to port,
+   and the ruling that needed making was made: **accept the drop**
+   (2026-08-03, cutover row 2.1). The migration guide names it as the one
+   removed public API, and `Builder` still holds the topology and the debug
+   labels, so a designed introspection surface can reintroduce the capability
+   later.
+3. **C7** — the other ⚪ carried into the cutover audit, ruled the other way:
+   **close it**. `stamp` / `stamp_precise` reach all three engines; only
+   `latency_report` stays interpreted-only, and that is structural (a
+   `compiled()` graph is outputs-only, so the stats handle could never escape).
+4. **A1–A7 are all closed**: the defer-to-start migration is complete for every
+   I/O adapter, A2 turned out to be **parity** rather than a gap (legacy is
+   single-run for I/O sources too, verified against its source), and A6 was
+   pinned to A3 and fixed with it. **A5a** is the one residual, ruled
+   *accept — legacy-parity* (cutover 2.5).
+
+The standing obligation is the one in "Keeping this current" below: re-run the
+greps after each adapter/engine PR. There is no open ruling.
 
 **Resolved / ratified since this register was written:** **A5** (graph-owned
 runtime, #548); **A1/A4 for `zmq_sub`** (deferred to `start()` via

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -1,10 +1,14 @@
 # Porting wingfoil to the Op pattern
 
-Status: **porting in progress** — the Phase 0 contract spikes have landed and
-several later phases are underway (see the ✅/🟡 markers throughout the body).
-The `wingfoil` and `wingfoil-derive` crates now live on this branch
-(with tests and lints passing) and implement the target pattern: `Op` trait
-(pure semantics, engine-owned state), a sparse dirty-list
+Status: **the port is complete; only the cutover is left.** Phases 0–6 have all
+landed — contract spikes, the node catalog, all 15 adapters, the engine
+execution model, the infrastructure and the Python binding surface (see the ✅
+markers throughout the body). What remains is Phase 7, and within it only the
+deletion of `legacy/`: the rename to `wingfoil` has already happened, and
+[`cutover-plan.md`](cutover-plan.md) + [`cutover-runbook.md`](cutover-runbook.md)
+carry the remaining sequence.
+The `wingfoil` and `wingfoil-derive` crates implement the target pattern:
+`Op` trait (pure semantics, engine-owned state), a sparse dirty-list
 interpreted engine (Phase 4.5 scheduling landed), a fully monomorphized
 `compiled()` expansion, compiled
 islands (`nested()`) mountable in interpreted graphs, busy-spin `poll`
@@ -1471,12 +1475,14 @@ dynamism is an interpreted-engine capability, matching legacy. See the Phase
 
 ## Phase 5 — infrastructure
 
-**Status: ✅ complete, with two ratified non-goals.** Every item below is
+**Status: ✅ complete, with one ratified non-goal.** Every item below is
 either landed or explicitly ruled out — there is no open engineering work in
-this phase. The two things next will *not* do (graph export; latency on the
-compiled path) are now carried as **C6** and **C7** in the
-[deviation register](./deviation-register.md), so they get a cutover ruling
-instead of reading as unfinished port work. The one downstream consequence —
+this phase. The one thing next will *not* do is graph export, carried as **C6**
+in the [deviation register](./deviation-register.md) so it gets a cutover ruling
+instead of reading as unfinished port work (it did: accept the drop). **C7 —
+latency on the compiled path — was the second such non-goal and is no longer
+one:** it was ruled *close it, don't ratify* at cutover and the stamps now reach
+all three engines (see the latency bullet). The one downstream consequence —
 deleting the `wingfoil-derive` crate once the legacy tree goes — is on the
 Phase 7 checklist. The remaining `#[op]` item (generating the *fluent* method
 too) is a deliberate deferral, not owed: see the sub-bullet below.
@@ -1489,11 +1495,20 @@ too) is a deliberate deferral, not owed: see the sub-bullet below.
   `wall_time_precise()` (fresh TSC read); the node layer is re-implemented as
   ops — `stamp`/`stamp_precise` (over `register_op1`) and the `latency_report`
   sink — exposed via the `LatencyStreamOps`/`LatencyReportOps` fluent traits.
-  **Deviation**: fluent/interpreted only (matching legacy, which exposes
-  latency solely through `LatencyStreamOps`); a stamp's stage is a compile-time
-  *type* parameter, which does not map onto the `nitro!` value-dispatch table,
-  so compiled/nested support is out of scope for this op family. Registered as
-  **C7** in the [deviation register](./deviation-register.md).
+  **Three-engine coverage ✅ landed** (cutover row 2.2, register **C7**). This
+  bullet used to record the op family as fluent/interpreted-only, on the
+  grounds that a stamp's stage is a compile-time *type* parameter and `nitro!`
+  forwards values. That obstacle was real but the shape of the fix was not what
+  was written: the stage now crosses **as a value whose type carries it** —
+  `#[op(explicit = S)]` gives each forwarder a leading `PhantomData<S>` and the
+  emission passes `PhantomData::<the_stage>`, so inference resolves it like any
+  other argument. `stamp` / `stamp_precise` work in all three expansions
+  (`stamps_reach_the_compiled_tier`, `stamps_reach_a_nested_island` in
+  `tests/latency.rs`), and the mechanism generalises to any op with a phantom
+  type parameter. **`latency_report` stays interpreted-only by structure, not
+  omission**: the sink's whole value is the `Rc<RefCell<LatencyStats>>` it hands
+  back, and `compiled()` is outputs-only by design, so the handle could never
+  escape.
   Cross-process proof: the `latency` example (`examples/latency/`) runs the
   full stamp → publish → subscribe → report loop over iceoryx2, and
   `tests/iceoryx2_adapter.rs` pins the `Traced` round trip.
@@ -1668,7 +1683,7 @@ tests covered — not "legacy pytest passes unchanged."
   dispatcher onto the engine's `StatisticsOps`, with `tests/test_statistics.py`
   as the legacy parity twin. The per-adapter bindings that followed are the next
   bullet.
-- **Per-adapter Python bindings** 🟡 *mechanical + stream-transform tiers landed (9 of 15)*: the `#[pyadapter]`
+- **Per-adapter Python bindings** ✅ *all four tiers landed — 15 of 15*: the `#[pyadapter]`
   exposure of the real `adapters::*` I/O adapters, each behind a
   `wingfoil-python` cargo feature of the same name (`crate::adapters::*`,
   registered in the `#[pymodule]` under the same `#[cfg]`). **postgres** is the
@@ -1923,7 +1938,7 @@ tests covered — not "legacy pytest passes unchanged."
   `check_stages` are `pub`, so an adapter binding — in this crate or a
   third-party one — splits and packs the wire header without a parallel copy of
   the record.
-- **Pytest parity audit** 🟡 *audited 2026-08; two surface gaps remain* — the
+- **Pytest parity audit** ✅ *audited 2026-08; both surface gaps since closed* — the
   gate stated at the top of this phase ("next-python's own pytest suite reaching
   parity with the surface the legacy tests covered") had never been checked, only
   assumed. Every test function in `legacy/wingfoil-python/tests/` (268, in 21 files) was
@@ -2090,24 +2105,39 @@ tests covered — not "legacy pytest passes unchanged."
 
 ## Phase 7 — cutover
 
-- Deprecate legacy engine internals (`MutableNode` wiring path), keep the
-  facade API.
-- Branch-1 codegen has been retired: `wingfoil::codegen::{generate,
+**In progress — the only unfinished phase.** The sequencing, the rulings and
+the audit trail live in [`cutover-plan.md`](cutover-plan.md); the step-by-step
+for what is left is [`cutover-runbook.md`](cutover-runbook.md). Status of each
+item this plan originally listed:
+
+- ✅ **Ruled 2026-08-03 (cutover row 1.4): no compatibility facade.** This
+  bullet used to read "deprecate legacy engine internals, keep the facade API".
+  There is no facade — the `MutableNode` wiring path retires with the legacy
+  tree and nothing re-exports it under the new name. Rust downstreams break at
+  the major bump, deliberately, and [`migration.md`](migration.md) is the
+  answer (the same call the Python binding made).
+- ✅ Branch-1 codegen has been retired: `wingfoil::codegen::{generate,
   generate_standalone, StaticRuntime}`, topology fingerprints, golden
   files, and `wingfoil-codegen-build-example` are removed. `Kernel`,
   `KernelWaker`, `waker_channel` remain (they are the engine core now).
-- **Delete the `wingfoil-derive` crate** (the `#[node]` attribute macro).
-  Nothing under `crates/` depends on it — the Phase-5 retirement is already
-  complete on the next side — so its removal is purely a consequence of the
-  legacy tree going away: drop the crate directory, its workspace member
-  entry, and the `wingfoil-derive` dependency from `wingfoil`'s manifest.
-- **Rule on the deviation register's open ⚪/🟡 items** — in particular **C6**
-  (`Graph::export` / GML, a public legacy API next deliberately does not
-  provide) and **C7** (latency ops are interpreted-only). Every remaining 🔴
-  and 🟡 needs an explicit accept/fix decision before the swap.
-- Docs: rewrite crate docs + CLAUDE.md for the op pattern; migration guide
-  from `#[node]` to `Op`.
-- Version: next merges into `wingfoil` as a major bump.
+- ⏸️ **Delete the `wingfoil-derive` crate** (the `#[node]` attribute macro —
+  now `legacy/wingfoil-derive`; the *next* crate of that name holds `nitro!`,
+  `#[op]` and `latency_stages!`). Nothing under `crates/` depends on it, and
+  legacy has since left the workspace, so it goes with `rm -rf legacy/` rather
+  than separately — cutover row 1.3, runbook step 1.
+- ✅ **The deviation register's open ⚪/🟡 items are all ruled** (2026-08-03,
+  cutover §2). **C6** (`Graph::export` / GML) — accept the drop, named in the
+  migration guide as the one removed public API. **C7** (latency ops
+  interpreted-only) — ruled *close it*, and the stamps now reach all three
+  engines. Nothing is left needing an accept/fix decision before the swap.
+- ✅ **Docs** — crate docs rewritten, root `CLAUDE.md` updated for the op
+  pattern, and the `#[node]` → `Op` migration guide written
+  ([`migration.md`](migration.md)), alongside
+  [`wingfoil-architecture.md`](wingfoil-architecture.md). Cutover §4, all four
+  rows.
+- 🟢 **Version** — the renamed crate is at **9.0.0**, over legacy's 8.x line
+  (cutover 5.6). What is still owed is the `next` → `main` merge itself, which
+  is the swap (runbook step 7).
 
 ## Testing strategy
 
@@ -2153,9 +2183,12 @@ tests covered — not "legacy pytest passes unchanged."
 ## Explicitly out of scope (v1)
 
 - Feedback inside `nitro!` / islands (fluent only).
-- Runtime graph mutation — the **Phase 4.5** dirty-list enabler has landed;
-  the mutation feature itself is still to be built (open blocker-vs-deviation
-  decision), not a permanent exclusion.
+- ~~Runtime graph mutation~~ — **no longer out of scope: it landed** in Phase
+  4.5 behind the `dynamic-graph` feature (`Runner::run_dynamic` + `Extension`,
+  `Builder::dynamic_group` with a pluggable `StreamStore`, and
+  `Builder::demux` / `demux_map` / `demux_it`). The blocker-vs-deviation
+  decision this bullet left open was settled by building it. The compiled and
+  island interiors stay static by design, matching legacy.
 - Arena value store for the interpreted engine — a deferred **Phase 4.5** perf
   follow-on with the slot boundary frozen so it stays internal; no longer
   indefinitely deferred and no longer a sequencing risk.
@@ -2242,24 +2275,21 @@ decision for both: does compiled gain a wake channel, or stay busy-spin +
 realtime-timer only? The busy-spin answer fits the compiled-perf story. Tracked
 as a capability gap in [`deviation-register.md`](./deviation-register.md) §C.
 
-### Engine architecture / orientation doc (was #507)
+### Engine architecture / orientation doc (was #507) — ✅ written
 
-An evidence-backed `docs/wingfoil-architecture.md` orienting a new
-contributor/agent to the Op-pattern engine, citing source at `file:line`.
-Deliberately a *current-state snapshot*, not a migration guide — so it is
-deferred until after the incoming refactor settles (a snapshot written now would
-go stale through it). Sections to regenerate against the post-refactor code:
-- The `Op` trait + engine-owned state; `Tick::{Value,Silent,Quiet}`; lifecycle
-  hooks.
-- The three execution tiers: interpreted sparse dirty-list (`Dispatch::Sparse`,
-  default) + full-sweep oracle; fully-monomorphized `compiled()`; `nested()`
-  islands.
-- Fluent API + `signal::Signal` facade.
-- Sources/edges (ticker/constant/poll/external/channel/feedback), bursts, the
-  shared `Kernel`.
-- Adapters + the "adding an op" recipe (post-#496 `#[op]` forwarder mechanism,
-  no macro op-table).
-- Testing strategy: parity-oracle vs legacy + three-engine agreement.
+Landed as [`wingfoil-architecture.md`](wingfoil-architecture.md) with the
+cutover docs pass (cutover row 4.4). It was deferred here until the refactor
+settled — a snapshot written earlier would have gone stale through it — and
+covers what this entry scoped: the `Op` trait + engine-owned state,
+`Tick::{Value,Silent,Quiet}` and the lifecycle hooks; the three execution tiers
+(interpreted sparse dirty-list + full-sweep oracle, monomorphized `compiled()`,
+`nested()` islands); the fluent API and the `signal::Signal` facade; sources,
+bursts and the shared `Kernel`; the adapters and the "adding an op" recipe; and
+the parity-oracle + three-engine testing strategy.
+
+It is a **current-state snapshot**, so it needs one revision at the deletion:
+the `legacy/` row and the parity-oracle framing go with the tree (runbook step
+5). CLAUDE.md points at it as the first thing to read.
 
 ## Sequencing and parallelism
 

--- a/docs/wingfoil-architecture.md
+++ b/docs/wingfoil-architecture.md
@@ -88,7 +88,7 @@ adapters/     I/O: csv, kafka, zmq, kdb, redis, postgres, etcd, fix, web,
               aeron, iceoryx2, fluvio, augurs, prometheus, otlp, lines
 runtime/      Shared core: NanoTime, RunMode/RunFor, TimeQueue, Kernel,
               Burst, the latency data layer
-compat.rs     A legacy-style Signal facade over the fallible lifecycle
+signal.rs     A builder-less Signal facade over the fallible lifecycle
 ```
 
 Plus `wingfoil-derive` (`nitro!` and `#[op]`), `wingfoil-python`


### PR DESCRIPTION
Reviewing the plan docs for unfinished work turned up mostly the docs' own drift: rows ticked in the body but not in their status markers, and two entries describing decisions that were later superseded by building the thing instead. Read as-is, they make the port look less finished than it is.

No code changed. No ruling, gate or deferral is altered.

## The one fix beyond bookkeeping

The architecture doc was written as `wingfoil-next-architecture.md` and the crate rename (#679) never moved it, so **every reference to it pointed at a path that does not exist** — `CLAUDE.md` twice, `crates/wingfoil/src/lib.rs:88`, `docs/migration.md:25`, and cutover row 4.4. Renamed to `docs/wingfoil-architecture.md`, the name everything already uses. Its file map is corrected too: it still listed `compat.rs`, which is `signal.rs`.

## Status markers reconciled with their own bodies

**`cutover-plan.md`**
- §4's four docs rows landed in #675 but were never ticked, and 4.1 still asserted that `lib.rs` opens on *"Design prototype"*. It hasn't since that PR.
- The Order table's five PRs have all landed (#671, #672, #674, #675, #679) — now marked, with numbers.
- "1.4 is the one ruling still owed" contradicted 1.4's own ✅ row three sections above.
- Status section now says step one of the swap is complete and points at `cutover-runbook.md` for step two.
- Open-issue routing is done: all 26 open issues carry `next` and none are left under `classic`, so that section becomes a pointer to what is actually left (closing #367) rather than a sweep to run.

**`port-plan.md`**
- Header still read "porting in progress" with phases 0–6 complete.
- Phase 5 recorded latency ops as a ratified non-goal (C7). The cutover ruled the other way and it closed — `stamp`/`stamp_precise` reach all three engines via `#[op(explicit = S)]`, with `latency_report` interpreted-only by structure rather than omission. Verified against `wingfoil-derive` and the two `stamps_reach_*` tests in `tests/latency.rs` before rewriting.
- Phase 6 headed its Python bindings "🟡 9 of 15" above a body ending "Remaining: 0", and its pytest audit "🟡 two surface gaps remain" above "**Remaining** — nothing".
- Runtime graph mutation was listed as out of scope with an open blocker-vs-deviation decision. It landed in Phase 4.5, which settled that decision by building it.
- The #507 architecture doc was listed as deferred work.
- Phase 7's checklist still assumed a compatibility facade that 1.4 ruled against.

**`deviation-register.md`** — "Recommended priorities" still led with B4 and C6 as open decisions, both resolved higher up in the same file. Rewritten as the record of how each closed, since the audit has run.

**`cutover-runbook.md`** — step 8 predated the re-labelling; it now names what is left.

## Deliberately unchanged

Gates 6.1 / 6.2 / 6.3 / 6.5 are still owed at the swap; 1.3, 5.2 and the 4.3 deletions stay sequenced with `rm -rf legacy/`; and the post-v1 items stay deferred — arena/SoA store, compiled-path IO ingestion (C4), multi-output islands (C3), bounded kafka/fluvio readers, and the 11 fluent-only `time_windowed_*` methods that `op_completeness.rs` classifies as a real gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq8BNdx3X612hC3gqo3EeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq8BNdx3X612hC3gqo3EeT)_