### PR TITLE
Add automatic disk cleanup for low-headroom environments

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -e
 
+# `--all-targets` below links ~69 example and bench binaries, each statically
+# carrying the whole dependency graph — the single largest thing this repo does
+# to a disk. Reclaim first if headroom is already low; `auto` is a no-op above
+# the threshold, so the normal cost here is one `df`.
+scripts/disk.sh auto
+
 cargo fmt --all
 cargo clippy --workspace --all-targets -- -D warnings

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
 
+# See the note in pre-commit: make room before the `--all-targets` build rather
+# than discovering there is none partway through the link step.
+scripts/disk.sh auto
+
 cargo build --workspace --all-targets
 cargo test --workspace

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "CARGO_INCREMENTAL": "0"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR:-.}/scripts/disk.sh\" hook",
+            "timeout": 120,
+            "statusMessage": "Checking disk headroom"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,10 +344,35 @@ where the space goes. `scripts/disk.sh` reports it and reclaims it:
 scripts/disk.sh          # what is using space
 scripts/disk.sh light    # drop examples/benches/incremental, keep deps/
 scripts/disk.sh deep     # also remove every target/ dir in the tree
+scripts/disk.sh auto     # light (then deep) only if headroom is low
 ```
 
 Reach for `light` mid-session: it keeps `target/*/deps`, so the next build
 relinks instead of recompiling 700+ crates.
+
+`auto` is the unattended form, and it is wired up in three places so you should
+rarely have to think about this at all:
+
+- **`.claude/settings.json`** runs it after every `Bash` call in a Claude Code
+  session, and sets `CARGO_INCREMENTAL=0` for those sessions (see below — worth
+  2.6GB, and an agent doing one-shot builds never collects on incremental).
+- **`.cargo-husky/hooks/pre-commit` and `pre-push`** run it before their
+  `--all-targets` step, so a low-headroom tree reclaims rather than dying
+  partway through the link.
+
+It costs one `df` and prints nothing when there is room, so it is cheap enough
+to hang off a per-command hook. Thresholds are in GB and tunable:
+`WINGFOIL_DISK_MIN_GB` (default 10) is where it runs `light`, and
+`WINGFOIL_DISK_FLOOR_GB` (default 4) is where a still-full tree escalates to
+`deep`. The 10GB default is sized off what it has to leave room for: a
+`--all-targets` dev build lands around 9.2GB.
+
+**This bites hardest in a Claude Code cloud sandbox**, where the writable disk
+is a fixed per-session allowance (~30GB) rather than the size `df` reports for
+the device. Two `--all-targets` feature sets plus `legacy/target` plus
+incremental will spend all of it. On "no space left on device", `light` first —
+deletes still succeed while writes fail, and the freed space is immediately
+usable, so the session is recoverable without starting a new one.
 
 Three things make the tree large, and they compound:
 
@@ -382,7 +407,9 @@ outright if you are only doing one-shot builds.
 Also note the git hooks installed by `.cargo-husky`: `pre-commit` runs
 `cargo fmt --all` and a full `cargo clippy --workspace --all-targets`, and
 `pre-push` runs `cargo build` plus `cargo test` across the workspace. Every
-commit and push rebuilds, so expect commits to take minutes, not seconds.
+commit and push rebuilds, so expect commits to take minutes, not seconds — and
+both now open with `scripts/disk.sh auto`, because that `--all-targets` step is
+the largest single demand this repo makes on a disk.
 
 **Toolchain gap (clippy):** CI runs clippy on the current **stable** rustc,
 which can be *newer* than the toolchain in a dev sandbox. Newer clippy adds

--- a/scripts/disk.sh
+++ b/scripts/disk.sh
@@ -5,11 +5,21 @@
 #   scripts/disk.sh light      # drop the cheap-to-rebuild bulk (examples, benches,
 #                              #   incremental, extracted registry sources)
 #   scripts/disk.sh deep       # light + every target/ dir in the tree
+#   scripts/disk.sh auto       # light (then deep) only if headroom is low
 #
 # `light` is the one to reach for mid-session: it keeps target/*/deps, so the
 # next `cargo build` relinks rather than recompiling 700+ crates. The example
 # and bench binaries it deletes are the bulk of the tree (each one statically
 # links the whole dependency graph) and nothing but `--all-targets` needs them.
+#
+# `auto` is the unattended form, for hooks: it costs one `df` and stays silent
+# unless it actually reclaimed something. Thresholds are in GB and tunable:
+#
+#   WINGFOIL_DISK_MIN_GB=10    # below this, run `light`
+#   WINGFOIL_DISK_FLOOR_GB=4   # still below this afterwards, escalate to `deep`
+#
+# The default of 10GB is sized off the build it has to leave room for: a
+# `--all-targets` dev build of this workspace lands around 9.2GB.
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -17,6 +27,9 @@ mode="${1:-report}"
 
 human() { du -sh "$@" 2>/dev/null | sort -hr; }
 avail() { df -h "$root" | awk 'NR==2 {print $4}'; }
+# Whole GB of headroom, for arithmetic. `df -Pk` rather than `--output=avail`
+# so this keeps working on macOS.
+avail_gb() { df -Pk "$root" | awk 'NR==2 {print int($4/1048576)}'; }
 
 # target/ dirs anywhere in the tree: the workspace root, plus the two trees
 # excluded from that workspace and so building into their own — wingfoil-wasm
@@ -59,9 +72,60 @@ deep() {
     echo "deep clean done — available: $(avail)"
 }
 
+# Silent no-op above the threshold; one line when it reclaimed something. That
+# silence is the point — this runs after every shell command in a Claude Code
+# session (see .claude/settings.json), and a hook that narrates every tick is a
+# hook people turn off.
+auto() {
+    local min="${WINGFOIL_DISK_MIN_GB:-10}"
+    local floor="${WINGFOIL_DISK_FLOOR_GB:-4}"
+    local before after
+    before="$(avail_gb)"
+    if [ "$before" -ge "$min" ]; then
+        return 0
+    fi
+
+    light >/dev/null
+    after="$(avail_gb)"
+    if [ "$after" -ge "$floor" ]; then
+        echo "disk: ${before}GB free (< ${min}GB) — ran \`scripts/disk.sh light\`," \
+             "dropping example/bench binaries, incremental and extracted registry sources." \
+             "Now ${after}GB free; target/*/deps kept, so the next build relinks."
+        return 0
+    fi
+
+    # Light left us under the floor, so the deps/ it was protecting are all
+    # that is left to give. A full rebuild beats a build that dies halfway
+    # through with ENOSPC.
+    deep >/dev/null
+    echo "disk: ${before}GB free (< ${min}GB), still ${after}GB after a light clean" \
+         "— ran \`scripts/disk.sh deep\`; every target/ is gone, so the next build is a full one." \
+         "Now $(avail_gb)GB free."
+}
+
+# `auto`, wrapped for a Claude Code PostToolUse hook (.claude/settings.json).
+# The envelope is what puts the reclaim into the model's context — a hook that
+# only writes to stdout tells the user but leaves the agent believing its
+# example binaries are still there.
+hook() {
+    local out
+    out="$(auto 2>&1)" || return 0
+    [ -n "$out" ] || return 0
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn --arg m "$out" \
+            '{systemMessage: $m,
+              hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $m}}'
+    else
+        # No jq: the user still gets told, the model just misses the context.
+        printf '%s\n' "$out"
+    fi
+}
+
 case "$mode" in
     report) report ;;
     light)  light; echo; report ;;
     deep)   deep; echo; report ;;
-    *) echo "usage: $(basename "$0") [report|light|deep]" >&2; exit 1 ;;
+    auto)   auto ;;
+    hook)   hook ;;
+    *) echo "usage: $(basename "$0") [report|light|deep|auto|hook]" >&2; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

Adds an `auto` mode to `scripts/disk.sh` that intelligently reclaims disk space when headroom falls below a threshold, with integration into Claude Code sessions and git hooks. This addresses the disk pressure problem in constrained environments like Claude Code cloud sandboxes (~30GB fixed per session).

## Key Changes

- **New `auto` mode in `scripts/disk.sh`**: Monitors available disk space and automatically runs `light` cleanup (preserving `target/*/deps` for faster rebuilds) when free space drops below 10GB, escalating to `deep` cleanup if still below 4GB floor. Thresholds are tunable via `WINGFOIL_DISK_MIN_GB` and `WINGFOIL_DISK_FLOOR_GB` environment variables.

- **New `hook` mode**: Wraps `auto` for Claude Code `PostToolUse` integration, outputting structured JSON (via `jq` if available) to inject disk reclamation context into the model's awareness, or plain text fallback.

- **`.claude/settings.json`** (new): Configures Claude Code to run `scripts/disk.sh hook` after every Bash command, and sets `CARGO_INCREMENTAL=0` to save ~2.6GB (incremental artifacts are wasted in one-shot builds).

- **Git hook integration**: Both `.cargo-husky/hooks/pre-commit` and `pre-push` now call `scripts/disk.sh auto` before their `--all-targets` build steps, preventing "no space left on device" failures during the largest single disk demand in the repo.

- **Documentation**: Updated `CLAUDE.md` with guidance on disk management, thresholds, and the three integration points. Added comments explaining the design rationale (e.g., why `df -Pk` for macOS compatibility, why silence above threshold).

## Implementation Details

- `avail_gb()` helper uses `df -Pk` (POSIX-compatible) instead of `--output=avail` to maintain macOS support.
- `auto` is a silent no-op above the threshold (cost: one `df` call), making it suitable for per-command hooks without noise.
- Escalation logic: if `light` doesn't bring headroom above the floor, `deep` is run to delete all `target/` dirs, forcing a full rebuild on the next build (preferable to a build that dies mid-link with ENOSPC).
- Hook output includes both user-facing messages and structured JSON for Claude Code's model context injection.

https://claude.ai/code/session_01SNT6eVusxCEgqQHEbiMPfS