### PR TITLE
docs: correct claims that overstate what ships

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,13 +309,25 @@ cargo lint-legacy    # clippy, default features (alias)
 cargo test-legacy    # the whole legacy workspace (alias)
 ```
 
-Two consequences to keep in mind. Legacy artifacts now build into
+Three consequences to keep in mind. Legacy artifacts now build into
 **`legacy/target/`**, not the root `target/` — `scripts/disk.sh` already finds
-both. And the git hooks only run the root workspace (`cargo clippy
+both. The git hooks only run the root workspace (`cargo clippy
 --workspace`, `cargo test --workspace`), so **a change under `legacy/` is not
 covered by the pre-commit or pre-push hook** — run the two aliases above by
 hand before pushing legacy work. CI still gates it, in the `Lint legacy` and
 `Test (wingfoil) & Coverage` jobs.
+
+And **`-p wingfoil` is ambiguous from the root** whenever the legacy crate is in
+the graph (it is a dev-dependency of `crates/wingfoil`, so `--all-features`
+pulls it in), because both packages carry that name:
+
+```
+error: There are multiple `wingfoil` packages in your project, and the
+specification `wingfoil` is ambiguous.
+```
+
+Disambiguate with the version — `-p wingfoil@9.0.0` for this tree,
+`-p wingfoil@8.0.0` for legacy — or use `--manifest-path`.
 
 `protoc` is required on the build machine (a transitive dependency builds proto
 files). On Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`, or run
@@ -324,7 +336,10 @@ files). On Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`, or run
 
 ### Aeron adapter system dependencies
 
-The Aeron adapter requires clang, libuuid, and a recent CMake (>=3.20):
+The Aeron adapter requires clang, libuuid, and a recent CMake (**>=3.30** — the
+vendored `rusteron-media-driver` Aeron sources set that floor in their own
+`cmake_minimum_required`, so 3.28 fails the build script outright with
+`CMake 3.30 or higher is required`):
 
 ```bash
 sudo apt update

--- a/README.md
+++ b/README.md
@@ -70,14 +70,20 @@ npm install @wingfoil/client  # TypeScript client for the web adapter
 - **Lossless by construction.** Same-instant values ride a single burst —
   never coalesced, never latest-wins, never dropped — identically in realtime
   and in replay.
-- **Sixteen production-ready adapters.** PostgreSQL, KDB+, Kafka, Redis, etcd,
-  Fluvio, ZeroMQ, FIX 4.4, iceoryx2, Aeron, WebSocket, Prometheus,
-  OpenTelemetry, CSV, augurs and line-oriented files — async/Tokio at your
-  graph edges, plus an LRU file cache for time-sliced readers. One runnable
-  example each, [indexed here](crates/wingfoil/examples/adapters/).
+- **Sixteen adapters.** PostgreSQL, KDB+, Kafka, Redis, etcd, Fluvio, ZeroMQ,
+  FIX 4.4, iceoryx2, Aeron, WebSocket, Prometheus, OpenTelemetry, CSV, augurs
+  and line-oriented files — async/Tokio at your graph edges, plus an LRU file
+  cache for time-sliced readers. One runnable example each,
+  [indexed here](crates/wingfoil/examples/adapters/). Three of them —
+  **iceoryx2, Aeron, and FIX in its spin mode** — poll from the graph thread and
+  belong on a latency-critical path; the rest reach the graph through a
+  background task and an OS wakeup, which is the right shape for what those
+  transports are and not a microsecond path.
 - **Latency tracing that survives a process hop.** Per-hop wall-clock stamps
   aggregating into one report, across shared memory and the wire — see
-  [`showcase/`](crates/wingfoil/examples/showcase/).
+  [`showcase/`](crates/wingfoil/examples/showcase/). `count`, `min`, `mean` and
+  `max` are exact; percentiles come off a sub-bucketed histogram and are
+  accurate to 3.125%.
 - **Fallible everywhere.** Every lifecycle function returns a `Result`; a
   producer error propagates into the graph and aborts the run with context,
   and cleanup still runs.


### PR DESCRIPTION
## What this changes

Three documentation inaccuracies, each verified against the code or reproduced on
this machine. No code changes.

## Why

**README — "Sixteen production-ready adapters."** This reads as though all
sixteen are equivalent for a latency-critical path. `Kernel::begin_cycle` only
enters its busy-spin loop when some node declares `Activation::ALWAYS`;
otherwise it parks on `recv_timeout` / `thread::sleep`. So only **iceoryx2, Aeron
and FIX in spin mode** poll from the graph thread — every async-backed adapter
(kafka, redis, etcd, postgres, fluvio, web) reaches the graph through a
background task plus a crossbeam channel plus an OS wakeup. That is the right
shape for what those transports *are*; it just isn't what "latency-critical" in
the headline promises, and an evaluator should not have to read the kernel to
find out which is which.

**README — the latency-tracing bullet** didn't distinguish exact aggregates from
estimated ones. It now says which are which.

**CLAUDE.md — CMake `>=3.20` is wrong.** The vendored
`rusteron-media-driver` Aeron sources set `3.30` in their own
`cmake_minimum_required`. Reproduced here on 3.28:

```
CMake Error at CMakeLists.txt:16 (cmake_minimum_required):
  CMake 3.30 or higher is required.  You are running version 3.28.3
```

The install snippet immediately below already fetches 3.31, so the stated floor
was the error, not the instructions.

**CLAUDE.md — `-p wingfoil` is ambiguous from the root.** Both packages carry
that name, and the legacy crate is a dev-dependency of `crates/wingfoil`, so
`--all-features` pulls it into the graph:

```
error: There are multiple `wingfoil` packages in your project, and the
specification `wingfoil` is ambiguous.
```

Now documented, with `-p wingfoil@9.0.0` as the fix.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [x] `scripts/check-example-docs.sh` — OK, 46 targets
- No code touched, so no test run applies.

## Notes for the reviewer

An earlier revision of this PR also added a `## Status` section to the README
describing the `next`/`legacy` split and two capability caveats. **Dropped** —
this branch is staging for `main`, so the branch state is not something the
user-facing README should qualify. Nothing is lost: the FIX adapter's lack of an
outbound message store and its non-certified status are in its module docs (#704),
and the payload-copy cost is in `benches/README.md`.

What remains here is only correction of statements that were inaccurate on their
own terms.