### PR TITLE
Stop a zero-length `window` hanging the run

### DIFF
--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -534,6 +534,20 @@ impl<T> Default for WindowState<T> {
     }
 }
 
+/// A [`Window`]'s interval in engine time, floored at one nanosecond.
+///
+/// The floor is not cosmetic: `cycle` advances the boundary with
+/// `while next_window <= now { next_window += interval }`, which **never
+/// terminates** for a zero interval — `window(Duration::ZERO)` hung the run
+/// outright. One nanosecond is the engine clock's own resolution and the limit
+/// the behaviour tends to as the window shrinks (every cycle is its own
+/// boundary, so each value flushes alone), and it matches how the rest of the
+/// catalog handles a degenerate size — the rolling ops all clamp with
+/// `(*cfg).max(1)`.
+fn window_interval(cfg: &Duration) -> NanoTime {
+    NanoTime::from(*cfg).max(NanoTime::new(1))
+}
+
 #[op(build = window, fluent)]
 impl<T: Clone + 'static> Op for Window<T> {
     type Cfg = Duration;
@@ -543,7 +557,7 @@ impl<T: Clone + 'static> Op for Window<T> {
     const ACTIVATION: Activation = Activation::NONE;
 
     fn start(cfg: &mut Duration, state: &mut WindowState<T>, ctx: &mut Ctx<'_>) -> Result<()> {
-        state.next_window = ctx.time() + NanoTime::from(*cfg);
+        state.next_window = ctx.time() + window_interval(cfg);
         Ok(())
     }
 
@@ -553,7 +567,7 @@ impl<T: Clone + 'static> Op for Window<T> {
         input: (&T,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<Vec<T>>> {
-        let interval = NanoTime::from(*cfg);
+        let interval = window_interval(cfg);
         let now = ctx.time();
         let mut out = None;
         if now >= state.next_window {

--- a/crates/wingfoil/tests/catalog.rs
+++ b/crates/wingfoil/tests/catalog.rs
@@ -204,6 +204,29 @@ fn window_flushes_on_time_boundaries() {
     );
 }
 
+/// A zero-length `window` must still terminate. `cycle` walks the boundary
+/// forward with `while next_window <= now { next_window += interval }`, which
+/// never ends for a zero interval — `window(Duration::ZERO)` hung the run
+/// outright, rather than degenerating like every other size-configured op in
+/// the catalog (the rolling ops all clamp with `(*cfg).max(1)`). Floored at the
+/// engine clock's one-nanosecond resolution, every cycle is its own boundary,
+/// so each value flushes alone.
+#[test]
+fn zero_length_window_flushes_every_cycle_rather_than_hanging() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(100)).count();
+    let acc = count.window(Duration::ZERO).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    // The first cycle has nothing buffered yet (the boundary is one tick ahead
+    // of it), so it stays quiet; each later cycle then flushes the single value
+    // its predecessor buffered. The 4th cycle's own value is buffered behind a
+    // boundary flush that already fired, which is `window`'s ordinary
+    // last-cycle behaviour at any interval — the extra flush is skipped when the
+    // boundary already emitted.
+    assert_eq!(vec![vec![1], vec![2], vec![3]], r.value(&acc));
+}
+
 /// `buffer` flushes a `Vec` every `capacity` values, plus a final partial
 /// flush — mirrors legacy `buffer::buffer_stream_works`.
 #[test]


### PR DESCRIPTION
## What this changes

`Window` floors its interval at one nanosecond, so `stream.window(Duration::ZERO)`
degenerates to a per-cycle flush instead of hanging the run.

## Why

`Window::cycle` walks its boundary forward with

```rust
while state.next_window <= now { state.next_window += interval }
```

which never terminates when `interval` is zero. Because the spin is *inside* a
single `cycle` call, nothing can stop it: no run bound applies, no error
surfaces, and no other node ever cycles again. I confirmed it by running a
`window(Duration::ZERO)` graph under a `RunFor::Cycles(3)` bound — it had to be
killed at the two-minute timeout.

`Window` is the one size-configured op in the catalog that doesn't clamp a
degenerate argument. The rolling ops all take `(*cfg).max(1)`,
`RollingExtremeState` takes `window.max(1)`, `sink_channel` takes `n.max(1)`.
This makes `Window` consistent with them, via a `window_interval` helper shared
by `start` and `cycle` so the first boundary and every later one can't
disagree.

One nanosecond is the engine clock's own resolution and the limit the behaviour
tends to as the window shrinks: every cycle becomes its own boundary, so each
value flushes alone.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
      — green apart from the `*_integration` binaries, which need live services
      this sandbox has none of; CI excludes that tier from the `test` job for
      the same reason.
- [x] New behaviour is covered by a test asserting values and tick times

## Notes for the reviewer

`zero_length_window_flushes_every_cycle_rather_than_hanging` pins the emitted
values, and its shape encodes the tick times: over four 100 ns ticks the
boundary lands on every cycle, so the run yields `[[1], [2], [3]]` — the first
cycle quiet (nothing buffered yet, the boundary sits one tick ahead of it) and
each later cycle flushing the single value its predecessor buffered.

The 4th value doesn't appear, and that isn't new: `cycle` skips the
`is_last_cycle` flush when a boundary flush already fired on the same cycle, at
any interval. I left that alone — it's existing `Window` semantics that a
degenerate-argument fix shouldn't quietly change — but it looks worth a second
look on its own, since the doc promises "plus a final flush on the last cycle".

Only the zero (and sub-nanosecond) case moves; every other interval is
arithmetically unchanged, which the existing
`window_flushes_on_time_boundaries` and the compiled/nitro parity tests cover.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nJY99N9zr2BacjmSF7LYE)_