### PR TITLE
Drain the same-cycle mark buffer in the FullSweep dispatch oracle

### DIFF
--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -2908,6 +2908,15 @@ impl Runner {
     fn run_cycles_full_sweep(&mut self, kernel: &mut Kernel) -> Option<anyhow::Error> {
         let n = self.nodes.len();
         let mut dirty = vec![false; n];
+        // Same-cycle mark-dirty targets, the oracle's counterpart of the sparse
+        // drain's `marks` handling. A routing node ([`Builder::demux`]) fires its
+        // chosen child through this buffer *only* — the child has no active
+        // upstream and no activation of its own — so a sweep that never drained
+        // it silently dropped every demuxed tick and grew `marks` without bound
+        // for the whole run. Wiring order puts a child after its parent, so
+        // absorbing the marks as each node is visited fires it in the same cycle,
+        // exactly as the sparse drain does.
+        let mut marked = vec![false; n];
         while !self.finished.get() && kernel.begin_cycle(&mut dirty) {
             // Braced so the cycle span covers exactly what the sparse path's
             // `drain_cycle` does — the sweep and its per-cycle reset, not the
@@ -2917,6 +2926,7 @@ impl Runner {
                 for (i, node) in self.nodes.iter_mut().enumerate() {
                     let due = node.activation.always
                         || (node.activation.callback_activated() && dirty[i])
+                        || marked[i]
                         || {
                             let t = self.ticked.borrow();
                             node.active_ups.iter().any(|&u| t[u])
@@ -2933,6 +2943,13 @@ impl Runner {
                         false
                     };
                     self.ticked.borrow_mut()[i] = did;
+                    if self.has_marks {
+                        for target in self.marks.borrow_mut().drain(..) {
+                            if let Some(m) = marked.get_mut(target) {
+                                *m = true;
+                            }
+                        }
+                    }
                 }
                 // The oracle's whole cost model: every node is visited every
                 // cycle, whether or not it is due. This is the `O(N)` term the
@@ -2942,6 +2959,9 @@ impl Runner {
                 self.node_visits += n as u64;
                 for t in self.ticked.borrow_mut().iter_mut() {
                     *t = false;
+                }
+                for m in marked.iter_mut() {
+                    *m = false;
                 }
             }
             kernel.end_cycle(&mut dirty);

--- a/crates/wingfoil/tests/dynamic_graph.rs
+++ b/crates/wingfoil/tests/dynamic_graph.rs
@@ -586,3 +586,28 @@ fn demux_it_routes_each_item_to_a_burst_per_child() {
     );
     assert_eq!(runner.value(&ov), vec![burst![30u64]], "overflow (key 30)");
 }
+
+/// `Dispatch::FullSweep` is documented as an *executable reference oracle*
+/// producing results identical to the default `Dispatch::Sparse` — it is what
+/// differential parity tests compare against. That contract has to hold for
+/// `demux` too, whose children are fired **only** by the same-cycle mark-dirty
+/// buffer (they have no active upstream and no activation of their own).
+#[test]
+fn demux_routes_identically_under_the_full_sweep_oracle() {
+    fn run(dispatch: wingfoil::interp::Dispatch) -> (Vec<u64>, Vec<u64>) {
+        let g = GraphBuilder::new();
+        let n = g.ticker(Duration::from_nanos(1)).count().handle();
+        let (children, _overflow) = g.with_builder(|b| b.demux(n, 2, |v: &u64| (*v % 2) as usize));
+        let c0 = g.wrap(children[0]).accumulate();
+        let c1 = g.wrap(children[1]).accumulate();
+        let mut runner = g.build().with_dispatch(dispatch);
+        runner.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+        (runner.value(&c0), runner.value(&c1))
+    }
+
+    assert_eq!(
+        run(wingfoil::interp::Dispatch::FullSweep),
+        run(wingfoil::interp::Dispatch::Sparse),
+        "FullSweep must reproduce Sparse exactly"
+    );
+}


### PR DESCRIPTION
## What this changes

`Dispatch::FullSweep` now honours `Runner::marks`, the same-cycle mark-dirty
buffer, so a `demux` graph produces the same values under the oracle as under
`Dispatch::Sparse`.

## Why

FullSweep is documented as producing results identical to Sparse — it is the
executable reference oracle differential parity tests compare against. It
didn't: it never touched `marks`.

That buffer is the *only* way a `demux` child ever fires. A child has no active
upstream and `Activation::NONE`, so the sweep's due-ness test
(`always || (callback_activated && dirty) || any upstream ticked`) is false for
it on every cycle of every run. Under FullSweep a demux graph emitted nothing
at all from its children, and `marks` grew one entry per routed value for the
whole run, never drained.

The fix absorbs each node's marks as it is visited and adds `marked[i]` to the
due-ness test. Wiring order puts a demux child after its parent, so it fires in
the same cycle — the same guarantee the sparse drain gets from layer order
(children sit at a strictly higher layer than the parent that marks them).
`marked` is cleared per cycle alongside `ticked`; an `O(N)` clear is the
oracle's own cost model, so it costs the sparse path nothing and doesn't blunt
`node_visits` as a sparse-vs-`N` metric.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
      — green apart from the `*_integration` binaries, which need live services
      this sandbox has none of; CI excludes that tier from the `test` job for
      the same reason.
- [x] New behaviour is covered by a test

## Notes for the reviewer

`demux_routes_identically_under_the_full_sweep_oracle` runs one demux graph
under both strategies and asserts the outputs match, which is the contract that
was broken. Before the fix it reported `([], [])` against
`([2, 4, 6], [1, 3, 5])`.

The assertion is strategy-vs-strategy rather than against literals on purpose:
the existing `demux_routes_each_value_to_its_child` already pins the literal
values and tick order under Sparse, so what was missing was specifically the
"both engines agree" leg.

Only the oracle path changed — `Dispatch::Sparse`, the production default, is
untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nJY99N9zr2BacjmSF7LYE)_