### PR TITLE
Take Duration as the time-windowed ops' Cfg, so they reach compiled

### DIFF
--- a/.claude/commands/new-op-next.md
+++ b/.claude/commands/new-op-next.md
@@ -282,8 +282,10 @@ current cases, not hypotheticals:
 - the fluent signature deliberately reorders the parameters —
   `delay_with_reset(delay, trigger)` puts the cfg before the edge;
 - the fluent signature's types differ from the op's `Cfg` — `logged` (see the
-  gotcha below), and every `time_windowed_*` statistic, whose method takes a
-  `Duration` the body converts to the op's `NanoTime` `Cfg`;
+  gotcha below). **Prefer changing the `Cfg` to fixing it here:** the
+  `time_windowed_*` family used to be the other example in this bullet, and
+  closing it (taking `Duration` as the `Cfg`, converting once in `start`) both
+  deleted 11 hand-written methods and put the family in `nitro!`;
 - the body does more than forward — `ewma_per_tick` `debug_assert!`s its alpha
   is in `[0, 1]` before wiring.
 
@@ -402,10 +404,15 @@ categories.
 If your op lands in **2b** (fluent signature ≠ the op's `Cfg`), say which of
 the two it is: a deliberate ergonomic split that costs nothing compiled
 (`logged` — a debug tap has no place in a compiled kernel), or a real gap
-worth closing later (the `time_windowed_*` family — a compiled kernel *should*
-carry a time-windowed statistic). The fix for the second kind is to take the
-ergonomic type as `Cfg` and convert in `start`, the way `Ticker` does — not to
-touch the macro.
+worth closing (a compiled kernel *should* carry the op). **Default to closing
+it.** The fix is to take the ergonomic type as `Cfg` and convert in `start`,
+the way `Ticker` does — never to touch the macro. The `time_windowed_*` family
+was 2b's worked example of the second kind and is now the worked example of
+the fix: `Cfg` became the `Duration` the fluent methods already took, the
+converted window moved into a `TimeWindowed<S>` state wrapper (the accumulators
+are shared with the count-windowed ops, which have no window to hold), and all
+11 methods became generated. If the state you would convert into is shared with
+another family, wrap it — do not add a field only one family reads.
 
 Compiled-specific stateful/lifecycle behaviour has its own suites
 (`tests/compiled_stateful_ops.rs`, `tests/compiled_lifecycle_ops.rs`,

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -1493,6 +1493,44 @@ fn aged_out(now: NanoTime, t: NanoTime, window: u64) -> bool {
     u64::from(now) - u64::from(t) > window
 }
 
+/// State wrapper for the time-windowed family: the window converted to engine
+/// nanoseconds **once** in `start`, beside whichever accumulator the statistic
+/// keeps.
+///
+/// It exists to let these ops take a `Duration` as their [`Op::Cfg`] — the same
+/// type their fluent methods take — which is what puts them in `nitro!` and
+/// `compiled()` alongside every other statistic. The compiled path uses the
+/// call-site argument tokens verbatim as the config, so an op whose `Cfg` was
+/// [`NanoTime`] while its fluent method took a `Duration` could not be spelled
+/// in a `nitro!` block at all; that mismatch is why this family was
+/// interpreted-only.
+///
+/// The conversion lands in `start` rather than `cycle` for the reason
+/// [`Ticker`] gives: per-cycle it is measurable on dense graphs, and here it
+/// would sit on the hot path of every windowed statistic in the graph.
+///
+/// The window is held *here* rather than as a field on the accumulators
+/// because three of the four — [`WindowedTimeWeightedMomentState`],
+/// [`TimeWeightedMedianState`] and the moment state — are shared with the
+/// **count**-windowed ops, which evict by index and have no window duration to
+/// hold. Wrapping keeps that boundary honest: the accumulator stays a pure
+/// accumulator, and only the ops that evict by age carry an eviction horizon.
+#[derive(Default)]
+pub struct TimeWindowed<S> {
+    /// The eviction horizon in engine nanoseconds; set by `arm` in `start`.
+    window: u64,
+    /// The statistic's own accumulator.
+    inner: S,
+}
+
+impl<S> TimeWindowed<S> {
+    /// Convert the configured window to engine nanoseconds. Called from each
+    /// op's `start`, so `cycle` reads a `u64` and never converts.
+    fn arm(&mut self, window: Duration) {
+        self.window = u64::from(NanoTime::from(window));
+    }
+}
+
 /// Ring-buffer state for the time-windowed sum: the `(time, value)` samples
 /// currently inside the window and their running total, maintained
 /// incrementally (add on push, subtract on evict) rather than rescanned.
@@ -1520,26 +1558,35 @@ impl TimeWindowSumState {
     }
 }
 
-/// Sum over a bounded time window of the last `window` (a [`NanoTime`] duration)
-/// of graph time — O(1) per tick. Mirrors the legacy `sum(Window::Time(_))`.
+/// Sum over a bounded time window of the last `window` (a [`Duration`], converted
+/// to engine time in `start`) of graph time — O(1) per tick. Mirrors the legacy `sum(Window::Time(_))`.
 pub struct TimeWindowedSum;
 
-#[op(build = time_windowed_sum)]
+#[op(build = time_windowed_sum, fluent)]
 impl Op for TimeWindowedSum {
-    type Cfg = NanoTime;
-    type State = TimeWindowSumState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWindowSumState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWindowSumState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowSumState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        let out = state.push(ctx.time(), *input.0, u64::from(*cfg));
+        let out = state.inner.push(ctx.time(), *input.0, state.window);
         Ok(Tick::Value(out))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowSumState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -1614,24 +1661,33 @@ impl TimeWindowMomentState {
 /// Mirrors the legacy `mean(Window::Time(_), Weighting::Count)`.
 pub struct TimeWindowedMean;
 
-#[op(build = time_windowed_mean)]
+#[op(build = time_windowed_mean, fluent)]
 impl Op for TimeWindowedMean {
-    type Cfg = NanoTime;
-    type State = TimeWindowMomentState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWindowMomentState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWindowMomentState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMomentState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        state.push(ctx.time(), *input.0, u64::from(*cfg));
+        state.inner.push(ctx.time(), *input.0, state.window);
         // The current sample is always in window, so `count >= 1` and `mean`
         // holds the window mean (equal to the sample on the first tick).
-        Ok(Tick::Value(state.mean))
+        Ok(Tick::Value(state.inner.mean))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMomentState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -1639,22 +1695,31 @@ impl Op for TimeWindowedMean {
 /// per tick. Mirrors the legacy `variance(Window::Time(_), Weighting::Count)`.
 pub struct TimeWindowedVar;
 
-#[op(build = time_windowed_var)]
+#[op(build = time_windowed_var, fluent)]
 impl Op for TimeWindowedVar {
-    type Cfg = NanoTime;
-    type State = TimeWindowMomentState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWindowMomentState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWindowMomentState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMomentState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        state.push(ctx.time(), *input.0, u64::from(*cfg));
-        Ok(Tick::Value(state.variance()))
+        state.inner.push(ctx.time(), *input.0, state.window);
+        Ok(Tick::Value(state.inner.variance()))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMomentState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -1664,22 +1729,31 @@ impl Op for TimeWindowedVar {
 /// Weighting::Count)`.
 pub struct TimeWindowedStd;
 
-#[op(build = time_windowed_std)]
+#[op(build = time_windowed_std, fluent)]
 impl Op for TimeWindowedStd {
-    type Cfg = NanoTime;
-    type State = TimeWindowMomentState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWindowMomentState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWindowMomentState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMomentState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        state.push(ctx.time(), *input.0, u64::from(*cfg));
-        Ok(Tick::Value(state.variance().max(0.0).sqrt()))
+        state.inner.push(ctx.time(), *input.0, state.window);
+        Ok(Tick::Value(state.inner.variance().max(0.0).sqrt()))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMomentState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -1735,22 +1809,31 @@ impl TimeWindowExtremeState {
 /// per tick. Mirrors the legacy `min(Window::Time(_))`.
 pub struct TimeWindowedMin;
 
-#[op(build = time_windowed_min)]
+#[op(build = time_windowed_min, fluent)]
 impl Op for TimeWindowedMin {
-    type Cfg = NanoTime;
-    type State = TimeWindowExtremeState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWindowExtremeState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWindowExtremeState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowExtremeState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        let out = state.push(ctx.time(), *input.0, u64::from(*cfg), true);
+        let out = state.inner.push(ctx.time(), *input.0, state.window, true);
         Ok(Tick::Value(out))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowExtremeState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -1758,22 +1841,31 @@ impl Op for TimeWindowedMin {
 /// per tick. Mirrors the legacy `max(Window::Time(_))`.
 pub struct TimeWindowedMax;
 
-#[op(build = time_windowed_max)]
+#[op(build = time_windowed_max, fluent)]
 impl Op for TimeWindowedMax {
-    type Cfg = NanoTime;
-    type State = TimeWindowExtremeState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWindowExtremeState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWindowExtremeState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowExtremeState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        let out = state.push(ctx.time(), *input.0, u64::from(*cfg), false);
+        let out = state.inner.push(ctx.time(), *input.0, state.window, false);
         Ok(Tick::Value(out))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowExtremeState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -1816,22 +1908,31 @@ impl TimeWindowMedianState {
 /// `median(Window::Time(_), Weighting::Count)`.
 pub struct TimeWindowedMedian;
 
-#[op(build = time_windowed_median)]
+#[op(build = time_windowed_median, fluent)]
 impl Op for TimeWindowedMedian {
-    type Cfg = NanoTime;
-    type State = TimeWindowMedianState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWindowMedianState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWindowMedianState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMedianState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        let out = state.push(ctx.time(), *input.0, u64::from(*cfg));
+        let out = state.inner.push(ctx.time(), *input.0, state.window);
         Ok(Tick::Value(out))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWindowMedianState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -2190,27 +2291,36 @@ impl Op for RollingStdTimeWeighted {
 }
 
 /// Time-weighted mean over a bounded time window of the last `window` (a
-/// [`NanoTime`] duration) of graph time. Mirrors the legacy
+/// [`Duration`], converted to engine time in `start`) of graph time. Mirrors the legacy
 /// `mean(Window::Time(_), Weighting::Time)`.
 pub struct TimeWindowedMeanTimeWeighted;
 
-#[op(build = time_windowed_mean_time_weighted)]
+#[op(build = time_windowed_mean_time_weighted, fluent)]
 impl Op for TimeWindowedMeanTimeWeighted {
-    type Cfg = NanoTime;
-    type State = WindowedTimeWeightedMomentState;
+    type Cfg = Duration;
+    type State = TimeWindowed<WindowedTimeWeightedMomentState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut WindowedTimeWeightedMomentState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<WindowedTimeWeightedMomentState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
         let sample = *input.0;
-        state.push_time(ctx.time(), sample, u64::from(*cfg));
-        Ok(Tick::Value(state.mean(sample)))
+        state.inner.push_time(ctx.time(), sample, state.window);
+        Ok(Tick::Value(state.inner.mean(sample)))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<WindowedTimeWeightedMomentState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -2218,22 +2328,31 @@ impl Op for TimeWindowedMeanTimeWeighted {
 /// legacy `variance(Window::Time(_), Weighting::Time)`.
 pub struct TimeWindowedVarTimeWeighted;
 
-#[op(build = time_windowed_var_time_weighted)]
+#[op(build = time_windowed_var_time_weighted, fluent)]
 impl Op for TimeWindowedVarTimeWeighted {
-    type Cfg = NanoTime;
-    type State = WindowedTimeWeightedMomentState;
+    type Cfg = Duration;
+    type State = TimeWindowed<WindowedTimeWeightedMomentState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut WindowedTimeWeightedMomentState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<WindowedTimeWeightedMomentState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        state.push_time(ctx.time(), *input.0, u64::from(*cfg));
-        Ok(Tick::Value(state.variance()))
+        state.inner.push_time(ctx.time(), *input.0, state.window);
+        Ok(Tick::Value(state.inner.variance()))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<WindowedTimeWeightedMomentState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -2242,22 +2361,31 @@ impl Op for TimeWindowedVarTimeWeighted {
 /// `std(Window::Time(_), Weighting::Time)`.
 pub struct TimeWindowedStdTimeWeighted;
 
-#[op(build = time_windowed_std_time_weighted)]
+#[op(build = time_windowed_std_time_weighted, fluent)]
 impl Op for TimeWindowedStdTimeWeighted {
-    type Cfg = NanoTime;
-    type State = WindowedTimeWeightedMomentState;
+    type Cfg = Duration;
+    type State = TimeWindowed<WindowedTimeWeightedMomentState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut WindowedTimeWeightedMomentState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<WindowedTimeWeightedMomentState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        state.push_time(ctx.time(), *input.0, u64::from(*cfg));
-        Ok(Tick::Value(state.variance().max(0.0).sqrt()))
+        state.inner.push_time(ctx.time(), *input.0, state.window);
+        Ok(Tick::Value(state.inner.variance().max(0.0).sqrt()))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<WindowedTimeWeightedMomentState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 
@@ -2428,25 +2556,34 @@ impl Op for RollingMedianTimeWeighted {
 /// `median(Window::Time(_), Weighting::Time)`.
 pub struct TimeWindowedMedianTimeWeighted;
 
-#[op(build = time_windowed_median_time_weighted)]
+#[op(build = time_windowed_median_time_weighted, fluent)]
 impl Op for TimeWindowedMedianTimeWeighted {
-    type Cfg = NanoTime;
-    type State = TimeWeightedMedianState;
+    type Cfg = Duration;
+    type State = TimeWindowed<TimeWeightedMedianState>;
     type In<'a> = (&'a f64,);
     type Out = f64;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
-        cfg: &mut NanoTime,
-        state: &mut TimeWeightedMedianState,
+        _cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWeightedMedianState>,
         input: (&f64,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<f64>> {
-        Ok(Tick::Value(state.push_time(
+        Ok(Tick::Value(state.inner.push_time(
             ctx.time(),
             *input.0,
-            u64::from(*cfg),
+            state.window,
         )))
+    }
+
+    fn start(
+        cfg: &mut Duration,
+        state: &mut TimeWindowed<TimeWeightedMedianState>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.arm(*cfg);
+        Ok(())
     }
 }
 

--- a/crates/wingfoil/src/stats.rs
+++ b/crates/wingfoil/src/stats.rs
@@ -9,8 +9,6 @@
 
 use std::time::Duration;
 
-use wingfoil::NanoTime;
-
 use crate::fluent::Stream;
 use crate::ops::EwmaDecay;
 
@@ -228,40 +226,19 @@ impl StatisticsOps for Stream<f64> {
 
     __wf_fluent_cumulative_median!();
 
-    fn time_windowed_sum(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_sum(h, window))
-    }
+    __wf_fluent_time_windowed_sum!();
 
-    fn time_windowed_mean(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_mean(h, window))
-    }
+    __wf_fluent_time_windowed_mean!();
 
-    fn time_windowed_min(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_min(h, window))
-    }
+    __wf_fluent_time_windowed_min!();
 
-    fn time_windowed_max(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_max(h, window))
-    }
+    __wf_fluent_time_windowed_max!();
 
-    fn time_windowed_var(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_var(h, window))
-    }
+    __wf_fluent_time_windowed_var!();
 
-    fn time_windowed_std(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_std(h, window))
-    }
+    __wf_fluent_time_windowed_std!();
 
-    fn time_windowed_median(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_median(h, window))
-    }
+    __wf_fluent_time_windowed_median!();
 
     __wf_fluent_cumulative_mean_time_weighted!();
 
@@ -275,27 +252,15 @@ impl StatisticsOps for Stream<f64> {
 
     __wf_fluent_rolling_std_time_weighted!();
 
-    fn time_windowed_mean_time_weighted(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_mean_time_weighted(h, window))
-    }
+    __wf_fluent_time_windowed_mean_time_weighted!();
 
-    fn time_windowed_var_time_weighted(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_var_time_weighted(h, window))
-    }
+    __wf_fluent_time_windowed_var_time_weighted!();
 
-    fn time_windowed_std_time_weighted(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_std_time_weighted(h, window))
-    }
+    __wf_fluent_time_windowed_std_time_weighted!();
 
     __wf_fluent_cumulative_median_time_weighted!();
 
     __wf_fluent_rolling_median_time_weighted!();
 
-    fn time_windowed_median_time_weighted(&self, window: Duration) -> Stream<f64> {
-        let window = NanoTime::from(window);
-        self.wire(move |b, h| b.time_windowed_median_time_weighted(h, window))
-    }
+    __wf_fluent_time_windowed_median_time_weighted!();
 }

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -36,8 +36,9 @@
 //! That rule is only as good as its coverage, and it had a hole: the whole of
 //! `StatisticsOps` — 36 methods — was in neither, because the guard was
 //! written against `StreamOps` and nobody extended it when the statistics
-//! surface landed. All 36 are now classified: 25 dual-mode, exercised in the
-//! `surface_stats_*` blocks, and 11 in category 2b below.
+//! surface landed. All 36 are now classified, and since the time-windowed
+//! family closed **every one of them is dual-mode**, exercised across the four
+//! `surface_stats_*` blocks. Category 2b is down to `logged` alone.
 //!
 //! **1. IO / cycle — not expressible by design** (capability matrix `❌`):
 //!   * `external`, `channel`, `poll` — IO / threaded / busy-poll sources; the
@@ -71,18 +72,17 @@
 //!     fluent method wires through; it just isn't spelled in a `nitro!` block.
 //!     A debug/logging tap has no place in a self-driving compiled kernel
 //!     anyway, so this costs nothing real.
-//!   * The **11 `time_windowed_*` statistics methods** — `time_windowed_sum`
-//!     / `_mean` / `_min` / `_max` / `_var` / `_std` / `_median`, and the
-//!     `_mean_time_weighted` / `_var_time_weighted` / `_std_time_weighted` /
-//!     `_median_time_weighted` four. Identical mechanism to `logged`: the ops'
-//!     `Cfg` is `NanoTime`, the fluent methods take a `Duration` and convert,
-//!     and `nitro!` cannot satisfy both with one set of call-site tokens.
-//!     Unlike `logged` this *is* a real gap — a time-windowed statistic is
-//!     exactly the kind of thing a compiled kernel should carry — and it
-//!     closes by moving the conversion into the op (take `Duration` as `Cfg`
-//!     and convert in `start`, as `Ticker` does), not by touching the macro.
-//!     The other 25 statistics ops are dual-mode and exercised in the three
-//!     `surface_stats_*` blocks below.
+//!     The **11 `time_windowed_*` statistics methods** used to sit here for the
+//!     same reason and have since **closed** — they are dual-mode now, in
+//!     `surface_stats_time_windowed` below. They were the one entry in this
+//!     category that was a *real* gap rather than a shrug: a compiled kernel
+//!     should carry a time-windowed statistic. The fix was the one this note
+//!     predicted — the ops take `Duration` as their `Cfg` and convert once in
+//!     `start` (into the `TimeWindowed<S>` state wrapper), as `Ticker` does —
+//!     so the macro was never involved. `logged` stays because its mismatch is
+//!     `&str` against `String`, which no `Cfg` change fixes without taking the
+//!     `format!`-able label away from callers, and because a debug tap has no
+//!     place in a self-driving compiled kernel anyway.
 //!
 //! **3. Currently interpreted-only — candidate follow-up, not by design:**
 //!   * *(empty — all four former members are now dual-mode.)* `join_passive`,
@@ -125,6 +125,9 @@ use wingfoil::{NanoTime, RunFor, RunMode};
 const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
 const P: Duration = Duration::from_millis(10);
 const RUN: RunFor = RunFor::Cycles(12);
+/// The time-windowed family's window: three ticker periods, so samples age out
+/// part-way through a `RUN`-length run rather than never.
+const W: Duration = Duration::from_millis(30);
 
 // The stateless / single-input `u64` surface: `count`, `map`, `map_filter`,
 // `distinct`, `drop_small_change`, `difference`, `limit`, `inspect`, `filter`
@@ -278,9 +281,9 @@ wingfoil::nitro! {
 //
 // `StatisticsOps` was absent from this guard entirely — not in a `nitro!`
 // block, not in a fluent-only list — i.e. exactly the "silently in neither"
-// state the module doc forbids, for a third of the op catalog. The three
-// blocks below put all 25 of its dual-mode ops under the two-sided guard; the
-// 11 that are not dual-mode are listed under category 2b in the module doc.
+// state the module doc forbids, for a third of the op catalog. The four
+// blocks below put **all 36 of them** under the two-sided guard — every one
+// dual-mode, since the time-windowed family closed.
 //
 // Every value here is `f64`, and the two engines run the same `cycle` code
 // over the same inputs in the same order, so the parity assertion is exact
@@ -322,6 +325,39 @@ wingfoil::nitro! {
         let median = x.cumulative_median();
         let out = sum
             .merge_all(&[&mean, &min, &max, &var, &std, &median])
+            .accumulate();
+        out
+    }
+}
+
+// The time-windowed family — all 11, count-weighted and time-weighted. These
+// were interpreted-only until their `Cfg` became the `Duration` their fluent
+// methods already took, so this block is the thing that could not be written
+// before: a `nitro!` graph naming a window as a call-site argument, which the
+// compiled emission then uses verbatim as the op's config.
+//
+// The window (30ms) is three ticker periods, chosen so eviction actually
+// happens inside a 12-cycle run — a window wider than the run would leave the
+// eviction path untested and the block would still compile, which is the way
+// this test could pass while proving less than it looks.
+wingfoil::nitro! {
+    fn surface_stats_time_windowed(g: &GraphBuilder) -> Stream<Vec<f64>> {
+        let x = g.ticker(P).count().map(|i| *i as f64);
+        let sum = x.time_windowed_sum(W);
+        let mean = x.time_windowed_mean(W);
+        let min = x.time_windowed_min(W);
+        let max = x.time_windowed_max(W);
+        let var = x.time_windowed_var(W);
+        let std = x.time_windowed_std(W);
+        let median = x.time_windowed_median(W);
+        let tw_mean = x.time_windowed_mean_time_weighted(W);
+        let tw_var = x.time_windowed_var_time_weighted(W);
+        let tw_std = x.time_windowed_std_time_weighted(W);
+        let tw_median = x.time_windowed_median_time_weighted(W);
+        let out = sum
+            .merge_all(&[
+                &mean, &min, &max, &var, &std, &median, &tw_mean, &tw_var, &tw_std, &tw_median,
+            ])
             .accumulate();
         out
     }
@@ -468,4 +504,36 @@ fn stats_cumulative_surface_three_engine_parity() {
 #[test]
 fn stats_time_weighted_surface_three_engine_parity() {
     assert_interp_eq_compiled!(surface_stats_time_weighted);
+}
+
+#[test]
+fn stats_time_windowed_surface_three_engine_parity() {
+    assert_interp_eq_compiled!(surface_stats_time_windowed);
+}
+
+/// The time-windowed family across all three expansions, not just two.
+///
+/// Worth doing here rather than leaning on the block above: these ops evict by
+/// *engine time*, and an island reads the outer engine's clock rather than
+/// keeping its own, so `nested` is the expansion where a window could plausibly
+/// disagree. It does not.
+#[test]
+fn stats_time_windowed_reaches_a_nested_island() {
+    let (mut runner, out) = surface_stats_time_windowed::interpreted();
+    runner.run(HISTORICAL, RUN).unwrap();
+    let interp = runner.value(out);
+    assert!(
+        !interp.is_empty(),
+        "surface_stats_time_windowed had no values"
+    );
+
+    let g = GraphBuilder::new();
+    let island = surface_stats_time_windowed::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, RUN).unwrap();
+    assert_eq!(
+        interp,
+        r.value(&island),
+        "interpreted vs nested drift in surface_stats_time_windowed"
+    );
 }

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -1582,12 +1582,16 @@ too) is a deliberate deferral, not owed: see the sub-bullet below.
     `tests/op_fluent_shapes.rs`, each invoked from a trait declared *outside*
     the crate, which is the property the behavioural suites cannot see.
 
-    What is left in `StatisticsOps` is not a generator gap but the same
-    `Cfg`-mismatch category as `logged`: the 11 `time_windowed_*` methods take
-    a `Duration` their body converts to the op's `NanoTime` `Cfg`, and
-    `ewma_per_tick` `debug_assert!`s its alpha before wiring. Closing those
-    means changing the ops' `Cfg` (convert in `start`, as `Ticker` does), not
-    the macro.
+    **35 of `StatisticsOps`' 36 methods are now generated.** The 11
+    `time_windowed_*` methods used to be hand-written for the same
+    `Cfg`-mismatch reason as `logged` — the method took a `Duration`, the op's
+    `Cfg` was `NanoTime` — and that closed exactly as this paragraph said it
+    would: by changing the ops rather than the macro. `Cfg` is now the
+    `Duration`, converted once in `start` into a `TimeWindowed<S>` state
+    wrapper (the accumulators are shared with the count-windowed family, which
+    has no window to hold, so the horizon lives in the wrapper rather than in
+    them). The last hand-written method is `ewma_per_tick`, whose body
+    `debug_assert!`s its alpha before wiring.
 
   - **`Signal` coverage ✅ landed** (and the module renamed `compat` →
     `signal`). `#[op(fluent)]` emits a second macro, `__wf_signal_<name>!`,
@@ -1640,11 +1644,15 @@ too) is a deliberate deferral, not owed: see the sub-bullet below.
     were in neither a `nitro!` block nor an allowlist — the "silently in
     neither" state `op_completeness.rs` exists to prevent, for a third of the
     catalog, because the file was written against `StreamOps` and never
-    widened. 25 are dual-mode and exercised in three new `surface_stats_*`
-    blocks with interpreted-vs-compiled parity; the 11 `time_windowed_*` are
-    recorded in category 2b, and unlike `logged` they are a **real** gap: a
-    compiled kernel should carry a time-windowed statistic, and closing it
-    means taking `Duration` as the op's `Cfg` and converting in `start`.
+    widened. **All 36 are dual-mode**, exercised across four `surface_stats_*`
+    blocks with interpreted-vs-compiled parity. It landed as 25 plus an
+    11-strong category-2b entry — the `time_windowed_*` family, the one 2b
+    member that was a **real** gap rather than an ergonomic shrug, since a
+    compiled kernel should carry a time-windowed statistic. That gap is now
+    closed (`Duration` as the ops' `Cfg`, converted in `start`), and the family
+    is covered by `surface_stats_time_windowed` plus a nested-island parity
+    test — an island reads the outer engine's clock, which is where an
+    age-evicting op could plausibly disagree.
 
 ## Phase 6 — Python bindings, examples, benches
 


### PR DESCRIPTION
Closes the one catalog gap that `op_completeness.rs` classified as **real** rather than an ergonomic shrug: the 11 `time_windowed_*` statistics were interpreted-only, and a compiled kernel should be able to carry a time-windowed statistic.

First of four PRs closing the gaps the plan docs still list; the others are `combine` in `nitro!`, a unified `kdb_source`, and bounded kafka/fluvio historical readers.

## The cause was never the macro

`nitro!` uses the call-site argument tokens verbatim as an op's `Cfg`. These ops declared `Cfg = NanoTime` while their fluent methods took a `Duration` and converted in the body — so no single set of tokens could satisfy both, and the family could not be spelled in a `nitro!` block at all. Making `Duration` the `Cfg` closes it, which is exactly the fix `port-plan.md` and the `/new-op-next` skill both predicted.

The conversion moves to `start`, per the rule `Ticker` documents: per-cycle it is measurable on dense graphs, and here it would sit on the hot path of every windowed statistic in the graph.

## Where the window lives is the one design choice

Three of the four accumulators — `WindowedTimeWeightedMomentState`, `TimeWeightedMedianState` and the moment state — are **shared with the count-windowed ops**, which evict by index and have no eviction horizon to hold. A `window` field on them would be read by half their users. So the horizon goes in a `TimeWindowed<S>` wrapper instead: the accumulators stay pure accumulators, and only the ops that evict by age carry an eviction horizon.

## Surface

- 11 hand-written fluent methods → `__wf_fluent_*!()` invocations. `StatisticsOps` is now **35 of 36 generated**; `ewma_per_tick` is the last hand-written one, for its wiring-time `debug_assert!`.
- No public signature changes: the fluent methods still take `Duration`, so the Python statistics dispatcher and every existing caller are untouched.

## Tests

- `surface_stats_time_windowed` — the `nitro!` block that could not be written before. The window is 30ms against a 10ms ticker, so eviction actually happens inside a 12-cycle run; a window wider than the run would still compile and prove less than it looks.
- `stats_time_windowed_reaches_a_nested_island` — the family through all three expansions. Worth its own test because an island borrows the *outer* engine's clock rather than keeping its own, making `nested` the expansion where an age-evicting op could plausibly disagree. It does not.
- The five existing statistics parity suites are unchanged and green — that is the claim that matters here: values did not move.
- Green locally: `op_completeness` 15/15, full default-feature suite, `cargo lint`, `cargo fmt --all`. `cargo lint-all` is re-running after installing CMake 3.31 (this sandbox had 3.28, below what `rusteron-client` requires); CI gates it either way.

## Docs

`port-plan.md`'s two statements of the gap, and the `/new-op-next` skill — whose category-2b guidance now says to **default to closing** this shape, with the wrap-don't-contaminate rule for shared state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq8BNdx3X612hC3gqo3EeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq8BNdx3X612hC3gqo3EeT)_