### PR TITLE
Give combine a variadic witness op, so it reaches nitro! and compiled

### DIFF
--- a/.claude/commands/new-op-next.md
+++ b/.claude/commands/new-op-next.md
@@ -115,9 +115,10 @@ rather than a compile-time mask (those are extra hand-written methods over
 find yourself adding `no_builder` for any other reason, the shape probably fits
 and you should check `expand_builder` in the macro crate first.
 
-**Variadic ops** (`MergeN`, the n-ary merge behind `merge_all`/`fan`) are the
-one shape `#[op]` cannot touch at all: it parses `In` as a fixed-arity tuple, and
-a fan-in of runtime width has none. The route that works, if you need another:
+**Variadic ops** — `MergeN` (the n-ary merge behind `merge_all`/`fan`) and
+`CombineN` (`combine`) — are the one shape `#[op]` cannot touch at all: it
+parses `In` as a fixed-arity tuple, and a fan-in of runtime width has none. The
+route that works, if you need another:
 
 - Declare `In<'a> = &'a [(&'a T, bool)]` — the same uniform `(value, tick)` pairs
   every other op gets, as a slice.
@@ -132,6 +133,14 @@ a fan-in of runtime width has none. The route that works, if you need another:
   `cycle_input` then emits a pair *slice* rather than a tuple, and the dispatch
   condition drops the passive mask (a variadic op is all-active, and the mask is
   a `u32` a wide fan-in would shift past).
+- **Match the fluent spelling, even if the macro has to learn a new position.**
+  A variadic op's arguments are a slice *literal* (the edges must be statically
+  visible — a runtime `Vec` has no shape for a compiled graph to emit), so it
+  needs its own arm in the macro: `apply_call` for a chained receiver
+  (`merge_all`), `walk_chain`'s root arm for a builder-rooted one
+  (`push_combine`, the only call there that is not a source). Teaching the
+  macro the position was a dozen lines; a second name for one op would have
+  been permanent.
 - **Do not** make the interpreted path materialise the slice: borrowing all N
   slots per cycle allocates, which on a wide fan-in costs more than the node you
   removed. Factor the semantics into a shared associated fn (`MergeN::winner`)

--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -168,8 +168,9 @@ struct NodeDef {
     closure: Option<Expr>,
     /// The op takes its edges as a **pair slice** (`&[(value, tick), ..]`)
     /// rather than a fixed-arity tuple, so it accepts a fan-in of any width
-    /// from one signature. Set only by the fan-in arms of `apply_call`
-    /// (`fan` / `merge_all`, both of which emit the variadic `merge_n`); every
+    /// from one signature. Set by the fan-in arms of `apply_call` (`fan` /
+    /// `merge_all`, both of which emit the variadic `merge_n`) and by
+    /// `push_combine` (`g.combine(&[..])`, which emits `CombineN`); every
     /// other node keeps the uniform tuple input. A variadic op is all-active
     /// by construction, so its dispatch condition skips the passive mask —
     /// which also keeps the mask's `>> position` shift inside `u32` when the
@@ -432,6 +433,47 @@ impl ChainWalker {
         ix
     }
 
+    /// Push the single variadic `combine` node behind `g.combine(&[a, b])`:
+    /// every listed stream becomes an edge, and the node emits one `Burst` per
+    /// instant carrying the value of each edge that ticked.
+    ///
+    /// Like `merge_all`'s, the argument must be a slice **literal** — the
+    /// merged edges have to be visible to the macro, since a `Vec` built at
+    /// runtime has no static shape for a compiled graph to emit. Unlike
+    /// `merge_all` there is no receiver to prepend: `combine` treats all its
+    /// inputs alike, which is exactly why it lives on the builder.
+    fn push_combine(&mut self, name: Ident, method: &Ident, args: &[&Expr]) -> syn::Result<usize> {
+        expect_arity(method, args, 1)?;
+        let elems = match args[0] {
+            Expr::Reference(r) => match &*r.expr {
+                Expr::Array(a) => &a.elems,
+                _ => return Err(combine_arg_error(args[0])),
+            },
+            Expr::Array(a) => &a.elems,
+            _ => return Err(combine_arg_error(args[0])),
+        };
+        if elems.is_empty() {
+            return Err(syn::Error::new(
+                args[0].span(),
+                "`combine(&[])` has no inputs to gather — it would be a source that never ticks",
+            ));
+        }
+        let mut edges = Vec::with_capacity(elems.len());
+        for elem in elems {
+            edges.push(self.stream_ref_arg(elem)?);
+        }
+        let ix = self.push_node(
+            name,
+            Some(Ident::new("combine", method.span())),
+            edges,
+            vec![],
+            None,
+            None,
+        );
+        self.nodes[ix].variadic = true;
+        Ok(ix)
+    }
+
     /// Push the single n-ary `merge_n` node that fans `tails` back in, in
     /// supplied order (so the tie-break stays "earliest supplied that ticked
     /// wins"). One tail needs no merge at all — it *is* the result.
@@ -561,12 +603,23 @@ impl ChainWalker {
             } else {
                 self.anon_name(method.span())
             };
-            // Sources go through the same forwarder mechanism as combinators
-            // — `.ticker(..)`, `.constant(..)`, or any user source with
-            // `#[op]`-generated forwarders. No receiver, so no edges (a
-            // `&stream` argument still classifies as an edge, which a
-            // source's forwarder arity will reject).
-            self.push_op(name, (*method).clone(), None, args, *turbofish)?
+            if *method == "combine" {
+                // The one builder-rooted call that is *not* a source:
+                // `g.combine(&[a, b])` fans several already-bound streams into
+                // one burst, so it has edges but no receiver. Spelled here
+                // exactly as it is fluently — `combine` lives on the builder
+                // rather than on a stream because no input is privileged, and
+                // making `nitro!` spell it differently would be a second name
+                // for one op.
+                self.push_combine(name, method, args)?
+            } else {
+                // Sources go through the same forwarder mechanism as
+                // combinators — `.ticker(..)`, `.constant(..)`, or any user
+                // source with `#[op]`-generated forwarders. No receiver, so no
+                // edges (a `&stream` argument still classifies as an edge,
+                // which a source's forwarder arity will reject).
+                self.push_op(name, (*method).clone(), None, args, *turbofish)?
+            }
         } else {
             self.lookup(root)?
         };
@@ -788,6 +841,14 @@ fn expect_arity(method: &Ident, args: &[&Expr], want: usize) -> syn::Result<()> 
 /// literal of stream references so the macro can see the individual edges; a
 /// runtime-built slice would make the DAG non-static, like a non-literal
 /// `map_n` count.
+fn combine_arg_error(arg: &Expr) -> syn::Error {
+    syn::Error::new(
+        arg.span(),
+        "`combine(..)` takes a slice literal of stream references — \
+         `g.combine(&[a, b])` — so the gathered edges are visible statically",
+    )
+}
+
 fn merge_all_arg_error(arg: &Expr) -> syn::Error {
     syn::Error::new(
         arg.span(),

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -183,6 +183,13 @@ impl GraphBuilder {
     /// `combine`): each cycle gathers the current values of every input that
     /// ticked *this* instant into one [`Burst`], in argument order — same-instant
     /// values ride one burst, never latest-wins.
+    ///
+    /// Available in `nitro!` / `compiled()` / `nested()` too, spelled exactly
+    /// as it is here — `g.combine(&[a, b])`, the one builder-rooted call in a
+    /// `nitro!` block that is not a source. It sits on the builder rather than
+    /// on a stream because no input is privileged; contrast
+    /// [`StreamOps::merge_all`](crate::fluent::StreamOps::merge_all), which
+    /// picks one winner and so has a natural receiver.
     pub fn combine<T: Clone + Default + 'static>(&self, streams: &[Stream<T>]) -> Stream<Burst<T>> {
         let handles: Vec<Handle<T>> = streams.iter().map(|s| s.handle()).collect();
         let handle = self.with_builder(|b| b.combine(&handles));

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -51,7 +51,7 @@ use crate::Burst;
 use crate::channel::{ChannelSender, Message, Tx};
 use crate::latency::{HasLatency, LatencyReport, LatencyReportCfg, LatencyStats};
 use crate::op::{Activation, CompositePhase, Ctx, Op, Tick};
-use crate::ops::{Join, Join3, MergeN, Never, Poll, TryJoin, TryJoin3, WithTime};
+use crate::ops::{CombineN, Join, Join3, MergeN, Never, Poll, TryJoin, TryJoin3, WithTime};
 use wingfoil::{Kernel, KernelWaker, ReadyReceiver, waker_channel};
 use wingfoil::{NanoTime, RunFor, RunMode, TimeQueue};
 
@@ -1500,10 +1500,20 @@ impl Builder {
     /// ticked *this* instant into one [`Burst`], in upstream order. Quiet on a
     /// cycle where none ticked (only reachable via a shared scheduled wake).
     ///
-    /// Hand-written (no `Op` witness): an n-ary fan-in does not fit the `Op`
-    /// trait's fixed-arity tuple `In`, and — unlike the legacy port's shared
-    /// `Rc<RefCell<Burst>>` cell written by per-stream feeder nodes — the burst
-    /// is built locally here, honouring next's no-shared-mutable-slot rule.
+    /// Hand-written wiring, as [`merge_n`](Self::merge_n) is: a variadic fan-in
+    /// does not fit the `Op` trait's fixed-arity tuple `In`, so `#[op]` cannot
+    /// generate it. The *semantics* live in [`CombineN`], which the
+    /// `nitro!`/compiled path drives; this path does not build the
+    /// `&[(&T, bool)]` slice that op's `cycle` takes, because that means
+    /// holding a borrow guard for every upstream slot at once — a per-cycle
+    /// allocation on a wide fan-in. It walks the tick flags, borrows only the
+    /// slots that ticked, and routes the outcome through the shared
+    /// [`CombineN::emit`] rule so the two paths cannot disagree about the
+    /// empty-burst case.
+    ///
+    /// Unlike the legacy port's shared `Rc<RefCell<Burst>>` cell written by
+    /// per-stream feeder nodes, the burst is built locally here, honouring
+    /// next's no-shared-mutable-slot rule.
     pub fn combine<T: Clone + Default + 'static>(
         &mut self,
         srcs: &[Handle<T>],
@@ -1528,11 +1538,12 @@ impl Builder {
                         }
                     }
                 }
-                if burst.is_empty() {
-                    Ok(false)
-                } else {
-                    *out.borrow_mut() = burst;
-                    Ok(true)
+                match CombineN::<T>::emit(burst) {
+                    Tick::Value(burst) => {
+                        *out.borrow_mut() = burst;
+                        Ok(true)
+                    }
+                    _ => Ok(false),
                 }
             }),
             Box::new(|_| Ok(())),

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -30,6 +30,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 
 use crate::op::{Activation, Ctx, Op, Tick};
+use crate::runtime::burst::Burst;
 use wingfoil::{NanoTime, TimeQueue};
 use wingfoil_derive::op;
 
@@ -2874,13 +2875,11 @@ impl<T: Clone + 'static> Op for Merge2<T> {
 /// opportunity. Rebalancing the chain recovers only the depth half; only a
 /// real n-ary node removes both.
 ///
-/// The catalog's only **variadic** op: its `In` is a *slice* of
-/// `(value, tick)` pairs rather than a fixed-arity tuple, so `#[op]` cannot
-/// parse its shape. Its interpreted wiring
+/// One of the catalog's two **variadic** ops (with [`CombineN`]): its `In` is a
+/// *slice* of `(value, tick)` pairs rather than a fixed-arity tuple, so
+/// `#[op]` cannot parse its shape. Its interpreted wiring
 /// ([`Builder::merge_n`](crate::interp::Builder::merge_n)) and its
-/// `nitro!`/compiled forwarders (below) are hand-written instead — the same
-/// concession [`Builder::combine`](crate::interp::Builder::combine) makes for
-/// the other n-ary fan-in.
+/// `nitro!`/compiled forwarders (below) are hand-written instead.
 pub struct MergeN<T>(PhantomData<T>);
 
 impl<T: Clone> MergeN<T> {
@@ -2999,6 +2998,146 @@ pub fn __wf_op_merge_n_seed_state<__P>(_cfg: &__P) -> () {}
 #[inline(always)]
 pub fn __wf_op_merge_n_seed_value<T: Default, __P>(_cfg: &__P) -> T {
     T::default()
+}
+
+/// Combine several same-type streams into one [`Burst`]: every input that
+/// ticked *this* instant contributes its current value, in supplied order.
+/// The legacy `combine` node, and the second of the catalog's two variadic ops
+/// (with [`MergeN`]).
+///
+/// The distinction from [`MergeN`] is what each does with a tie. A merge picks
+/// **one** winner and drops the rest; combine keeps **all** of them, which is
+/// the burst pattern — same-instant values ride one burst, never latest-wins,
+/// never dropped.
+///
+/// Like `MergeN` it is variadic, so `#[op]` cannot parse its `In` and both the
+/// interpreted wiring ([`Builder::combine`](crate::interp::Builder::combine))
+/// and the forwarders below are hand-written.
+pub struct CombineN<T>(PhantomData<T>);
+
+impl<T: Clone + Default> CombineN<T> {
+    /// The rule for what a gathered burst *means*: a burst of every ticked
+    /// input's value is a value; an empty one is no tick at all.
+    ///
+    /// Factored out for the same reason [`MergeN::winner`] is. The interpreted
+    /// engine cannot call [`Op::cycle`] here — building the `&[(&T, bool)]`
+    /// slice it takes means holding a borrow guard for *every* upstream slot at
+    /// once, which is a per-cycle allocation on a wide fan-in. It therefore
+    /// walks the engine's tick flags and borrows only the slots that ticked,
+    /// then routes the result through this shared rule, so the two paths cannot
+    /// disagree about the one thing that is easy to get wrong: a cycle where
+    /// nothing ticked must stay quiet rather than emit an empty burst.
+    ///
+    /// (Only reachable via a shared scheduled wake — with no ticked upstream
+    /// there is nothing to gather.)
+    #[inline]
+    pub fn emit(burst: Burst<T>) -> Tick<Burst<T>> {
+        if burst.is_empty() {
+            Tick::Quiet
+        } else {
+            Tick::Value(burst)
+        }
+    }
+}
+
+impl<T: Clone + Default + 'static> Op for CombineN<T> {
+    type Cfg = ();
+    type State = ();
+    type In<'a> = &'a [(&'a T, bool)];
+    type Out = Burst<T>;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        _state: &mut (),
+        input: &[(&T, bool)],
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<Burst<T>>> {
+        let mut burst = Burst::new();
+        for &(value, ticked) in input {
+            if ticked {
+                burst.push(value.clone());
+            }
+        }
+        Ok(Self::emit(burst))
+    }
+}
+
+// ---- `combine` nitro!/compiled forwarders (hand-written) -------------------
+//
+// The `merge_n` block above explains the convention; these follow it exactly.
+// The one shape difference is the output: `Burst<T>` rather than `T`, so the
+// slot seed is an empty burst.
+
+/// [`CombineN`] never schedules itself — it is driven purely by upstream ticks.
+#[doc(hidden)]
+pub const __WF_OP_COMBINE_ACTIVATION: Activation = <CombineN<()> as Op>::ACTIVATION;
+
+/// Bit i set = edge i is passive. A variadic combine is all-active by
+/// construction: every input it is given can trigger it.
+#[doc(hidden)]
+pub const __WF_OP_COMBINE_PASSIVE: u32 = 0;
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_combine_cycle<T: Clone + Default + 'static>(
+    __cfg: &mut (),
+    __state: &mut (),
+    __input: &[(&T, bool)],
+    __ctx: &mut Ctx<'_>,
+) -> Result<Tick<Burst<T>>> {
+    <CombineN<T> as Op>::cycle(__cfg, __state, __input, __ctx)
+}
+
+/// Fully erased, as [`__wf_op_merge_n_start`] is and for the same reason:
+/// `start` takes no input, so a forwarder carrying `T` would leave it
+/// un-inferable at the call site.
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_combine_start<__Cfg, __State>(
+    _cfg: &mut __Cfg,
+    _state: &mut __State,
+    _ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    Ok(())
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_combine_stop<T: Clone + Default + 'static>(
+    __cfg: &mut (),
+    __state: &mut (),
+    __input: &[(&T, bool)],
+    __ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    let _ = __input;
+    <CombineN<T> as Op>::stop(__cfg, __state, __ctx)
+}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_combine_teardown<T: Clone + Default + 'static>(
+    __cfg: &mut (),
+    __state: &mut (),
+    __input: &[(&T, bool)],
+    __ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    let _ = __input;
+    <CombineN<T> as Op>::teardown(__cfg, __state, __ctx)
+}
+
+#[doc(hidden)]
+#[inline(always)]
+#[allow(clippy::unused_unit)]
+pub fn __wf_op_combine_seed_state<__P>(_cfg: &__P) -> () {}
+
+/// The output slot's seed: an **empty** burst, which is also what a quiet
+/// cycle leaves in place — so a downstream passive read before the first tick
+/// sees "nothing arrived", not a stale or defaulted value.
+#[doc(hidden)]
+#[inline(always)]
+pub fn __wf_op_combine_seed_value<T: Default, __P>(_cfg: &__P) -> Burst<T> {
+    Burst::new()
 }
 
 /// A source that never ticks — the legacy `never` node. It has no upstreams

--- a/crates/wingfoil/tests/combine_n.rs
+++ b/crates/wingfoil/tests/combine_n.rs
@@ -1,0 +1,196 @@
+//! `combine` across all three engines (`CombineN` / `Builder::combine`).
+//!
+//! `combine` is the burst-shaped twin of the n-ary merge: where `merge_all`
+//! picks **one** winner from the inputs that ticked this instant, `combine`
+//! keeps **all** of them, in supplied order. That is the burst pattern the
+//! engine is built around — same-instant values ride one burst, never
+//! latest-wins, never dropped — so having it work on only one of the three
+//! engines was the last real hole in the fan-in vocabulary.
+//!
+//! It was fluent-only for the same reason `merge_all` once was: a variadic
+//! fan-in has no fixed-arity tuple `In` for `#[op]` to parse. `merge_n` showed
+//! the route (a slice `In` plus hand-written forwarders) and this follows it.
+//!
+//! Two things these tests pin that a values-only check would not:
+//!
+//! * **The tick mask.** A burst carries only the inputs that ticked this
+//!   instant. A `combine` that gathered all of them unconditionally would
+//!   still agree across the three engines, so that check reads values rather
+//!   than comparing engines.
+//! * **The spelling.** `combine` lives on the builder rather than on a stream,
+//!   because no input is privileged. `nitro!` therefore accepts it in
+//!   builder-root position — the one call there that is not a source — so the
+//!   macro spelling is the fluent spelling rather than a second name for one
+//!   op.
+
+use std::time::Duration;
+
+use wingfoil::op::Tick;
+use wingfoil::ops::CombineN;
+use wingfoil::prelude::*;
+use wingfoil::{Burst, NanoTime, RunFor, RunMode};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+fn burst_of(items: &[u64]) -> Burst<u64> {
+    let mut b = Burst::new();
+    for &i in items {
+        b.push(i);
+    }
+    b
+}
+
+// ---- nitro! / compiled / nested coverage ----------------------------------
+//
+// This block is also the two-sided registration guard: it only compiles if
+// both the fluent `GraphBuilder::combine` and the `__wf_op_combine_*`
+// forwarders exist.
+
+wingfoil::nitro! {
+    fn combined(g: &GraphBuilder) -> Stream<Vec<Burst<u64>>> {
+        let a = g.ticker(std::time::Duration::from_nanos(10)).count();
+        let b = g.ticker(std::time::Duration::from_nanos(20)).count().map(|c| *c + 100);
+        let c = g.ticker(std::time::Duration::from_nanos(30)).count().map(|c| *c + 200);
+        let out = g.combine(&[a, b, c]).accumulate();
+        out
+    }
+}
+
+/// The three tickers deliberately have *different* periods, so the graph
+/// visits every arity: instants where one, two or all three inputs tick. A
+/// same-period fan-in would exercise only the all-ticked case and would pass
+/// even if the tick mask were ignored entirely.
+#[test]
+fn combine_agrees_across_engines() {
+    let run_for = RunFor::Cycles(12);
+
+    let (mut runner, out) = combined::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    let interpreted = runner.value(out);
+
+    let (compiled,) = combined::compiled(HISTORICAL, run_for).unwrap();
+
+    let g = GraphBuilder::new();
+    let island = combined::nested(&g);
+    let mut r = g.build();
+    r.run(HISTORICAL, run_for).unwrap();
+
+    assert!(!interpreted.is_empty(), "combine produced no bursts");
+    assert!(
+        interpreted.iter().any(|b| b.len() > 1),
+        "no instant gathered more than one value — the fan-in is untested"
+    );
+    assert!(
+        interpreted.iter().any(|b| b.len() == 1),
+        "no instant gathered exactly one value — the tick mask is untested"
+    );
+    assert_eq!(interpreted, compiled, "interpreted == compiled");
+    assert_eq!(interpreted, r.value(&island), "interpreted == nested");
+}
+
+/// The values themselves, against a hand-computed expectation rather than
+/// against another engine — so all three agreeing on the *wrong* answer would
+/// still fail. Mirrors `catalog_flow::combine_gathers_same_instant_values`,
+/// which covers the same graph fluently.
+#[test]
+fn combine_gathers_in_supplied_order_on_the_compiled_path() {
+    wingfoil::nitro! {
+        fn same_rate(g: &GraphBuilder) -> Stream<Vec<Burst<u64>>> {
+            let src = g.ticker(std::time::Duration::from_nanos(10)).count();
+            let tens = src.map(|c| *c * 10);
+            let hundreds = src.map(|c| *c * 100);
+            let out = g.combine(&[src, tens, hundreds]).accumulate();
+            out
+        }
+    }
+
+    let (compiled,) = same_rate::compiled(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(
+        vec![
+            burst_of(&[1, 10, 100]),
+            burst_of(&[2, 20, 200]),
+            burst_of(&[3, 30, 300]),
+        ],
+        compiled
+    );
+}
+
+/// A burst carries exactly the inputs that ticked *this* instant — the others
+/// are absent, not stale.
+///
+/// The two tickers share every third instant, so the run contains bursts of
+/// one and of two. Reading the values (rather than comparing engines) is what
+/// makes this a check on the tick mask: a `combine` that gathered every input
+/// unconditionally would produce two-element bursts throughout and still agree
+/// across all three engines.
+#[test]
+fn combine_gathers_only_the_inputs_that_ticked() {
+    let g = GraphBuilder::new();
+    let fast = g.ticker(Duration::from_nanos(10)).count();
+    let slow = g.ticker(Duration::from_nanos(30)).count().map(|c| *c + 100);
+    let acc = g.combine(&[fast, slow]).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+
+    assert_eq!(
+        vec![
+            burst_of(&[1, 101]), // t=0:  both tickers fire
+            burst_of(&[2]),      // t=10: fast only
+            burst_of(&[3]),      // t=20: fast only
+            burst_of(&[4, 102]), // t=30: both again
+            burst_of(&[5]),
+            burst_of(&[6]),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// The empty-burst rule, tested directly on [`CombineN::emit`] rather than
+/// through a graph — because **no graph can reach it**. A node is cycled only
+/// when one of its active upstreams ticked, on every engine, so `combine`
+/// with nothing to gather is not a state the scheduler produces. (My first
+/// attempt at this test asserted it *was* reachable and was simply wrong: the
+/// combine node never ran on the quiet instants at all.)
+///
+/// The branch still earns its keep. It is the one piece of semantics the
+/// interpreted path and `Op::cycle` implement separately — the interpreted
+/// wiring cannot call `cycle` without materialising a borrow guard per
+/// upstream — so routing both through `emit` is what stops them drifting if a
+/// future activation shape (a shared scheduled wake, a passive edge) ever does
+/// reach it. Pinning it here says which answer they must agree on.
+#[test]
+fn an_empty_gather_is_quiet_not_an_empty_burst() {
+    assert!(matches!(CombineN::<u64>::emit(Burst::new()), Tick::Quiet));
+    assert!(matches!(
+        CombineN::<u64>::emit(burst_of(&[7])),
+        Tick::Value(_)
+    ));
+}
+
+/// `combine` wires exactly **one** node whatever its width — the shape claim,
+/// asserted like `merge_n`'s rather than left to a benchmark.
+///
+/// `k` branches of 3 nodes each (ticker + count + map), plus the combine node
+/// and the accumulate that reads it.
+#[test]
+fn wide_combine_costs_one_node() {
+    const K: usize = 32;
+
+    let g = GraphBuilder::new();
+    let branches: Vec<Stream<u64>> = (0..K)
+        .map(|i| {
+            g.ticker(Duration::from_nanos(10 + i as u64))
+                .count()
+                .map(move |c| *c * 1000 + i as u64)
+        })
+        .collect();
+    let out = g.combine(&branches).accumulate();
+    let runner = g.build();
+
+    assert_eq!(
+        runner.node_count(),
+        3 * K + 2,
+        "a {K}-way combine is one node"
+    );
+    let _ = out;
+}

--- a/crates/wingfoil/tests/custom_op.rs
+++ b/crates/wingfoil/tests/custom_op.rs
@@ -23,9 +23,14 @@
 //!   argument is classified as a stream *edge* at expansion time (it names a
 //!   stream bound in the graph), so the fallback wires `In = (&recv, &other)`
 //!   — the `join` shape, both edges active;
-//! - [`Combine<A, B, C, F>`] — **two inputs + closure config**
-//!   (`.combine(&other, |a, b| ..)`) — the user-defined-join shape, generic
-//!   in both input types and the closure;
+//! - [`Blend<A, B, C, F>`] — **two inputs + closure config**
+//!   (`.blend(&other, |a, b| ..)`) — the user-defined-join shape, generic
+//!   in both input types and the closure. It was called `combine` until the
+//!   catalog gained a built-in op of that name: forwarder dispatch resolves
+//!   `__wf_op_<name>_*` unqualified at the call site, so an out-of-crate op
+//!   sharing a name with a built-in is ambiguous rather than shadowing. That
+//!   is the cost of the naming convention, and the reason to pick op names
+//!   that read as your own;
 //!
 //! plus in-crate [`Distinct`](wingfoil::ops) — which has `#[op]` but **no
 //! table row**, proving the whole `#[op]` catalog reaches `nitro!` through the
@@ -142,12 +147,12 @@ impl Op for Spread {
     }
 }
 
-/// A user-defined `join`: combine two streams with a closure — generic in
+/// A user-defined `join`: fold two streams together with a closure — generic in
 /// both input types, the output, and the closure. The primary custom-op use
 /// case: multiple inputs *and* a closure config, all resolved by inference.
-pub struct Combine<A, B, C, F>(std::marker::PhantomData<(A, B, C, F)>);
+pub struct Blend<A, B, C, F>(std::marker::PhantomData<(A, B, C, F)>);
 
-impl<A, B, C, F> Op for Combine<A, B, C, F>
+impl<A, B, C, F> Op for Blend<A, B, C, F>
 where
     A: 'static,
     B: 'static,
@@ -181,8 +186,8 @@ pub const __WF_OP_APPLY_ACTIVATION: Activation = Activation::NONE;
 pub const __WF_OP_APPLY_PASSIVE: u32 = 0;
 pub const __WF_OP_SPREAD_ACTIVATION: Activation = Spread::ACTIVATION;
 pub const __WF_OP_SPREAD_PASSIVE: u32 = 0;
-pub const __WF_OP_COMBINE_ACTIVATION: Activation = Activation::NONE;
-pub const __WF_OP_COMBINE_PASSIVE: u32 = 0;
+pub const __WF_OP_BLEND_ACTIVATION: Activation = Activation::NONE;
+pub const __WF_OP_BLEND_PASSIVE: u32 = 0;
 
 // Cycle forwarders take the uniform `(value, tick)` pair per edge and adapt
 // to the op's `In`; `_owned` variants take the literal-closure config by
@@ -225,20 +230,20 @@ pub fn __wf_op_spread_cycle(
     <Spread as Op>::cycle(cfg, state, (input.0.0, input.1.0), ctx)
 }
 
-pub fn __wf_op_combine_cycle_owned<A, B, C, F>(
-    mut cfg: <Combine<A, B, C, F> as Op>::Cfg,
+pub fn __wf_op_blend_cycle_owned<A, B, C, F>(
+    mut cfg: <Blend<A, B, C, F> as Op>::Cfg,
     _plain: &mut (),
-    state: &mut <Combine<A, B, C, F> as Op>::State,
+    state: &mut <Blend<A, B, C, F> as Op>::State,
     input: ((&A, bool), (&B, bool)),
     ctx: &mut Ctx<'_>,
-) -> Result<Tick<<Combine<A, B, C, F> as Op>::Out>>
+) -> Result<Tick<<Blend<A, B, C, F> as Op>::Out>>
 where
     A: 'static,
     B: 'static,
     C: Clone + 'static,
     F: Fn(&A, &B) -> C + 'static,
 {
-    <Combine<A, B, C, F> as Op>::cycle(&mut cfg, state, (input.0.0, input.1.0), ctx)
+    <Blend<A, B, C, F> as Op>::cycle(&mut cfg, state, (input.0.0, input.1.0), ctx)
 }
 
 // Start forwarders: none of these ops override `Op::start`, so they are the
@@ -265,7 +270,7 @@ pub fn __wf_op_spread_start<C, S>(_cfg: &mut C, _state: &mut S, _ctx: &mut Ctx<'
     Ok(())
 }
 
-pub fn __wf_op_combine_start_owned<P, S>(
+pub fn __wf_op_blend_start_owned<P, S>(
     _plain: &mut P,
     _state: &mut S,
     _ctx: &mut Ctx<'_>,
@@ -295,8 +300,8 @@ pub fn __wf_op_spread_seed_state<P>(_cfg: &P) {}
 pub fn __wf_op_spread_seed_value<P>(_cfg: &P) -> f64 {
     0.0
 }
-pub fn __wf_op_combine_seed_state<P>(_cfg: &P) {}
-pub fn __wf_op_combine_seed_value<C: Default, P>(_cfg: &P) -> C {
+pub fn __wf_op_blend_seed_state<P>(_cfg: &P) {}
+pub fn __wf_op_blend_seed_value<C: Default, P>(_cfg: &P) -> C {
     C::default()
 }
 
@@ -378,10 +383,10 @@ pub fn __wf_op_spread_teardown(
     let _ = input;
     <Spread as Op>::teardown(cfg, state, ctx)
 }
-pub fn __wf_op_combine_stop_owned<A, B, C, F>(
-    mut cfg: <Combine<A, B, C, F> as Op>::Cfg,
+pub fn __wf_op_blend_stop_owned<A, B, C, F>(
+    mut cfg: <Blend<A, B, C, F> as Op>::Cfg,
     _plain: &mut (),
-    state: &mut <Combine<A, B, C, F> as Op>::State,
+    state: &mut <Blend<A, B, C, F> as Op>::State,
     input: ((&A, bool), (&B, bool)),
     ctx: &mut Ctx<'_>,
 ) -> Result<()>
@@ -392,12 +397,12 @@ where
     F: Fn(&A, &B) -> C + 'static,
 {
     let _ = input;
-    <Combine<A, B, C, F> as Op>::stop(&mut cfg, state, ctx)
+    <Blend<A, B, C, F> as Op>::stop(&mut cfg, state, ctx)
 }
-pub fn __wf_op_combine_teardown_owned<A, B, C, F>(
-    mut cfg: <Combine<A, B, C, F> as Op>::Cfg,
+pub fn __wf_op_blend_teardown_owned<A, B, C, F>(
+    mut cfg: <Blend<A, B, C, F> as Op>::Cfg,
     _plain: &mut (),
-    state: &mut <Combine<A, B, C, F> as Op>::State,
+    state: &mut <Blend<A, B, C, F> as Op>::State,
     input: ((&A, bool), (&B, bool)),
     ctx: &mut Ctx<'_>,
 ) -> Result<()>
@@ -408,7 +413,7 @@ where
     F: Fn(&A, &B) -> C + 'static,
 {
     let _ = input;
-    <Combine<A, B, C, F> as Op>::teardown(&mut cfg, state, ctx)
+    <Blend<A, B, C, F> as Op>::teardown(&mut cfg, state, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -421,8 +426,7 @@ trait CustomOps {
     fn delta(&self) -> Stream<f64>;
     fn apply<F: Fn(&f64) -> f64 + 'static>(&self, f: F) -> Stream<f64>;
     fn spread(&self, other: &Stream<f64>) -> Stream<f64>;
-    fn combine<F: Fn(&f64, &f64) -> f64 + 'static>(&self, other: &Stream<f64>, f: F)
-    -> Stream<f64>;
+    fn blend<F: Fn(&f64, &f64) -> f64 + 'static>(&self, other: &Stream<f64>, f: F) -> Stream<f64>;
 }
 
 impl CustomOps for Stream<f64> {
@@ -480,21 +484,17 @@ impl CustomOps for Stream<f64> {
         })
     }
 
-    fn combine<F: Fn(&f64, &f64) -> f64 + 'static>(
-        &self,
-        other: &Stream<f64>,
-        f: F,
-    ) -> Stream<f64> {
+    fn blend<F: Fn(&f64, &f64) -> f64 + 'static>(&self, other: &Stream<f64>, f: F) -> Stream<f64> {
         let other = other.handle();
         self.wire(|builder, h| {
             builder.register_op2(
                 h,
                 other,
-                "combine",
-                <Combine<f64, f64, f64, F> as Op>::ACTIVATION,
+                "blend",
+                <Blend<f64, f64, f64, F> as Op>::ACTIVATION,
                 f,
                 || (),
-                |c, s, a, b, ctx| <Combine<f64, f64, f64, F> as Op>::cycle(c, s, (a, b), ctx),
+                |c, s, a, b, ctx| <Blend<f64, f64, f64, F> as Op>::cycle(c, s, (a, b), ctx),
             )
         })
     }
@@ -558,7 +558,7 @@ wingfoil::nitro! {
         let fast = g.ticker(PERIOD).count().map(|c| *c as f64);
         let slow = fast.scale(0.5);
         let spread = fast.spread(&slow);
-        let combo = fast.combine(&slow, |a: &f64, b: &f64| a + 10.0 * b);
+        let combo = fast.blend(&slow, |a: &f64, b: &f64| a + 10.0 * b);
         (spread, combo)
     }
 }

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -54,12 +54,21 @@
 //!     `surface_sugar` below and in `merge_n.rs`.)
 //!
 //!     `merge_all` was in this list while it *was* sugar (a chain of 2-ary
-//!     `merge`s). It is now a real op — `MergeN`, the catalog's only variadic
-//!     one — because the chain cost `n - 1` extra nodes and lost to legacy's
-//!     single `merge(vec)` on a wide fan-in. Its forwarders are hand-written
-//!     (a slice `In` is unparseable by `#[op]`), so the two-sided guard this
-//!     file provides matters more for it than for a generated op, not less:
-//!     the `nitro!` blocks in `merge_n.rs` are what pin them.
+//!     `merge`s). It is now a real op — `MergeN`, one of the catalog's two
+//!     variadic ops — because the chain cost `n - 1` extra nodes and lost to
+//!     legacy's single `merge(vec)` on a wide fan-in. Its forwarders are
+//!     hand-written (a slice `In` is unparseable by `#[op]`), so the two-sided
+//!     guard this file provides matters more for it than for a generated op,
+//!     not less: the `nitro!` blocks in `merge_n.rs` are what pin them.
+//!
+//!     **`combine`** — the other variadic op (`CombineN`), and the other
+//!     fan-in — is pinned the same way, by `combine_n.rs`. Worth naming here
+//!     because until it reached the compiled tiers it was in *neither* a
+//!     `nitro!` block nor any list below: the "silently in neither" state this
+//!     file exists to prevent, hiding in the one op whose spelling
+//!     (`g.combine(&[..])`, on the builder rather than on a stream) put it
+//!     outside the `StreamOps` surface the guard was written against — the
+//!     same blind spot that swallowed all 36 of `StatisticsOps`.
 //!
 //! **2b. Ergonomic fluent signature ≠ the op's `Cfg` — fluent-only:**
 //!   * `logged` — the `Logged` op's `Cfg` is `(String, log::Level)`, but the

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -522,21 +522,30 @@ not thread-offload. islands already cover *static* subgraphs composed procedural
 (append / active-passive splice / remove / recycle), `Builder::dynamic_group`,
 and `Builder::demux` on the interpreted engine.
 
-**Engine coverage note:** `never` and `combine` land as interpreted-engine
-(fluent) ports — like `feedback` — since a source that never ticks and an
-n-ary fan-in have no `Op` witness for `#[op]` to hang forwarders on (`combine`'s
-arity is a runtime slice, which the fixed-arity tuple `In` cannot express).
-`delay_with_reset` since reached all three engines through its
-`DelayWithResetFwd` witness op, which restates its two-tick-flag `In` in the
-uniform one-`(value, tick)`-pair-per-edge form `#[op]` parses.
+**Engine coverage note:** `never` lands as an interpreted-engine (fluent) port
+— like `feedback` — since a source that never ticks has no `Op` witness for
+`#[op]` to hang forwarders on. `delay_with_reset` reached all three engines
+through its `DelayWithResetFwd` witness op, which restates its two-tick-flag
+`In` in the uniform one-`(value, tick)`-pair-per-edge form `#[op]` parses.
 `split`/`collapse` are pure sugar over `map`/`map_filter`, so they reach every
-engine for free. Extending `combine` to `nitro!`/compiled is a follow-up (as it
-is for `feedback`) — and it is now a *smaller* one than this note implies: the
-other n-ary fan-in, `merge_n`, reached all three engines by declaring
-`In<'a> = &'a [(&'a T, bool)]` and having `nitro!` emit a variadic node's edges
-as a pair slice rather than a tuple. `combine` can follow the same route; the
-"fixed-arity tuple `In` cannot express it" obstacle applies to `#[op]`
-generation, not to the engines.
+engine for free.
+
+**`combine` ✅ reaches all three engines**, closing what this note used to
+carry as a follow-up. It took the route the note predicted, the one `merge_n`
+proved: a `CombineN` witness op declaring `In<'a> = &'a [(&'a T, bool)]` with
+hand-written forwarders, and a `nitro!` arm emitting the node's edges as a pair
+slice. The obstacle was never the engines — a runtime-width fan-in defeats
+`#[op]`'s *generation*, not the emission.
+
+Two things fell out of doing it. The macro gained its **first builder-rooted
+call that is not a source**: `combine` lives on `GraphBuilder` rather than on a
+stream (no input is privileged), so `nitro!` had to accept edges in root
+position — worth it to keep one spelling, `g.combine(&[a, b])`, across fluent
+and macro. And the interpreted path deliberately does **not** call
+`CombineN::cycle`: materialising the `&[(&T, bool)]` slice means holding a
+borrow guard per upstream, a per-cycle allocation on a wide fan-in, so it walks
+the tick flags and routes only the empty-vs-not decision through the shared
+`CombineN::emit`. Tests: `tests/combine_n.rs`.
 
 **Gate 2:** every legacy node test has a next twin producing identical
 values and tick times.


### PR DESCRIPTION
`combine` is the burst-shaped twin of the n-ary merge — where `merge_all` picks **one** winner from the inputs that ticked this instant, `combine` keeps **all** of them, which is the burst pattern the engine is built around. It ran on the interpreted engine only: the last real hole in the fan-in vocabulary.

Second of four PRs closing the catalog gaps the plan docs list. (#683 was the first.)

## The route is the one `merge_n` proved

`CombineN` declares `In<'a> = &'a [(&'a T, bool)]` — the same uniform `(value, tick)` pairs every other op gets, as a slice — with hand-written forwarders, because `#[op]` parses `In` as a fixed-arity tuple and a fan-in of runtime width has none. `port-plan.md` predicted exactly this and noted the obstacle was generation, not the engines. It was right.

## Two things fell out of doing it

**The macro gained its first builder-rooted call that is not a source.** `combine` sits on `GraphBuilder` rather than on a stream because no input is privileged, so `nitro!` had to accept edges in root position (`push_combine`). That is a dozen lines, and it keeps one spelling — `g.combine(&[a, b])` — across fluent and macro. The cheap alternative, a chained `a.combine(&[&b])`, would have avoided the macro change and left the op with two names permanently.

**The interpreted path deliberately does not call `CombineN::cycle`.** Materialising the slice means holding a borrow guard for every upstream at once — a per-cycle allocation on a wide fan-in, the same trap `MergeN::winner` exists to avoid. It walks the tick flags, borrows only what ticked, and routes the empty-vs-not decision through the shared `CombineN::emit`, so the two paths cannot drift on the one piece of semantics they implement separately.

## One consequence for users, not just tests

`tests/custom_op.rs` defined an out-of-crate op **named `combine`**, which became ambiguous the moment the catalog had one: forwarder dispatch resolves `__wf_op_<name>_*` unqualified at the call site, so a user op sharing a built-in's name does not shadow it — it fails to compile. The test op is now `blend`, and its module doc records why. Worth knowing before picking an op name; it is the standing cost of naming-convention dispatch, and adding any built-in can trigger it.

## A test I got wrong first

I asserted a graph could reach `combine` with nothing to gather. It cannot — a node is cycled only when an active upstream ticked, on every engine — so the combine node simply never ran on the quiet instants and the test proved nothing. The rule still needs pinning, since it is the semantics the two paths implement separately, so it is now tested directly on `CombineN::emit` with the unreachability recorded rather than papered over.

## Coverage (`tests/combine_n.rs`)

- Three-engine agreement over tickers of *differing* periods, so the run visits one-, two- and three-input instants — a same-rate fan-in would pass even if the tick mask were ignored.
- Hand-computed values on the compiled path, so all three engines agreeing on a *wrong* answer still fails.
- The tick mask read from values rather than by comparing engines.
- The empty-gather rule.
- The shape claim — a k-way combine is **one** node — on `node_count()`, like `merge_n`'s.

Green locally: full default-feature suite, `cargo lint`, `cargo lint-all`, `cargo fmt --all`.

## Docs

`port-plan.md`'s "Engine coverage note" (which carried this as a follow-up), the macro's `NodeDef::variadic` doc, the fluent `combine` doc, `op_completeness.rs` — where `combine` had been in *neither* a `nitro!` block nor any exclusion list, the same blind spot that once swallowed all 36 `StatisticsOps` methods — and the `/new-op-next` skill's variadic section, which now covers matching the fluent spelling even when the macro has to learn a new call position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq8BNdx3X612hC3gqo3EeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq8BNdx3X612hC3gqo3EeT)_