### PR TITLE
Keep a multi-line query from corrupting the file cache's payload framing

### DIFF
--- a/crates/wingfoil/src/adapters/cache.rs
+++ b/crates/wingfoil/src/adapters/cache.rs
@@ -119,6 +119,25 @@ impl CacheConfig {
     }
 }
 
+/// Render `query` as a single line, so the newline `put` appends after it is
+/// unambiguously the payload boundary `get` frames on. Backslash-escapes the
+/// two characters that would otherwise break the line (`\n`, `\r`) and the
+/// escape character itself, C-style — so the header stays human-readable under
+/// `head -1` and a query containing no newline is written byte-for-byte as
+/// before (cache files from earlier runs keep hitting).
+fn escape_header(query: &str) -> String {
+    let mut out = String::with_capacity(query.len());
+    for c in query.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 /// `PhantomData<fn() -> T>` is always `Send + Sync` regardless of `T`, which is
 /// correct here because `FileCache<T>` never actually stores a `T` value — the
 /// type parameter only appears in the bounds of the async `get`/`put` methods.
@@ -154,7 +173,9 @@ impl<T> FileCache<T> {
             Err(e) => return Err(e.into()),
             Ok(b) => b,
         };
-        // Skip the newline-terminated query header written by `put`.
+        // Skip the newline-terminated query header written by `put`. `put`
+        // escapes the query's own newlines, so the first one here is always the
+        // header terminator.
         let payload = bytes
             .iter()
             .position(|&b| b == b'\n')
@@ -183,6 +204,15 @@ impl<T> FileCache<T> {
     /// bincode-encoded payload. This makes cache files self-documenting:
     /// `head -1 <hex>.cache` shows the exact query that produced the file.
     ///
+    /// The header is written through [`escape_header`], so a **multi-line**
+    /// query (an ordinary shape for a `format!`-built q or SQL query) still
+    /// occupies exactly one line. It has to: [`get`](Self::get) frames the
+    /// payload at the first newline, so an unescaped multi-line query put the
+    /// rest of itself where the bincode was expected — every read of such an
+    /// entry failed to decode, and callers that treat a decode failure as a miss
+    /// (`kdb_read_cached` does) re-fetched and re-wrote on every single run,
+    /// silently never hitting the cache.
+    ///
     /// **Eviction:** before the atomic rename, the folder is scanned for
     /// `*.cache` files. Files are sorted by modification time (oldest first)
     /// and deleted until the combined size of existing files plus the new file
@@ -203,7 +233,7 @@ impl<T> FileCache<T> {
         let tmp = path.with_extension("tmp");
 
         let serializable: Vec<(u64, &T)> = data.iter().map(|(t, v)| (u64::from(*t), v)).collect();
-        let mut buf = format!("{query}\n").into_bytes();
+        let mut buf = format!("{}\n", escape_header(query)).into_bytes();
         buf.extend(bincode::serialize(&serializable)?);
         tokio::fs::write(&tmp, &buf).await?;
 

--- a/crates/wingfoil/tests/cache_adapter.rs
+++ b/crates/wingfoil/tests/cache_adapter.rs
@@ -278,3 +278,41 @@ fn cache_key_hex(key: &CacheKey) -> String {
         .trim_end_matches("\")")
         .to_string()
 }
+
+/// A multi-line query must still round-trip. `put` frames the payload with a
+/// newline after the query header and `get` splits on the first one, so an
+/// unescaped multi-line query — the ordinary shape of a `format!`-built q/SQL
+/// query — left the rest of itself where the bincode was expected. `get` then
+/// failed to decode, and `kdb_read_cached` (which treats a decode failure as a
+/// miss) re-queried and re-wrote on every run: the entry could never hit.
+#[tokio::test]
+async fn test_round_trip_with_a_multi_line_query() {
+    let dir = unique_dir("multiline");
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    let cache = unbounded_cache(&dir);
+    let key = test_key("multiline");
+    let query = "select from trades\n  where date = 2024.01.01,\n        sym = `AAPL";
+
+    let data = vec![(NanoTime::new(1_000), 1.5_f64), (NanoTime::new(2_000), 2.5)];
+    cache.put(&key, query, &data).await.unwrap();
+
+    let got = cache
+        .get(&key)
+        .await
+        .expect("a multi-line header must not corrupt the payload framing")
+        .expect("the entry was just written, so this must be a hit");
+    assert_eq!(got, data);
+
+    // Still self-documenting: the whole query is on the first line, escaped.
+    // (Read as bytes — everything past that line is bincode, not UTF-8.)
+    let raw = tokio::fs::read(dir.join(format!("{}.cache", cache_key_hex(&key))))
+        .await
+        .unwrap();
+    let end = raw.iter().position(|&b| b == b'\n').unwrap();
+    assert_eq!(
+        std::str::from_utf8(&raw[..end]).unwrap(),
+        "select from trades\\n  where date = 2024.01.01,\\n        sym = `AAPL"
+    );
+
+    tokio::fs::remove_dir_all(&dir).await.unwrap();
+}


### PR DESCRIPTION
## What this changes

`FileCache::put` escapes newlines in the query header it writes, so a
multi-line query no longer breaks the payload framing `FileCache::get` relies
on. A `kdb_read_cached` slice keyed by such a query can now actually hit.

## Why

`put` writes `<query>\n<bincode payload>` and `get` frames the payload at the
*first* newline in the file. Those two agree only while the query is a single
line. A multi-line query — the ordinary shape of a `format!`-built q or SQL
query — leaves the rest of itself where the bincode was expected, so `get`
fails to decode every time.

The failure is silent exactly where it costs most. `kdb_read_cached` treats a
`get` error as a miss ("cache read error (falling back to KDB)"), so the entry
is re-queried and re-written on *every single run*: the cache is written, never
read, and the backtest pays the full fetch each time while looking like it is
cached. Nothing surfaces but a warning line.

Escaping the header (`\n`, `\r`, and the escape character itself, C-style)
guarantees one line, which is what makes `get`'s framing unambiguous.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
      — green apart from the `*_integration` binaries, which need live services
      this sandbox has none of; CI excludes that tier from the `test` job for
      the same reason.
- [x] New behaviour is covered by a test

## Notes for the reviewer

**No cache invalidation needed.** A query containing no newline is escaped to
itself, so `put` writes byte-for-byte what it wrote before and existing `.cache`
files keep hitting. Entries written with a multi-line query were already
unreadable, so there is nothing to lose there either. The escaping is
write-side only — `get` is unchanged apart from a comment — so files written by
an older build stay readable by this one.

`head -1 <hex>.cache` stays useful, which was the point of the header: the
whole query is on that line, with `\n` where the line breaks were. The new test
asserts that rendering explicitly as well as the round trip, and reads the file
as bytes because everything past the header is bincode, not UTF-8.

`FileCache` is a pure utility with no graph edge, so there are no tick times to
assert — consistent with the rest of `tests/cache_adapter.rs`.

Two neighbouring things I noticed and deliberately left alone:

- `get` touches mtime for LRU by **rewriting the whole file**, so a cache hit
  costs a full-size non-atomic write (`tokio::fs::write` truncates first). A
  crash mid-touch truncates the entry. `File::set_times` would do it in O(1)
  and atomically, but that is a separate change with its own LRU implications.
- `CacheKey`'s doc says the key is built from `[host, port, query]`, while
  `kdb_read_cached` passes only `[query]` — so two hosts serving different data
  for the same query share an entry. That matches legacy (`read_cached.rs:113`
  passes `&[&query]` there too), so it is parity-correct; it is the doc that is
  ahead of the callers.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nJY99N9zr2BacjmSF7LYE)_