### PR TITLE
feat(fluent): split_some — two independently-ticking outputs from one node

### DIFF
--- a/crates/wingfoil/examples/core/order_book/README.md
+++ b/crates/wingfoil/examples/core/order_book/README.md
@@ -1,47 +1,67 @@
-## Order book: stateful top-of-book
+## Order book: one stateful node, two output streams
 
 A stateful streaming example: a limit order book maintained entirely in `fold`
-state. Each tick applies one synthetic message (a resting limit order, or an
-occasional aggressive order that crosses and consumes a level), and the graph
-emits the *top of book* — best bid and best ask — but only when it changes.
+state. Each tick applies one synthetic message — a resting limit order, or an
+occasional aggressive order that crosses and consumes a level — and the graph
+emits **two** streams from that one node: the *fills* it produced, and the *top
+of book* (best bid and best ask).
+
+The two tick at different rates, which is the point. Every message moves the
+prices; only some produce a fill.
 
 ```rust
-let book = g
+// Fold state is `(Book, Option<Fill>)`: the book carries across ticks, the
+// fill is what *this* message produced.
+let applied = g
     .ticker(Duration::from_millis(1))
-    .fold(Book::new(seed), |book, _| book.apply());
+    .fold((Book::new(seed), None), |state, _| {
+        state.1 = state.0.apply();
+    });
 
-let top = book.map(|b| b.top()).distinct();
-let _out = top.for_each(|p| { println!(...); Ok(()) });
+// One node, two outputs at different rates.
+let (fills, tops) = applied
+    .map(|(book, fill)| (fill.clone(), Some(book.top())))
+    .split_some();
+
+let _prices = tops.distinct().for_each(|p| { println!(...); Ok(()) });
+let _fills = fills.for_each(|f| { println!(...); Ok(()) });
 ```
 
 Sample output:
 
 ```text
-bid  99   ask   -   spread -
-bid  99   ask 101   spread 2
-bid 100   ask 101   spread 1
-...
+price   bid  99   ask   -   spread -
+price   bid  99   ask 103   spread 4
+fill    buy    7 @ 103
+price   bid  99   ask   -   spread -
+price   bid  99   ask 104   spread 5
+price   bid  99   ask 101   spread 2
+price   bid 100   ask 101   spread 1
+fill    buy    1 @ 101
+price   bid 100   ask 102   spread 2
+fill    sell  15 @ 100
 ```
 
 ### Scope and idiom
 
-This is a *simplified* port of the legacy `order_book` example. The legacy
-version reads real LOBSTER market-data CSV, executes it through a `lobster`
-matching engine, and `split()`s the result into two output streams — a fills
-stream and a prices stream — written to separate CSV files.
+The load-bearing idea is an arbitrary stateful aggregation (a `BTreeMap`-backed
+order book) carried in `fold` state, fanned out into two independently-ticking
+streams, and drained through `for_each` sinks — all in the fluent API.
 
-Two of those pieces are **not yet available on the wingfoil engine**, so the port
-takes a different shape rather than forcing them:
+**How two outputs come out of one node.** An `Op` has a single `Out` by
+construction: that is what lets the engine own every value slot, and what makes
+the compiled tiers possible. So a node that wants to emit two things emits *one*
+value describing both — here `(Option<Fill>, Option<TwoWayPrice>)` — and
+[`split_some`](https://docs.rs/wingfoil/latest/wingfoil/fluent/struct.Stream.html)
+fans it out at wiring time, giving each branch its own tick. Use plain `split()`
+when both outputs really do tick together.
 
-- **`split()` / multi-output nodes** — the legacy example emits *both* fills
-  and prices from one node. The wingfoil engine's ops are single-output, so this
-  port emits a single top-of-book stream. (A stateful book that produced fills
-  and prices would need a demux/split op.)
-- **The CSV replay + write adapter** — the wingfoil engine has a `csv` feature
-  (`examples/csv_adapter`), but this example keeps its feed self-contained (a
-  deterministic LCG) so it runs with no data file and no extra feature flag.
+Both branches read the same upstream node, so the book update happens once
+however many branches read it.
 
-What it *does* demonstrate, cleanly, is the load-bearing idea: an arbitrary
-stateful aggregation (`BTreeMap`-backed order book) carried in `fold` state,
-projected with `map`, de-duplicated with `distinct`, and drained through a
-`for_each` sink — all in the fluent API.
+This remains a *simplified* port of the legacy `order_book` example in one
+respect: the legacy version reads real LOBSTER market-data CSV through a
+`lobster` matching engine and writes its two streams to separate CSV files. The
+wingfoil engine has a `csv` feature (`examples/csv_adapter`), but this example
+keeps its feed self-contained — a deterministic LCG — so it runs with no data
+file and no extra feature flag.

--- a/crates/wingfoil/examples/core/order_book/main.rs
+++ b/crates/wingfoil/examples/core/order_book/main.rs
@@ -40,7 +40,8 @@ impl Book {
 
     /// Apply one synthetic message: mostly resting limit orders around a mid of
     /// 100, occasionally an aggressive order that crosses and consumes a level.
-    fn apply(&mut self) {
+    /// Returns the [`Fill`] if this message crossed, and `None` if it rested.
+    fn apply(&mut self) -> Option<Fill> {
         let r = self.next_rand();
         let is_bid = r & 1 == 0;
         let offset = (r >> 1) % 5; // 0..4 ticks off the mid
@@ -48,14 +49,28 @@ impl Book {
 
         if r.is_multiple_of(7) {
             // Aggressive order: take the best level on the opposite side.
-            if is_bid {
-                if let Some((&px, _)) = self.asks.iter().next() {
-                    self.asks.remove(&px);
-                }
-            } else if let Some((&px, _)) = self.bids.iter().next_back() {
-                self.bids.remove(&px);
-            }
-            return;
+            let taken = if is_bid {
+                self.asks
+                    .iter()
+                    .next()
+                    .map(|(&px, &q)| (px, q))
+                    .inspect(|(px, _)| {
+                        self.asks.remove(px);
+                    })
+            } else {
+                self.bids
+                    .iter()
+                    .next_back()
+                    .map(|(&px, &q)| (px, q))
+                    .inspect(|(px, _)| {
+                        self.bids.remove(px);
+                    })
+            };
+            return taken.map(|(price, quantity)| Fill {
+                price,
+                quantity,
+                aggressor_is_bid: is_bid,
+            });
         }
 
         // Resting limit order: bids below the mid, asks above it.
@@ -66,6 +81,7 @@ impl Book {
             let px = 101 + offset;
             *self.asks.entry(px).or_insert(0) += qty;
         }
+        None
     }
 
     fn top(&self) -> TwoWayPrice {
@@ -83,29 +99,54 @@ struct TwoWayPrice {
     ask: Option<u64>,
 }
 
+/// One execution: an aggressive order consumed a resting level.
+#[derive(Clone, Default)]
+struct Fill {
+    price: u64,
+    quantity: u64,
+    aggressor_is_bid: bool,
+}
+
 fn main() -> anyhow::Result<()> {
     let g = GraphBuilder::new();
 
-    // One synthetic message per tick, folded into the book. `fold` emits the
-    // whole book each tick; we then project to top-of-book, keep only the ticks
-    // where it *changed*, and print them.
-    let book = g
-        .ticker(Duration::from_millis(1))
-        .fold(Book::new(0x1234_5678), |book, _| book.apply());
+    // One synthetic message per tick, folded into the book. The fold state is
+    // `(Book, Option<Fill>)`: the book carries across ticks, the fill is what
+    // *this* message produced — `Some` only when the order crossed.
+    let applied =
+        g.ticker(Duration::from_millis(1))
+            .fold((Book::new(0x1234_5678), None), |state, _| {
+                state.1 = state.0.apply();
+            });
 
-    let top = book.map(|b| b.top()).distinct();
+    // One node, two outputs at different rates. `split_some` gives each branch
+    // its own tick: prices on every message, fills only when one crossed.
+    let (fills, tops) = applied
+        .map(|(book, fill)| (fill.clone(), Some(book.top())))
+        .split_some();
 
-    let _out = top.for_each(|p| {
+    // Prices are noisy — only report when the top of book actually moved.
+    let _prices = tops.distinct().for_each(|p| {
         let fmt = |o: &Option<u64>| o.map_or_else(|| "  -".to_string(), |v| format!("{v:>3}"));
         let spread = match (p.bid, p.ask) {
             (Some(b), Some(a)) => format!("{}", a as i64 - b as i64),
             _ => "-".to_string(),
         };
         println!(
-            "bid {}   ask {}   spread {}",
+            "price   bid {}   ask {}   spread {}",
             fmt(&p.bid),
             fmt(&p.ask),
             spread
+        );
+        Ok(())
+    });
+
+    let _fills = fills.for_each(|f| {
+        println!(
+            "fill    {} {:>3} @ {:>3}",
+            if f.aggressor_is_bid { "buy " } else { "sell" },
+            f.quantity,
+            f.price
         );
         Ok(())
     });

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -1333,7 +1333,70 @@ where
     /// Decompose a stream of pairs into its two component streams (the legacy
     /// `split`) — sugar over two [`map`](StreamOps::map)s. Both branches tick
     /// whenever the source does.
+    ///
+    /// When the two outputs are produced at *different* rates — a book that
+    /// emits a fill only sometimes, but a price on every message — make the
+    /// node's output `(Option<A>, Option<B>)` and use
+    /// [`split_some`](Stream::split_some) instead, so each branch ticks only
+    /// when it has something to say.
     pub fn split(&self) -> (Stream<A>, Stream<B>) {
         (self.map(|t| t.0.clone()), self.map(|t| t.1.clone()))
+    }
+}
+
+impl<A, B> Stream<(Option<A>, Option<B>)>
+where
+    A: Clone + Default + 'static,
+    B: Clone + Default + 'static,
+{
+    /// Decompose a stream of optional pairs into two **independently ticking**
+    /// streams: each branch ticks on the cycles where its own side is `Some`,
+    /// and stays quiet otherwise.
+    ///
+    /// This is how a single node emits two outputs at different rates. An
+    /// [`Op`](crate::op::Op) has one `Out` by construction — that is what lets
+    /// the engine own every value slot and what makes the compiled tiers
+    /// possible — so a node that wants to emit two things emits *one* value
+    /// describing both, and the fan-out happens here at wiring time. The
+    /// canonical case is a stateful order book: every message updates the
+    /// prices, only some produce a fill.
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use wingfoil::prelude::*;
+    /// # use wingfoil::{NanoTime, RunFor, RunMode};
+    /// let g = GraphBuilder::new();
+    /// // Emits a "fill" on every third tick, a "price" on every tick.
+    /// let (fills, prices) = g
+    ///     .ticker(Duration::from_nanos(100))
+    ///     .count()
+    ///     .map(|n: &u64| (n.is_multiple_of(3).then_some(*n), Some(n * 10)))
+    ///     .split_some();
+    ///
+    /// let fills = fills.accumulate();
+    /// let prices = prices.accumulate();
+    /// let mut r = g.build();
+    /// r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(6))?;
+    ///
+    /// assert_eq!(vec![3, 6], r.value(&fills));
+    /// assert_eq!(vec![10, 20, 30, 40, 50, 60], r.value(&prices));
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    ///
+    /// Both branches read the same upstream node, so the shared work — the book
+    /// update — happens once however many branches read it. Downstream of the
+    /// split each side is an ordinary stream and recombines glitch-free like any
+    /// other.
+    pub fn split_some(&self) -> (Stream<A>, Stream<B>) {
+        (
+            self.map_filter(|t| match &t.0 {
+                Some(v) => (v.clone(), true),
+                None => (A::default(), false),
+            }),
+            self.map_filter(|t| match &t.1 {
+                Some(v) => (v.clone(), true),
+                None => (B::default(), false),
+            }),
+        )
     }
 }

--- a/crates/wingfoil/tests/split_some.rs
+++ b/crates/wingfoil/tests/split_some.rs
@@ -1,0 +1,168 @@
+//! `Stream::split_some` — two independently-ticking outputs from one node.
+//!
+//! An `Op` has a single `Out`, so a node emitting two things at different rates
+//! emits one value describing both and fans out at wiring time. These tests pin
+//! that the two branches tick *separately* (the whole point), that the shared
+//! upstream is still computed once, and that the branches recombine
+//! glitch-free like any other stream.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const STEP: Duration = Duration::from_nanos(100);
+
+/// Each branch ticks only on the cycles where its own side is `Some`, and the
+/// ticks land at the source's times — not renumbered by the filtering.
+#[test]
+fn each_branch_ticks_only_when_its_own_side_is_some() {
+    let g = GraphBuilder::new();
+    let (evens, thirds) = g
+        .ticker(STEP)
+        .count()
+        .map(|n: &u64| {
+            (
+                n.is_multiple_of(2).then_some(*n),
+                n.is_multiple_of(3).then_some(n * 100),
+            )
+        })
+        .split_some();
+
+    let evens = evens.with_time().accumulate();
+    let thirds = thirds.with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).expect("run completes");
+
+    // Counts 1..=6 at t = 0, 100, .. 500.
+    assert_eq!(
+        vec![
+            (NanoTime::new(100), 2),
+            (NanoTime::new(300), 4),
+            (NanoTime::new(500), 6),
+        ],
+        r.value(&evens)
+    );
+    assert_eq!(
+        vec![(NanoTime::new(200), 300), (NanoTime::new(500), 600)],
+        r.value(&thirds)
+    );
+}
+
+/// A branch that is `None` for the whole run never ticks at all — it does not
+/// emit `Default` values, which is what a plain `split()` of an `Option` pair
+/// would do.
+#[test]
+fn a_branch_that_never_fires_stays_completely_quiet() {
+    let g = GraphBuilder::new();
+    let (never, always) = g
+        .ticker(STEP)
+        .count()
+        .map(|n: &u64| (None::<u64>, Some(*n)))
+        .split_some();
+
+    let never = never.accumulate();
+    let always = always.accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).expect("run completes");
+
+    assert!(
+        r.value(&never).is_empty(),
+        "the quiet branch emitted values"
+    );
+    assert_eq!(vec![1, 2, 3, 4], r.value(&always));
+}
+
+/// The shared upstream is one node, cycled once per tick however many branches
+/// read it — the property that makes this cheaper than computing the book twice.
+#[test]
+fn the_shared_upstream_is_evaluated_once_per_tick() {
+    let evaluations = Rc::new(RefCell::new(0usize));
+    let counter = evaluations.clone();
+
+    let g = GraphBuilder::new();
+    let (a, b) = g
+        .ticker(STEP)
+        .count()
+        .map(move |n: &u64| {
+            *counter.borrow_mut() += 1;
+            (Some(*n), Some(*n))
+        })
+        .split_some();
+
+    let a = a.accumulate();
+    let b = b.accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).expect("run completes");
+
+    assert_eq!(vec![1, 2, 3, 4, 5], r.value(&a));
+    assert_eq!(vec![1, 2, 3, 4, 5], r.value(&b));
+    assert_eq!(
+        5,
+        *evaluations.borrow(),
+        "the shared node was evaluated more than once per tick"
+    );
+}
+
+/// Downstream of the split each side is an ordinary stream: recombining them
+/// fires **once** per cycle, after both, like any other branch-and-recombine.
+#[test]
+fn the_two_branches_recombine_glitch_free() {
+    let fires = Rc::new(RefCell::new(0usize));
+    let counter = fires.clone();
+
+    let g = GraphBuilder::new();
+    let (a, b) = g
+        .ticker(STEP)
+        .count()
+        .map(|n: &u64| (Some(*n), Some(n * 2)))
+        .split_some();
+
+    let combined = a
+        .join(&b, move |x: &u64, y: &u64| {
+            *counter.borrow_mut() += 1;
+            x + y
+        })
+        .with_time()
+        .accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).expect("run completes");
+
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 3),
+            (NanoTime::new(100), 6),
+            (NanoTime::new(200), 9),
+            (NanoTime::new(300), 12),
+        ],
+        r.value(&combined)
+    );
+    assert_eq!(
+        4,
+        *fires.borrow(),
+        "the recombine fired more than once per cycle — a glitch"
+    );
+}
+
+/// The plain `split()` is unchanged: both branches tick together, on every
+/// source tick. Keeping the contrast pinned is what stops the two being
+/// confused for one another.
+#[test]
+fn plain_split_still_ticks_both_branches_together() {
+    let g = GraphBuilder::new();
+    let (a, b) = g.ticker(STEP).count().map(|n: &u64| (*n, n * 2)).split();
+
+    let a = a.accumulate();
+    let b = b.accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(3)).expect("run completes");
+
+    assert_eq!(vec![1, 2, 3], r.value(&a));
+    assert_eq!(vec![2, 4, 6], r.value(&b));
+}


### PR DESCRIPTION
## What this changes

`Stream<(Option<A>, Option<B>)>::split_some()` fans one node's value out into two streams, each ticking **only** on the cycles where its own side is `Some`.

Also rewires the `order_book` example to emit fills *and* top-of-book, which is what its README said it could not do.

## Why

An `Op` has a single `Out` by construction — that is what lets the engine own every value slot, and what makes the compiled tiers possible. The consequence for wiring is that a node with two things to say at different rates had nowhere to say them.

`split()` exists, but it is two `map`s over a pair, so both branches tick together. Modelling "no fill this tick" through it means emitting a `Default` fill and filtering it downstream — which puts a sentinel in the type and a filter in every consumer.

`split_some` keeps the node single-output and does the fan-out at wiring time, so:

- the shared work (the book update) happens **once**, however many branches read it;
- each branch ticks at its own rate;
- downstream of the split each side is an ordinary stream and recombines glitch-free like any other.

### It closes a gap the example documented against itself

`examples/core/order_book/README.md` said:

> **`split()` / multi-output nodes** — the legacy example emits *both* fills and prices from one node. The wingfoil engine's ops are single-output, so this port emits a single top-of-book stream.

The example now emits both, at their natural rates:

```text
price   bid  99   ask 103   spread 4
fill    buy    7 @ 103
price   bid  99   ask   -   spread -
price   bid  99   ask 104   spread 5
price   bid  99   ask 101   spread 2
price   bid 100   ask 101   spread 1
fill    buy    1 @ 101
price   bid 100   ask 102   spread 2
fill    sell  15 @ 100
```

The README now describes the idiom rather than the absence, and that sample output is a real capture of the rewired example (per house rules — I ran it and pasted what it printed).

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
- [x] New behaviour is covered by a test asserting **values and tick times**
- [x] `scripts/check-example-docs.sh` — 46 targets, all documented and indexed

New `tests/split_some.rs`, five tests:

- `each_branch_ticks_only_when_its_own_side_is_some` — asserts tick **times**, so a branch that fired on the wrong cycle would be caught even if its values looked right.
- `a_branch_that_never_fires_stays_completely_quiet` — no `Default` values leak out, which is what distinguishes this from `split()` over an `Option` pair.
- `the_shared_upstream_is_evaluated_once_per_tick` — counts closure invocations; this is the property that makes the idiom cheaper than computing the book twice.
- `the_two_branches_recombine_glitch_free` — the recombine fires once per cycle, not once per branch.
- `plain_split_still_ticks_both_branches_together` — keeps the contrast pinned so the two are not confused for one another.

## Notes for the reviewer

- **This is sugar, not an engine change.** `split_some` is two `map_filter`s over the same upstream handle; nothing in `interp.rs` or the `Op` contract moves. That is deliberate — the single-`Out` contract is load-bearing and I did not want to touch it to solve a wiring-ergonomics problem.
- **Naming.** `split_some` reads as "split the `Some`s apart", pairing with the existing `split`. `unzip_filter` and `split_optional` were the alternatives; happy to change it.
- **Two outputs only.** Three-plus wants either a nested pair or a variadic form; I left that until something asks for it rather than guessing at the shape.
- `split()` is untouched, and its docs now point at `split_some` for the different-rates case.
- The example's `Book::apply` now returns `Option<Fill>` instead of `()`, and the fold state becomes `(Book, Option<Fill>)` — the fill is what *this* message produced, the book carries across ticks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpxC33xz95kWNJE8Q7TfFg)_