### PR TITLE
docs: correct the stale aeron feature comment in wingfoil-python

### DIFF
--- a/crates/wingfoil-python/Cargo.toml
+++ b/crates/wingfoil-python/Cargo.toml
@@ -99,10 +99,12 @@ prometheus = ["wingfoil/prometheus", "_common"]
 # payload edge marshals Python values through `serde_json::Value`.
 web = ["wingfoil/web-tls", "dep:serde_json", "_common"]
 # Aeron: the `aeron_sub` / `aeron_pub` pair and their `_with_status` twins.
-# Deliberately **not** in `all-adapters` and **not** in the wheel's default
-# feature set: `rusteron-client` builds the Aeron C library from source, needing
-# clang, libuuid and CMake >= 3.30. Its tests run in
-# `aeron-next-integration.yml`, which installs that toolchain.
+# **In** `all-adapters`, and so in the Linux wheel (cutover ruling, #367) — but
+# **not** in the wheel's default feature set, because `rusteron-client` builds
+# the Aeron C library from source, needing clang, libuuid and CMake >= 3.30.
+# `pypi-publish.yml` installs that toolchain for the Linux leg only, which is
+# why the macOS/Windows wheels fall back to the pyproject list without it. Its
+# tests run in `aeron-next-integration.yml`, which installs the same toolchain.
 aeron = ["wingfoil/aeron", "_common"]
 # iceoryx2: the `iceoryx2_sub` / `iceoryx2_pub` slice pair. Pure Rust, so it
 # *is* in `all-adapters` and its tests run in the normal job — but it stays out


### PR DESCRIPTION
Comment-only fix surfaced by a tracker audit of the open GitHub issues.

## The problem

`crates/wingfoil-python/Cargo.toml` contradicted itself about aeron. The per-feature comment said:

> Deliberately **not** in `all-adapters` and **not** in the wheel's default feature set

while the `all-adapters` list six lines below it starts with `"aeron"` — and that list's own comment already said the opposite:

> It is genuinely *all* of them, aeron and iceoryx2 included (cutover ruling, #367)

The aeron comment went stale when #367 was decided and the adapter was folded into the roll-up. Anyone reading top-to-bottom hits the wrong statement first.

## The fix

Restate what is actually true, and keep the distinction the original comment was reaching for — `all-adapters` vs the wheel's *default* feature set are two different things:

- aeron **is** in `all-adapters`, and so in the Linux wheel
- it is **not** in the wheel's default set, because `rusteron-client` builds the Aeron C library from source (clang, libuuid, CMake >= 3.30)
- `pypi-publish.yml` installs that toolchain for the Linux leg only, which is why the macOS/Windows wheels fall back to the pyproject list without it

## Verification

Comment-only — no feature resolution changes. Pre-commit ran `cargo fmt --all` and `cargo clippy --workspace --all-targets`; both clean.

## Context

Part of a tracker audit that closed six issues as legacy-only or already-done (#127, #125, #453, #454, #113, #367) and rescoped seven others against the next tree. #367 is the one this comment had drifted from; it is now closed, with this loose end called out in its closing comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JozqvfaQXpu9Z6QHmiSZh2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JozqvfaQXpu9Z6QHmiSZh2)_