### PR TITLE
Keep filter quiet until the source's first tick

### DIFF
--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -842,7 +842,9 @@ pub trait StreamOps<T>: Sized {
         D: Clone + Default + 'static,
         F: Fn(&T, &B, &C) -> Result<D> + 'static;
 
-    /// Emit only when `condition`'s current value is true.
+    /// Emit when either this stream or `condition` ticks while the condition's
+    /// current value is true. Condition ticks resample the held source after the
+    /// first source tick; before that, the filter stays quiet.
     ///
     /// Gates on a *stream*. When the test is a pure function of this stream's
     /// own value, [`filter_value`](StreamOps::filter_value) says it in one
@@ -852,7 +854,9 @@ pub trait StreamOps<T>: Sized {
         T: Clone + Default + 'static;
 
     /// Emit only the values `predicate` accepts — the predicate twin of
-    /// [`filter`](StreamOps::filter):
+    /// [`filter`](StreamOps::filter).
+    /// The predicate runs only when this stream ticks, so it never resamples a
+    /// held value.
     ///
     /// ```text
     /// price.filter_value(|p| *p > 100.0)

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -2666,24 +2666,30 @@ impl Op for TimeWindowedMedianTimeWeighted {
 }
 
 /// Emits its source value when the condition stream's current value is true.
+/// Condition ticks resample the held source value after the source has ticked
+/// at least once. Before the first source tick, the filter stays quiet.
 pub struct Filter<T>(PhantomData<T>);
 
 #[op(build = filter, fluent)]
 impl<T: Clone + 'static> Op for Filter<T> {
     type Cfg = ();
-    type State = ();
-    type In<'a> = (&'a T, &'a bool);
+    type State = bool;
+    type In<'a> = ((&'a T, bool), (&'a bool, bool));
     type Out = T;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
         _cfg: &mut (),
-        _state: &mut (),
-        input: (&T, &bool),
+        source_seen: &mut bool,
+        input: ((&T, bool), (&bool, bool)),
         _ctx: &mut Ctx<'_>,
     ) -> Result<Tick<T>> {
-        if *input.1 {
-            Ok(Tick::Value(input.0.clone()))
+        let ((source, source_ticked), (condition, _)) = input;
+        if source_ticked {
+            *source_seen = true;
+        }
+        if *source_seen && *condition {
+            Ok(Tick::Value(source.clone()))
         } else {
             Ok(Tick::Quiet)
         }

--- a/crates/wingfoil/tests/catalog_filter_value_scan.rs
+++ b/crates/wingfoil/tests/catalog_filter_value_scan.rs
@@ -97,6 +97,30 @@ fn filter_value_matches_map_plus_filter() {
     assert_eq!(r.value(&via_stream), r.value(&via_predicate));
 }
 
+#[test]
+fn filter_stays_quiet_until_source_ticks_then_samples_on_condition_ticks() {
+    let g = GraphBuilder::new();
+    let source = g
+        .ticker(Duration::from_nanos(100))
+        .count()
+        .map_filter(|i| (*i, *i >= 2));
+    let condition = g.ticker(Duration::from_nanos(30)).map(|_| true);
+    let values = source.filter(&condition).with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(10)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(100), 2),
+            (NanoTime::new(120), 2),
+            (NanoTime::new(150), 2),
+            (NanoTime::new(180), 2),
+            (NanoTime::new(200), 3),
+            (NanoTime::new(210), 3),
+        ],
+        r.value(&values)
+    );
+}
+
 /// Shape gate, not just results: `filter_value` must cost **one** node. Legacy
 /// desugars it into two (a `map` for the condition plus `FilterStream`), and
 /// the results-parity test above passes either way — so assert the node count,

--- a/crates/wingfoil/tests/compiled_parity.rs
+++ b/crates/wingfoil/tests/compiled_parity.rs
@@ -54,6 +54,8 @@ fn compiled_odds_evens(run_for: RunFor) -> anyhow::Result<Vec<String>> {
     let mut even_str_f = |i: &u64| format!("{i} is even");
     let mut acc_f = |acc: &mut Vec<String>, v: &String| acc.push(v.clone());
     let mut acc_state: Vec<String> = Vec::new();
+    let mut odds_source_seen = false;
+    let mut evens_source_seen = false;
 
     // value slots
     let mut v_count = 0u64;
@@ -128,7 +130,12 @@ fn compiled_odds_evens(run_for: RunFor) -> anyhow::Result<Vec<String>> {
         // [4] odds = filter(count, is_odd)
         let t_odds = (t_count || t_is_odd) && {
             let mut ctx = Ctx::new(&mut k, 4);
-            match <Filter<u64>>::cycle(&mut (), &mut (), (&v_count, &v_is_odd), &mut ctx)? {
+            match <Filter<u64>>::cycle(
+                &mut (),
+                &mut odds_source_seen,
+                ((&v_count, t_count), (&v_is_odd, t_is_odd)),
+                &mut ctx,
+            )? {
                 Tick::Value(v) => {
                     v_odds = v;
                     true
@@ -158,7 +165,12 @@ fn compiled_odds_evens(run_for: RunFor) -> anyhow::Result<Vec<String>> {
         // [6] evens = filter(count, is_even)
         let t_evens = (t_count || t_is_even) && {
             let mut ctx = Ctx::new(&mut k, 6);
-            match <Filter<u64>>::cycle(&mut (), &mut (), (&v_count, &v_is_even), &mut ctx)? {
+            match <Filter<u64>>::cycle(
+                &mut (),
+                &mut evens_source_seen,
+                ((&v_count, t_count), (&v_is_even, t_is_even)),
+                &mut ctx,
+            )? {
                 Tick::Value(v) => {
                     v_evens = v;
                     true


### PR DESCRIPTION
## What this changes

Keeps `filter` quiet until its source has ticked once. Later condition ticks still resample the held source value.

## Why

Closes #440.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`
- [ ] `cargo lint-all` (the local Windows host lacks libclang)
- [ ] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features` (same local toolchain limitation)
- [x] New behaviour is covered by a test asserting **values and tick times**
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test --workspace`