### PR TITLE
feat(fluent): shared/unshared — collapse the per-hop payload clone

### DIFF
--- a/crates/wingfoil/benches/README.md
+++ b/crates/wingfoil/benches/README.md
@@ -369,6 +369,45 @@ The `Vec` − `Rc<Vec>` gap is what slot-aliasing could recover: **4.3×**, or
 17.2 ms of the 22.3 ms run. That is the ceiling on the zero-copy passthrough
 work, and it is large. [Violin plot](images/ops/store_forward_clone.svg).
 
+### What the third row means for the arena decision
+
+The `f64` floor is the row that answers the go/no-go, and it is easy to read
+past. A paired re-run on a 4-core VM (all three bars back to back, so the
+ratios hold even though the absolute times differ from the capture above):
+
+| Payload | Time | Per hop |
+|---|---|---|
+| `Vec<u64>` (8 KiB deep copy per hop) | 18.24 ms | ~228 ns |
+| `Rc<Vec<u64>>` (refcount bump per hop) | 3.80 ms | ~48 ns |
+| `f64` (scalar floor) | 2.36 ms | ~30 ns |
+
+**79% of the owned-`Vec` run is payload copying.** But the floor is where an
+arena would land at best — it is the same graph with nothing to copy — and
+`Rc` gets to within 1.6× of it. In distance terms:
+
+```
+owned Vec ──────────────── 18.24 ms
+                             │
+                   Rc closes │ 14.44 ms  (91% of the available distance)
+                             ▼
+Rc<Vec>          3.80 ms ────┤
+      arena could close      │  1.44 ms  (9%)
+scalar floor     2.36 ms ────┘
+```
+
+So the ordering that matters is: **the `Rc` payload idiom, available today from
+the wiring with no engine change, recovers ~91% of what an arena/slot-aliasing
+value store could ever deliver on this shape.** The remaining ~9% is the `Rc`
+clone/drop and the wider slot.
+
+That does not close the arena question — SoA cache locality is a separate axis
+this bench does not isolate, and a graph forwarding *many* small owned payloads
+sits somewhere else on the curve. It does mean the arena is not the thing
+standing between a heap-payload graph and its performance, and that the
+cheapest correct advice for such a graph is
+[`Stream::shared`](https://docs.rs/wingfoil/latest/wingfoil/fluent/struct.Stream.html),
+not "wait for the arena".
+
 ## Topological sort vs per-path propagation
 
 [`topological_vs_per_path/`](topological_vs_per_path/) — the branch/recombine

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -1325,6 +1325,81 @@ impl<T: Clone + Default + 'static> Stream<Burst<T>> {
     }
 }
 
+impl<T: Clone + Default + 'static> Stream<T> {
+    /// Wrap the values in an [`Rc`] so the pass-through hops downstream cost a
+    /// refcount bump instead of a deep copy.
+    ///
+    /// **Why this exists.** Every op that republishes its input clones it:
+    /// `filter`, `sample`, `distinct`, `delay`, `merge`, `throttle` all end in
+    /// `input.clone()`, because [`Op::Out`](crate::op::Op) is an owned value and
+    /// the engine owns the slot it lands in. For a scalar that is a register
+    /// copy and invisible. For a payload that owns heap — a decoded book
+    /// update, a `Vec` of levels, a `String` symbol — it is a full `memcpy` per
+    /// hop, per tick.
+    ///
+    /// Measured on the `store_baseline` bench (an 8 KiB `Vec<u64>` forwarded
+    /// through 16 `filter` hops, 5,000 cycles, shared 4-core VM):
+    ///
+    /// | payload | time | per hop |
+    /// |---|---|---|
+    /// | owned `Vec<u64>` | 18.24 ms | ~228 ns |
+    /// | `Rc<Vec<u64>>` | 3.80 ms | ~48 ns |
+    /// | `f64` (the floor — nothing to copy) | 2.36 ms | ~30 ns |
+    ///
+    /// So on that shape **79% of the runtime is payload copying**, `Rc` removes
+    /// 4.8× of it, and what is left sits within 1.6× of a graph forwarding a
+    /// scalar. An arena / slot-aliasing value store — the deferred engine-level
+    /// fix — could recover the remaining gap to that floor; this recovers
+    /// **91%** of the same distance today, from the wiring, with no engine
+    /// change and no new invariants.
+    ///
+    /// ```
+    /// # use std::rc::Rc;
+    /// # use std::time::Duration;
+    /// # use wingfoil::prelude::*;
+    /// # use wingfoil::{NanoTime, RunFor, RunMode};
+    /// # let g = GraphBuilder::new();
+    /// # let hot = g.ticker(Duration::from_nanos(100)).count().map(|n: &u64| n.is_multiple_of(2));
+    /// let book = g
+    ///     .ticker(Duration::from_nanos(100))
+    ///     .count()
+    ///     .map(|n: &u64| vec![*n; 1024])
+    ///     .shared();          // one clone here…
+    ///
+    /// // …and every hop after it is a refcount bump.
+    /// let quoted = book.filter(&hot).delay(Duration::from_nanos(100));
+    /// # let out = quoted.map(|v: &Rc<Vec<u64>>| v.len()).accumulate();
+    /// # let mut r = g.build();
+    /// # r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(4))?;
+    /// # let _ = r.value(&out);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    ///
+    /// `Rc<T>` derefs to `T`, so downstream closures mostly read unchanged;
+    /// [`unshared`](Stream::unshared) clones back out where a consumer needs an
+    /// owned value.
+    ///
+    /// `Rc` rather than `Arc` because a graph runs on one thread. Values
+    /// crossing the channel layer to another thread must be `Send`, so unshare
+    /// before sending.
+    pub fn shared(&self) -> Stream<Rc<T>> {
+        self.map(|v: &T| Rc::new(v.clone()))
+    }
+}
+
+impl<T: Clone + Default + 'static> Stream<Rc<T>> {
+    /// Clone the value back out of its [`Rc`] — the inverse of
+    /// [`shared`](Stream::shared).
+    ///
+    /// Needed where a consumer wants an owned `T`: a sink sending across the
+    /// channel layer (`Rc` is not `Send`), or an op whose closure takes `T` by
+    /// value. Costs exactly the one deep copy that `shared` was avoiding on
+    /// every hop in between.
+    pub fn unshared(&self) -> Stream<T> {
+        self.map(|v: &Rc<T>| (**v).clone())
+    }
+}
+
 impl<A, B> Stream<(A, B)>
 where
     A: Clone + Default + 'static,

--- a/crates/wingfoil/tests/shared_payload.rs
+++ b/crates/wingfoil/tests/shared_payload.rs
@@ -1,0 +1,198 @@
+//! `Stream::shared` / `unshared` — the `Rc` payload idiom.
+//!
+//! Pass-through ops republish their input by clone (`Op::Out` is an owned value
+//! and the engine owns the slot it lands in), so a heap-carrying payload pays a
+//! full copy per hop per tick. `shared()` makes each hop a refcount bump
+//! instead. These tests pin that the wrapping is *transparent* — same values,
+//! same tick times as the unwrapped graph — and that the copy really is being
+//! avoided rather than merely moved.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const STEP: Duration = Duration::from_nanos(100);
+
+/// A payload that counts its own clones, so "did the hop copy?" is observable
+/// rather than inferred from a timing.
+#[derive(Default, Debug)]
+struct Counted {
+    id: u64,
+    clones: Rc<RefCell<usize>>,
+}
+
+impl Clone for Counted {
+    fn clone(&self) -> Self {
+        *self.clones.borrow_mut() += 1;
+        Self {
+            id: self.id,
+            clones: self.clones.clone(),
+        }
+    }
+}
+
+/// The headline: a chain of pass-through hops over a `shared()` payload deep-
+/// copies the value **once**, not once per hop.
+#[test]
+fn sharing_collapses_the_per_hop_clone_to_one() {
+    fn deep_clones(share: bool) -> usize {
+        let clones = Rc::new(RefCell::new(0usize));
+        let counter = clones.clone();
+
+        let g = GraphBuilder::new();
+        let keep = g.ticker(STEP).count().map(|_: &u64| true);
+        let src = g.ticker(STEP).count().map(move |n: &u64| Counted {
+            id: *n,
+            clones: counter.clone(),
+        });
+
+        // Six forwarding hops, the shape a real graph reaches quickly.
+        let last_id = if share {
+            let mut cur = src.shared();
+            for _ in 0..6 {
+                cur = cur.filter(&keep);
+            }
+            cur.map(|c: &Rc<Counted>| c.id).accumulate()
+        } else {
+            let mut cur = src;
+            for _ in 0..6 {
+                cur = cur.filter(&keep);
+            }
+            cur.map(|c: &Counted| c.id).accumulate()
+        };
+
+        let mut r = g.build();
+        r.run(HISTORICAL, RunFor::Cycles(1)).expect("run completes");
+        // Both shapes must agree on what came out.
+        assert_eq!(vec![1u64], r.value(&last_id));
+        *clones.borrow()
+    }
+
+    let owned = deep_clones(false);
+    let shared = deep_clones(true);
+
+    assert!(
+        owned >= 6,
+        "expected at least one deep clone per hop, got {owned}"
+    );
+    assert_eq!(
+        1, shared,
+        "sharing should deep-copy once at the boundary and never again \
+         (got {shared} against {owned} unshared)"
+    );
+}
+
+/// Wrapping is transparent: identical values at identical tick times.
+#[test]
+fn a_shared_graph_produces_the_same_values_and_tick_times() {
+    fn run(share: bool) -> Vec<(NanoTime, usize)> {
+        let g = GraphBuilder::new();
+        let even = g.ticker(STEP).count().map(|n: &u64| n.is_multiple_of(2));
+        let src = g.ticker(STEP).count().map(|n: &u64| vec![*n; 4]);
+
+        let out = if share {
+            src.shared()
+                .filter(&even)
+                .delay(STEP)
+                .map(|v: &Rc<Vec<u64>>| v.len() + v[0] as usize)
+                .with_time()
+                .accumulate()
+        } else {
+            src.filter(&even)
+                .delay(STEP)
+                .map(|v: &Vec<u64>| v.len() + v[0] as usize)
+                .with_time()
+                .accumulate()
+        };
+
+        let mut r = g.build();
+        r.run(HISTORICAL, RunFor::Cycles(8)).expect("run completes");
+        r.value(&out)
+    }
+
+    let owned = run(false);
+    let shared = run(true);
+    assert!(!owned.is_empty(), "the fixture produced nothing to compare");
+    assert_eq!(
+        owned, shared,
+        "sharing changed the values or their tick times"
+    );
+}
+
+/// `unshared` is the inverse and costs exactly one copy.
+#[test]
+fn unshared_recovers_the_owned_value() {
+    let clones = Rc::new(RefCell::new(0usize));
+    let counter = clones.clone();
+
+    let g = GraphBuilder::new();
+    let keep = g.ticker(STEP).count().map(|_: &u64| true);
+    let out = g
+        .ticker(STEP)
+        .count()
+        .map(move |n: &u64| Counted {
+            id: *n,
+            clones: counter.clone(),
+        })
+        .shared()
+        .filter(&keep)
+        .filter(&keep)
+        .unshared()
+        .map(|c: &Counted| c.id)
+        .accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(1)).expect("run completes");
+
+    assert_eq!(vec![1u64], r.value(&out));
+    // One at `shared`, one at `unshared`; the two `filter` hops in between are
+    // refcount bumps. (The trailing `map` reads by reference.)
+    assert_eq!(2, *clones.borrow());
+}
+
+/// A shared value fans out to several branches, each of which is still just a
+/// refcount bump — the case that motivates it most, since fan-out is where a
+/// clone-per-hop cost multiplies.
+#[test]
+fn fan_out_over_a_shared_payload_stays_copy_free() {
+    let clones = Rc::new(RefCell::new(0usize));
+    let counter = clones.clone();
+
+    let g = GraphBuilder::new();
+    let keep = g.ticker(STEP).count().map(|_: &u64| true);
+    let shared = g
+        .ticker(STEP)
+        .count()
+        .map(move |n: &u64| Counted {
+            id: *n,
+            clones: counter.clone(),
+        })
+        .shared();
+
+    let a = shared
+        .filter(&keep)
+        .map(|c: &Rc<Counted>| c.id)
+        .accumulate();
+    let b = shared
+        .filter(&keep)
+        .map(|c: &Rc<Counted>| c.id)
+        .accumulate();
+    let c = shared
+        .filter(&keep)
+        .map(|c: &Rc<Counted>| c.id)
+        .accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(2)).expect("run completes");
+
+    assert_eq!(vec![1u64, 2], r.value(&a));
+    assert_eq!(vec![1u64, 2], r.value(&b));
+    assert_eq!(vec![1u64, 2], r.value(&c));
+    // Two ticks, one deep copy each at the `shared` boundary — the three
+    // branches added none.
+    assert_eq!(2, *clones.borrow());
+}


### PR DESCRIPTION
## What this changes

`Stream::shared()` wraps values in an `Rc` so pass-through hops downstream cost a refcount bump instead of a deep copy; `Stream<Rc<T>>::unshared()` clones back out where a consumer needs an owned value.

Also records what the `store_baseline` numbers actually say about the deferred arena decision.

## Why

Every op that republishes its input clones it — `filter`, `sample`, `distinct`, `delay`, `merge`, `throttle` all end in `input.clone()`, because `Op::Out` is an owned value and the engine owns the slot it lands in. For a scalar that is a register copy and invisible. For a payload that owns heap — a decoded book update, a `Vec` of levels, a `String` symbol — it is a full `memcpy` per hop per tick, and a real graph reaches six forwarding hops without trying.

## The measurement, and what it says about the arena

Paired `store_baseline` re-run (8 KiB `Vec<u64>` through 16 `filter` hops, 5,000 cycles, shared 4-core VM — all three bars back to back, so the ratios hold even though absolute times differ from the capture already in the README):

| Payload | Time | Per hop |
|---|---|---|
| owned `Vec<u64>` | 18.24 ms | ~228 ns |
| `Rc<Vec<u64>>` | 3.80 ms | ~48 ns |
| `f64` (scalar floor) | 2.36 ms | ~30 ns |

**79% of the owned-`Vec` run is payload copying.** The README already noted that as a 4.3× ceiling. What it did not draw out is the third row: the `f64` bar is *the same graph with nothing to copy*, so it is where an arena / slot-aliasing store would land **at best** — and `Rc` gets within 1.6× of it.

```
owned Vec ──────────────── 18.24 ms
                             │
                   Rc closes │ 14.44 ms  (91% of the available distance)
                             ▼
Rc<Vec>          3.80 ms ────┤
      arena could close      │  1.44 ms  (9%)
scalar floor     2.36 ms ────┘
```

So: **the `Rc` payload idiom recovers ~91% of what slot aliasing could ever deliver on this shape** — today, from the wiring, with no engine change and no new invariants.

That does not close the arena question, and I have not written it as though it does: SoA cache locality is a separate axis this bench does not isolate, and a graph forwarding many *small* owned payloads sits elsewhere on the curve. It does mean the arena is not the thing standing between a heap-payload graph and its performance, and that the cheapest correct advice for such a graph is `shared()` rather than "wait for the arena".

`benches/README.md` gains that reading beside the existing capture (which is left as-is, matching how the other superseded readings there are handled).

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
- [x] New behaviour is covered by a test asserting **values and tick times**

New `tests/shared_payload.rs`, four tests. They use a payload that **counts its own clones**, so "did the hop copy?" is observable rather than inferred from a timing — which is what makes them a real regression guard rather than a benchmark that happens to be in the test suite:

- `sharing_collapses_the_per_hop_clone_to_one` — six forwarding hops: 1 deep copy shared, ≥6 unshared.
- `a_shared_graph_produces_the_same_values_and_tick_times` — the same graph either way through `filter` + `delay`, asserted equal including tick times. Transparency is the property that makes this safe to reach for.
- `unshared_recovers_the_owned_value` — exactly two copies (in and out), the hops in between free.
- `fan_out_over_a_shared_payload_stays_copy_free` — three branches add none, which is where clone-per-hop cost multiplies fastest.

## Notes for the reviewer

- **This is deliberately not the arena.** The port plan defers slot aliasing pending numbers; the numbers are now here and they argue for landing the wiring-level lever first. I did not touch the value store.
- **`Rc`, not `Arc`** — a graph runs on one thread. Values crossing the channel layer must be `Send`, so `unshared()` before sending. That is on the docs.
- **Aliasing the slot outright would not be sound for `filter`** and it is worth writing down why, since it is the obvious "why not just share the `Rc` the engine already holds": a filter's slot must retain the last *accepted* value for passive readers, so aliasing it to the upstream slot would expose values the filter rejected. That is a semantic change, not an optimisation — which is part of why the arena is a bigger piece of work than it looks.
- The two `impl` blocks are inherent on `Stream`, alongside the existing `Stream<()>` and `Stream<(A, B)>` blocks, rather than on `StreamOps` — they are type-directed (`T` → `Rc<T>` and back) rather than general combinators.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpxC33xz95kWNJE8Q7TfFg)_