### PR TITLE
Cut the boilerplate in adding an op: registration guards, and self-registering Python bindings

### DIFF
--- a/.claude/commands/bind-adapter.md
+++ b/.claude/commands/bind-adapter.md
@@ -148,20 +148,32 @@ the first adapter after postgres:
 pub mod common;
 ```
 
-`src/python.rs` — register the generated `#[pyfunction]`s in
-`register_adapters` under the **same** `#[cfg]`, importing them **by name**:
+`src/python.rs` — **nothing to do for the functions.** `#[pyadapter]` emits a
+link-time registration alongside each `#[pyfunction]` it generates (see
+`wingfoil_python::PyFnRegistrar`), and the `#[pymodule]` iterates those, so a
+binding reaches Python from its own definition site. A feature that is off
+contributes no registrar, which is why there is no longer a `#[cfg]` arm per
+adapter either.
+
+This used to be a hand-maintained list of ~40 `m.add_function(...)` calls, each
+needing its own `#[cfg]` block and a **by-name** `use` import (a
+module-qualified path does not resolve, because `wrap_pyfunction!` needs
+pyo3's hidden wrapper in scope). Nothing checked that list against the
+definitions, so a binding whose second mention was forgotten silently did not
+exist in Python.
+
+Two things still belong in `register_adapters`, both under the same `#[cfg]`:
+
+- a `#[pyclass]` the adapter exposes as a **handle** (`PyFixConnection`,
+  `PyWebServer`) — classes are not collected, only functions;
+- a hand-written `#[pyfunction]` that `#[pyadapter]` did not generate. Register
+  it at its definition site instead:
 
 ```rust
-#[cfg(feature = "$ARGUMENTS")]
-{
-    use crate::adapters::$ARGUMENTS::{$ARGUMENTS_read, $ARGUMENTS_write};
-    m.add_function(wrap_pyfunction!($ARGUMENTS_read, m)?)?;
-    m.add_function(wrap_pyfunction!($ARGUMENTS_write, m)?)?;
-}
+#[pyfunction]
+fn $ARGUMENTS_helper(...) -> PyResult<...> { ... }
+crate::register_pyfn!($ARGUMENTS_helper);
 ```
-
-`wrap_pyfunction!` needs pyo3's hidden wrapper in scope, so a module-qualified
-path (`crate::adapters::foo::bar`) does **not** resolve. Import by name.
 
 ## 4. Write the bindings — `src/adapters/$ARGUMENTS.rs`
 

--- a/.claude/commands/bind-adapter.md
+++ b/.claude/commands/bind-adapter.md
@@ -175,6 +175,13 @@ fn $ARGUMENTS_helper(...) -> PyResult<...> { ... }
 crate::register_pyfn!($ARGUMENTS_helper);
 ```
 
+Collection is checked against the real artefact, not just in tests: the
+`build-wheels` job in `pypi-publish.yml` installs each wheel it builds and
+asserts one binding per registration path is present. That is deliberately at
+wheel level — `cargo test` links the rlib, while the wheel ships a cdylib, and
+whether the linker keeps the registration section is a per-platform question
+only an import can answer.
+
 ## 4. Write the bindings — `src/adapters/$ARGUMENTS.rs`
 
 (Or `src/$ARGUMENTS.rs`, for a non-adapter engine module — see step 2.)

--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -502,8 +502,12 @@ Pick the lightest tool that fits:
 
 Then:
 
-1. **Register** the generated function in the `#[pymodule]` in
-   `src/python.rs`: `m.add_function(wrap_pyfunction!($ARGUMENTS, m)?)?;`.
+1. **Registration is automatic** — `#[pyop]` and `pyop_fn!` emit a link-time
+   registration with the function they generate, and the `#[pymodule]` iterates
+   those (see `wingfoil_python::PyFnRegistrar`), so there is nothing to add to
+   `src/python.rs`. A *hand-written* `#[pyfunction]` — the closure-`Cfg` case
+   below, or a post-run helper — registers itself at its definition site with
+   `crate::register_pyfn!($ARGUMENTS);`.
 2. **Edge conversions**: `PyElement <-> f64/i64/bool/String` already ship; a
    custom value type needs its own `From`/`TryInto` impls at the edge only.
 3. **Rust seam test** in `tests/plugin_seam.rs` — wire the op over

--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -328,12 +328,32 @@ hand-written until 2026-08, and it silently fell 15 methods behind the catalog
 each op author had no reason to think of it. One line now, or the same drift
 again.
 
-The macro is skipped in exactly two cases, both mirroring step 4: a **source**
+The macro is skipped in exactly three cases. Two mirror step 4: a **source**
 (it enters the facade as a free function that *makes* the graph — hand-write it
 next to `ticker`/`constant`), and an op whose `Signal` signature is not a plain
 forward (`logged`'s `&str` label vs its `(String, Level)` `Cfg`). Put those in
 one of the bound-grouped blocks lower in the file with a comment saying which
 case applies.
+
+The third is **the whole statistics surface, and it is structural**: `Signal`'s
+generated combinators are *inherent* methods, always in scope on the type,
+while `StatisticsOps` is deliberately kept out of the prelude so callers opt in
+with `use wingfoil::stats::StatisticsOps;`. There is no opt-in inherent method,
+so invoking `__wf_signal_<stat>!` would put all 35 statistics combinators
+permanently on `Signal<f64>` and quietly overturn that convention. **If you are
+adding a statistics op, skip 4b** — it reaches `Signal` through
+`Signal::as_stream`. This held for the surface's entire life without being
+written down anywhere, so it read as drift every time anyone looked.
+
+**Generating the macro does not enforce the obligation — the invocation is
+still a line somebody writes.** `tests/op_registration_coverage.rs` is what
+holds the facade level with the catalog: it scans `ops.rs` for
+`#[op(build = …, fluent)]` and fails if an op reaches neither a fluent surface
+nor the `Signal` facade, with the statistics exemption *derived* (an op whose
+fluent surface lives in `stats.rs`) rather than kept as a name list that would
+rot. Nothing else catches this: absence generates no token for a compiler to
+trip over, which is why the same omission has landed three times, each at trait
+granularity.
 
 Note the generated body wires through `Stream::wire` and the op's `Builder`
 method — **not** through the fluent method. A hand-written trait declaration

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -90,6 +90,69 @@ jobs:
         # wheels building rather than enrich them.
         run: maturin build --verbose --release --strip -o wheelhouse
 
+      # Import the wheel that is about to be published and check its bindings
+      # are actually there. Nothing else in this job runs the artefact, so
+      # without this a broken wheel reaches PyPI and the first report is a
+      # user's AttributeError.
+      #
+      # The specific hazard is that every `#[pyfunction]` reaches the module
+      # through **link-time collection** (see `wingfoil_python::PyFnRegistrar`)
+      # rather than a list in the `#[pymodule]`. That removes the "forgot to
+      # register it" bug entirely, but it leans on the linker keeping a section
+      # that differs per platform — `.init_array` on Linux, `__mod_init_func`
+      # on macOS, `.CRT$XCU` on Windows — and these wheels are built
+      # `--release --strip` on all three. If collection ever silently stopped,
+      # the module would come up with **no functions at all**, and a unit test
+      # cannot see it: `cargo test` links the rlib, while the wheel ships a
+      # cdylib. Only an import of the built artefact answers the question, so
+      # it happens here, once per OS and Python version in the matrix.
+      - name: Smoke-test the built wheel
+        working-directory: crates/wingfoil-python
+        # bash on all three runners (Windows defaults to PowerShell otherwise),
+        # so one script covers the matrix.
+        shell: bash
+        # `--no-index` keeps it to the wheel just built — the package has no
+        # runtime dependencies, so nothing legitimately needs fetching, and a
+        # resolver that reached PyPI could silently test a *published* wheel
+        # instead of this one.
+        run: |
+          python -m pip install --no-index --find-links wheelhouse wingfoil-python
+          python - <<'PY'
+          import wingfoil
+
+          # One representative binding per registration path, so a regression
+          # names the mechanism that broke rather than just a count:
+          #   square         -> #[pyop]
+          #   scale          -> pyop_fn!
+          #   compiled_island-> #[pygraph]
+          #   csv_read       -> #[pyadapter]   (csv is in every wheel's feature set)
+          #   stamp          -> register_pyfn! (hand-written #[pyfunction])
+          paths = {
+              "#[pyop]": "square",
+              "pyop_fn!": "scale",
+              "#[pygraph]": "compiled_island",
+              "#[pyadapter]": "csv_read",
+              "register_pyfn!": "stamp",
+          }
+          missing = {k: v for k, v in paths.items() if not hasattr(wingfoil, v)}
+          if missing:
+              raise SystemExit(
+                  "wheel is missing bindings from these registration paths: "
+                  + ", ".join(f"{k} (expected `{v}`)" for k, v in sorted(missing.items()))
+                  + "\nLink-time collection did not survive into this wheel."
+              )
+
+          # A floor as well as the samples: the paths above could all be present
+          # while collection dropped most of the catalog.
+          fns = [n for n in dir(wingfoil) if not n.startswith("_") and callable(getattr(wingfoil, n))]
+          if len(fns) < 20:
+              raise SystemExit(
+                  f"wheel exposes only {len(fns)} callables ({sorted(fns)}); "
+                  "expected at least 20. Collection is broken, not the catalog."
+              )
+          print(f"OK: {len(fns)} callables, all five registration paths present")
+          PY
+
       - name: Upload wheels as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3321,6 +3321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7675,6 +7684,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "csv",
+ "inventory",
  "log",
  "pyo3",
  "serde_json",

--- a/crates/wingfoil-python-derive/src/lib.rs
+++ b/crates/wingfoil-python-derive/src/lib.rs
@@ -9,8 +9,10 @@
 //!
 //! A user op becomes a **free function** `module.name(stream[, cfg])`, not a
 //! `Stream` method — pyo3 forbids `#[pymethods]` on a foreign pyclass (the
-//! polars-plugin shape). The generated function is named after `name`; register
-//! it with `wrap_pyfunction!` in your `#[pymodule]`.
+//! polars-plugin shape). The generated function is named after `name` and
+//! **registers itself**: the expansion carries a link-time submission (see
+//! `wingfoil_python::PyFnRegistrar`) that a `#[pymodule]` picks up by
+//! iterating, so there is no `wrap_pyfunction!` line to remember.
 //!
 //! ```ignore
 //! use wingfoil_python::{pyop, Op, Tick, Activation, Ctx};
@@ -26,7 +28,7 @@
 //!     fn cycle(_c: &mut (), _s: &mut (), input: (&f64,), _ctx: &mut Ctx)
 //!         -> anyhow::Result<Tick<f64>> { Ok(Tick::Value(input.0 * input.0)) }
 //! }
-//! // => wingfoil.square(stream)   (register: wrap_pyfunction!(square, m)?)
+//! // => wingfoil.square(stream)   (registered automatically)
 //! ```
 //!
 //! **Scope:** one- to four-input concrete (non-generic) ops:
@@ -380,6 +382,7 @@ fn expand_pygraph(args: &PyGraphArgs, func: &ItemFn) -> syn::Result<TokenStream2
     };
 
     let docs = doc_attrs(&func.attrs);
+    let register = self_register(py_name);
     Ok(quote! {
         #[pyo3::pyfunction]
         #[allow(clippy::too_many_arguments)]
@@ -393,6 +396,7 @@ fn expand_pygraph(args: &PyGraphArgs, func: &ItemFn) -> syn::Result<TokenStream2
             #bind_outs
             #ret_expr
         }
+        #register
     })
 }
 
@@ -508,6 +512,33 @@ pub fn pyadapter(attr: TokenStream, item: TokenStream) -> TokenStream {
         )
         .to_compile_error()
         .into(),
+    }
+}
+
+/// Emit the link-time registration for a generated `#[pyfunction]`, so the
+/// binding reaches the module from its own definition site.
+///
+/// Without this every generated binding had to be named a second time, by hand,
+/// in the `#[pymodule]` — and nothing checked the two halves against each
+/// other, so a forgotten second mention meant the binding silently did not
+/// exist in Python. See [`wingfoil_python::PyFnRegistrar`] for why collection
+/// being per-shared-object is what makes this safe to emit unconditionally,
+/// including from third-party crates: their submissions land in their own
+/// cdylib, and their `#[pymodule]` chooses whether to iterate at all.
+fn self_register(py_name: &Ident) -> TokenStream2 {
+    // `add_function` is trait-qualified rather than called as a method: the
+    // expansion lands wherever the binding is defined, and that module need not
+    // have `PyModuleMethods` in scope (`island.rs` does not).
+    quote! {
+        ::wingfoil_python::inventory::submit! {
+            ::wingfoil_python::PyFnRegistrar(|m| {
+                ::pyo3::types::PyModuleMethods::add_function(
+                    m,
+                    ::pyo3::wrap_pyfunction!(#py_name, m)?,
+                )?;
+                Ok(())
+            })
+        }
     }
 }
 
@@ -809,6 +840,7 @@ fn emit_pyadapter(
         py_name.span(),
     );
     let py_attrs = forward_pyo3_attrs(raw_py_attrs, &receiver_name);
+    let register = self_register(py_name);
     // An adapter's knobs plus the generated receiver routinely exceed clippy's
     // argument threshold, and the author cannot annotate generated code.
     let preamble = quote! {
@@ -849,6 +881,7 @@ fn emit_pyadapter(
                 #bind
                 #body
             }
+            #register
         })
     } else {
         // Sink / transform: `(&Stream<T>, args…) -> Stream<U> | Stream<Burst<U>>`
@@ -886,6 +919,7 @@ fn emit_pyadapter(
                 #bind
                 #body
             }
+            #register
         })
     }
 }
@@ -1168,5 +1202,9 @@ fn expand(args: &PyOpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
             )
         }
     };
-    Ok(body)
+    let register = self_register(name);
+    Ok(quote! {
+        #body
+        #register
+    })
 }

--- a/crates/wingfoil-python/Cargo.toml
+++ b/crates/wingfoil-python/Cargo.toml
@@ -134,6 +134,11 @@ all-adapters = [
 # rlib links libpython normally; the eventual `#[pymodule]` glue crate turns
 # `extension-module` on. Pinned to match the legacy `wingfoil-python` bindings.
 pyo3 = "0.29"
+# Link-time collection of `#[pyfunction]` registrations, so a binding
+# registers itself where it is defined instead of in a hand-maintained list in
+# the `#[pymodule]`. Collection is per-shared-object, which is what makes this
+# safe for third-party crates: their submissions land in their own cdylib.
+inventory = "0.3"
 anyhow = { workspace = true }
 # The interpreted engine the object form wraps: GraphBuilder / Stream / Runner.
 wingfoil = { path = "../wingfoil", version = "9.0.0" }

--- a/crates/wingfoil-python/src/adapters/fix.rs
+++ b/crates/wingfoil-python/src/adapters/fix.rs
@@ -426,6 +426,7 @@ pub fn fix_connect_tls(
         connection,
     })
 }
+crate::register_pyfn!(fix_connect_tls);
 
 #[cfg(test)]
 mod tests {

--- a/crates/wingfoil-python/src/adapters/postgres.rs
+++ b/crates/wingfoil-python/src/adapters/postgres.rs
@@ -549,6 +549,7 @@ fn write(
 pub fn postgres_notify_trigger_sql(table: String, channel: String) -> String {
     pg_notify_trigger_sql(&table, &channel)
 }
+crate::register_pyfn!(postgres_notify_trigger_sql);
 
 #[cfg(test)]
 mod tests {

--- a/crates/wingfoil-python/src/latency.rs
+++ b/crates/wingfoil-python/src/latency.rs
@@ -537,6 +537,7 @@ fn wire_stamp(stream: &PyStream, stage: String, precise: bool) -> PyStream {
 pub fn stamp(stream: PyRef<'_, Stream>, stage: String) -> Stream {
     Stream::from(wire_stamp(stream.object(), stage, false))
 }
+crate::register_pyfn!(stamp);
 
 /// [`stamp`], wired only when `enabled`. When false the stream is returned
 /// unchanged — no node, no runtime cost — so one config flag can turn stamping
@@ -549,6 +550,7 @@ pub fn stamp_if(stream: PyRef<'_, Stream>, stage: String, enabled: bool) -> Stre
         Stream::from(stream.object().clone())
     }
 }
+crate::register_pyfn!(stamp_if);
 
 /// [`stamp`] reading a **fresh** clock sample per tick rather than the
 /// cycle-start snap, so stages stamping within one engine cycle get distinct
@@ -557,6 +559,7 @@ pub fn stamp_if(stream: PyRef<'_, Stream>, stage: String, enabled: bool) -> Stre
 pub fn stamp_precise(stream: PyRef<'_, Stream>, stage: String) -> Stream {
     Stream::from(wire_stamp(stream.object(), stage, true))
 }
+crate::register_pyfn!(stamp_precise);
 
 /// [`stamp_precise`], wired only when `enabled` — see [`stamp_if`].
 #[pyfunction]
@@ -567,6 +570,7 @@ pub fn stamp_precise_if(stream: PyRef<'_, Stream>, stage: String, enabled: bool)
         Stream::from(stream.object().clone())
     }
 }
+crate::register_pyfn!(stamp_precise_if);
 
 /// The report sink's config: where the samples land, and whether to print.
 struct ReportCfg {
@@ -632,6 +636,7 @@ pub fn latency_report(
     let (sink, stats) = wire_report(stream.object(), stages, print_on_teardown);
     Ok((Stream::from(sink), PyLatencyStats(stats)))
 }
+crate::register_pyfn!(latency_report);
 
 /// [`latency_report`], aggregating only when `enabled`.
 ///
@@ -661,6 +666,7 @@ pub fn latency_report_if(
     let stats = Rc::new(RefCell::new(DynLatencyStats::new(stages)));
     Ok((Stream::from(sink), PyLatencyStats(stats)))
 }
+crate::register_pyfn!(latency_report_if);
 
 #[cfg(test)]
 mod tests {

--- a/crates/wingfoil-python/src/lib.rs
+++ b/crates/wingfoil-python/src/lib.rs
@@ -55,3 +55,62 @@ pub use wingfoil_python_derive::pyadapter;
 // Re-exported so third-party op crates (and the `pyop!`/`#[pyop]` macros) can
 // name the op vocabulary without depending on `wingfoil` directly.
 pub use wingfoil::op::{Activation, Ctx, Op, Tick};
+
+// Named by `register_pyfn!` through `$crate::inventory`, so a caller does not
+// have to depend on `inventory` itself.
+#[doc(hidden)]
+pub use inventory;
+
+/// A deferred `#[pyfunction]` registration, collected at link time.
+///
+/// **Why this exists.** Every binding used to be named twice: once where it is
+/// defined, and once more in a hand-maintained list inside the `#[pymodule]` —
+/// 64 `m.add_function(wrap_pyfunction!(…))?` lines, plus the `#[cfg(feature)]`
+/// blocks and `use` imports that list needed to reach feature-gated adapters.
+/// Nothing checked the two halves against each other: a binding whose second
+/// mention was forgotten simply did not exist in Python, and compiled fine.
+///
+/// Now a binding registers itself where it is defined. `#[pyadapter]` and
+/// `#[pyop]` emit the submission with the function they generate, so those are
+/// zero-touch; a hand-written `#[pyfunction]` uses [`register_pyfn!`].
+///
+/// **Collection is per-shared-object**, which is what makes this safe for the
+/// third-party crates `#[pyadapter]` is meant to serve. Their submissions land
+/// in *their* cdylib's section, not this one's, and their `#[pymodule]` decides
+/// whether to iterate at all — so an out-of-tree adapter cannot inject itself
+/// into the `wingfoil` module, and this module's bindings do not leak into
+/// theirs.
+///
+/// Iteration order is unspecified. That is fine here and must stay fine:
+/// registering into a module dict is order-independent. Do not add a
+/// registrar whose effect depends on running before or after another.
+pub struct PyFnRegistrar(pub fn(&pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()>);
+inventory::collect!(PyFnRegistrar);
+
+/// Register a hand-written `#[pyfunction]` with the module, at its definition
+/// site rather than in the `#[pymodule]`.
+///
+/// ```ignore
+/// #[pyfunction]
+/// fn my_helper() -> i64 { 7 }
+/// register_pyfn!(my_helper);
+/// ```
+///
+/// `#[pyadapter]` and `#[pyop]` already emit this for the functions they
+/// generate — reach for it only when the `#[pyfunction]` is written by hand.
+#[macro_export]
+macro_rules! register_pyfn {
+    ($f:path) => {
+        // Trait-qualified so the caller's module does not need
+        // `PyModuleMethods` in scope.
+        $crate::inventory::submit! {
+            $crate::PyFnRegistrar(|m| {
+                ::pyo3::types::PyModuleMethods::add_function(
+                    m,
+                    ::pyo3::wrap_pyfunction!($f, m)?,
+                )?;
+                Ok(())
+            })
+        }
+    };
+}

--- a/crates/wingfoil-python/src/macros.rs
+++ b/crates/wingfoil-python/src/macros.rs
@@ -27,7 +27,8 @@
 //! ```
 //!
 //! The generated function still needs adding to the module
-//! (`m.add_function(wrap_pyfunction!(scale, m)?)?`).
+//! The generated function registers itself with the module (see
+//! [`crate::PyFnRegistrar`]), so there is nothing to add to the `#[pymodule]`.
 
 /// Generate a `#[pyfunction]` for a stateless single-input op. See the module
 /// docs for the two forms (with / without a config argument).
@@ -51,6 +52,7 @@ macro_rules! pyop_fn {
                 $body,
             ))
         }
+        $crate::register_pyfn!($name);
     };
     (
         $(#[$meta:meta])*
@@ -67,5 +69,6 @@ macro_rules! pyop_fn {
                 $body,
             ))
         }
+        $crate::register_pyfn!($name);
     };
 }

--- a/crates/wingfoil-python/src/python.rs
+++ b/crates/wingfoil-python/src/python.rs
@@ -771,6 +771,7 @@ fn build_dataframe(streams: &Bound<'_, pyo3::types::PyDict>) -> PyResult<Py<PyAn
     }
     crate::graph::build_dataframe(&columns).map_err(to_pyerr)
 }
+crate::register_pyfn!(build_dataframe);
 
 /// Parse a case-insensitive level name into a [`log::Level`] for
 /// [`Stream::logged`]. A ValueError names the accepted set on a bad input.
@@ -793,6 +794,15 @@ fn parse_log_level(level: &str) -> PyResult<log::Level> {
 /// the `wingfoil` package under `python/` re-exports it.
 #[pymodule]
 fn _wingfoil(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Every `#[pyfunction]` in the wheel, collected at link time from its own
+    // definition site (see `crate::PyFnRegistrar`). This replaces the list of
+    // 64 `add_function` calls that used to live here, along with the
+    // `#[cfg(feature)]` blocks and `use` imports it needed to reach the
+    // feature-gated adapters — a wheel built without an adapter simply
+    // contributes no registrar for it.
+    for r in inventory::iter::<crate::PyFnRegistrar> {
+        (r.0)(m)?;
+    }
     m.add_class::<Graph>()?;
     m.add_class::<Stream>()?;
     // The statistics argument objects: `Window` / `Weighting` / `EwmaSpan`
@@ -800,23 +810,6 @@ fn _wingfoil(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyWindow>()?;
     m.add_class::<PyWeighting>()?;
     m.add_class::<PyEwmaSpan>()?;
-    m.add_function(wrap_pyfunction!(scale, m)?)?;
-    m.add_function(wrap_pyfunction!(square, m)?)?;
-    m.add_function(wrap_pyfunction!(running_total, m)?)?;
-    m.add_function(wrap_pyfunction!(weighted_add, m)?)?;
-    m.add_function(wrap_pyfunction!(blend3, m)?)?;
-    m.add_function(wrap_pyfunction!(blend4, m)?)?;
-    m.add_function(wrap_pyfunction!(clamped_scale, m)?)?;
-    m.add_function(wrap_pyfunction!(doubled_running_total, m)?)?;
-    m.add_function(wrap_pyfunction!(spread_and_mid, m)?)?;
-    m.add_function(wrap_pyfunction!(crate::island::compiled_island, m)?)?;
-    m.add_function(wrap_pyfunction!(crate::island::interpreted_twin, m)?)?;
-    m.add_function(wrap_pyfunction!(ramp_source, m)?)?;
-    m.add_function(wrap_pyfunction!(list_sink, m)?)?;
-    m.add_function(wrap_pyfunction!(pair_source, m)?)?;
-    m.add_function(wrap_pyfunction!(burst_list_sink, m)?)?;
-    m.add_function(wrap_pyfunction!(split_source, m)?)?;
-    m.add_function(wrap_pyfunction!(build_dataframe, m)?)?;
     register_latency(m)?;
     register_adapters(m)?;
     Ok(())
@@ -825,151 +818,34 @@ fn _wingfoil(m: &Bound<'_, PyModule>) -> PyResult<()> {
 /// Register the latency surface (see [`crate::latency`]). Unconditional — the
 /// engine's `latency` module is not feature-gated, so every wheel has it.
 fn register_latency(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Imported by name for the same reason the adapter registrations are: the
-    // hidden wrapper `wrap_pyfunction!` resolves is defined beside each
-    // `#[pyfunction]`, so a module-qualified path does not resolve.
-    use crate::latency::{
-        PyLatency, PyLatencyStats, PyTracedBytes, latency_report, latency_report_if, stamp,
-        stamp_if, stamp_precise, stamp_precise_if,
-    };
+    // Classes only: the latency `#[pyfunction]`s register themselves beside
+    // their definitions in `crate::latency` (see `crate::PyFnRegistrar`).
+    use crate::latency::{PyLatency, PyLatencyStats, PyTracedBytes};
     m.add_class::<PyLatency>()?;
     m.add_class::<PyTracedBytes>()?;
     m.add_class::<PyLatencyStats>()?;
-    m.add_function(wrap_pyfunction!(stamp, m)?)?;
-    m.add_function(wrap_pyfunction!(stamp_if, m)?)?;
-    m.add_function(wrap_pyfunction!(stamp_precise, m)?)?;
-    m.add_function(wrap_pyfunction!(stamp_precise_if, m)?)?;
-    m.add_function(wrap_pyfunction!(latency_report, m)?)?;
-    m.add_function(wrap_pyfunction!(latency_report_if, m)?)?;
     Ok(())
 }
 
-/// Register the per-adapter bindings the wheel was built with. Each adapter is
-/// behind its own cargo feature (see `crate::adapters`), so a wheel built
+/// Register the per-adapter **classes** the wheel was built with. Each adapter
+/// is behind its own cargo feature (see `crate::adapters`), so a wheel built
 /// without it simply has no such attribute.
+///
+/// Only classes appear here. Every adapter `#[pyfunction]` now registers itself
+/// beside its own definition — `#[pyadapter]` emits the submission along with
+/// the function it generates (see [`crate::PyFnRegistrar`]) — so a feature that
+/// is off contributes no registrar and needs no `#[cfg]` arm here at all. This
+/// function used to carry one `#[cfg]` block and a name-by-name `use` for every
+/// one of ~40 adapter bindings, purely so `wrap_pyfunction!` could resolve the
+/// hidden wrapper pyo3 defines beside each `#[pyfunction]`.
 fn register_adapters(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    #[cfg(feature = "postgres")]
-    {
-        // Imported by name (rather than called through the module path) because
-        // `wrap_pyfunction!` resolves the hidden wrapper pyo3 defines alongside
-        // each `#[pyfunction]`, which needs the name in scope.
-        use crate::adapters::postgres::{
-            postgres_notify_trigger_sql, postgres_read, postgres_source, postgres_sub,
-            postgres_write,
-        };
-        m.add_function(wrap_pyfunction!(postgres_read, m)?)?;
-        m.add_function(wrap_pyfunction!(postgres_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(postgres_source, m)?)?;
-        m.add_function(wrap_pyfunction!(postgres_write, m)?)?;
-        m.add_function(wrap_pyfunction!(postgres_notify_trigger_sql, m)?)?;
-    }
-    #[cfg(feature = "kafka")]
-    {
-        use crate::adapters::kafka::{kafka_pub, kafka_sub};
-        m.add_function(wrap_pyfunction!(kafka_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(kafka_pub, m)?)?;
-    }
-    #[cfg(feature = "redis")]
-    {
-        use crate::adapters::redis::{redis_pub, redis_stream_read, redis_stream_write, redis_sub};
-        m.add_function(wrap_pyfunction!(redis_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(redis_pub, m)?)?;
-        m.add_function(wrap_pyfunction!(redis_stream_read, m)?)?;
-        m.add_function(wrap_pyfunction!(redis_stream_write, m)?)?;
-    }
-    #[cfg(feature = "etcd")]
-    {
-        use crate::adapters::etcd::{etcd_pub, etcd_sub};
-        m.add_function(wrap_pyfunction!(etcd_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(etcd_pub, m)?)?;
-    }
-    #[cfg(feature = "fluvio")]
-    {
-        use crate::adapters::fluvio::{fluvio_pub, fluvio_sub};
-        m.add_function(wrap_pyfunction!(fluvio_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(fluvio_pub, m)?)?;
-    }
-    #[cfg(feature = "csv")]
-    {
-        use crate::adapters::csv::{csv_read, csv_write};
-        m.add_function(wrap_pyfunction!(csv_read, m)?)?;
-        m.add_function(wrap_pyfunction!(csv_write, m)?)?;
-    }
-    #[cfg(feature = "augurs")]
-    {
-        use crate::adapters::augurs::{
-            augurs_changepoint, augurs_cluster, augurs_dtw, augurs_forecast, augurs_outlier,
-            augurs_seasons,
-        };
-        m.add_function(wrap_pyfunction!(augurs_forecast, m)?)?;
-        m.add_function(wrap_pyfunction!(augurs_changepoint, m)?)?;
-        m.add_function(wrap_pyfunction!(augurs_seasons, m)?)?;
-        m.add_function(wrap_pyfunction!(augurs_outlier, m)?)?;
-        m.add_function(wrap_pyfunction!(augurs_dtw, m)?)?;
-        m.add_function(wrap_pyfunction!(augurs_cluster, m)?)?;
-    }
-    #[cfg(feature = "kdb")]
-    {
-        use crate::adapters::kdb::{kdb_read, kdb_sub, kdb_write};
-        m.add_function(wrap_pyfunction!(kdb_read, m)?)?;
-        m.add_function(wrap_pyfunction!(kdb_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(kdb_write, m)?)?;
-    }
     #[cfg(feature = "fix")]
-    {
-        use crate::adapters::fix::{
-            PyFixConnection, fix_accept, fix_connect, fix_connect_tls, fix_send,
-        };
-        m.add_class::<PyFixConnection>()?;
-        m.add_function(wrap_pyfunction!(fix_connect, m)?)?;
-        m.add_function(wrap_pyfunction!(fix_accept, m)?)?;
-        m.add_function(wrap_pyfunction!(fix_send, m)?)?;
-        m.add_function(wrap_pyfunction!(fix_connect_tls, m)?)?;
-    }
+    m.add_class::<crate::adapters::fix::PyFixConnection>()?;
     #[cfg(feature = "prometheus")]
-    {
-        use crate::adapters::prometheus::PyPrometheusExporter;
-        m.add_class::<PyPrometheusExporter>()?;
-    }
+    m.add_class::<crate::adapters::prometheus::PyPrometheusExporter>()?;
     #[cfg(feature = "web")]
-    {
-        use crate::adapters::web::PyWebServer;
-        m.add_class::<PyWebServer>()?;
-    }
-    #[cfg(feature = "aeron")]
-    {
-        use crate::adapters::aeron::{
-            aeron_pub, aeron_pub_with_status, aeron_sub, aeron_sub_with_status,
-        };
-        m.add_function(wrap_pyfunction!(aeron_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(aeron_sub_with_status, m)?)?;
-        m.add_function(wrap_pyfunction!(aeron_pub, m)?)?;
-        m.add_function(wrap_pyfunction!(aeron_pub_with_status, m)?)?;
-    }
-    #[cfg(feature = "iceoryx2")]
-    {
-        use crate::adapters::iceoryx2::{iceoryx2_pub, iceoryx2_sub};
-        m.add_function(wrap_pyfunction!(iceoryx2_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(iceoryx2_pub, m)?)?;
-    }
-    #[cfg(feature = "otlp")]
-    {
-        use crate::adapters::otlp::otlp_push;
-        m.add_function(wrap_pyfunction!(otlp_push, m)?)?;
-    }
-    #[cfg(feature = "zmq")]
-    {
-        use crate::adapters::zmq::{zmq_pub, zmq_sub};
-        m.add_function(wrap_pyfunction!(zmq_sub, m)?)?;
-        m.add_function(wrap_pyfunction!(zmq_pub, m)?)?;
-        #[cfg(feature = "etcd")]
-        {
-            use crate::adapters::zmq::{zmq_pub_etcd, zmq_sub_etcd};
-            m.add_function(wrap_pyfunction!(zmq_sub_etcd, m)?)?;
-            m.add_function(wrap_pyfunction!(zmq_pub_etcd, m)?)?;
-        }
-    }
-    // `m` is unused when no adapter feature is on.
+    m.add_class::<crate::adapters::web::PyWebServer>()?;
+    // `m` is unused when none of those three features is on.
     let _ = m;
     Ok(())
 }

--- a/crates/wingfoil-python/tests/registration.rs
+++ b/crates/wingfoil-python/tests/registration.rs
@@ -1,0 +1,76 @@
+//! Guard for the link-time binding registration (see
+//! [`wingfoil_python::PyFnRegistrar`]).
+//!
+//! Bindings no longer appear in a hand-written list inside the `#[pymodule]` —
+//! `#[pyop]`, `#[pygraph]`, `#[pyadapter]` and `pyop_fn!` each emit a
+//! submission beside the function they generate, and the module iterates what
+//! was collected. That removes the "forgot the second mention" failure mode,
+//! but replaces it with a quieter one: if collection ever stopped working, the
+//! module would come up **empty of functions** and every `add_function` call
+//! that used to be here would be gone, with nothing to fail at compile time.
+//!
+//! The pytest suite would notice (it calls the bindings), but only after a
+//! wheel build, and the failure would read as "wingfoil has no attribute
+//! `csv_read`" rather than pointing here. This test names the mechanism
+//! directly.
+//!
+//! **Scope.** This runs against the *rlib*, so it proves the submissions exist
+//! and are collected in an ordinary Rust binary. The shipped artefact is the
+//! **cdylib**, where collection depends on the linker keeping the section — a
+//! genuinely different question, and one only an actual module import can
+//! answer. `crates/wingfoil-python/tests/test_interop.py` and its neighbours
+//! are what cover that, by importing the built extension and calling the
+//! bindings.
+
+use pyo3::types::{PyDictMethods, PyModuleMethods};
+use wingfoil_python::{PyFnRegistrar, inventory};
+
+/// Collection yields the bindings this crate defines.
+///
+/// The floor is deliberately loose — this is not an inventory of the catalog,
+/// it is a check that link-time collection happens at all. A default-feature
+/// build carries the built-in ops, the `#[pygraph]` islands, the latency
+/// surface and the demo ops; adapters add more, and are feature-gated, so an
+/// exact count would be a maintenance burden that fails for the wrong reason.
+#[test]
+fn bindings_are_collected() {
+    let n = inventory::iter::<PyFnRegistrar>().count();
+    assert!(
+        n >= 15,
+        "link-time collection produced only {n} binding registrars. Every \
+         Python binding registers itself this way — `#[pyop]` / `#[pygraph]` / \
+         `#[pyadapter]` / `pyop_fn!` emit the submission, and a hand-written \
+         `#[pyfunction]` calls `register_pyfn!`. A count this low means \
+         collection is broken, not that the catalog shrank, and the shipped \
+         module would be missing its functions entirely."
+    );
+}
+
+/// Every registrar is callable, and none of them panics or errors when run
+/// against a real module.
+///
+/// A registrar is a function pointer built by macro expansion; running the
+/// whole set here is the cheapest way to catch one that expanded into
+/// something that cannot actually register (a duplicate name, say), rather
+/// than discovering it at interpreter start-up.
+#[test]
+fn every_registrar_registers_cleanly() {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
+        let m = pyo3::types::PyModule::new(py, "registration_probe")
+            .expect("invariant: creating an empty module cannot fail");
+        for (i, r) in inventory::iter::<PyFnRegistrar>().enumerate() {
+            (r.0)(&m).unwrap_or_else(|e| {
+                panic!("binding registrar #{i} failed against a fresh module: {e}")
+            });
+        }
+        let n = inventory::iter::<PyFnRegistrar>().count();
+        let listed = m.dict().len();
+        assert!(
+            listed >= n,
+            "{n} registrars ran but the module ended up with only {listed} \
+             attributes — two bindings are registering under the same name, so \
+             one is silently shadowing the other"
+        );
+    });
+}

--- a/crates/wingfoil/src/signal.rs
+++ b/crates/wingfoil/src/signal.rs
@@ -29,11 +29,27 @@
 //! proof of concept, and it drifted — 15 of [`StreamOps`]' 41 methods were
 //! simply missing, one per op nobody remembered to come back for. Each
 //! `#[op(build = x, fluent)]` now emits `__wf_signal_x!` alongside its fluent
-//! twin, and the `impl` blocks below invoke it, so an op cannot land in the
-//! catalog and skip this facade. What stays hand-written is what is not a plain
-//! forward: the source free functions (they *make* the graph), `run` /
-//! `peek_value` (the facade's whole point), and the few combinators whose
-//! `Signal` signature genuinely differs from the fluent one.
+//! twin, and the `impl` blocks below invoke it. What stays hand-written is what
+//! is not a plain forward: the source free functions (they *make* the graph),
+//! `run` / `peek_value` (the facade's whole point), and the few combinators
+//! whose `Signal` signature genuinely differs from the fluent one.
+//!
+//! Generating the macro does **not** by itself keep this facade level with the
+//! catalog, and it is worth being exact about why: the invocation below is
+//! still a line somebody has to write, so an op can still land in the catalog
+//! and never arrive here. `tests/op_registration_coverage.rs` is what actually
+//! holds the two together — it fails if a `fluent` op reaches neither this
+//! facade nor a documented exemption.
+//!
+//! **The statistics surface is such an exemption, by design.** None of the 35
+//! [`StatisticsOps`](crate::stats::StatisticsOps) combinators appears here,
+//! because the methods this module generates are *inherent* — always in scope
+//! on the type — while the statistics trait is deliberately kept out of the
+//! prelude so callers opt in with `use wingfoil::stats::StatisticsOps;`. There
+//! is no such thing as an opt-in inherent method, so invoking
+//! `__wf_signal_<stat>!` here would put the whole statistics surface
+//! permanently on `Signal<f64>` and overturn that convention. A statistics op
+//! is reached from a `Signal` by going through its underlying [`Stream`].
 
 use std::cell::RefCell;
 use std::fmt::Debug;

--- a/crates/wingfoil/tests/op_registration_coverage.rs
+++ b/crates/wingfoil/tests/op_registration_coverage.rs
@@ -1,0 +1,170 @@
+//! Registration-coverage guard: an op in the catalog reaches **every** surface
+//! it owes, or names the reason it does not.
+//!
+//! [`op_completeness`](op_completeness.rs) already guards the *engine* axis —
+//! a combinator used inside a `nitro!` block only compiles if it has both a
+//! fluent method and a `__wf_op_<name>_*` forwarder, so dropping either side
+//! breaks that build. This file guards the axis that one cannot see: the
+//! **fluent** and [`Signal`] facade surfaces, neither of which any compiler
+//! checks for *absence*. Nothing fails to build when an op is simply never
+//! registered — it just quietly does not exist for callers.
+//!
+//! That is not hypothetical. The same omission has landed three times, and
+//! each time at *trait* granularity, which is why per-op review kept missing
+//! it:
+//!
+//! 1. The `Signal` facade was hand-forwarded and fell **15 of 41** methods
+//!    behind `StreamOps` (`signal.rs` module docs). Fixed by generating the
+//!    forwarding — but generating it only means the macro *exists*; the
+//!    invocation is still a line somebody has to write.
+//! 2. `op_completeness.rs` was written against `StreamOps`, so the whole of
+//!    `StatisticsOps` — 36 methods — sat in neither its `nitro!` blocks nor
+//!    its allowlist for the surface's entire life.
+//! 3. All 35 statistics ops are absent from the `Signal` facade to this day.
+//!    That one turns out to be *principled* (see `signal_exempt` below) — but
+//!    it was nowhere written down, so it read exactly like the first two.
+//!
+//! The test is a source scan rather than a compile-time trick because absence
+//! is what it looks for, and absence does not generate a token to trip over.
+
+/// The op catalog and the three files that publish it.
+const OPS_RS: &str = include_str!("../src/ops.rs");
+const FLUENT_RS: &str = include_str!("../src/fluent.rs");
+const STATS_RS: &str = include_str!("../src/stats.rs");
+const SIGNAL_RS: &str = include_str!("../src/signal.rs");
+
+/// Every `#[op(build = <name> …)]` in the catalog, paired with whether that
+/// attribute also carries the `fluent` flag.
+fn catalog_ops() -> Vec<(String, bool)> {
+    let mut out = Vec::new();
+    let mut rest = OPS_RS;
+    while let Some(at) = rest.find("#[op(build") {
+        rest = &rest[at..];
+        let Some(end) = rest.find(")]") else { break };
+        let attr = &rest[..end];
+        rest = &rest[end..];
+        let Some(eq) = attr.find('=') else { continue };
+        let after = attr[eq + 1..].trim_start();
+        let name: String = after
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if !name.is_empty() {
+            // `fluent` as a flag, not as a substring of some other token.
+            let has_fluent = attr[eq + 1..].split(',').any(|tok| tok.trim() == "fluent");
+            out.push((name, has_fluent));
+        }
+    }
+    out
+}
+
+/// Does `src` invoke `macro_stem<name>!`, or declare the method by hand?
+///
+/// Both count as registered: an op whose fluent or `Signal` signature is not a
+/// plain forward keeps a hand-written method on purpose (`with_time`,
+/// `delay_with_reset`, `logged`), and this guard is about the surface
+/// existing, not about how it was produced.
+fn registered(src: &str, macro_stem: &str, name: &str) -> bool {
+    if src.contains(&format!("{macro_stem}{name}!")) {
+        return true;
+    }
+    // A hand-written `fn <name>(` / `fn <name><`, at a word boundary so
+    // `join` never matches inside `join_passive`.
+    let mut rest = src;
+    while let Some(at) = rest.find(&format!("fn {name}")) {
+        let after = &rest[at + 3 + name.len()..];
+        if after.starts_with('(') || after.starts_with('<') {
+            return true;
+        }
+        rest = &rest[at + 3 + name.len()..];
+    }
+    false
+}
+
+/// Ops exempt from the [`Signal`] facade, and why.
+///
+/// **The statistics surface is exempt, and the reason is structural rather
+/// than an oversight.** `Signal`'s generated combinators are *inherent*
+/// methods (`impl<T: 'static> Signal<T>` in `signal.rs`), whereas
+/// `StatisticsOps` is deliberately kept **out of the prelude** so callers opt
+/// in with `use wingfoil::stats::StatisticsOps;` (see `CLAUDE.md`, "Working
+/// conventions"). An inherent method cannot be opted into — it is in scope on
+/// the type unconditionally — so invoking `__wf_signal_<stat>!` would put all
+/// 35 statistics combinators permanently on `Signal<f64>` and quietly overturn
+/// that convention.
+///
+/// So the exemption is derived, not a hand-maintained name list: an op whose
+/// fluent surface lives in `stats.rs` is exempt, and one whose surface lives in
+/// `fluent.rs` is not. A new statistics op inherits the exemption; a new
+/// `StreamOps` op inherits the obligation. A list of 35 names would have to be
+/// edited to stay true, which is the failure mode this file exists to catch.
+fn signal_exempt(name: &str) -> bool {
+    registered(STATS_RS, "__wf_fluent_", name)
+}
+
+#[test]
+fn every_fluent_op_has_a_fluent_surface() {
+    let missing: Vec<_> = catalog_ops()
+        .into_iter()
+        .filter(|(_, fluent)| *fluent)
+        .map(|(name, _)| name)
+        .filter(|n| {
+            !registered(FLUENT_RS, "__wf_fluent_", n) && !registered(STATS_RS, "__wf_fluent_", n)
+        })
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these ops declare `#[op(build = …, fluent)]` but no fluent surface \
+         invokes `__wf_fluent_<name>!` (and no method of that name is written \
+         by hand) in `fluent.rs` or `stats.rs`, so they are unreachable for \
+         callers: {missing:?}\n\
+         Add the one-line invocation to the extension trait's `impl` block — \
+         see `/new-op` step 4."
+    );
+}
+
+#[test]
+fn every_fluent_op_reaches_the_signal_facade() {
+    let missing: Vec<_> = catalog_ops()
+        .into_iter()
+        .filter(|(_, fluent)| *fluent)
+        .map(|(name, _)| name)
+        .filter(|n| !registered(SIGNAL_RS, "__wf_signal_", n) && !signal_exempt(n))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these ops declare `#[op(build = …, fluent)]` but never reach the \
+         `Signal` facade — `__wf_signal_<name>!` is emitted for each and never \
+         invoked, so `signal.rs` silently lags the catalog exactly as it did \
+         when it fell 15 methods behind: {missing:?}\n\
+         Add the one line to the generated `impl<T: 'static> Signal<T>` block — \
+         see `/new-op` step 4b. A source is not registered this way (it enters \
+         the facade as a free function); if this op is one, or its `Signal` \
+         signature is genuinely not a plain forward, write the method by hand \
+         instead."
+    );
+}
+
+/// The guard is only worth its coverage — so pin the coverage itself.
+///
+/// Without this, `catalog_ops` silently returning nothing (a parse that
+/// stopped matching after some future edit to the attribute spelling) would
+/// make both tests above pass vacuously, which is precisely the shape of
+/// failure they exist to prevent.
+#[test]
+fn the_scan_actually_finds_the_catalog() {
+    let ops = catalog_ops();
+    let fluent = ops.iter().filter(|(_, f)| *f).count();
+    assert!(
+        ops.len() > 60 && fluent > 60,
+        "the source scan found only {} ops ({fluent} fluent) in `ops.rs`; it \
+         has almost certainly stopped parsing the `#[op(build = …)]` \
+         attribute rather than the catalog having shrunk by half. Fix the \
+         scan — a vacuous pass here disables both guards in this file.",
+        ops.len()
+    );
+    assert!(
+        ops.iter().any(|(n, _)| n == "map"),
+        "the scan did not find `map`, so it is not reading the catalog correctly"
+    );
+}


### PR DESCRIPTION
## What this changes

Adding an op meant registering it at several sites, none of which anything checked. Two of those are now impossible to get wrong: a guard test fails when a catalog op reaches neither the fluent surface nor the `Signal` facade, and every Python binding registers itself where it is defined instead of in a hand-maintained list in the `#[pymodule]` (which loses 124 lines from `python.rs`).

## Why

**The fluent/`Signal` axis had no guard at all.** `op_completeness.rs` covers the engine axis — a combinator used in a `nitro!` block only compiles with both a fluent method and a forwarder — but absence generates no token for a compiler to trip over. An unregistered op does not fail to build; it quietly does not exist.

That omission has landed three times, each at *trait* granularity, which is why per-op review kept missing it: the `Signal` facade fell 15 of 41 methods behind `StreamOps`; `op_completeness.rs` was written against `StreamOps`, so all 36 `StatisticsOps` methods sat in neither its blocks nor its allowlist; and all 35 statistics ops are absent from `Signal` today.

**On the Python side every binding was named twice** — once where defined, once in the `#[pymodule]` — as 64 `add_function` calls plus the `#[cfg(feature)]` block and by-name `use` import each feature-gated adapter needed so `wrap_pyfunction!` could resolve pyo3's hidden wrapper. Nothing checked the halves against each other, so a forgotten second mention meant the binding silently did not exist in Python.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`; `cargo lint-all` substituted — it is a workspace all-features build that compiles legacy **aeron**, which needs a native toolchain unavailable in the sandbox (the caveat `/new-op` documents). Ran clippy across all 43 non-aeron/iceoryx2 features of `crates/wingfoil` plus `-p wingfoil-python --all-targets`, both `-D warnings` clean. Full `lint-all` still runs in CI.
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml`
- [x] `cargo test --manifest-path crates/wingfoil-python/Cargo.toml`, and `pytest` — 327 passed, 28 skipped
- [x] New behaviour covered by tests — see below

The Python refactor is verified by **diffing the module surface**: `dir(_wingfoil)` is identical before and after, 40 attributes, on a build with `csv,redis,kdb` enabled so the deleted `register_adapters` arms are actually exercised. That diff caught a real gap mid-way — `#[pyop]` has its own emission site separate from `#[pygraph]`, and its 6 functions were missing until it was patched.

Both new guards were negative-tested: removing `__wf_signal_throttle!` fails the coverage test naming `["throttle"]`, and the wheel smoke test exits 1 naming the registration path when a binding is absent.

## Notes for the reviewer

**The statistics absence from `Signal` is principled, and was nowhere written down.** `Signal`'s generated combinators are *inherent* methods, while `StatisticsOps` is deliberately kept out of the prelude for opt-in — and there is no such thing as an opt-in inherent method, so wiring stats into `Signal` would put all 35 permanently on `Signal<f64>`. The exemption is therefore **derived** (an op whose fluent surface lives in `stats.rs`) rather than a 35-name list that would rot. `signal.rs` claimed an op "cannot land in the catalog and skip this facade", which was untrue of 35 of them; it now says what actually holds the two level.

**A fourth approach was built, measured, and rejected** — worth knowing so it is not proposed again. Generating the fluent *declaration* from the op shape (`__wf_fluent_decl_<name>!`) worked: 70 declarations converted, crate green. A rustdoc signature diff then showed it was a net **+15 lines** — the invocation's braces cost about what the signature they replace costs, and the 35 `StatisticsOps` declarations are already one-liners — while regressing public parameter names to `__cfg`/`__e1` and silently dropping `accumulate`'s stricter `T: Default`. E0276 catches an impl stricter than its trait; nothing catches a declaration *looser* than it was. Reverted.

**Blast radius on the Python side changed, deliberately.** Before: forget a line, lose one binding. Now: if link-time collection ever failed, the module loses every function at once. That trade is only sound if the low probability is verified, so: collection is confirmed working in the cdylib (a function reachable only through inventory), including in a `--release --strip` wheel. macOS and Windows cannot be tested here — which is why the third commit adds a smoke test to `pypi-publish.yml`. It builds wheels for 3 OSes × 7 Python versions and previously published them **without ever importing one**; each is now installed and checked for one binding per registration path. If `inventory` does not work on a platform, that job goes red and no wheel ships. This also retroactively closes a pre-existing hole, independent of this PR.

**`inventory` is a new runtime dependency** in the shipped wheel — small and widely used, but it does mean static-initializer machinery runs at import.

Collection is per-shared-object, which is what makes the macros safe to emit submissions unconditionally for the third-party crates `#[pyadapter]` serves: their submissions land in their own cdylib, and their `#[pymodule]` chooses whether to iterate.

Skills updated in the same PR, per their own standing instruction: `/new-op` gains the `Signal` obligation's guard and the statistics exemption; `/bind-adapter`'s registration step is rewritten (it described the list that no longer exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXtLAZS7StDmyvjVVHHsAw

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXtLAZS7StDmyvjVVHHsAw)_