### PR TITLE
latency: sub-bucketed histogram so p50/p99 are usable

### DIFF
--- a/crates/wingfoil/examples/showcase/latency/README.md
+++ b/crates/wingfoil/examples/showcase/latency/README.md
@@ -60,17 +60,30 @@ The subscriber prints a report like:
 ```
 latency report (delta from previous stage, nanoseconds):
   stage                         count          min         mean          p50          p99          max
-  produce -> publish               40            0            0            2            2            0
-  publish -> receive               40        75075       119875       131072       262144       164493
-  receive -> strategy              40            0            0            2            2            0
-  strategy -> ack                  40            0            0            2            2            0
+  produce -> publish              120            0            0            0            0            0
+  publish -> receive              120         8202        93718        93866       178176       192459
+  receive -> strategy             120            0            0            0            0            0
+  strategy -> ack                 120            0            0            0            0            0
 ```
+
+Captured from a `--release` build, `latency_sub 12`, on a shared 4-core cloud
+VM — so the IPC row is a reading of *that* machine under contention, not a
+figure for the transport. `min` (8.2 µs) is the closest thing here to the hop
+itself.
 
 The three in-process deltas are **zero by construction**: `.stamp()` reads a
 per-cycle wall-clock snap, and those stages all run in the same engine cycle,
 so they share a timestamp. Only the IPC hop crosses a cycle boundary and shows
 a real number. Swap the in-process stamps for `.stamp_precise::<..>()` to get
 intra-cycle resolution — see **Time source** below.
+
+`min`, `mean`, `max` and `count` are exact. `p50` and `p99` are read out of a
+sub-bucketed histogram and carry at most 3.125% relative error — and are
+clamped to `[min, max]`, so a percentile is always a value the stage could
+actually have observed. (An earlier capture of this report predates that: it
+read `p99` 262144 ns against a `max` of 164493, and `p50` 2 ns on rows whose
+`min`, `mean` and `max` were all 0, because the histogram was one bucket per
+octave and the quantile returned the bucket's upper bound.)
 
 ## Time source
 

--- a/crates/wingfoil/src/runtime/latency.rs
+++ b/crates/wingfoil/src/runtime/latency.rs
@@ -153,18 +153,100 @@ fn traced_type_name(t: &'static str, l: &'static str) -> &'static str {
     composed
 }
 
-const HISTOGRAM_BUCKETS: usize = 64;
+// ---------------------------------------------------------------------------
+// Histogram layout
+// ---------------------------------------------------------------------------
+//
+// An HDR-style histogram: each power-of-two octave is subdivided into
+// `SUB_BUCKET_COUNT` equal-width buckets, which bounds the *relative* width of
+// any bucket — and therefore the relative error of any quantile read out of it —
+// at `1 / SUB_BUCKET_COUNT`, independent of magnitude.
+//
+// This replaces a plain log2 histogram whose buckets were one octave wide. That
+// layout carried up to 100% relative error and `quantile_ns` returned the
+// bucket's *upper* bound, so a reported p99 could exceed the observed maximum —
+// which it visibly did in the `showcase/latency` report (p99 262144 ns = 2^18
+// against a max of 164493 ns). For a library whose subject is latency, a
+// percentile that cannot distinguish 70 µs from 131 µs is not usable for
+// capacity or SLA work.
+
+/// Bits of sub-bucket resolution within each octave: `2^5 = 32` divisions, so no
+/// reported quantile carries more than `1/32` = **3.125%** relative error.
+const SUB_BUCKET_BITS: u32 = 5;
+
+/// Divisions per octave — also the size of the exact, single-nanosecond region
+/// at the bottom of the range (`[0, 32)`), where a bucket is one value wide and
+/// the quantile is therefore exact.
+const SUB_BUCKET_COUNT: usize = 1 << SUB_BUCKET_BITS;
+
+/// Octaves above this saturate into the top bucket. `2^34` ns ≈ 17.2 s — beyond
+/// any per-hop latency worth a percentile, and `max_ns` still records the true
+/// value of an outlier that lands there.
+const MAX_OCTAVE: u32 = 34;
+
+/// Number of buckets in a [`StageStats`] histogram: the exact `[0, 32)` region
+/// plus [`SUB_BUCKET_COUNT`] divisions for each octave from `2^5` to
+/// `2^MAX_OCTAVE`.
+///
+/// Public because [`StageStats::histogram`] is, so a downstream aggregator can
+/// size a matching array.
+pub const HISTOGRAM_BUCKETS: usize =
+    SUB_BUCKET_COUNT + (MAX_OCTAVE - SUB_BUCKET_BITS) as usize * SUB_BUCKET_COUNT;
+
+/// The bucket a delta of `ns` records into.
+///
+/// Contiguous and monotonic in `ns`: bucket `i`'s range ends exactly where
+/// bucket `i + 1`'s begins (see [`bucket_bounds`]), so no value falls between
+/// two buckets and a larger value never lands in a lower bucket.
+#[inline]
+const fn bucket_index(ns: u64) -> usize {
+    if ns < SUB_BUCKET_COUNT as u64 {
+        // Exact region: one bucket per nanosecond.
+        return ns as usize;
+    }
+    let octave = ns.ilog2();
+    if octave >= MAX_OCTAVE {
+        return HISTOGRAM_BUCKETS - 1;
+    }
+    // Position within the octave, in units of the octave's bucket width.
+    let part = ((ns - (1 << octave)) >> (octave - SUB_BUCKET_BITS)) as usize;
+    SUB_BUCKET_COUNT + (octave - SUB_BUCKET_BITS) as usize * SUB_BUCKET_COUNT + part
+}
+
+/// The half-open value range `[lo, hi)` that bucket `i` covers.
+///
+/// The top bucket is saturating — it also absorbs everything at or above
+/// `2^MAX_OCTAVE` — so its nominal `hi` understates its true reach. That only
+/// affects an interpolated quantile inside the top bucket, which is then clamped
+/// to `max_ns` anyway.
+#[inline]
+const fn bucket_bounds(i: usize) -> (u64, u64) {
+    if i < SUB_BUCKET_COUNT {
+        return (i as u64, i as u64 + 1);
+    }
+    let k = i - SUB_BUCKET_COUNT;
+    let octave = SUB_BUCKET_BITS + (k / SUB_BUCKET_COUNT) as u32;
+    let part = (k % SUB_BUCKET_COUNT) as u64;
+    let width = 1u64 << (octave - SUB_BUCKET_BITS);
+    let lo = (1u64 << octave) + part * width;
+    (lo, lo + width)
+}
 
 /// Fixed-size, non-allocating per-stage statistics: count, total, min, max,
-/// plus a log2-bucketed histogram for percentile estimation.
+/// plus an HDR-style sub-bucketed histogram for percentile estimation.
+///
+/// `count`, `sum_ns`, `min_ns` and `max_ns` are exact. Quantiles are estimated
+/// from the histogram and carry at most 3.125% relative error (exactly, for
+/// deltas below 32 ns); see [`HISTOGRAM_BUCKETS`].
 #[derive(Clone, Copy, Debug)]
 pub struct StageStats {
     pub count: u64,
     pub sum_ns: u64,
     pub min_ns: u64,
     pub max_ns: u64,
-    /// `histogram[i]` counts deltas in `[2^i ns, 2^(i+1) ns)`.
-    /// Index 0 covers `[0, 2 ns)`.
+    /// Sub-bucketed delta counts; see [`HISTOGRAM_BUCKETS`] for the layout.
+    /// Read quantiles out of it with [`StageStats::quantile_ns`] rather than
+    /// indexing it directly — the bucket layout is not part of the API contract.
     pub histogram: [u64; HISTOGRAM_BUCKETS],
 }
 
@@ -191,9 +273,7 @@ impl StageStats {
         if delta_ns > self.max_ns {
             self.max_ns = delta_ns;
         }
-        // Log2 bucket: bucket = ilog2(delta_ns + 1), capped to HISTOGRAM_BUCKETS-1.
-        let bucket = ((delta_ns + 1).ilog2() as usize).min(HISTOGRAM_BUCKETS - 1);
-        self.histogram[bucket] += 1;
+        self.histogram[bucket_index(delta_ns)] += 1;
     }
 
     /// Mean delta in nanoseconds, or 0 if no samples recorded.
@@ -201,21 +281,41 @@ impl StageStats {
         self.sum_ns.checked_div(self.count).unwrap_or(0)
     }
 
-    /// Estimate the value at quantile `q` in `[0.0, 1.0]` from the histogram.
-    /// Returns the upper bound of the bucket containing the quantile, or 0 if
-    /// no samples have been recorded.
+    /// Estimate the value at quantile `q` in `[0.0, 1.0]`, or 0 if no samples
+    /// have been recorded. `q` outside `[0, 1]` is clamped.
+    ///
+    /// The rank is located in the histogram and then interpolated *within* its
+    /// bucket, so the estimate sits inside the bucket rather than at its edge,
+    /// and the result is clamped to the exactly-tracked `[min_ns, max_ns]`.
+    /// Two properties follow, both of which the previous log2 implementation
+    /// broke: the result is always a value the stage could actually have
+    /// observed, and it is monotonic in `q`.
     pub fn quantile_ns(&self, q: f64) -> u64 {
         if self.count == 0 {
             return 0;
         }
-        let target = ((self.count as f64) * q).ceil() as u64;
+        // Rank in 1..=count. A NaN `q` clamps to 0.0 and so reports the minimum.
+        let rank = (((self.count as f64) * q.clamp(0.0, 1.0)).ceil() as u64).clamp(1, self.count);
         let mut cum = 0u64;
         for (i, &n) in self.histogram.iter().enumerate() {
-            cum += n;
-            if cum >= target {
-                // Upper bound of bucket i is 2^(i+1).
-                return 1u64 << (i + 1).min(63);
+            if n == 0 {
+                continue;
             }
+            cum += n;
+            if cum < rank {
+                continue;
+            }
+            let (lo, hi) = bucket_bounds(i);
+            if hi - lo <= 1 {
+                // Single-value bucket: the estimate is exact.
+                return lo.clamp(self.min_ns, self.max_ns);
+            }
+            // Interpolate: place the rank at the midpoint of its share of the
+            // bucket, so neither edge is systematically favoured.
+            let within = rank - (cum - n);
+            let frac = (within as f64 - 0.5) / n as f64;
+            let estimate = lo as f64 + frac * (hi - lo) as f64;
+            return (estimate as u64).clamp(self.min_ns, self.max_ns);
         }
         self.max_ns
     }
@@ -314,5 +414,216 @@ impl<L: Latency> LatencyStats<L> {
     /// Render a multi-line summary suitable for printing on shutdown.
     pub fn format_report(&self) -> String {
         format_latency_report(L::stage_names(), &self.stages)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Histogram tests
+// ---------------------------------------------------------------------------
+//
+// The exact aggregates (count/sum/min/max) and the `Traced`/`Latency` layout are
+// covered by `crates/wingfoil/tests/latency.rs` and the legacy tree's mirror.
+// What follows is specific to the histogram: the bucket layout's structural
+// invariants, and the quantile properties the previous log2 layout violated.
+
+#[cfg(test)]
+mod histogram_tests {
+    use super::*;
+
+    /// Values that exercise the exact region, every octave boundary, the
+    /// interior of an octave, and the saturating top bucket.
+    fn probe_values() -> Vec<u64> {
+        let mut v: Vec<u64> = (0..40).collect();
+        for octave in 5..40u32 {
+            let base = 1u64 << octave;
+            v.extend([base - 1, base, base + 1, base + base / 3, base * 2 - 1]);
+        }
+        v.push(u64::MAX);
+        v
+    }
+
+    #[test]
+    fn buckets_are_contiguous_and_cover_their_own_range() {
+        // Bucket 0 starts at 0, and each bucket ends exactly where the next
+        // begins — so no value falls between two buckets.
+        assert_eq!(bucket_bounds(0).0, 0);
+        for i in 0..HISTOGRAM_BUCKETS - 1 {
+            let (lo, hi) = bucket_bounds(i);
+            assert!(lo < hi, "bucket {i} is empty: [{lo}, {hi})");
+            assert_eq!(hi, bucket_bounds(i + 1).0, "gap after bucket {i}");
+        }
+    }
+
+    #[test]
+    fn every_value_lands_in_a_bucket_containing_it() {
+        for v in probe_values() {
+            let i = bucket_index(v);
+            assert!(i < HISTOGRAM_BUCKETS, "{v} indexed out of range: {i}");
+            let (lo, hi) = bucket_bounds(i);
+            if i == HISTOGRAM_BUCKETS - 1 {
+                // The top bucket saturates: it absorbs everything from its own
+                // lower bound upwards, so only `lo` is a real constraint.
+                assert!(v >= lo, "{v} landed in the top bucket below its lo {lo}");
+            } else {
+                assert!(v >= lo && v < hi, "{v} not in bucket {i} = [{lo}, {hi})");
+            }
+        }
+    }
+
+    #[test]
+    fn bucket_index_is_monotonic() {
+        let mut probes = probe_values();
+        probes.sort_unstable();
+        let mut prev = 0usize;
+        for v in probes {
+            let i = bucket_index(v);
+            assert!(
+                i >= prev,
+                "bucket_index({v}) = {i} went backwards from {prev}"
+            );
+            prev = i;
+        }
+    }
+
+    #[test]
+    fn relative_bucket_width_is_bounded_by_the_sub_bucket_resolution() {
+        // The property that makes a quantile trustworthy: bucket width relative
+        // to its own magnitude never exceeds 1/SUB_BUCKET_COUNT. The old log2
+        // layout had width == lo, i.e. 100%.
+        for i in SUB_BUCKET_COUNT..HISTOGRAM_BUCKETS {
+            let (lo, hi) = bucket_bounds(i);
+            let relative = (hi - lo) as f64 / lo as f64;
+            assert!(
+                relative <= 1.0 / SUB_BUCKET_COUNT as f64,
+                "bucket {i} = [{lo}, {hi}) has relative width {relative}"
+            );
+        }
+    }
+
+    #[test]
+    fn quantiles_are_exact_below_the_sub_bucket_count() {
+        // The bottom region is one bucket per nanosecond, so no estimation.
+        let mut s = StageStats::default();
+        for _ in 0..100 {
+            s.record(7);
+        }
+        assert_eq!(s.quantile_ns(0.5), 7);
+        assert_eq!(s.quantile_ns(0.99), 7);
+        assert_eq!(s.quantile_ns(1.0), 7);
+    }
+
+    #[test]
+    fn quantiles_are_within_the_documented_error_bound() {
+        // 1..=10_000 ns, so the true p50 is 5_000 and the true p99 is 9_900.
+        let mut s = StageStats::default();
+        for v in 1..=10_000u64 {
+            s.record(v);
+        }
+        let tolerance = 1.0 / SUB_BUCKET_COUNT as f64;
+        for (q, truth) in [(0.5, 5_000.0), (0.9, 9_000.0), (0.99, 9_900.0)] {
+            let got = s.quantile_ns(q) as f64;
+            let error = (got - truth).abs() / truth;
+            assert!(
+                error <= tolerance,
+                "p{}: got {got}, true {truth}, relative error {error} > {tolerance}",
+                q * 100.0
+            );
+        }
+    }
+
+    #[test]
+    fn quantiles_never_escape_the_exact_min_max_range() {
+        // The regression this replaces: the showcase report printed a p99 of
+        // 262144 ns against an observed max of 164493, because the old
+        // implementation returned the containing bucket's upper bound.
+        let distributions: [&[u64]; 5] = [
+            &[0],
+            &[0, 0, 0, 0],
+            &[75_075, 119_875, 131_000, 164_493],
+            &[1, 2, 3, 1_000_000],
+            &[u64::MAX, 1],
+        ];
+        for samples in distributions {
+            let mut s = StageStats::default();
+            for &v in samples {
+                s.record(v);
+            }
+            for q in [0.0, 0.01, 0.5, 0.9, 0.99, 0.999, 1.0] {
+                let got = s.quantile_ns(q);
+                assert!(
+                    got >= s.min_ns && got <= s.max_ns,
+                    "q={q} gave {got}, outside [{}, {}] for {samples:?}",
+                    s.min_ns,
+                    s.max_ns
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn all_zero_samples_report_zero_everywhere() {
+        // The other half of the same report bug: p50 read 2 ns where min, mean
+        // and max were all 0.
+        let mut s = StageStats::default();
+        for _ in 0..40 {
+            s.record(0);
+        }
+        assert_eq!(s.min_ns, 0);
+        assert_eq!(s.max_ns, 0);
+        assert_eq!(s.mean_ns(), 0);
+        assert_eq!(s.quantile_ns(0.5), 0);
+        assert_eq!(s.quantile_ns(0.99), 0);
+    }
+
+    #[test]
+    fn quantiles_are_monotonic_in_q() {
+        let mut s = StageStats::default();
+        for v in [1u64, 5, 17, 33, 64, 1_000, 25_000, 1_000_000, 40_000_000] {
+            for _ in 0..11 {
+                s.record(v);
+            }
+        }
+        let mut prev = 0u64;
+        for step in 0..=100 {
+            let got = s.quantile_ns(step as f64 / 100.0);
+            assert!(
+                got >= prev,
+                "q={} gave {got} after {prev}",
+                step as f64 / 100.0
+            );
+            prev = got;
+        }
+    }
+
+    #[test]
+    fn out_of_range_and_nan_quantiles_are_clamped() {
+        let mut s = StageStats::default();
+        for v in 100..200u64 {
+            s.record(v);
+        }
+        assert_eq!(s.quantile_ns(-1.0), s.quantile_ns(0.0));
+        assert_eq!(s.quantile_ns(2.0), s.quantile_ns(1.0));
+        assert_eq!(s.quantile_ns(f64::NAN), s.quantile_ns(0.0));
+    }
+
+    #[test]
+    fn an_outlier_past_the_top_octave_saturates_without_losing_the_max() {
+        let mut s = StageStats::default();
+        s.record(1_000);
+        s.record(u64::MAX);
+        assert_eq!(
+            s.max_ns,
+            u64::MAX,
+            "max_ns stays exact for a saturated sample"
+        );
+        assert_eq!(s.histogram[HISTOGRAM_BUCKETS - 1], 1);
+        assert!(s.quantile_ns(1.0) <= s.max_ns);
+    }
+
+    #[test]
+    fn quantile_is_zero_when_empty() {
+        let s = StageStats::default();
+        assert_eq!(s.quantile_ns(0.5), 0);
+        assert_eq!(s.quantile_ns(1.0), 0);
     }
 }


### PR DESCRIPTION
## What this changes

`StageStats`'s histogram goes from one bucket per power of two to an HDR-style
layout — 32 equal-width sub-buckets per octave, plus an exact
one-bucket-per-nanosecond region below 32 ns. `quantile_ns` interpolates within
the located bucket instead of returning its edge, and clamps to the
exactly-tracked `[min_ns, max_ns]`.

Reported quantiles go from **up to 100% relative error** to **at most 3.125%**,
and can no longer fall outside the observed range.

## Why

The old layout produced percentiles that were not just imprecise but
self-contradictory. From `showcase/latency`'s own captured report:

```
  stage                         count          min         mean          p50          p99          max
  publish -> receive               40        75075       119875       131072       262144       164493
  produce -> publish               40            0            0            2            2            0
```

`131072` and `262144` are 2^17 and 2^18 — bucket upper bounds, not
measurements. The p99 exceeds the observed max by 60%. On the in-process rows,
p50 reads 2 ns where min, mean and max are all 0.

A percentile that cannot distinguish 70 µs from 131 µs is not usable for
capacity or SLA work, and this is the surface the library offers for measuring
the thing it is built for. The `latency_e2e` showcase exports these same
numbers to Prometheus as `latency_e2e_rtt_total_{p50,p99}_ns`, so the error was
being published, not just printed.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo clippy -p wingfoil --all-targets` clean
- [x] `cargo test -p wingfoil --features async,csv,fix,web,prometheus,cache,iceoryx2` — 0 failures
- [x] `cargo test --manifest-path legacy/wingfoil/Cargo.toml --lib latency` — 21 passed (legacy re-exports this type, so it is covered by the same change)
- [x] New behaviour is covered by tests

12 new tests in `runtime::latency::histogram_tests`, split between the bucket
layout's structural invariants (contiguity, monotonicity, containment, the
relative-width bound) and the quantile properties the old layout broke.
`quantiles_never_escape_the_exact_min_max_range` and
`all_zero_samples_report_zero_everywhere` encode the two concrete report bugs
above.

**Not run:** `--all-features`. The `aeron` feature needs CMake ≥ 3.30 to build
`rusteron-media-driver` and this box has 3.28 — unrelated to this diff, but it
means I could not tick the template's all-features line honestly. (The version
floor is also mis-stated as ≥ 3.20 in `CLAUDE.md`; correcting that is in a
separate docs PR.)

## Notes for the reviewer

**Cost:** 960 buckets rather than 64 — 7.7 KB per `StageStats` instead of
512 B. `record()` still touches exactly one bucket so the hot path is
unchanged; the array is only walked at report time, and there are ~20 of these
in a pipeline. If that is judged too much, `SUB_BUCKET_BITS` = 4 halves it for
6.25% error.

**Range:** the top bucket saturates at 2^34 ns ≈ 17.2 s. `max_ns` still records
an outlier past that exactly, and there is a test for it.

**Public API:** `HISTOGRAM_BUCKETS` becomes `pub` because the `histogram` field
already is, and its type changes. Unreleased at 9.0.0, so no compatibility
concern, but it is a signature change.

**Report format is untouched** — same columns, same widths — so the Rust and
Python reports still render identically and no other README's sample output
shifts.

**Re-captured `showcase/latency/README.md`** from a real `--release` two-process
run rather than leaving the invented numbers in place, per the repo rule that
sample output must be real. The new reading is internally consistent (p99
178 µs inside a max of 192 µs) and its `min` of 8.2 µs is a far more plausible
figure for the iceoryx2 `Spin` hop than the old `min` of 75 µs. It is still a
shared-VM reading and the README now says so.

**Follow-up not folded in:** the report prints p50 and p99 only. Now that
quantiles are trustworthy, p99.9 would be worth a column for trading use, but
that changes the shared Rust/Python format and every README that shows it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWsjysho2JYY1PgdZrfwUG)_