### PR TITLE
docs(python): fix 7 broken links in the PyPI landing page

### DIFF
--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -15,7 +15,7 @@ plus a plugin seam that lets you author ops, sub-graphs and adapters *in Rust*
 and compose them from Python.
 
 > Coming from the original `wingfoil` package? This one supersedes it —
-> see the [migration guide](https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/docs/migration.rst), which lists every renamed
+> see the [migration guide](https://github.com/wingfoil-io/wingfoil/blob/next/crates/wingfoil-python/docs/migration.rst), which lists every renamed
 > entry point and every place wingfoil deliberately behaves differently.
 
 ---
@@ -483,7 +483,7 @@ non-`dict` where a record was expected aborts the run naming the offending
 field, rather than defaulting to empty bytes or an empty burst.
 
 Every entry point carries a full docstring — `help(wf.kafka_sub)` — and the
-[API reference](https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/docs/api.rst) tabulates the whole surface.
+[API reference](https://github.com/wingfoil-io/wingfoil/blob/next/crates/wingfoil-python/docs/api.rst) tabulates the whole surface.
 
 ### PostgreSQL
 
@@ -922,18 +922,18 @@ docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine
 pytest -m requires_postgres tests/test_postgres.py
 ```
 
-Runnable examples live in [`examples/`](https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/examples) and are smoke-tested by
+Runnable examples live in [`examples/`](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-python/examples) and are smoke-tested by
 `tests/test_examples.py`, so they stay working as the binding evolves.
 
 ---
 
 ## Documentation
 
-- [`docs/`](https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/docs) — the Sphinx source for the published module documentation:
-  this guide, the [API reference](https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/docs/api.rst), and the
-  [migration guide](https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/docs/migration.rst) for the legacy `wingfoil` package.
+- [`docs/`](https://github.com/wingfoil-io/wingfoil/tree/next/crates/wingfoil-python/docs) — the Sphinx source for the published module documentation:
+  this guide, the [API reference](https://github.com/wingfoil-io/wingfoil/blob/next/crates/wingfoil-python/docs/api.rst), and the
+  [migration guide](https://github.com/wingfoil-io/wingfoil/blob/next/crates/wingfoil-python/docs/migration.rst) for the legacy `wingfoil` package.
   Build it with `maturin develop` followed by `make html` in `docs/`; see
-  [`docs/README.md`](https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/docs/README.md).
+  [`docs/README.md`](https://github.com/wingfoil-io/wingfoil/blob/next/crates/wingfoil-python/docs/README.md).
 - Every adapter's module docs (`src/adapters/<name>.rs`) carry its entry-point
   table, its argument semantics, and how its surface differs from the legacy
   binding. Those doc comments *are* the Python docstrings — `help(wf.csv_read)`.


### PR DESCRIPTION
## What

Fixes all seven GitHub links in `crates/wingfoil-python/README.md`.

## Why

Every link was shaped:

```
https://github.com/wingfoil-io/wingfoil/tree/crates/wingfoil-python/docs/migration.rst
```

GitHub parses `/tree/<ref>/<path>`, so this asks for branch **`crates`**, path `wingfoil-python/docs/migration.rst`. The repo only has `main` and `next`, so **all seven 404'd** — including both links to the migration guide, which is the document a user coming from the legacy `wingfoil` package is explicitly pointed at.

This file is published as the **PyPI project description**, so these are the first links a prospective user follows.

## How

Point them at `next`, and use the right verb per target type:

| Line | Target | Now |
|---|---|---|
| 18, 934 | `docs/migration.rst` | `/blob/next/…` |
| 486, 933 | `docs/api.rst` | `/blob/next/…` |
| 936 | `docs/README.md` | `/blob/next/…` |
| 925 | `examples/` | `/tree/next/…` |
| 932 | `docs/` | `/tree/next/…` |

`next` rather than `main` because the crate lives at `crates/wingfoil-python` only on `next`; `main` still carries the legacy layout with `wingfoil-python` at the repository root, so these paths do not exist there.

## Verification

All five distinct targets confirmed present at `origin/next` via `git cat-file -e`. No `tree/crates/` occurrences remain in the file.

Docs-only change — no code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_018hjWKaLKeRkciYtrfS1iVa)_