### PR TITLE
tests: compare against the legacy engine, not against transcribed literals

### DIFF
--- a/crates/wingfoil/tests/engine_differential.rs
+++ b/crates/wingfoil/tests/engine_differential.rs
@@ -1,0 +1,349 @@
+//! Differential engine parity: run the **legacy** op and its wingfoil twin over
+//! the same scenario in the same process, and compare **values and tick times**
+//! exactly — rather than against a hand-transcribed expectation.
+//!
+//! CLAUDE.md makes the legacy tree the parity oracle: "the wingfoil twin must
+//! produce identical values and tick times". Most of the suite encodes that as
+//! literals a person derived by reading the legacy node; this file has legacy
+//! itself produce them, so the tick-time half of the claim is enforced rather
+//! than assumed.
+//!
+//! `scheduling_ops_sweep` is the point of the harness: once the comparison is a
+//! function, covering twelve periods and sixteen window sizes costs nothing, and
+//! that is the range a transcribed expectation will never have.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+use legacy_wingfoil::{NodeOperators, StreamOperators};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const PERIOD: Duration = Duration::from_nanos(100);
+const CYCLES: u32 = 25;
+
+type Series = Vec<(u64, i64)>;
+
+fn legacy_src() -> Rc<dyn legacy_wingfoil::Stream<i64>> {
+    legacy_wingfoil::ticker(PERIOD)
+        .count()
+        .map(|n: u64| ((n * 7) % 13) as i64)
+}
+
+fn wingfoil_src(g: &GraphBuilder) -> wingfoil::fluent::Stream<i64> {
+    g.ticker(PERIOD)
+        .count()
+        .map(|n: &u64| ((*n * 7) % 13) as i64)
+}
+
+fn legacy_run(
+    build: impl Fn(&Rc<dyn legacy_wingfoil::Stream<i64>>) -> Rc<dyn legacy_wingfoil::Stream<i64>>,
+) -> Series {
+    let out = build(&legacy_src());
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let tap = {
+        let seen = seen.clone();
+        out.for_each(move |v, t| seen.borrow_mut().push((u64::from(t), v)))
+    };
+    tap.run(HISTORICAL, RunFor::Cycles(CYCLES))
+        .expect("legacy run");
+    seen.borrow().clone()
+}
+
+fn wingfoil_run(
+    build: impl Fn(&wingfoil::fluent::Stream<i64>) -> wingfoil::fluent::Stream<i64>,
+) -> Series {
+    let g = GraphBuilder::new();
+    let out = build(&wingfoil_src(&g));
+    let acc = out.with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(CYCLES))
+        .expect("wingfoil run");
+    r.value(&acc)
+        .into_iter()
+        .map(|(t, v)| (u64::from(t), v))
+        .collect()
+}
+
+fn compare(name: &str, legacy: Series, next: Series) {
+    assert_eq!(
+        legacy, next,
+        "\n{name}: legacy and wingfoil differ (time, value) pairs\n  legacy  = {legacy:?}\n  wingfoil= {next:?}"
+    );
+}
+
+#[test]
+fn map_parity() {
+    compare(
+        "map",
+        legacy_run(|s| s.map(|v: i64| v * 2)),
+        wingfoil_run(|s| s.map(|v: &i64| v * 2)),
+    );
+}
+
+#[test]
+fn filter_value_parity() {
+    compare(
+        "filter_value / map_filter",
+        legacy_run(|s| s.filter_value(|v: &i64| *v > 5)),
+        wingfoil_run(|s| s.map_filter(|v: &i64| (*v, *v > 5))),
+    );
+}
+
+#[test]
+fn distinct_parity() {
+    compare(
+        "distinct",
+        legacy_run(|s| s.distinct()),
+        wingfoil_run(|s| s.distinct()),
+    );
+}
+
+#[test]
+fn difference_parity() {
+    compare(
+        "difference",
+        legacy_run(|s| s.difference()),
+        wingfoil_run(|s| s.difference()),
+    );
+}
+
+#[test]
+fn limit_parity() {
+    compare(
+        "limit(5)",
+        legacy_run(|s| s.limit(5)),
+        wingfoil_run(|s| s.limit(5)),
+    );
+}
+
+#[test]
+fn delay_parity() {
+    let d = Duration::from_nanos(250);
+    compare(
+        "delay(250ns)",
+        legacy_run(|s| s.delay(d)),
+        wingfoil_run(|s| s.delay(d)),
+    );
+}
+
+#[test]
+fn throttle_parity() {
+    let i = Duration::from_nanos(300);
+    compare(
+        "throttle(300ns)",
+        legacy_run(|s| s.throttle(i)),
+        wingfoil_run(|s| s.throttle(i)),
+    );
+}
+
+#[test]
+fn fold_parity() {
+    compare(
+        "fold (running sum)",
+        legacy_run(|s| s.fold(|acc: &mut i64, v: i64| *acc += v)),
+        wingfoil_run(|s| s.fold(0i64, |acc: &mut i64, v: &i64| *acc += *v)),
+    );
+}
+
+#[test]
+fn sample_parity() {
+    let trigger = Duration::from_nanos(300);
+    compare(
+        "sample(300ns ticker)",
+        legacy_run(|s| s.sample(legacy_wingfoil::ticker(trigger))),
+        wingfoil_run(|s| {
+            let g = s.graph();
+            s.sample(&g.ticker(trigger))
+        }),
+    );
+}
+
+#[test]
+fn window_parity() {
+    let w = Duration::from_nanos(300);
+    compare(
+        "window(300ns) -> summed",
+        legacy_run(|s| s.window(w).map(|v: Vec<i64>| v.iter().sum::<i64>())),
+        wingfoil_run(|s| s.window(w).map(|v: &Vec<i64>| v.iter().sum::<i64>())),
+    );
+}
+
+#[test]
+fn window_len_parity() {
+    let w = Duration::from_nanos(300);
+    compare(
+        "window(300ns) -> len",
+        legacy_run(|s| s.window(w).map(|v: Vec<i64>| v.len() as i64)),
+        wingfoil_run(|s| s.window(w).map(|v: &Vec<i64>| v.len() as i64)),
+    );
+}
+
+#[test]
+fn buffer_parity() {
+    compare(
+        "buffer(4) -> summed",
+        legacy_run(|s| s.buffer(4).map(|v: Vec<i64>| v.iter().sum::<i64>())),
+        wingfoil_run(|s| s.buffer(4).map(|v: &Vec<i64>| v.iter().sum::<i64>())),
+    );
+}
+
+#[test]
+fn buffer_len_parity() {
+    compare(
+        "buffer(4) -> len",
+        legacy_run(|s| s.buffer(4).map(|v: Vec<i64>| v.len() as i64)),
+        wingfoil_run(|s| s.buffer(4).map(|v: &Vec<i64>| v.len() as i64)),
+    );
+}
+
+#[test]
+fn merge_tiebreak_parity() {
+    // Two tickers at different periods that coincide every 3rd/2nd tick — the
+    // merge tie-break at a shared instant is the interesting part.
+    compare(
+        "merge(200ns, 300ns)",
+        {
+            let a = legacy_wingfoil::ticker(Duration::from_nanos(200))
+                .count()
+                .map(|n: u64| n as i64);
+            let b = legacy_wingfoil::ticker(Duration::from_nanos(300))
+                .count()
+                .map(|n: u64| -(n as i64));
+            let out = legacy_wingfoil::merge(vec![a, b]);
+            let seen = Rc::new(RefCell::new(Vec::new()));
+            let tap = {
+                let seen = seen.clone();
+                out.for_each(move |v, t| seen.borrow_mut().push((u64::from(t), v)))
+            };
+            tap.run(HISTORICAL, RunFor::Cycles(CYCLES)).expect("legacy");
+            seen.borrow().clone()
+        },
+        {
+            let g = GraphBuilder::new();
+            let a = g
+                .ticker(Duration::from_nanos(200))
+                .count()
+                .map(|n: &u64| *n as i64);
+            let b = g
+                .ticker(Duration::from_nanos(300))
+                .count()
+                .map(|n: &u64| -(*n as i64));
+            let out = a.merge(&b);
+            let acc = out.with_time().accumulate();
+            let mut r = g.build();
+            r.run(HISTORICAL, RunFor::Cycles(CYCLES)).expect("wingfoil");
+            let out: Series = r
+                .value(&acc)
+                .into_iter()
+                .map(|(t, v)| (u64::from(t), v))
+                .collect();
+            out
+        },
+    );
+}
+
+/// Parameter sweep: rather than one value per op, run every scheduling op over
+/// a range of periods against the legacy engine and compare (time, value)
+/// series exactly. This is where a tick-time deviation would hide.
+#[test]
+fn scheduling_ops_sweep() {
+    let mut failures: Vec<String> = Vec::new();
+    for ns in [1u64, 50, 99, 100, 101, 150, 200, 250, 300, 700, 1000, 2500] {
+        let d = Duration::from_nanos(ns);
+
+        let l = legacy_run(|s| s.delay(d));
+        let w = wingfoil_run(|s| s.delay(d));
+        if l != w {
+            failures.push(format!("delay({ns}ns)\n  legacy  ={l:?}\n  wingfoil={w:?}"));
+        }
+
+        let l = legacy_run(|s| s.throttle(d));
+        let w = wingfoil_run(|s| s.throttle(d));
+        if l != w {
+            failures.push(format!(
+                "throttle({ns}ns)\n  legacy  ={l:?}\n  wingfoil={w:?}"
+            ));
+        }
+
+        let l = legacy_run(|s| s.window(d).map(|v: Vec<i64>| v.len() as i64));
+        let w = wingfoil_run(|s| s.window(d).map(|v: &Vec<i64>| v.len() as i64));
+        if l != w {
+            failures.push(format!(
+                "window({ns}ns).len\n  legacy  ={l:?}\n  wingfoil={w:?}"
+            ));
+        }
+
+        let l = legacy_run(|s| s.sample(legacy_wingfoil::ticker(d)));
+        let w = wingfoil_run(|s| {
+            let g = s.graph();
+            s.sample(&g.ticker(d))
+        });
+        if l != w {
+            failures.push(format!(
+                "sample({ns}ns)\n  legacy  ={l:?}\n  wingfoil={w:?}"
+            ));
+        }
+    }
+    for n in [0usize, 1, 2, 3, 7, 24, 25, 26, 100] {
+        let l = legacy_run(|s| s.buffer(n).map(|v: Vec<i64>| v.len() as i64));
+        let w = wingfoil_run(|s| s.buffer(n).map(|v: &Vec<i64>| v.len() as i64));
+        if l != w {
+            failures.push(format!(
+                "buffer({n}).len\n  legacy  ={l:?}\n  wingfoil={w:?}"
+            ));
+        }
+    }
+    for n in [0u32, 1, 2, 24, 25, 26, 100] {
+        let l = legacy_run(|s| s.limit(n));
+        let w = wingfoil_run(|s| s.limit(n));
+        if l != w {
+            failures.push(format!("limit({n})\n  legacy  ={l:?}\n  wingfoil={w:?}"));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} divergence(s) from the legacy engine:\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}
+
+#[test]
+fn harness_is_not_vacuous() {
+    let base = legacy_run(|s| s.map(|v: i64| v));
+    println!("base series ({} pts) = {base:?}", base.len());
+    assert!(base.len() >= 20, "source series too short: {}", base.len());
+
+    let d = Duration::from_nanos(250);
+    for (name, l, w) in [
+        (
+            "delay",
+            legacy_run(|s| s.delay(d)),
+            wingfoil_run(|s| s.delay(d)),
+        ),
+        (
+            "throttle",
+            legacy_run(|s| s.throttle(d)),
+            wingfoil_run(|s| s.throttle(d)),
+        ),
+        (
+            "window.len",
+            legacy_run(|s| s.window(d).map(|v: Vec<i64>| v.len() as i64)),
+            wingfoil_run(|s| s.window(d).map(|v: &Vec<i64>| v.len() as i64)),
+        ),
+    ] {
+        println!("{name}: legacy {} pts {:?}", l.len(), &l[..l.len().min(6)]);
+        assert!(
+            !l.is_empty(),
+            "{name}: legacy series empty — harness vacuous"
+        );
+        assert!(
+            !w.is_empty(),
+            "{name}: wingfoil series empty — harness vacuous"
+        );
+    }
+}

--- a/crates/wingfoil/tests/stats_differential.rs
+++ b/crates/wingfoil/tests/stats_differential.rs
@@ -1,0 +1,139 @@
+//! Differential parity for the statistics catalog: run the **legacy**
+//! `StatisticsOperators` and their wingfoil `StatisticsOps` twins over the same
+//! scenario in the same process, and compare the emitted series directly.
+//!
+//! The rest of the statistics suite (`statistics_rolling.rs` and friends)
+//! asserts against a *hand-computed* expected series "derived from the legacy
+//! node semantics". That transcription is the thing this file removes: here the
+//! legacy engine computes the expectation, so a divergence is caught by the
+//! oracle CLAUDE.md names rather than by whoever wrote the literal down.
+//!
+//! Irregularly-spaced scenarios — where the time-weighted operators stop being
+//! degenerate — live in `stats_differential_irregular.rs`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::prelude::*;
+use wingfoil::stats::StatisticsOps;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+use legacy_wingfoil::adapters::statistics::{StatisticsOperators, Weighting, Window};
+use legacy_wingfoil::{NodeOperators, StreamOperators};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const PERIOD: Duration = Duration::from_nanos(100);
+const CYCLES: u32 = 40;
+
+/// `((n * 7) % 13)` for n = 1.., as f64 — the same non-monotonic sequence the
+/// wingfoil statistics tests use.
+fn legacy_series() -> Rc<dyn legacy_wingfoil::Stream<f64>> {
+    legacy_wingfoil::ticker(PERIOD)
+        .count()
+        .map(|n: u64| ((n * 7) % 13) as f64)
+}
+
+fn wingfoil_series(g: &GraphBuilder) -> wingfoil::fluent::Stream<f64> {
+    g.ticker(PERIOD)
+        .count()
+        .map(|n: &u64| ((*n * 7) % 13) as f64)
+}
+
+/// Run a legacy stat op and collect its emitted series.
+fn legacy_run(
+    build: impl Fn(&Rc<dyn legacy_wingfoil::Stream<f64>>) -> Rc<dyn legacy_wingfoil::Stream<f64>>,
+) -> Vec<f64> {
+    let src = legacy_series();
+    let out = build(&src);
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let tap = {
+        let seen = seen.clone();
+        out.for_each(move |v, _t| seen.borrow_mut().push(v))
+    };
+    tap.run(HISTORICAL, RunFor::Cycles(CYCLES))
+        .expect("legacy run");
+    seen.borrow().clone()
+}
+
+/// Run the wingfoil twin and collect its emitted series.
+fn wingfoil_run(
+    build: impl Fn(&wingfoil::fluent::Stream<f64>) -> wingfoil::fluent::Stream<f64>,
+) -> Vec<f64> {
+    let g = GraphBuilder::new();
+    let src = wingfoil_series(&g);
+    let out = build(&src);
+    let acc = out.accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(CYCLES))
+        .expect("wingfoil run");
+    r.value(&acc)
+}
+
+fn compare(name: &str, legacy: Vec<f64>, next: Vec<f64>) {
+    assert_eq!(
+        legacy.len(),
+        next.len(),
+        "{name}: series length differs\n legacy={legacy:?}\n wingfoil={next:?}"
+    );
+    for (i, (l, n)) in legacy.iter().zip(next.iter()).enumerate() {
+        assert!(
+            (l - n).abs() < 1e-9,
+            "{name}: diverges at index {i}: legacy={l} wingfoil={n}\n legacy={legacy:?}\n wingfoil={next:?}"
+        );
+    }
+}
+
+#[test]
+fn rolling_mean_matches_legacy() {
+    compare(
+        "rolling_mean(5)",
+        legacy_run(|s| s.mean(Window::Count(5), Weighting::Count)),
+        wingfoil_run(|s| s.rolling_mean(5)),
+    );
+}
+
+#[test]
+fn rolling_var_matches_legacy() {
+    compare(
+        "rolling_var(5)",
+        legacy_run(|s| s.variance(Window::Count(5), Weighting::Count)),
+        wingfoil_run(|s| s.rolling_var(5)),
+    );
+}
+
+#[test]
+fn rolling_median_matches_legacy() {
+    compare(
+        "rolling_median(5)",
+        legacy_run(|s| s.median(Window::Count(5), Weighting::Count)),
+        wingfoil_run(|s| s.rolling_median(5)),
+    );
+}
+
+#[test]
+fn cumulative_var_matches_legacy() {
+    compare(
+        "cumulative_var",
+        legacy_run(|s| s.variance(Window::Unbounded, Weighting::Count)),
+        wingfoil_run(|s| s.cumulative_var()),
+    );
+}
+
+#[test]
+fn time_weighted_mean_matches_legacy() {
+    compare(
+        "cumulative_mean_time_weighted",
+        legacy_run(|s| s.mean(Window::Unbounded, Weighting::Time)),
+        wingfoil_run(|s| s.cumulative_mean_time_weighted()),
+    );
+}
+
+#[test]
+fn time_windowed_mean_matches_legacy() {
+    compare(
+        "time_windowed_mean(500ns)",
+        legacy_run(|s| s.mean(Window::Time(Duration::from_nanos(500)), Weighting::Count)),
+        wingfoil_run(|s| s.time_windowed_mean(Duration::from_nanos(500))),
+    );
+}

--- a/crates/wingfoil/tests/stats_differential_irregular.rs
+++ b/crates/wingfoil/tests/stats_differential_irregular.rs
@@ -1,0 +1,187 @@
+//! Differential parity for the statistics catalog under the scenarios the
+//! hand-written suite does *not* cover: **irregular tick spacing** — where the
+//! time-weighted and time-windowed operators stop being degenerate — plus
+//! even-sized median windows and window sizes at the edges (1, and larger than
+//! the series).
+//!
+//! Every existing statistics test drives a uniform ticker, which makes a
+//! time-weighted mean agree with a count-weighted one for the wrong reason.
+//! Here the source only ticks when `n % 3 != 0`, so the gaps alternate
+//! 100ns / 200ns and the weighting actually has to be right.
+//!
+//! See `stats_differential.rs` for the regularly-spaced cases and for why the
+//! comparison runs against the legacy engine rather than a transcribed
+//! expectation.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::prelude::*;
+use wingfoil::stats::StatisticsOps;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+use legacy_wingfoil::adapters::statistics::{StatisticsOperators, Weighting, Window};
+use legacy_wingfoil::{NodeOperators, StreamOperators};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const PERIOD: Duration = Duration::from_nanos(100);
+const CYCLES: u32 = 40;
+
+/// An **irregularly spaced** f64 series: values arrive on a 100ns ticker but
+/// only on ticks where `n % 3 != 0`, so the gaps alternate 100ns / 200ns. Every
+/// time-weighted and time-windowed operator should notice; a count-weighted one
+/// should not.
+fn legacy_irregular() -> Rc<dyn legacy_wingfoil::Stream<f64>> {
+    legacy_wingfoil::ticker(PERIOD)
+        .count()
+        .filter_value(|n: &u64| !n.is_multiple_of(3))
+        .map(|n: u64| ((n * 7) % 13) as f64)
+}
+
+fn wingfoil_irregular(g: &GraphBuilder) -> wingfoil::fluent::Stream<f64> {
+    g.ticker(PERIOD)
+        .count()
+        .map_filter(|n: &u64| (((*n * 7) % 13) as f64, !(*n).is_multiple_of(3)))
+}
+
+fn legacy_run(
+    build: impl Fn(&Rc<dyn legacy_wingfoil::Stream<f64>>) -> Rc<dyn legacy_wingfoil::Stream<f64>>,
+) -> Vec<f64> {
+    let out = build(&legacy_irregular());
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let tap = {
+        let seen = seen.clone();
+        out.for_each(move |v, _t| seen.borrow_mut().push(v))
+    };
+    tap.run(HISTORICAL, RunFor::Cycles(CYCLES))
+        .expect("legacy run");
+    seen.borrow().clone()
+}
+
+fn wingfoil_run(
+    build: impl Fn(&wingfoil::fluent::Stream<f64>) -> wingfoil::fluent::Stream<f64>,
+) -> Vec<f64> {
+    let g = GraphBuilder::new();
+    let out = build(&wingfoil_irregular(&g));
+    let acc = out.accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(CYCLES))
+        .expect("wingfoil run");
+    r.value(&acc)
+}
+
+fn compare(name: &str, legacy: Vec<f64>, next: Vec<f64>) {
+    assert_eq!(
+        legacy.len(),
+        next.len(),
+        "{name}: series LENGTH differs — legacy emitted {} values, wingfoil {}\n legacy={legacy:?}\n wingfoil={next:?}",
+        legacy.len(),
+        next.len()
+    );
+    for (i, (l, n)) in legacy.iter().zip(next.iter()).enumerate() {
+        assert!(
+            (l - n).abs() < 1e-9,
+            "{name}: diverges at index {i}: legacy={l} wingfoil={n}\n legacy={legacy:?}\n wingfoil={next:?}"
+        );
+    }
+}
+
+#[test]
+fn irregular_time_weighted_mean() {
+    compare(
+        "cumulative_mean_time_weighted (irregular)",
+        legacy_run(|s| s.mean(Window::Unbounded, Weighting::Time)),
+        wingfoil_run(|s| s.cumulative_mean_time_weighted()),
+    );
+}
+
+#[test]
+fn irregular_time_weighted_var() {
+    compare(
+        "cumulative_var_time_weighted (irregular)",
+        legacy_run(|s| s.variance(Window::Unbounded, Weighting::Time)),
+        wingfoil_run(|s| s.cumulative_var_time_weighted()),
+    );
+}
+
+#[test]
+fn irregular_time_windowed_mean() {
+    compare(
+        "time_windowed_mean(500ns) (irregular)",
+        legacy_run(|s| s.mean(Window::Time(Duration::from_nanos(500)), Weighting::Count)),
+        wingfoil_run(|s| s.time_windowed_mean(Duration::from_nanos(500))),
+    );
+}
+
+#[test]
+fn irregular_time_windowed_var() {
+    compare(
+        "time_windowed_var(500ns) (irregular)",
+        legacy_run(|s| s.variance(Window::Time(Duration::from_nanos(500)), Weighting::Count)),
+        wingfoil_run(|s| s.time_windowed_var(Duration::from_nanos(500))),
+    );
+}
+
+#[test]
+fn irregular_time_windowed_median() {
+    compare(
+        "time_windowed_median(500ns) (irregular)",
+        legacy_run(|s| s.median(Window::Time(Duration::from_nanos(500)), Weighting::Count)),
+        wingfoil_run(|s| s.time_windowed_median(Duration::from_nanos(500))),
+    );
+}
+
+#[test]
+fn irregular_time_weighted_median() {
+    compare(
+        "cumulative_median_time_weighted (irregular)",
+        legacy_run(|s| s.median(Window::Unbounded, Weighting::Time)),
+        wingfoil_run(|s| s.cumulative_median_time_weighted()),
+    );
+}
+
+#[test]
+fn even_median_window() {
+    compare(
+        "rolling_median(4) (irregular, even window)",
+        legacy_run(|s| s.median(Window::Count(4), Weighting::Count)),
+        wingfoil_run(|s| s.rolling_median(4)),
+    );
+}
+
+#[test]
+fn window_of_one() {
+    compare(
+        "rolling_var(1)",
+        legacy_run(|s| s.variance(Window::Count(1), Weighting::Count)),
+        wingfoil_run(|s| s.rolling_var(1)),
+    );
+}
+
+#[test]
+fn window_larger_than_series() {
+    compare(
+        "rolling_var(1000)",
+        legacy_run(|s| s.variance(Window::Count(1000), Weighting::Count)),
+        wingfoil_run(|s| s.rolling_var(1000)),
+    );
+}
+
+#[test]
+fn irregular_time_weighted_count_window_mean() {
+    compare(
+        "mean(Count(5), Time) (irregular)",
+        legacy_run(|s| s.mean(Window::Count(5), Weighting::Time)),
+        wingfoil_run(|s| s.rolling_mean_time_weighted(5)),
+    );
+}
+
+#[test]
+fn irregular_time_weighted_count_window_var() {
+    compare(
+        "variance(Count(5), Time) (irregular)",
+        legacy_run(|s| s.variance(Window::Count(5), Weighting::Time)),
+        wingfoil_run(|s| s.rolling_var_time_weighted(5)),
+    );
+}


### PR DESCRIPTION
CLAUDE.md makes the legacy tree the parity oracle — *"the wingfoil twin must produce identical values and tick times, or document precisely why it deviates"*. In practice only 2 of the 78 files in `crates/wingfoil/tests/` run legacy code (`engine_semantics.rs`, `zmq_cross_engine_integration.rs`). The rest assert against numbers a person derived by reading the legacy node. `statistics_rolling.rs` states it in its own header:

> against a **hand-computed** expected series derived from the legacy node semantics

That transcription step is the gap: it is the same failure mode as the adapter READMEs that were written from invented output, applied to the parity claim itself. The legacy crate is already a dev-dependency for exactly this purpose, so closing it costs a helper pair per scenario.

## What this adds

Three test files, 33 tests, ~0.2s to run.

**`engine_differential.rs`** — map, map_filter, distinct, difference, limit, delay, throttle, fold, sample, window, buffer and merge tie-break, each run on both engines over the same scenario and compared as exact `(time, value)` pairs. Comparing tick times rather than just values is what makes this enforce the second half of the parity claim instead of assuming it.

`scheduling_ops_sweep` is the point of the harness: once the comparison is a function, covering 12 periods × 4 scheduling ops plus 16 count-window sizes costs nothing, and that is the range a transcribed expectation will never have.

**`stats_differential.rs`** — rolling mean/var/median, cumulative var, time-weighted mean, time-windowed mean against the legacy `StatisticsOperators` with the matching `Window` / `Weighting` pair.

**`stats_differential_irregular.rs`** — the same operators under **irregular tick spacing**, where the time-weighted family stops being degenerate. Every existing statistics test drives a uniform ticker, which makes a time-weighted mean agree with a count-weighted one for the wrong reason; here the source only ticks when `n % 3 != 0`, so the gaps alternate 100ns/200ns and the weighting has to be right. Plus even-sized median windows, `window = 1`, and a window larger than the series.

## Result

All 33 pass. This records the port as correct rather than changing it — the value is that a future regression is now caught by the oracle CLAUDE.md names, rather than by whoever next transcribes an expectation.

`harness_is_not_vacuous` guards the harness itself: an empty series on both sides would compare equal and prove nothing, so it pins the source series length and asserts each op's output is non-empty.

## Checks

- `cargo fmt --all` — clean
- `cargo lint` (default features, workspace) — clean
- `cargo clippy --manifest-path crates/wingfoil/Cargo.toml --tests -- -D warnings` — clean
- Full suite for the feature set excluding aeron/iceoryx2 — **630 passed, 0 failed**
- Pre-commit hook (`fmt` + workspace `clippy --all-targets`) and pre-push hook (workspace build + test) both ran green

`cargo lint-all` could not run locally: the aeron and iceoryx2 build scripts need CMake ≥ 3.30 and the dev box has 3.28.3. Those two features are unaffected by this change (it adds test targets only), and CI covers them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FofnEWK5QSoQ2rehpF8ccn)_