### PR TITLE
docs: make the GitHub landing page carry its own weight

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Something in the engine, an adapter or a binding behaves incorrectly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. The single most useful thing you can include is a
+        graph small enough to run — see
+        [`examples/core/hello_graph`](https://github.com/wingfoil-io/wingfoil/tree/main/crates/wingfoil/examples/core/hello_graph/)
+        for the shape of a minimal one.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you observed, and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: >
+        A graph wiring that shows the problem, ideally runnable. Rust, Python
+        or TypeScript is fine.
+      render: rust
+    validations:
+      required: true
+
+  - type: dropdown
+    id: run-mode
+    attributes:
+      label: Run mode
+      description: >
+        Historical and realtime schedule differently, so this narrows it down
+        a long way.
+      options:
+        - HistoricalFrom
+        - RealTime
+        - Both
+        - Not applicable
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Execution tier
+      description: A difference between tiers is itself a strong signal — say so if you tried more than one.
+      multiple: true
+      options:
+        - Interpreted
+        - Compiled (`nitro!` … `::compiled()`)
+        - Nested island (`nitro!` … `::nested()`)
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Crate version, `pip show wingfoil`, or the commit SHA if building from source.
+      placeholder: "wingfoil 9.0.0 / commit 16a81c5"
+    validations:
+      required: true
+
+  - type: input
+    id: features
+    attributes:
+      label: Feature flags
+      description: Which cargo features were enabled — adapters in particular.
+      placeholder: "kafka, async"
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, architecture and rustc version.
+      placeholder: "Ubuntu 24.04, x86_64, rustc 1.88.0"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or backtrace
+      description: >
+        Any error output. `RUST_LOG=debug` and `RUST_BACKTRACE=1` are usually
+        worth a run.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or idea
+    url: https://github.com/wingfoil-io/wingfoil/discussions
+    about: Ask how to wire something, or float an idea before it becomes an issue.
+  - name: Chat on Discord
+    url: https://discord.gg/rfGqf3Ff
+    about: The fastest way to get a question answered.
+  - name: Security vulnerability
+    url: https://github.com/wingfoil-io/wingfoil/security/advisories/new
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature request
+description: A new op, adapter, binding or engine capability
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Adapters and ops are the two things most often asked for, and both
+        have a written recipe — so a request for one is genuinely close to a
+        contribution. See
+        [CONTRIBUTING.md](https://github.com/wingfoil-io/wingfoil/blob/main/CONTRIBUTING.md).
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of addition
+      options:
+        - An op / combinator (map-like, stateful, statistical)
+        - An I/O adapter (source, sink, or both)
+        - A Python binding
+        - A TypeScript / browser capability
+        - An engine or runtime capability
+        - Documentation or an example
+        - Something else
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: >
+        What are you trying to build, and where does Wingfoil currently make
+        it awkward or impossible? Describe the situation rather than the fix
+        you have in mind — it often admits a better one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: sketch
+    attributes:
+      label: How it might look
+      description: >
+        Optional. If you can sketch the wiring you wish you could write, do —
+        the fluent surface is the part hardest to change later.
+      render: rust
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you are doing instead
+      description: Workarounds you have tried, or other libraries that solve this.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Would you like to implement it?
+      options:
+        - label: I would be interested in opening a PR for this

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for contributing. Keep this short — the diff is the detail, this is
+the orientation. Delete any section that doesn't apply.
+-->
+
+## What this changes
+
+<!-- One or two sentences. What is different after this lands? -->
+
+## Why
+
+<!-- The problem being solved. Link the issue if there is one: "Closes #123". -->
+
+## How it was verified
+
+<!--
+Which of these you ran, and anything that needed a service or a feature flag.
+The pre-commit hook covers fmt and clippy; tests are the part worth naming.
+-->
+
+- [ ] `cargo fmt --all`
+- [ ] `cargo lint` and `cargo lint-all`
+- [ ] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
+- [ ] New behaviour is covered by a test asserting **values and tick times**
+
+## Notes for the reviewer
+
+<!--
+Anything that would be hard to see from the diff: a deviation from the legacy
+parity oracle and why, a deliberate performance trade-off, a follow-up you
+chose not to fold in.
+-->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,3 +106,57 @@ jobs:
     secrets: inherit
     with:
       pypi-target: prod
+
+  github-release:
+    name: Publish GitHub release
+    # Last, and only once every registry has the artifacts: the tag is what
+    # the publish jobs build from, but the *release* is the announcement, and
+    # a release pointing at versions that are not yet installable is worse
+    # than no release at all.
+    needs: [preflight, publish-crates, publish-npm, publish-pypi]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.preflight.outputs.tag }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          # The install block, then GitHub's own generated changelog appended
+          # underneath it. Generating through the API rather than
+          # `gh release create --generate-notes` is what lets the two be
+          # combined in a defined order.
+          cat > notes.md <<'HEADER'
+          ### Install
+          HEADER
+          cat >> notes.md <<EOF
+
+          \`\`\`toml
+          # Cargo.toml
+          [dependencies]
+          wingfoil = "$VERSION"
+          \`\`\`
+
+          \`\`\`sh
+          pip install wingfoil==$VERSION
+          npm install @wingfoil/client@$VERSION
+          \`\`\`
+
+          Published to [crates.io](https://crates.io/crates/wingfoil/$VERSION),
+          [PyPI](https://pypi.org/project/wingfoil/$VERSION/) and
+          [npm](https://www.npmjs.com/package/@wingfoil/client/v/$VERSION).
+
+          EOF
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f "tag_name=$TAG" --jq .body >> notes.md
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.preflight.outputs.tag }}
+        run: gh release create "$TAG" --title "$TAG" --notes-file notes.md --verify-tag

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors and maintainers pledge to make participation in
+the Wingfoil project a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive and healthy community.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints and experiences.
+- Giving and gracefully accepting constructive feedback — on code, this means
+  reviewing the change rather than the person who wrote it.
+- Accepting responsibility, apologising to those affected by our mistakes, and
+  learning from the experience.
+- Focusing on what is best for the community as a whole.
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances
+  of any kind.
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement responsibilities
+
+Maintainers are responsible for clarifying and enforcing these standards, and
+will take appropriate and fair corrective action in response to any behaviour
+they deem inappropriate, threatening, offensive or harmful.
+
+Maintainers have the right and responsibility to remove, edit or reject
+comments, commits, code, issues and other contributions that are not aligned
+to this Code of Conduct, and will communicate reasons for moderation decisions
+when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the repository,
+issues, pull requests, discussions and the Discord server — and also applies
+when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing or otherwise unacceptable behaviour may be
+reported to the maintainers at `hello@wingfoil.io`. All complaints will be
+reviewed and investigated promptly and fairly.
+
+Maintainers are obligated to respect the privacy and security of the reporter
+of any incident.
+
+### Enforcement guidelines
+
+Maintainers will follow these guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+1. **Correction** — a private, written warning from the maintainers, providing
+   clarity around the nature of the violation and an explanation of why the
+   behaviour was inappropriate. A public apology may be requested.
+2. **Warning** — a warning with consequences for continued behaviour. No
+   interaction with the people involved for a specified period. Violating
+   these terms may lead to a temporary or permanent ban.
+3. **Temporary ban** — a temporary ban from any sort of interaction or public
+   communication with the project for a specified period.
+4. **Permanent ban** — a permanent ban from any sort of public interaction
+   within the project.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor
+Covenant](https://www.contributor-covenant.org/), version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,58 @@
 # Contributing to Wingfoil
 
-Wingfoil is the ground-up rebuild of the legacy engine
+We'd love your help. Say hi on [Discord](https://discord.gg/rfGqf3Ff), open a
+[discussion](https://github.com/wingfoil-io/wingfoil/discussions), or comment
+on any issue you fancy.
+
+## Getting set up
+
+You need the Rust toolchain (latest stable, with `rustfmt` and `clippy`) and
+`protoc` — a transitive dependency builds proto files, so a plain workspace
+build needs it:
+
+```bash
+scripts/setup-dev.sh              # installs protoc; Debian/Ubuntu and macOS
+```
+
+Then check everything works end to end:
+
+```bash
+git clone https://github.com/wingfoil-io/wingfoil.git && cd wingfoil
+cargo test --manifest-path crates/wingfoil/Cargo.toml
+cargo run  --manifest-path crates/wingfoil/Cargo.toml --example hello_graph
+```
+
+A few adapters need more (Aeron wants clang, libuuid and CMake ≥ 3.20; some
+adapter tests want a server) — [`CLAUDE.md`](CLAUDE.md) has the details, and
+none of it is needed to work on the engine.
+
+**Where to start:** the
+[`good first issue`](https://github.com/wingfoil-io/wingfoil/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+label, or anything labelled `size: small`. Issues also carry `priority:` and
+area labels (`core`, `io-adapter`, `python`) if you want to browse by
+interest. Not sure whether an idea fits? Ask first in an issue or on Discord —
+that is cheaper for both of us than a PR that has to be unwound.
+
+**Read first:** [`docs/wingfoil-architecture.md`](docs/wingfoil-architecture.md)
+is the shape of the engine and the one decision everything else follows from.
+Worth 20 minutes before your first non-trivial change.
+
+## How the work is organised
+
+Wingfoil is a ground-up rebuild of the legacy engine
 ([`legacy/CONTRIBUTING.md`](legacy/CONTRIBUTING.md)) on the Op pattern — see
 [`README.md`](README.md) for the design objectives and
-[`docs/port-plan.md`](docs/port-plan.md) for the roadmap. Community channels,
-licensing and general contribution etiquette are shared with the main
-project: see the [legacy CONTRIBUTING](legacy/CONTRIBUTING.md).
+[`docs/port-plan.md`](docs/port-plan.md) for the roadmap.
+
+Two trees, two workflows, and it matters which one you are in:
+
+| You are changing | Branch from | PR targets |
+|---|---|---|
+| Anything outside `legacy/` | `next` | `next` |
+| Anything under `legacy/` | `main` | `main` |
+
+Never commit directly to `next` or `main`. Branch names are simple and
+descriptive — `add-metrics`, `fix-error-handling`.
 
 ## What contributions look like here
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -152,4 +152,4 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
                                  END OF TERMS AND CONDITIONS
 
-Copyright [YEAR] [OWNER]
+Copyright 2025 Wingfoil

--- a/README.md
+++ b/README.md
@@ -1,66 +1,23 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/wingfoil-io/wingfoil/rust-test.yml?branch=main&label=CI)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust-test.yml)
 [![codecov](https://codecov.io/gh/wingfoil-io/wingfoil/graph/badge.svg)](https://codecov.io/gh/wingfoil-io/wingfoil)
+[![Crates.io Version](https://img.shields.io/crates/v/wingfoil.svg)](https://crates.io/crates/wingfoil)
+[![Docs.rs](https://docs.rs/wingfoil/badge.svg)](https://docs.rs/wingfoil/)
+[![PyPI - Version](https://img.shields.io/pypi/v/wingfoil.svg)](https://pypi.org/project/wingfoil/)
+[![npm](https://img.shields.io/npm/v/@wingfoil/client.svg)](https://www.npmjs.com/package/@wingfoil/client)
+[![Documentation Status](https://readthedocs.org/projects/wingfoil/badge/?version=latest)](https://wingfoil.readthedocs.io/en/latest/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE.txt)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/rfGqf3Ff)
 
 # Wingfoil
 
-Wingfoil is a blazingly fast, highly scalable stream processing engine
-designed for latency-critical use cases such as electronic trading and
-real-time AI systems.
+**A stream processing engine for latency-critical systems.** Wire a graph of
+calculations once; run it interpreted, compile it into a single monomorphized
+function, or mount compiled islands inside an interpreted graph — from the
+same definition. Backtest it over history, then run it live without changing
+the wiring.
 
-You describe your graph of calculations once, in a single fluent wiring, and
-choose how to run it: an **interpreted** engine for a fully open, dynamic
-world; a fully monomorphized **compiled** runner for maximum throughput; or
-**nested** compiled islands mounted inside an interpreted graph. Every tier is
-derived from the same definition, so they cannot drift — there is no
-duplicated execution logic anywhere.
-
-Wingfoil simplifies receiving, processing, distributing and monitoring
-streaming data across your entire stack.
-
-
-## Features
-
-- **Fast**: ultra low latency and high throughput from an efficient
-  [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph)-based execution
-  engine, with a `compiled()` tier that monomorphizes the whole graph into one
-  function for the compiler to optimise across node boundaries.
-- **Three execution tiers**: run any graph interpreted (open-world, dynamic),
-  fully compiled (static, fastest), or as compiled islands nested inside an
-  interpreted graph — all from one wiring definition.
-- **Backtesting**: replay historical data deterministically to backtest and
-  optimise strategies, then swap to realtime with the same graph wiring.
-- **Lossless**: same-instant values ride a single burst — never coalesced,
-  never latest-wins — identically in realtime and historical replay.
-- **Fallible everywhere**: every lifecycle function returns a `Result`; errors
-  abort the run with context and cleanup still runs.
-- **Simple to use**: define your graph of calculations; Wingfoil manages its
-  execution.
-- **Adapters**: sixteen production-ready integrations — PostgreSQL, KDB+,
-  Kafka, Redis, etcd, Fluvio, ZeroMQ, FIX 4.4, iceoryx2, Aeron, WebSocket,
-  Prometheus, OpenTelemetry, CSV, augurs and line-oriented files — with
-  async/Tokio at your graph edges, plus an LRU file cache for time-sliced
-  readers. One runnable example each,
-  [indexed here](crates/wingfoil/examples/adapters/).
-- **Multi-language**: a Rust crate, a [Python
-  package](crates/wingfoil-python/) exposing the same graph model,
-  adapters and latency surface, and a [TypeScript/JavaScript client](js/) for
-  the web adapter.
-- **Latency tracing**: per-hop wall-clock stamps that survive a process hop and
-  aggregate into one report — see
-  [`showcase/`](crates/wingfoil/examples/showcase/).
-- **Graph dynamism**: add and remove nodes on a
-  [running graph](crates/wingfoil/examples/core/dynamism/), between cycles.
-- **Multi-threading**: distribute graph execution across threads through the
-  channel layer.
-- **Extensible**: add sources, combinators, statistics and adapters as
-  extension traits; your own ops get interpreted *and* compiled coverage with
-  `#[op]`, with no macro table to edit.
-
-
-## Quick Start
-
-In this example we build a simple, linear pipeline with all nodes ticking in
-lock-step — wired, built and run as a single chain.
+Built for electronic trading and real-time AI, in Rust, with
+[Python](crates/wingfoil-python/) and [TypeScript](js/) on top.
 
 ```rust
 use std::time::Duration;
@@ -79,21 +36,66 @@ fn main() {
 }
 ```
 
-`build()` is available at the end of a chain as well as on the `GraphBuilder`,
-and builds the whole graph either way. Keep the builder and the streams in
-bindings when you branch, or when you want to read values back after the run
-(`runner.value(&stream)`) — as the worked example below does.
-
-This output is produced:
-
 ```pre
 hello, world 1
 hello, world 2
 hello, world 3
 ```
 
+```sh
+cargo add wingfoil          # Rust
+pip install wingfoil        # Python
+npm install @wingfoil/client  # TypeScript client for the web adapter
+```
+
+> New here? Run three examples in order — they cover the whole model between
+> them: [`hello_graph`](crates/wingfoil/examples/core/hello_graph/) →
+> [`ema_crossover`](crates/wingfoil/examples/core/ema_crossover/) →
+> [`order_book`](crates/wingfoil/examples/core/order_book/). Commands are
+> [below](#start-here).
+
+
+## Why Wingfoil
+
+- **Three execution tiers, one wiring.** Interpreted for an open, dynamic
+  world; `compiled()` for a static DAG monomorphized into one function; or
+  compiled islands `nested()` inside an interpreted graph. Every tier is
+  derived from the same definition, so they cannot drift — there is no
+  duplicated execution logic anywhere. Compiled runs
+  [4.4×–37× faster](#performance) than interpreted.
+- **Backtest and live are the same graph.** `RunMode::HistoricalFrom` replays
+  deterministically off source-driven engine time — no clock is consulted at
+  all — and `RunMode::RealTime` runs the identical wiring. Same code, same
+  results.
+- **Lossless by construction.** Same-instant values ride a single burst —
+  never coalesced, never latest-wins, never dropped — identically in realtime
+  and in replay.
+- **Sixteen production-ready adapters.** PostgreSQL, KDB+, Kafka, Redis, etcd,
+  Fluvio, ZeroMQ, FIX 4.4, iceoryx2, Aeron, WebSocket, Prometheus,
+  OpenTelemetry, CSV, augurs and line-oriented files — async/Tokio at your
+  graph edges, plus an LRU file cache for time-sliced readers. One runnable
+  example each, [indexed here](crates/wingfoil/examples/adapters/).
+- **Latency tracing that survives a process hop.** Per-hop wall-clock stamps
+  aggregating into one report, across shared memory and the wire — see
+  [`showcase/`](crates/wingfoil/examples/showcase/).
+- **Fallible everywhere.** Every lifecycle function returns a `Result`; a
+  producer error propagates into the graph and aborts the run with context,
+  and cleanup still runs.
+- **Dynamic when you need it.** Add and remove nodes on a
+  [running graph](crates/wingfoil/examples/core/dynamism/), between cycles.
+- **Multi-threaded.** Distribute graph execution across threads through the
+  channel layer, with no locks on the graph execution path.
+- **Extensible without forking.** Add sources, combinators, statistics and
+  adapters as extension traits; your own ops get interpreted *and* compiled
+  coverage from `#[op]`, with no macro table to edit.
+
 
 ## A Worked Example
+
+The chain above builds and runs in one expression — `build()` is available at
+the end of a chain as well as on the `GraphBuilder`. Keep the builder and the
+streams in bindings when you branch, or when you want to read values back
+after the run (`runner.value(&stream)`), as here.
 
 Wingfoil lets you wire up complex business logic, splitting and recombining
 streams and modulating the frequency of data. Here a price stream is folded
@@ -134,10 +136,73 @@ expands to a module offering all three tiers:
 | Compiled | `my_graph::compiled(run_mode, run_for)` | The whole graph monomorphized into one function, state in locals — fastest, static DAGs. |
 | Nested (island) | `my_graph::nested(&g, inputs...)` | A compiled sub-graph mounted as one node of an interpreted graph — hot core compiled, edges stay open. |
 
+```mermaid
+flowchart LR
+    W["one wiring<br/>nitro! fn my_graph"]
+
+    W --> I["interpreted()<br/>one dyn boundary per op<br/>open world: threaded sources,<br/>feedback, dynamism"]
+    W --> C["compiled()<br/>whole graph in one fn,<br/>state in locals<br/>static DAG, fastest"]
+    W --> N["nested()<br/>compiled island inside<br/>an interpreted graph<br/>hot core compiled,<br/>edges stay open"]
+
+    I --> R(["same values<br/>same tick times"])
+    C --> R
+    N --> R
+```
+
+There is no duplicated execution logic behind those three doors: semantics
+live once, in each op's `cycle` function, and the tiers differ only in how the
+engine reaches it. See
+[`core/dual_mode`](crates/wingfoil/examples/core/dual_mode/) for the rules
+governing what a `nitro!` wiring accepts.
+
+
+## Performance
+
+Read the **ratios**, not the absolute times — these were captured on shared
+4-core cloud VMs, and each comparison is between bars measured back to back in
+the same run. Full method, caveats, plots and per-workload tables:
+[`benches/README.md`](crates/wingfoil/benches/README.md).
+
+| | Measurement |
+|---|---|
+| Engine overhead per node cycle | **~27 ns** (10×10 graph, 100 nodes, every node ticking every cycle) |
+| Reading the graph clock | **24.3 ns** — and a cycle in which nothing stamps latency never pays it |
+| Compiled vs interpreted | **4.4×–37× faster** across eight workloads |
+| Nested island vs interpreted | **2.2×–10.2× faster** |
+| Interpreted vs the legacy engine | **0.56×–0.84×** — the port is faster on all eight |
+
+The eight workloads span dense chains, fan-out, fan-in at widths 16/64/256,
+accumulation and sparse graphs up to 781 nodes.
+
+### Why a DAG engine, and not reactive streams
+
+Wingfoil visits every node once per tick, in topological order. Libraries that
+propagate along one path at a time re-visit shared nodes once per path — so on
+a branch-and-recombine graph their cost **doubles with every level** while
+Wingfoil's stays flat. Benchmarked head to head against rxrust and tokio async
+streams, at depth 10:
+
+| Engine | Per iteration | vs Wingfoil interpreted |
+|---|---|---|
+| Wingfoil, interpreted | 287.5 ns | 1× |
+| rxrust | 22.595 µs | **~79× slower** |
+| tokio async streams | 38.487 µs | **~134× slower** |
+
+Against the compiled tier the same two gaps are 945× and 1610×, and Wingfoil
+stays flat across all ten levels while both path-at-a-time libraries measured
+2.01× and 1.94× per level.
+
+At depth 20 the same slopes put the gap in the millions. Both multipliers are
+stated conservatively — the
+[method notes](crates/wingfoil/benches/README.md#topological-sort-vs-per-path-propagation)
+list the caveats, and they cut against Wingfoil.
+[`core/topological_sort`](crates/wingfoil/examples/core/topological_sort/)
+explains the mechanism in 40 lines.
+
 
 ## Examples
 
-Around 40 runnable examples, each in its own directory with a README covering
+46 runnable examples, each in its own directory with a README covering
 what it teaches, the wiring, and its expected output. Full index:
 [`examples/README.md`](crates/wingfoil/examples/README.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report it privately through either channel:
+
+- [GitHub private vulnerability reporting](https://github.com/wingfoil-io/wingfoil/security/advisories/new)
+  — preferred, and keeps the report attached to the repository.
+- Email `hello@wingfoil.io` with `SECURITY` in the subject line.
+
+Please include enough to reproduce: the version (or commit), the feature flags
+enabled, the adapter involved if any, and a minimal graph or test that shows
+the problem.
+
+We aim to acknowledge a report within three working days, and to keep you
+updated as we work through it. When a fix ships we will credit you in the
+advisory unless you would rather we didn't.
+
+## Supported versions
+
+Wingfoil has not yet reached a long-term-support release. Fixes land on the
+latest published version; there is no backporting to earlier majors. See the
+[releases](https://github.com/wingfoil-io/wingfoil/releases) for what is
+current.
+
+## Scope
+
+In scope:
+
+- The engine and runtime (`crates/wingfoil`), including anything reachable
+  from a graph built with untrusted input.
+- The I/O adapters — in particular the ones parsing bytes off a network
+  (`fix`, `web`, `aeron`, `zmq`, `kafka`, `redis`, `etcd`) or reading files
+  from disk (`csv`, `lines`, `kdb`).
+- The Python bindings (`crates/wingfoil-python`) and the WASM/TypeScript
+  client, where a memory-safety or sandbox-escape issue would cross a
+  language boundary.
+
+Out of scope:
+
+- Vulnerabilities in third-party services the adapters talk to — report those
+  upstream.
+- Denial of service achieved only by configuring a graph to consume unbounded
+  resources. Wingfoil runs the graph you wire; it is not a sandbox for
+  untrusted graph definitions.
+- Findings from automated scanners with no demonstrated impact.
+
+## Dependency vulnerabilities
+
+Dependency advisories are picked up by `cargo audit`
+([`security-audit.yml`](.github/workflows/security-audit.yml)) and Dependabot.
+You are welcome to open a normal public issue for those — they are already
+public by definition.

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,7 +1,8 @@
 # Wingfoil Crates
 
-Four crates. Two carry the engine and its bindings; two are the proc-macro crates
-that generate the boilerplate each of those would otherwise need.
+Six crates. Two carry the engine and its Python bindings; two are the
+proc-macro crates that generate the boilerplate each of those would otherwise
+need; two more carry the browser side.
 
 ```
 wingfoil                 the engine — ops, fluent wiring, adapters, runtime core
@@ -9,6 +10,9 @@ wingfoil                 the engine — ops, fluent wiring, adapters, runtime co
 
 wingfoil-python          the Python extension module (`import wingfoil`)
   └── wingfoil-python-derive   #[pyop]
+
+wingfoil-wire-types      wire format shared by the web adapter and the browser
+  └── wingfoil-wasm      the browser-side codec (own workspace, wasm32 target)
 ```
 
 | Crate | What it is |
@@ -17,6 +21,12 @@ wingfoil-python          the Python extension module (`import wingfoil`)
 | [**`wingfoil-derive`**](wingfoil-derive/) | `nitro!` — one wiring function expands to interpreted, compiled and nested runners. `#[op]` — an `Op` impl gains its fluent builder method and the forwarders `nitro!` dispatches through. |
 | [**`wingfoil-python`**](wingfoil-python/) | The PyO3 bindings, built with maturin. Importable as `wingfoil`. |
 | [**`wingfoil-python-derive`**](wingfoil-python-derive/) | `#[pyop]` — derives a Python-callable function from an `Op` impl, so a new op reaches Python without hand-written glue. |
+| [**`wingfoil-wire-types`**](wingfoil-wire-types/) | The wire-format types shared by the `web` adapter and the browser client — one definition, so the two ends cannot drift. |
+| [**`wingfoil-wasm`**](wingfoil-wasm/) | The browser-side WASM codec behind [`@wingfoil/client`](../js/). Excluded from the default workspace: it targets `wasm32-unknown-unknown`. |
+
+The TypeScript client that consumes the last two is [`js/`](../js/) — an npm
+package rather than a Cargo crate, which is why it sits outside this
+directory.
 
 ## Why the macro crates are separate
 

--- a/crates/wingfoil/Cargo.toml
+++ b/crates/wingfoil/Cargo.toml
@@ -5,8 +5,18 @@ edition = "2024"
 authors = ["wingfoil@wingfoil.io"]
 license = "Apache-2.0"
 homepage = "https://github.com/wingfoil-io/wingfoil/"
+repository = "https://github.com/wingfoil-io/wingfoil/"
 documentation = "https://docs.rs/wingfoil"
 keywords = ["graph", "stream", "dag", "hft", "trading"]
+# crates.io browse categories — how people find a crate without knowing its
+# name. Five is the registry maximum.
+categories = [
+    "asynchronous",
+    "concurrency",
+    "finance",
+    "network-programming",
+    "simulation",
+]
 rust-version.workspace = true
 # Publishable from the cutover on (was `false` while these crates were
 # prototypes under interim names). Same registry list as the legacy


### PR DESCRIPTION
## What this changes

Fixes what a first-time visitor to the GitHub project page actually sees: a sidebar reading "License: Other / No releases published" on a project shipping v8, a README opening with ten feature bullets before any code, and no community health files at all. Also restores five badges the README rewrite dropped, and surfaces the benchmark numbers that were buried three clicks deep.

No source changes — docs, metadata, workflow and templates only.

## Why

Walked the repo as a new visitor would: landing page → About box → README → examples → issues → crates.io. The content is strong; the packaging was undercutting it.

The two that cost the most credibility for the least effort to fix:

- **`LICENSE.txt` still contained the Apache template's `Copyright [YEAR] [OWNER]` placeholder.** That is what stopped GitHub's classifier — the API returned `NOASSERTION` and the sidebar said "Other", despite every manifest declaring `Apache-2.0`.
- **No GitHub Release had ever been cut.** `release.yml` pushes a tag and publishes to crates.io, npm and PyPI, but nothing creates the release — so the Releases page read "No releases published" while crates.io served v8.0.0.

## How it was verified

- [x] `cargo metadata --no-deps` — manifests parse with the new `repository` / `categories` keys
- [x] All four new/changed YAML files load under `yaml.safe_load`
- [x] `scripts/check-example-docs.sh` — OK, 46 example targets documented and indexed
- [x] Every relative link in the changed markdown resolves to a real path
- [ ] `cargo test` — not run; no Rust source changed

## Notes for the reviewer

**Release job placement.** It runs after `publish-crates` / `publish-npm` / `publish-pypi` rather than after `tag`, so a release never announces versions that aren't installable yet. This is adjacent to the concern in #449 ("release tags before publishing") but does not restructure the tag/publish ordering itself.

**Notes generation.** Uses the `repos/{owner}/{repo}/releases/generate-notes` API and concatenates, rather than `gh release create --generate-notes --notes-file`. I could not verify that gh accepts that flag combination, and the documented API endpoint gives a defined ordering (install block first, changelog under it).

**Performance section.** Numbers are lifted from `crates/wingfoil/benches/README.md`, keeping its own framing — ratios rather than absolutes, with the shared-VM caveat stated and the method notes linked. The rxrust / tokio table cites the README's figures directly; the compiled-tier gaps are given as its stated ratios rather than as a derived absolute.

**Deliberately not included:** a `CHANGELOG.md`. With generated release notes the Releases page becomes the changelog, and a stub file would go stale immediately. Happy to add one if you'd rather.

**Two follow-ups this PR cannot cover**, both repo-admin settings: the About description (still "graph based stream processing framework" — no "Rust", no differentiator, and it is what appears in search results and social cards) and a social preview image. Suggested description text is in the session notes.

**One thing worth checking:** two different Discord invites are live in the tree — `discord.gg/rfGqf3Ff` (README) and `discord.gg/WfZwpQnZUA` (`legacy/CONTRIBUTING.md`). I used the README's in the new files; one is likely stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D62WoeLex4ke5qsdsKeuo3)_