### PR TITLE
feat(interp): opt-in per-node error containment

### DIFF
--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -32,7 +32,8 @@ use wingfoil::{NanoTime, RunFor, RunMode};
 use crate::Burst;
 use crate::channel::ChannelSender;
 use crate::interp::{
-    AsHandle, Builder, ExternalSource, FeedbackSink, Handle, Runner, SlotRef, StopHandle,
+    AsHandle, Builder, ErrorAction, ExternalSource, FeedbackSink, Handle, NodeError, Runner,
+    SlotRef, StopHandle,
 };
 use crate::op::{Activation, Ctx, Tick};
 
@@ -617,6 +618,61 @@ impl<T> Stream<T> {
     /// handle, wrapping the produced handle as a new stream. Every combinator
     /// is a one-liner over this — e.g. `self.wire(|b, h| b.map(h, f))` — so an
     /// op trait never touches the builder's internals.
+    /// Route `cycle` errors from **this** node through `f`, which decides
+    /// whether the run aborts (the default), skips the cycle, or retires the
+    /// node for the rest of the run. Returns the same stream, so it drops into
+    /// a chain where the risk is:
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use wingfoil::prelude::*;
+    /// # use wingfoil::interp::ErrorAction;
+    /// # use wingfoil::{NanoTime, RunFor, RunMode};
+    /// # let g = GraphBuilder::new();
+    /// let decoded = g
+    ///     .ticker(Duration::from_millis(1))
+    ///     .count()
+    ///     .try_map(|n: &u64| match n.is_multiple_of(5) {
+    ///         true => anyhow::bail!("malformed message {n}"),
+    ///         false => Ok(*n),
+    ///     })
+    ///     .on_error(|e| {
+    ///         log::warn!("dropping bad tick at node {}: {}", e.index, e.error);
+    ///         ErrorAction::SkipCycle
+    ///     })
+    ///     .accumulate();
+    ///
+    /// let mut r = g.build();
+    /// r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(12))?;
+    /// // 5 and 10 were dropped; the run carried on regardless.
+    /// assert_eq!(vec![1, 2, 3, 4, 6, 7, 8, 9, 11, 12], r.value(&decoded));
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    ///
+    /// Without a handler a node's error aborts the whole run — correct for a
+    /// backtest, and correct for most live graphs, but not for a graph holding
+    /// live orders where one instrument's decode failure should not take down
+    /// the leg managing risk on another. Containment is opt-in per node, and
+    /// never silent: the handler that selects it is also the thing that gets
+    /// told.
+    ///
+    /// Applies to `cycle` only — see
+    /// [`Builder::set_error_handler`](crate::interp::Builder::set_error_handler).
+    pub fn on_error<F>(&self, f: F) -> Stream<T>
+    where
+        F: Fn(&NodeError<'_>) -> ErrorAction + 'static,
+    {
+        assert!(
+            !self.built.get(),
+            "invariant: attaching an error handler after GraphBuilder::build(); \
+             the graph is already consumed"
+        );
+        self.inner
+            .borrow_mut()
+            .set_error_handler(self.handle, Rc::new(f));
+        self.clone()
+    }
+
     pub fn wire<B, F>(&self, f: F) -> Stream<B>
     where
         F: FnOnce(&mut Builder, Handle<T>) -> Handle<B>,

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -381,6 +381,59 @@ type PendingMut = Box<dyn FnOnce(&mut Runner, &mut Kernel) -> Result<()>>;
 /// `cycle` closure (so this struct stays non-generic and all nodes live in one
 /// `Vec`), while the fields here are the engine-visible facts: what activates
 /// the node, and its lifecycle hooks.
+/// What the engine should do about an error a node's `cycle` returned.
+///
+/// The default — with no handler attached — is [`Abort`](Self::Abort), which is
+/// what the engine has always done and what most graphs want: a failure is a
+/// failure and the run should stop with context.
+///
+/// The other two exist because "the run stops" is not always the least-bad
+/// outcome. A graph carrying live orders is one where a decode error on one
+/// instrument's leg should not take down the leg that is managing risk on
+/// another. Containment there is a deliberate, per-node choice — never the
+/// default, and never silent, because the handler that selects it is also the
+/// thing that gets told.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ErrorAction {
+    /// Stop the run and report the error with node context, running
+    /// `stop`/`teardown` on the way out. The default.
+    Abort,
+    /// Treat this cycle as [`Tick::Quiet`] and carry on. The node stays live
+    /// and is cycled again the next time it is activated — the right choice
+    /// for a transient failure (one malformed message on an otherwise healthy
+    /// feed).
+    SkipCycle,
+    /// Retire the node for the rest of the run: it is never cycled again and
+    /// so never ticks, which quiets everything downstream of it while the rest
+    /// of the graph keeps running. The right choice for a failure that will not
+    /// fix itself, where the graph has a degraded mode worth staying in.
+    ///
+    /// Note the reach: quarantining a node silences its whole downstream cone,
+    /// so aim it at a leaf or at the root of a subtree you can afford to lose.
+    Quarantine,
+}
+
+/// The error a node raised, handed to its error handler.
+///
+/// Carries the node's identity as well as the error so one shared handler can
+/// serve a whole graph — log it, publish it, trip a kill switch — and still
+/// tell which node it came from.
+pub struct NodeError<'a> {
+    /// The node's index in the graph.
+    pub index: usize,
+    /// The node's op label, as it would appear in the aborting error's context
+    /// (e.g. `TryMap`).
+    pub label: &'static str,
+    /// The error itself, before the engine adds node context.
+    pub error: &'a anyhow::Error,
+}
+
+/// A per-node error handler: sees the error, decides what happens next.
+///
+/// `Rc` rather than `Box` so one handler — a kill switch, a channel into an
+/// alerting sink — can be attached to many nodes.
+pub type ErrorHandler = Rc<dyn Fn(&NodeError<'_>) -> ErrorAction>;
+
 struct NodeRt {
     /// Indices of upstream nodes whose tick activates this one (the active
     /// edges). A cycle runs when any of these ticked — see the dispatch loop
@@ -412,6 +465,10 @@ struct NodeRt {
     /// wiring-time initial values before a second [`Runner::run`]. See
     /// [`ResetFn`]. Defaults to a no-op; stateful nodes overwrite it.
     reset: ResetFn,
+    /// What to do if this node's `cycle` returns an error. `None` — the
+    /// default for every node — means [`ErrorAction::Abort`], the engine's
+    /// long-standing behaviour. See [`Builder::set_error_handler`].
+    on_error: Option<ErrorHandler>,
 }
 
 /// The producer half of an [`external`](Builder::external) source: send a
@@ -1069,8 +1126,25 @@ impl Builder {
             stop: Box::new(|_| Ok(())),
             teardown: Box::new(|_| Ok(())),
             reset: Box::new(|| {}),
+            on_error: None,
         });
         self.ticked.borrow_mut().push(false);
+    }
+
+    /// Attach an error handler to the node behind `handle`, so a `cycle` error
+    /// there is routed through `f` instead of aborting the run outright.
+    ///
+    /// Applies to **`cycle` only**. `start`, `stop` and `teardown` keep
+    /// aborting: a `start` failure is a connect/configuration problem where
+    /// carrying on would mean running a graph that is not actually wired up,
+    /// and the cleanup hooks already run error-safely.
+    ///
+    /// The fluent form is [`Stream::on_error`](crate::fluent::Stream::on_error).
+    pub fn set_error_handler<T>(&mut self, handle: impl AsHandle<T>, f: ErrorHandler) {
+        let idx = handle.as_handle().index();
+        if let Some(node) = self.nodes.get_mut(idx) {
+            node.on_error = Some(f);
+        }
     }
 
     /// Attach a re-run hook to the node most recently pushed. Called by the
@@ -2367,6 +2441,7 @@ impl Builder {
             active_downs,
             passive_downs,
             removed: vec![false; n],
+            quarantined: vec![false; n],
             pending: self.pending,
             marks: self.marks,
             has_marks: self.has_marks,
@@ -2483,6 +2558,12 @@ pub struct Runner {
     /// all-false on a static run.
     #[cfg_attr(not(feature = "dynamic-graph"), allow(dead_code))]
     removed: Vec<bool>,
+    /// `quarantined[i]` — set when node `i`'s error handler returned
+    /// [`ErrorAction::Quarantine`]. The node is skipped by the dispatch drain
+    /// from then on, so it never cycles and never ticks; everything downstream
+    /// of it goes quiet while the rest of the graph keeps running. Cleared by
+    /// [`reset`](Runner::reset), and all-false unless a handler is attached.
+    quarantined: Vec<bool>,
     /// Mutations staged by in-graph dynamic nodes during a cycle, drained and
     /// applied at each cycle boundary by [`run_dynamic`](Runner::run_dynamic).
     /// Shares the `Rc` the [`Builder`] handed to any staging node. Empty on a
@@ -2687,6 +2768,11 @@ impl Runner {
         for t in self.ticked.borrow_mut().iter_mut() {
             *t = false;
         }
+        // A quarantine lasts for the run that imposed it, not forever: a
+        // re-run starts from a clean graph, exactly as node state does.
+        for q in &mut self.quarantined {
+            *q = false;
+        }
         self.finished.set(false);
     }
 
@@ -2830,6 +2916,13 @@ impl Runner {
             let mut current = std::mem::take(&mut buckets[l]);
             current.sort_unstable();
             for &i in &current {
+                // A quarantined node is skipped entirely: it does not cycle, so
+                // it cannot tick, so nothing downstream of it is marked. The
+                // check is a bounds-checked bool load on the hot path and the
+                // vector is all-false unless an error handler is attached.
+                if self.quarantined[i] {
+                    continue;
+                }
                 // Braced so the per-node span (when enabled) closes on the
                 // node's own `cycle`, not on the downstream marking below.
                 let did = {
@@ -2838,7 +2931,39 @@ impl Runner {
                         Ok(did) => did,
                         Err(e) => {
                             let label = self.nodes[i].label;
-                            return Some(e.context(format!("node {i} ({label}) cycle")));
+                            // Cloned (an `Rc` bump) so the handler can run
+                            // without holding a borrow of `self.nodes` — it may
+                            // want to look at the graph, and `Quarantine` has to
+                            // write back.
+                            match self.nodes[i].on_error.clone() {
+                                // No handler: the long-standing behaviour, and
+                                // the default for every node.
+                                None => {
+                                    return Some(e.context(format!("node {i} ({label}) cycle")));
+                                }
+                                Some(handler) => {
+                                    let reported = NodeError {
+                                        index: i,
+                                        label,
+                                        error: &e,
+                                    };
+                                    match handler(&reported) {
+                                        ErrorAction::Abort => {
+                                            return Some(
+                                                e.context(format!("node {i} ({label}) cycle")),
+                                            );
+                                        }
+                                        // Both continue the run with this cycle
+                                        // treated as `Tick::Quiet`; they differ
+                                        // in whether the node is cycled again.
+                                        ErrorAction::SkipCycle => false,
+                                        ErrorAction::Quarantine => {
+                                            self.quarantined[i] = true;
+                                            false
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 };
@@ -3308,11 +3433,13 @@ impl Runner {
             // (a second `run`) is a static-graph capability; a graph mutated
             // via `run_dynamic` rebuilds its dynamic region on the next run.
             reset: Box::new(|| {}),
+            on_error: None,
         });
         self.ticked.borrow_mut().push(false);
         self.active_downs.push(Vec::new());
         self.passive_downs.push(Vec::new());
         self.removed.push(false);
+        self.quarantined.push(false);
         self.layer.push(lyr);
         if activation.always {
             self.always_nodes.push(idx);

--- a/crates/wingfoil/tests/error_policy.rs
+++ b/crates/wingfoil/tests/error_policy.rs
@@ -1,0 +1,282 @@
+//! Per-node error containment: `Stream::on_error` and [`ErrorAction`].
+//!
+//! Without a handler, any node's `cycle` error aborts the whole run — the
+//! engine's long-standing behaviour, and the right one for a backtest. These
+//! tests pin the opt-in alternatives, which exist for the case the default
+//! serves badly: a live graph where one leg's decode failure should not take
+//! down the leg managing risk on another.
+//!
+//! Everything here runs `HistoricalFrom(ZERO)` and asserts **values and tick
+//! times**, so a containment bug that showed up as a shifted schedule rather
+//! than a wrong value would still be caught.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use anyhow::bail;
+use wingfoil::interp::{ErrorAction, NodeError};
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const STEP: Duration = Duration::from_nanos(100);
+
+/// A counter stream that fails on the counts in `fail_on`.
+fn failing_counter(g: &GraphBuilder, fail_on: &'static [u64]) -> Stream<u64> {
+    g.ticker(STEP).count().try_map(move |n: &u64| {
+        if fail_on.contains(n) {
+            bail!("synthetic failure at {n}");
+        }
+        Ok(*n)
+    })
+}
+
+/// The default is unchanged: no handler, so the first error aborts the run and
+/// is reported with node context.
+#[test]
+fn without_a_handler_an_error_still_aborts_the_run() {
+    let g = GraphBuilder::new();
+    let out = failing_counter(&g, &[3]).accumulate();
+    let mut r = g.build();
+
+    let err = r
+        .run(HISTORICAL, RunFor::Cycles(6))
+        .expect_err("the run must abort");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("cycle") && chain.contains("synthetic failure at 3"),
+        "error lost its node context: {chain}"
+    );
+    // Everything before the failure still reached the accumulator.
+    assert_eq!(vec![1, 2], r.value(&out));
+}
+
+/// `SkipCycle` treats the failing cycle as `Tick::Quiet`: the value is dropped,
+/// the node stays live, and the next activation is cycled normally.
+#[test]
+fn skip_cycle_drops_the_value_and_keeps_the_node_live() {
+    let seen: Rc<RefCell<Vec<usize>>> = Rc::new(RefCell::new(Vec::new()));
+    let recorder = seen.clone();
+
+    let g = GraphBuilder::new();
+    let out = failing_counter(&g, &[2, 4])
+        .on_error(move |e: &NodeError<'_>| {
+            recorder.borrow_mut().push(e.index);
+            ErrorAction::SkipCycle
+        })
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).expect("run completes");
+
+    // Counts 2 and 4 are dropped; 5 and 6 prove the node was still cycled
+    // after two failures.
+    let got = r.value(&out);
+    let values: Vec<u64> = got.iter().map(|(_, v)| *v).collect();
+    assert_eq!(vec![1, 3, 5, 6], values);
+
+    // And the surviving ticks kept their original times — a dropped cycle must
+    // not reschedule the ones after it.
+    let times: Vec<NanoTime> = got.iter().map(|(t, _)| *t).collect();
+    assert_eq!(
+        vec![
+            NanoTime::new(0),
+            NanoTime::new(200),
+            NanoTime::new(400),
+            NanoTime::new(500),
+        ],
+        times
+    );
+
+    // The handler was called once per failure, naming the same node both times.
+    let calls = seen.borrow();
+    assert_eq!(2, calls.len());
+    assert_eq!(calls[0], calls[1]);
+}
+
+/// `Quarantine` retires the node: it is never cycled again, so it never ticks
+/// and its downstream goes quiet — while the rest of the graph runs on.
+#[test]
+fn quarantine_silences_one_branch_and_leaves_the_rest_running() {
+    let calls = Rc::new(RefCell::new(0usize));
+    let counted = calls.clone();
+
+    let g = GraphBuilder::new();
+    let ticks = g.ticker(STEP).count();
+
+    // The branch that fails, quarantined on its first error.
+    let risky = ticks
+        .try_map(|n: &u64| {
+            if *n == 3 {
+                bail!("this leg is done");
+            }
+            Ok(*n)
+        })
+        .on_error(move |_: &NodeError<'_>| {
+            *counted.borrow_mut() += 1;
+            ErrorAction::Quarantine
+        });
+    let risky_out = risky.with_time().accumulate();
+
+    // A sibling branch off the same source, which must be untouched.
+    let healthy_out = ticks.map(|n: &u64| n * 10).with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).expect("run completes");
+
+    // The risky branch stops at its failure and never resumes.
+    let risky_vals: Vec<u64> = r.value(&risky_out).iter().map(|(_, v)| *v).collect();
+    assert_eq!(vec![1, 2], risky_vals);
+
+    // The healthy branch ran the whole way, on the original schedule.
+    let healthy = r.value(&healthy_out);
+    assert_eq!(
+        vec![10, 20, 30, 40, 50, 60],
+        healthy.iter().map(|(_, v)| *v).collect::<Vec<u64>>()
+    );
+    assert_eq!(
+        vec![
+            NanoTime::new(0),
+            NanoTime::new(100),
+            NanoTime::new(200),
+            NanoTime::new(300),
+            NanoTime::new(400),
+            NanoTime::new(500),
+        ],
+        healthy.iter().map(|(t, _)| *t).collect::<Vec<NanoTime>>()
+    );
+
+    // Quarantined means quarantined: the handler fired exactly once, not once
+    // per remaining activation.
+    assert_eq!(1, *calls.borrow());
+}
+
+/// A handler that returns `Abort` is the explicit spelling of the default, and
+/// still gets to see the error on the way past — the shape you want for
+/// "log it, then die".
+#[test]
+fn a_handler_can_still_choose_to_abort() {
+    let saw: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+    let recorder = saw.clone();
+
+    let g = GraphBuilder::new();
+    let _out = failing_counter(&g, &[2]).on_error(move |e: &NodeError<'_>| {
+        *recorder.borrow_mut() = Some(format!("{} @ {}", e.error, e.label));
+        ErrorAction::Abort
+    });
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(6))
+        .expect_err("Abort still aborts");
+    let seen = saw.borrow();
+    let seen = seen.as_ref().expect("the handler ran before aborting");
+    assert!(seen.starts_with("synthetic failure at 2 @ "));
+    assert!(!seen.ends_with("@ "), "the node label was empty: {seen}");
+}
+
+/// One handler, many nodes — the kill-switch shape. `ErrorHandler` is an `Rc`
+/// precisely so a single closure can serve a whole graph and still tell which
+/// node spoke.
+#[test]
+fn one_handler_can_serve_several_nodes_and_still_identify_them() {
+    let seen: Rc<RefCell<Vec<usize>>> = Rc::new(RefCell::new(Vec::new()));
+
+    let g = GraphBuilder::new();
+    let ticks = g.ticker(STEP).count();
+
+    let mut outs = Vec::new();
+    for modulus in [2u64, 3] {
+        let recorder = seen.clone();
+        outs.push(
+            ticks
+                .try_map(move |n: &u64| {
+                    if n.is_multiple_of(modulus) {
+                        bail!("mod {modulus}");
+                    }
+                    Ok(*n)
+                })
+                .on_error(move |e: &NodeError<'_>| {
+                    recorder.borrow_mut().push(e.index);
+                    ErrorAction::SkipCycle
+                })
+                .accumulate(),
+        );
+    }
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).expect("run completes");
+
+    assert_eq!(vec![1, 3, 5], r.value(&outs[0]));
+    assert_eq!(vec![1, 2, 4, 5], r.value(&outs[1]));
+
+    // Two distinct node indices reported through the one closure.
+    let calls = seen.borrow();
+    let mut distinct: Vec<usize> = calls.clone();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(2, distinct.len(), "both nodes reported through one handler");
+}
+
+/// A quarantine belongs to the run that imposed it. A re-run of a re-runnable
+/// graph starts clean, exactly as node state does.
+#[test]
+fn a_re_run_clears_a_quarantine() {
+    let g = GraphBuilder::new();
+    let out = g
+        .ticker(STEP)
+        .count()
+        .try_map(|n: &u64| {
+            if *n == 2 {
+                bail!("boom");
+            }
+            Ok(*n)
+        })
+        .on_error(|_: &NodeError<'_>| ErrorAction::Quarantine)
+        .accumulate();
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(5)).expect("first run");
+    assert_eq!(vec![1], r.value(&out));
+
+    r.run(HISTORICAL, RunFor::Cycles(5)).expect("second run");
+    assert_eq!(
+        vec![1],
+        r.value(&out),
+        "the second run must reproduce the first exactly, not start quarantined"
+    );
+}
+
+/// A **sink** is containable too, which is the case that motivated all this: a
+/// publish that fails should be able to drop the message (or take that leg out)
+/// without stopping the graph that is still managing the position.
+#[test]
+fn a_failing_sink_can_be_contained_without_stopping_the_graph() {
+    let published: Rc<RefCell<Vec<u64>>> = Rc::new(RefCell::new(Vec::new()));
+    let sink = published.clone();
+
+    let g = GraphBuilder::new();
+    let ticks = g.ticker(STEP).count();
+    // The sink fails on every third value, as a flaky downstream would.
+    ticks
+        .for_each(move |n: &u64| {
+            if n.is_multiple_of(3) {
+                bail!("publish rejected");
+            }
+            sink.borrow_mut().push(*n);
+            Ok(())
+        })
+        .on_error(|_: &NodeError<'_>| ErrorAction::SkipCycle);
+    // A second consumer of the same source stands in for the risk leg.
+    let position = ticks.fold(0u64, |acc, n: &u64| *acc += n);
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(7)).expect("run completes");
+
+    assert_eq!(vec![1, 2, 4, 5, 7], *published.borrow());
+    assert_eq!(
+        1 + 2 + 3 + 4 + 5 + 6 + 7,
+        r.value(&position),
+        "the risk leg saw every tick, including the ones the sink rejected"
+    );
+}


### PR DESCRIPTION
## What this changes

`Stream::on_error(f)` attaches an error handler to one node. When that node's `cycle` returns `Err`, the handler sees it and returns an `ErrorAction`:

| action | effect |
|---|---|
| `Abort` | Stop the run with node context. **The default**, and what happens with no handler attached. |
| `SkipCycle` | Treat this cycle as `Tick::Quiet` and carry on. The node stays live and is cycled again next activation. |
| `Quarantine` | Retire the node for the rest of the run — it never cycles again, so it never ticks, so its downstream cone goes quiet while the rest of the graph keeps running. |

## Why

A node's `cycle` error aborts the whole run. That is right for a backtest and right for most live graphs, and it stays the default. It is the wrong shape for a graph carrying live orders, where a decode failure on one instrument's leg takes down the leg managing risk on another. Today the only way to say otherwise is to catch every error inside the closure and invent a sentinel value — which loses the error and pushes the failure downstream as data.

Two properties I tried to keep:

- **Containment is never silent.** The handler that selects it is also the thing that gets told, so "the graph quietly stopped producing" is not a reachable state. There is no config flag that turns errors off.
- **One handler can serve a whole graph.** `ErrorHandler` is an `Rc<dyn Fn(&NodeError) -> ErrorAction>`, so a kill switch or a channel into an alerting sink attaches to many nodes and still identifies which one spoke, via `NodeError::index` / `::label`.

**Scoped to `cycle`.** `start` keeps aborting — a connect or configuration failure means the graph is not wired to what it claims to be — and `stop`/`teardown` already run error-safely.

`Quarantine` silences the node's whole downstream cone, so it wants aiming at a leaf or at the root of a subtree you can afford to lose. That is on the enum docs.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
- [x] New behaviour is covered by a test asserting **values and tick times**

New `tests/error_policy.rs`, seven tests, all `HistoricalFrom(ZERO)`:

- `without_a_handler_an_error_still_aborts_the_run` — the default is untouched, context intact.
- `skip_cycle_drops_the_value_and_keeps_the_node_live` — asserts the surviving ticks keep their **original times**, so a dropped cycle cannot quietly reschedule the ones after it.
- `quarantine_silences_one_branch_and_leaves_the_rest_running` — a sibling branch off the same source runs the full schedule; the handler fires exactly once, not once per remaining activation.
- `a_handler_can_still_choose_to_abort` — sees the error on the way past ("log it, then die").
- `one_handler_can_serve_several_nodes_and_still_identify_them`.
- `a_re_run_clears_a_quarantine` — a quarantine belongs to the run that imposed it, as node state does.
- `a_failing_sink_can_be_contained_without_stopping_the_graph` — the motivating case: a rejected publish drops the message while the risk leg still sees every tick.

## Notes for the reviewer

- **Hot-path cost is one bounds-checked bool load per node cycle** (`quarantined[i]`), on a vector that is all-false unless a handler is attached. The `Option<ErrorHandler>` is only read on the error path, and cloned there (an `Rc` bump) so the handler runs without holding a borrow of `self.nodes` — it may want to inspect the graph, and `Quarantine` has to write back.
- **`quarantined` is separate from the existing `removed` tombstone** rather than reusing it: `removed` is `dynamic-graph`-gated and also unlinks edges and suppresses the end-of-run `stop`/`teardown`. A quarantined node should still get its cleanup hooks, and containment should not require the feature.
- `run_dynamic` is covered — `quarantined` grows alongside `removed` when a node is appended mid-run.
- This is the engine-level half. A follow-up worth considering is a first-class errors *stream* (`GraphBuilder::errors() -> Stream<Burst<..>>`) so failures can be wired rather than callback-ed; I left it out because delivering into the same cycle needs a layer-ordering answer the `marks` mechanism does not straightforwardly give, and the `Rc` handler covers the wire-it-to-a-channel case today.
- Interpreted only. `compiled()` is a closed box with no error-handler plumbing, and this is squarely an open-world/live-graph feature — but worth a line in the capability matrix if you want it tracked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpxC33xz95kWNJE8Q7TfFg)_