### PR TITLE
Fix subscribe race that flaked the web adapter tests

### DIFF
--- a/crates/wingfoil/src/adapters/web/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/web/CLAUDE.md
@@ -44,6 +44,7 @@ removes the PEM files afterwards.
 | `WebServerBuilder::start()` | handle | binds a real port |
 | `WebServerBuilder::start_historical()` | handle | **binds nothing**; `web_pub`/`web_sub` become no-ops |
 | `server.port()` / `codec()` / `is_tls()` / `is_historical_noop()` / `stop()` | handle | |
+| `server.subscriber_count(topic)` | handle | receivers a publish would reach *now*; 0 → 1 when the server has acted on a client's `Subscribe` |
 | `web_sub::<T>(g, &server, topic)` | source | `Result<Stream<Burst<T>>>` |
 | `WebSinkOps::web_pub(&server, topic)` | sink trait on `Stream<T>` | one scalar payload per frame |
 | `WebBurstSinkOps::web_pub_bursts(&server, topic)` | sink trait on `Stream<Burst<T>>` | the whole same-instant group as one array frame |
@@ -75,6 +76,16 @@ removes the PEM files afterwards.
 
   Note `web_sub` is therefore **not** rejected at wiring, unlike the live `_sub`
   sources of register B2 — it is *finite* under historical replay.
+- **A client's `Subscribe` takes effect asynchronously, and there is no ack.**
+  The connection's reader task calls `broadcast::Sender::subscribe()` when it
+  processes the frame; until then the client has no receiver, and
+  `broadcast` *drops* rather than queues for a receiver that does not exist. So
+  anything published between a client sending `Subscribe` and the server acting
+  on it is lost. Publishers that run for a while don't notice; a short, finite
+  publish can vanish entirely. `WebServer::subscriber_count(topic)` is the
+  observable — wait for it to reach the expected count before publishing, which
+  is what `tests/web_adapter.rs`'s `wait_for_subscribers` does. This was a live
+  test flake, not a hypothetical.
 - **Clients never back-pressure the graph.** The broadcast buffer is lossy: a
   client that cannot keep up drops frames. For a faithful, loss-free replay,
   keep the graph from outrunning the client (e.g. a genuinely compute-bound

--- a/crates/wingfoil/src/adapters/web/server.rs
+++ b/crates/wingfoil/src/adapters/web/server.rs
@@ -142,6 +142,24 @@ impl WebServer {
         self.historical_noop
     }
 
+    /// How many connected clients a publish on `topic` would currently reach.
+    ///
+    /// A client's `Subscribe` is processed asynchronously by its connection's
+    /// reader task, so a client that has *sent* one is not yet receiving:
+    /// [`tokio::sync::broadcast`] delivers only to receivers that already
+    /// exist, and a frame published before then is dropped, not queued. This
+    /// counts the receivers the publisher can actually reach, so it steps from
+    /// 0 to 1 exactly when a publish would start being delivered — which makes
+    /// it the thing to wait on before publishing a short, finite sequence.
+    pub fn subscriber_count(&self, topic: &str) -> usize {
+        self.inner
+            .pub_topics
+            .lock()
+            .expect("pub_topics lock poisoned")
+            .get(topic)
+            .map_or(0, |sender| sender.receiver_count())
+    }
+
     /// True when the server is terminating TLS (i.e. clients should
     /// connect via `https://` / `wss://`).
     pub fn is_tls(&self) -> bool {

--- a/crates/wingfoil/tests/web_adapter.rs
+++ b/crates/wingfoil/tests/web_adapter.rs
@@ -36,6 +36,21 @@ struct UiClick {
     count: u32,
 }
 
+/// How long a single `recv` waits before the client loops go round again.
+///
+/// Exceeding it means no frame has arrived *yet*, not that the stream ended.
+/// The loops below must therefore retry rather than break: a loaded CI runner
+/// can take longer than this to deliver the first frame, and treating that as
+/// end-of-stream makes the test assert against an empty vec.
+const RECV_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The real bound on a client thread waiting for the frames a test expects.
+///
+/// Kept under nextest's 10s `slow-timeout` (`.config/nextest.toml`), which
+/// *terminates* a test rather than letting it fail. A deadline at or above that
+/// turns a genuine failure into a kill with no assertion message.
+const CLIENT_DEADLINE: Duration = Duration::from_secs(8);
+
 async fn connect(port: u16) -> anyhow::Result<TungsteniteStream> {
     let url = format!("ws://127.0.0.1:{port}/ws");
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -99,6 +114,32 @@ async fn recv_envelope(
     }
 }
 
+/// Block until a publish on `topic` would actually reach the client.
+///
+/// The `ready` channel every client here sends on only says it *wrote* its
+/// `Subscribe` frame; the server registers that asynchronously on the
+/// connection's reader task. A `broadcast` channel drops anything published
+/// before the receiver exists, so a test that starts its graph on the `ready`
+/// signal alone can lose the whole sequence — which is exactly what it looks
+/// like when `burst_stream_publishes_atomic_arrays` asserts against `[]`.
+///
+/// Tests publishing over a long window (the ticker ones) survive that race by
+/// accident; the ones publishing a short finite sequence do not. Wait here
+/// instead of sleeping a guessed interval.
+fn wait_for_subscribers(server: &WebServer, topic: &str, count: usize) {
+    let deadline = Instant::now() + CLIENT_DEADLINE;
+    while Instant::now() < deadline {
+        if server.subscriber_count(topic) >= count {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    panic!(
+        "server registered {} of {count} subscribers for `{topic}` within {CLIENT_DEADLINE:?}",
+        server.subscriber_count(topic),
+    );
+}
+
 /// Spawn a client on its own thread + tokio runtime that subscribes to `topic`
 /// and captures up to `max_frames` envelopes. Returns a handle whose `join()`
 /// produces the collected envelopes.
@@ -125,17 +166,14 @@ fn spawn_subscriber(
             ready.send(()).ok();
 
             let mut out = Vec::with_capacity(max_frames);
-            let overall_deadline = Instant::now() + Duration::from_secs(10);
+            let overall_deadline = Instant::now() + CLIENT_DEADLINE;
             while out.len() < max_frames && Instant::now() < overall_deadline {
-                match tokio::time::timeout(
-                    Duration::from_secs(2),
-                    recv_envelope(&mut socket, codec),
-                )
-                .await
-                {
+                match tokio::time::timeout(RECV_TIMEOUT, recv_envelope(&mut socket, codec)).await {
                     Ok(Ok(env)) if env.topic == topic => out.push(env),
                     Ok(Ok(_)) => continue, // ignore other topics (hello, etc.)
-                    Ok(Err(_)) | Err(_) => break,
+                    Ok(Err(_)) => break,
+                    // Nothing yet — keep waiting until the outer deadline.
+                    Err(_) => continue,
                 }
             }
             Ok(out)
@@ -173,6 +211,7 @@ fn pub_round_trip_bincode() -> anyhow::Result<()> {
     ready_rx
         .recv_timeout(Duration::from_secs(5))
         .expect("client failed to subscribe");
+    wait_for_subscribers(&server, "tick", 1);
 
     let g = GraphBuilder::new();
     let _sink = g
@@ -261,6 +300,7 @@ fn pub_round_trip_json() -> anyhow::Result<()> {
     ready_rx
         .recv_timeout(Duration::from_secs(5))
         .expect("client failed to subscribe");
+    wait_for_subscribers(&server, "answer", 1);
 
     // Run on a ticker so the constant value ticks at least once after the
     // subscriber is connected.
@@ -315,17 +355,17 @@ fn historical_streaming_completes() -> anyhow::Result<()> {
 
             let mut values = Vec::new();
             let mut completed = false;
-            let deadline = Instant::now() + Duration::from_secs(10);
+            let deadline = Instant::now() + CLIENT_DEADLINE;
             while Instant::now() < deadline {
-                let env = match tokio::time::timeout(
-                    Duration::from_secs(2),
-                    recv_envelope(&mut socket, codec),
-                )
-                .await
-                {
-                    Ok(Ok(env)) => env,
-                    Ok(Err(_)) | Err(_) => break,
-                };
+                let env =
+                    match tokio::time::timeout(RECV_TIMEOUT, recv_envelope(&mut socket, codec))
+                        .await
+                    {
+                        Ok(Ok(env)) => env,
+                        Ok(Err(_)) => break,
+                        // Nothing yet — keep waiting until the outer deadline.
+                        Err(_) => continue,
+                    };
                 if env.topic == "hist" {
                     values.push(codec.decode::<u64>(&env.payload)?);
                 } else if env.topic == CONTROL_TOPIC
@@ -343,6 +383,7 @@ fn historical_streaming_completes() -> anyhow::Result<()> {
     ready_rx
         .recv_timeout(Duration::from_secs(5))
         .expect("client failed to subscribe");
+    wait_for_subscribers(&server, "hist", 1);
 
     // 50 values, well under the broadcast buffer, so a loopback client receives
     // every one with no loss.
@@ -393,17 +434,17 @@ fn burst_stream_publishes_atomic_arrays() -> anyhow::Result<()> {
             ready_tx.send(()).ok();
 
             let mut frames: Vec<Vec<u32>> = Vec::new();
-            let deadline = Instant::now() + Duration::from_secs(10);
+            let deadline = Instant::now() + CLIENT_DEADLINE;
             while Instant::now() < deadline {
-                let env = match tokio::time::timeout(
-                    Duration::from_secs(2),
-                    recv_envelope(&mut socket, codec),
-                )
-                .await
-                {
-                    Ok(Ok(env)) => env,
-                    Ok(Err(_)) | Err(_) => break,
-                };
+                let env =
+                    match tokio::time::timeout(RECV_TIMEOUT, recv_envelope(&mut socket, codec))
+                        .await
+                    {
+                        Ok(Ok(env)) => env,
+                        Ok(Err(_)) => break,
+                        // Nothing yet — keep waiting until the outer deadline.
+                        Err(_) => continue,
+                    };
                 if env.topic == "burst" {
                     // A same-time burst decodes to a whole array in one frame.
                     frames.push(codec.decode::<Vec<u32>>(&env.payload)?);
@@ -420,6 +461,7 @@ fn burst_stream_publishes_atomic_arrays() -> anyhow::Result<()> {
     ready_rx
         .recv_timeout(Duration::from_secs(5))
         .expect("client failed to subscribe");
+    wait_for_subscribers(&server, "burst", 1);
 
     // Two values at t=100 (grouped into one Burst) and one at t=200. The burst
     // sink converts each `Burst<T>` to the wire array itself.
@@ -510,6 +552,7 @@ fn multiple_subscribers_receive_same_frames() -> anyhow::Result<()> {
     let b_client = spawn_subscriber(port, "bcast", codec, 3, b_tx);
     a_rx.recv_timeout(Duration::from_secs(5))?;
     b_rx.recv_timeout(Duration::from_secs(5))?;
+    wait_for_subscribers(&server, "bcast", 2);
 
     let g = GraphBuilder::new();
     let _sink = g
@@ -575,6 +618,7 @@ fn bad_envelope_is_ignored_not_fatal() -> anyhow::Result<()> {
         })
     });
     ready_rx.recv_timeout(Duration::from_secs(5))?;
+    wait_for_subscribers(&server, "safe", 1);
 
     let g = GraphBuilder::new();
     let _sink = g
@@ -706,17 +750,14 @@ fn pub_round_trip_tls() -> anyhow::Result<()> {
             ready_tx.send(()).ok();
 
             let mut out = Vec::new();
-            let stop_at = Instant::now() + Duration::from_secs(5);
+            let stop_at = Instant::now() + CLIENT_DEADLINE;
             while out.len() < 3 && Instant::now() < stop_at {
-                match tokio::time::timeout(
-                    Duration::from_secs(2),
-                    recv_envelope(&mut socket, codec),
-                )
-                .await
-                {
+                match tokio::time::timeout(RECV_TIMEOUT, recv_envelope(&mut socket, codec)).await {
                     Ok(Ok(env)) if env.topic == topic_thread => out.push(env),
                     Ok(Ok(_)) => continue,
-                    Ok(Err(_)) | Err(_) => break,
+                    Ok(Err(_)) => break,
+                    // Nothing yet — keep waiting until the outer deadline.
+                    Err(_) => continue,
                 }
             }
             Ok(out)
@@ -726,6 +767,7 @@ fn pub_round_trip_tls() -> anyhow::Result<()> {
     ready_rx
         .recv_timeout(Duration::from_secs(5))
         .expect("tls client failed to subscribe");
+    wait_for_subscribers(&server, &topic, 1);
 
     let g = GraphBuilder::new();
     let _sink = g


### PR DESCRIPTION
## Why

`burst_stream_publishes_atomic_arrays` and `historical_streaming_completes` fail intermittently in CI, asserting against an empty vec:

```
assertion `left == right` failed: same-time values must arrive as one atomic array frame
  left: []
 right: [[1, 2], [3]]
```

Seen most recently on #688, whose diff touches only benchmarks and docs. The flake is not specific to that branch — it reproduces on `next`.

## Root cause

Both tests publish a short, finite sequence as soon as their client signals ready. That signal is sent the moment the client has **written** its `Subscribe` frame, not when the server has acted on it.

The server registers a subscription asynchronously on the connection's reader task, calling `broadcast::Sender::subscribe()` there (`server.rs`). A `tokio::sync::broadcast` channel delivers only to receivers that already exist — anything published before then is **dropped, not queued**. Under load that window widens past the whole publish and the client collects nothing.

This is why only these two tests flake: the ticker-driven tests publish over a 500ms window and survive the race by accident. The two that publish a fixed handful of values do not.

## What changed

- **`WebServer::subscriber_count(topic)`** — reports how many receivers a publish would currently reach. It steps 0 → 1 exactly when a publish starts being delivered, which makes it the real precondition rather than a guessed sleep. Useful beyond tests as a "how many browsers are attached" probe.
- **`wait_for_subscribers(server, topic, count)`** in `tests/web_adapter.rs`, called after every ready-signal wait and before the graph runs.
- **Recv loops no longer treat a timeout as end-of-stream.** They matched `Ok(Err(_)) | Err(_) => break`, where `Err(_)` is the elapsed `tokio::time::timeout` — so a slow first frame silently truncated the collected frames. Timeouts now continue to the enclosing deadline; only a socket error breaks. This was a genuine second defect, though not the cause of the observed failure.
- **Deadline constants named and lowered to 8s** (`RECV_TIMEOUT`, `CLIENT_DEADLINE`), under nextest's 10s `slow-timeout`, so a genuine hang fails with its assertion instead of being killed with no message.
- **`adapters/web/CLAUDE.md`** records the async-Subscribe gotcha and the new entry point.

## Verification

- Reproduced the original failure: full `web_adapter` suite under 8 busy-loop threads on 4 cores, failing roughly 1 run in 3, with the same `left: []`.
- After the fix: **12/12 clean** under identical load.
- `cargo fmt --all -- --check`, `cargo lint`, and `cargo clippy --features web-tls-integration-test --all-targets -- -D warnings` all clean. The last one matters here — `cargo lint` runs default features, so the `web`-gated code needs the explicit run.
- `--features web-tls-integration-test --test web_adapter`: 13 passed.

Two caveats, stated plainly: the repro used `cargo test`'s thread parallelism because nextest could not be installed in this sandbox (`get.nexte.st` is blocked by the proxy), and CI uses nextest's process parallelism. And `cargo lint-all` could not run locally — the aeron C toolchain is absent — so CI is the first full-feature check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QN1VheFY6njLi2xwtnQnF

---
_Generated by [Claude Code](https://claude.ai/code/session_016QN1VheFY6njLi2xwtnQnF)_