### PR TITLE
bench(pool): payload-strategy benchmark and the steady-state allocation gate

### DIFF
--- a/crates/wingfoil/Cargo.toml
+++ b/crates/wingfoil/Cargo.toml
@@ -541,6 +541,10 @@ harness = false
 name = "store_baseline"
 harness = false
 
+[[bench]]
+name = "pooled_channel"
+harness = false
+
 # --- Ports of the legacy `legacy/wingfoil/benches/*` suite --------------------------
 # Target names, paths and `required-features` gating mirror the legacy
 # declarations one-for-one so `cargo bench --bench <name>` is the same

--- a/crates/wingfoil/benches/README.md
+++ b/crates/wingfoil/benches/README.md
@@ -18,7 +18,10 @@ wall-clock thresholds are too noisy on shared runners, so nothing in
 `.github/workflows/` runs `cargo bench`; this suite is a run-on-demand
 scaffold. The deterministic perf gates are *tests* — see
 `tests/sparse_graph.rs` and `tests/merge_n.rs`, and `docs/port-plan.md`
-("The perf gate — a test, not a benchmark").
+("The perf gate — a test, not a benchmark"). The pool's zero-payload-alloc
+claim is gated the same way: `tests/steady_state_allocs.rs` wraps a counting
+`#[global_allocator]` around the pooled order-book pipeline and asserts
+allocation *counts*, which are exact where wall-clock is noisy.
 
 ## Targets
 
@@ -27,6 +30,7 @@ scaffold. The deterministic perf gates are *tests* — see
 | `tiers` | — | *(wingfoil-only)* | legacy / interpreted / compiled / nested, side by side, on eight workloads |
 | `custom_op` | — | *(wingfoil-only)* | a user op through the generic fallback vs a built-in table row, both compiled |
 | `store_baseline` | — | *(wingfoil-only)* | the pre-arena baseline: sparse-vs-full-sweep dispatch, and the payload-clone ceiling/floor |
+| `pooled_channel` | — | *(wingfoil-only)* | payload strategies on channel ingress: owned `Book` vs `Arc<Book>` vs `pooled_channel` loans |
 | `graph` | `bench` | `graph` | graph overhead: one engine cycle through a `width` × `depth` DAG |
 | `nanotime` | — | `nanotime` | cost of reading the graph clock |
 | `bfs_vs_dfs_wingfoil` | — | `bfs_vs_dfs_wingfoil` | branch/recombine at depths 1–10 on the wingfoil engine, all three tiers: interpreted, whole-program compiled, compiled island |
@@ -52,6 +56,7 @@ graphs from an internal ticker instead, and needs no feature at all.
 cargo bench --manifest-path crates/wingfoil/Cargo.toml --bench tiers
 cargo bench --manifest-path crates/wingfoil/Cargo.toml --bench custom_op
 cargo bench --manifest-path crates/wingfoil/Cargo.toml --bench store_baseline
+cargo bench --manifest-path crates/wingfoil/Cargo.toml --bench pooled_channel
 
 # graph overhead / clock
 cargo bench --manifest-path crates/wingfoil/Cargo.toml --features bench --bench graph
@@ -425,6 +430,33 @@ This section was measured on machine B (see [above](#results)); everything
 above it is machine A, and the two do not compare.
 Full numbers and commentary:
 [`topological_vs_per_path/README.md`](topological_vs_per_path/README.md).
+
+## Payload strategies (pooled channel)
+
+[`pooled_channel`](pooled_channel.rs) drives the same order-book ingress
+pipeline (`channel → latest → weighted mid → fold`, 10 000 books of 2×128
+levels, flat-out producer thread, realtime mode) under the three payload
+strategies. Captured on a shared cloud VM — read the ratios:
+
+| strategy | median / 10k msgs | per message | throughput |
+|---|---|---|---|
+| owned `Book` | 25.66 ms | 2.57 µs | 390 Kelem/s |
+| `Arc<Book>` | 31.37 ms | 3.14 µs | 319 Kelem/s |
+| `pooled_channel` | **8.72 ms** | **0.87 µs** | **1.15 Melem/s** |
+
+Two readings:
+
+- **Pooled is ~3× owned and ~3.6× `Arc`** on this workload: the loan path
+  does no per-message allocation (see `tests/steady_state_allocs.rs`, which
+  measures 1.12 small allocs/message and zero payload-scale), while both
+  baselines construct a fresh two-`Vec` book per message on the producer
+  thread and free it on the graph thread.
+- **`Arc` loses to owned here, and that is not a mistake.** Its supposed win
+  — cheap routing clones — barely fires on a burst-heavy ingress (the
+  `latest` clone runs once per *burst*, and a flat-out producer makes bursts
+  large), while its extra per-message allocation and atomics always fire.
+  `Arc` payloads earn their keep in clone-heavy *graph* topologies (wide
+  fan-out, `delay`/`sample` chains), not at the ingress boundary.
 
 ## Not covered here
 

--- a/crates/wingfoil/benches/pooled_channel.rs
+++ b/crates/wingfoil/benches/pooled_channel.rs
@@ -1,0 +1,197 @@
+//! Payload-strategy comparison on the channel ingress path: the same
+//! order-book pipeline (`channel → latest → mid → fold`) three ways —
+//!
+//! - **owned** — a fresh heap-owning `Book` constructed per send, the naive
+//!   baseline (allocates per message; the routing clone is a deep copy);
+//! - **arc** — `Arc<Book>` built per send, the pattern a good user writes
+//!   today with no engine support (routing clones become atomic refcount
+//!   bumps; per-message allocation remains);
+//! - **pooled** — `pooled_channel` loans: recycled buffers, in-place refill,
+//!   non-atomic graph-side handles (steady-state payload allocations: zero).
+//!
+//! The producer runs on its own thread sending `MESSAGES` books flat-out
+//! (realtime mode, waker-driven, no sleeps), so the measurement covers the
+//! steady-state regime the pool exists for — including its backpressure.
+//! Throughput is reported per message.
+//!
+//! `arc` is the honest baseline to beat — see `benches/README.md`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use wingfoil::pool::Pooled;
+use wingfoil::prelude::*;
+use wingfoil::{RunFor, RunMode};
+
+/// One price level: 16 bytes, no heap.
+#[derive(Clone, Copy, Default)]
+struct Level {
+    price: f64,
+    qty: f64,
+}
+
+/// A fixed-depth order book: ~48B of struct + 2×`DEPTH`×16B of heap.
+#[derive(Clone, Default)]
+struct Book {
+    seq: u64,
+    bids: Vec<Level>,
+    asks: Vec<Level>,
+}
+
+const DEPTH: usize = 128;
+const MESSAGES: u64 = 10_000;
+const POOL: usize = 64;
+
+impl Book {
+    fn with_depth() -> Self {
+        Self {
+            seq: 0,
+            bids: Vec::with_capacity(DEPTH),
+            asks: Vec::with_capacity(DEPTH),
+        }
+    }
+
+    /// Overwrite in place: `clear()` keeps the Vec capacity, so a recycled
+    /// book refills without touching the allocator.
+    fn refill(&mut self, seq: u64) {
+        self.seq = seq;
+        self.bids.clear();
+        self.asks.clear();
+        let base = 100.0 + (seq % 100) as f64 * 0.01;
+        for i in 0..DEPTH {
+            let d = i as f64 * 0.01;
+            self.bids.push(Level {
+                price: base - d,
+                qty: 1.0 + i as f64,
+            });
+            self.asks.push(Level {
+                price: base + 0.01 + d,
+                qty: 1.0 + i as f64,
+            });
+        }
+    }
+
+    /// Touches both fields of both top levels, so the transform reads real
+    /// payload data (and no field is dead in the bench).
+    fn mid(&self) -> f64 {
+        let (b, a) = (&self.bids[0], &self.asks[0]);
+        (b.price * a.qty + a.price * b.qty) / (b.qty + a.qty)
+    }
+}
+
+/// Time one full run: build the graph, spawn the producer, run realtime until
+/// the producer closes. Returns elapsed wall time for the whole exchange.
+fn timed_run<S, P>(wire: impl FnOnce(&GraphBuilder) -> (Stream<f64>, S), produce: P) -> Duration
+where
+    S: Send + 'static,
+    P: FnOnce(S) + Send + 'static,
+{
+    let g = GraphBuilder::new();
+    let (mids, sender) = wire(&g);
+    let sum = mids.fold(0.0f64, |acc, v| *acc += v);
+    let mut r = g.build();
+
+    let start = Instant::now();
+    let producer = std::thread::spawn(move || produce(sender));
+    r.run(RunMode::RealTime, RunFor::Forever)
+        .expect("bench run");
+    let elapsed = start.elapsed();
+    producer.join().expect("producer thread");
+    // Keep the fold observable so nothing is optimised away.
+    assert!(r.value(&sum) != 0.0);
+    elapsed
+}
+
+fn bench_payload_strategies(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pooled_channel/ingress");
+    group.throughput(Throughput::Elements(MESSAGES));
+    group.sample_size(10);
+
+    group.bench_function("owned", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    timed_run(
+                        |g| {
+                            let (books, sender) = g.channel::<Book>();
+                            let mids = books
+                                .map(|b: &Burst<Book>| b.last().expect("non-empty burst").clone())
+                                .map(|book: &Book| book.mid());
+                            (mids, sender)
+                        },
+                        |sender| {
+                            for seq in 0..MESSAGES {
+                                let mut book = Book::with_depth();
+                                book.refill(seq);
+                                sender.send(book);
+                            }
+                            sender.close();
+                        },
+                    )
+                })
+                .sum()
+        })
+    });
+
+    group.bench_function("arc", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    timed_run(
+                        |g| {
+                            let (books, sender) = g.channel::<Arc<Book>>();
+                            let mids = books
+                                .map(|b: &Burst<Arc<Book>>| {
+                                    b.last().expect("non-empty burst").clone()
+                                })
+                                .map(|book: &Arc<Book>| book.mid());
+                            (mids, sender)
+                        },
+                        |sender| {
+                            for seq in 0..MESSAGES {
+                                let mut book = Book::with_depth();
+                                book.refill(seq);
+                                sender.send(Arc::new(book));
+                            }
+                            sender.close();
+                        },
+                    )
+                })
+                .sum()
+        })
+    });
+
+    group.bench_function("pooled", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    timed_run(
+                        |g| {
+                            let (books, sender) = g.pooled_channel_with(POOL, Book::with_depth);
+                            let mids = books
+                                .map(|b: &Burst<Pooled<Book>>| {
+                                    b.last().expect("non-empty burst").clone()
+                                })
+                                .map(|book: &Pooled<Book>| book.mid());
+                            (mids, sender)
+                        },
+                        |mut sender| {
+                            for seq in 0..MESSAGES {
+                                let mut loan = sender.loan();
+                                loan.refill(seq);
+                                sender.send(loan);
+                            }
+                            sender.close();
+                        },
+                    )
+                })
+                .sum()
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_payload_strategies);
+criterion_main!(benches);

--- a/crates/wingfoil/tests/steady_state_allocs.rs
+++ b/crates/wingfoil/tests/steady_state_allocs.rs
@@ -1,0 +1,193 @@
+//! The steady-state allocation gate: a counting `#[global_allocator]` wrapped
+//! around the pooled-channel order-book pipeline, asserting that the payload
+//! path stays off the allocator. This is the enforcement half of the pool's
+//! "zero payload allocations at steady state" claim — a regression *test*,
+//! deliberately not a Criterion bench (wall-clock is noisy on shared runners;
+//! allocation counts are exact).
+//!
+//! What is asserted, and why these numbers:
+//!
+//! - **Zero large allocations** (≥ `LARGE` bytes) between run start and run
+//!   end: a payload (`Book` holds two 2KB level Vecs) can only be built by
+//!   crossing this threshold, so zero large allocs proves every book the
+//!   graph saw lived in a recycled pool buffer.
+//! - **A small per-message budget** for the residuals the pool deliberately
+//!   leaves (documented in `pool.rs`): the handle's `Rc` control block and
+//!   the transport queue's node, plus occasional `Burst` spill. The budget is
+//!   a pinned ceiling so a regression (a clone sneaking onto the path, a
+//!   fresh `Vec` per message) fails loudly.
+//!
+//! One test per binary: the counters are process-global, so this file must
+//! not gain a second concurrent `#[test]`.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use wingfoil::pool::Pooled;
+use wingfoil::prelude::*;
+use wingfoil::{RunFor, RunMode};
+
+/// Payload-sized threshold: anything this big is payload construction. Sized
+/// well above the engine's infrastructure blocks (waker-channel slot blocks,
+/// thread bookkeeping, queue growth — all ≤ 8KB in practice, and amortized)
+/// and at exactly the book's per-side `Vec` block, so a single payload built
+/// or deep-cloned outside the pool trips the gate.
+const LARGE: usize = 16_000;
+
+static ALLOCS: AtomicU64 = AtomicU64::new(0);
+static LARGE_ALLOCS: AtomicU64 = AtomicU64::new(0);
+/// First few large-alloc sizes, for the failure message — attribution beats
+/// a bare count when this gate trips.
+static LARGE_SIZES: [AtomicU64; 8] = [const { AtomicU64::new(0) }; 8];
+
+fn record_large(size: usize) {
+    let n = LARGE_ALLOCS.fetch_add(1, Ordering::Relaxed) as usize;
+    if let Some(slot) = LARGE_SIZES.get(n) {
+        slot.store(size as u64, Ordering::Relaxed);
+    }
+}
+
+struct Counting;
+
+// SAFETY: delegates every operation to `System` unchanged; the counters are
+// relaxed atomics with no side effects on allocation behaviour.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        if layout.size() >= LARGE {
+            record_large(layout.size());
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        if new_size >= LARGE {
+            record_large(new_size);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static COUNTING: Counting = Counting;
+
+#[derive(Clone, Copy, Default)]
+struct Level {
+    price: f64,
+    qty: f64,
+}
+
+/// Two 1024-level sides: each `Vec` is 16KB — over `LARGE`, so any fresh
+/// construction (or deep clone) is caught by the large-alloc counter.
+#[derive(Default)]
+struct Book {
+    seq: u64,
+    bids: Vec<Level>,
+    asks: Vec<Level>,
+}
+
+const DEPTH: usize = 1024;
+const MESSAGES: u64 = 1_000;
+const POOL: usize = 64;
+
+/// Residual budget per message: the `Pooled` handle's `Rc` box, the mpsc
+/// node, and headroom for `Burst` spill — the documented residuals, nothing
+/// more. A deep payload clone or per-message construction blows through this
+/// immediately (each would add 3 allocs including two large ones).
+const PER_MESSAGE_BUDGET: u64 = 8;
+/// Slack for one-off run machinery (thread spawn, run start/stop, waker).
+const FIXED_SLACK: u64 = 200;
+
+impl Book {
+    fn with_depth() -> Self {
+        Self {
+            seq: 0,
+            bids: Vec::with_capacity(DEPTH),
+            asks: Vec::with_capacity(DEPTH),
+        }
+    }
+
+    fn refill(&mut self, seq: u64) {
+        self.seq = seq;
+        self.bids.clear();
+        self.asks.clear();
+        let base = 100.0 + (seq % 100) as f64 * 0.01;
+        for i in 0..DEPTH {
+            let d = i as f64 * 0.01;
+            self.bids.push(Level {
+                price: base - d,
+                qty: 1.0 + i as f64,
+            });
+            self.asks.push(Level {
+                price: base + 0.01 + d,
+                qty: 1.0 + i as f64,
+            });
+        }
+    }
+}
+
+#[test]
+fn pooled_pipeline_stays_off_the_allocator() {
+    // Wire and build BEFORE the measured window: graph construction and pool
+    // prefill are the setup phase and allocate freely.
+    let g = GraphBuilder::new();
+    let (books, mut sender) = g.pooled_channel_with(POOL, Book::with_depth);
+    let sum = books
+        .map(|b: &Burst<Pooled<Book>>| b.last().expect("non-empty burst").clone())
+        .map(|book: &Pooled<Book>| {
+            let (b, a) = (&book.bids[0], &book.asks[0]);
+            (b.price * a.qty + a.price * b.qty) / (b.qty + a.qty)
+        })
+        .fold(0.0f64, |acc, v| *acc += v);
+    let mut r = g.build();
+
+    let allocs_before = ALLOCS.load(Ordering::Relaxed);
+    let large_before = LARGE_ALLOCS.load(Ordering::Relaxed);
+
+    let producer = std::thread::spawn(move || {
+        for seq in 0..MESSAGES {
+            let mut loan = sender.loan();
+            loan.refill(seq);
+            sender.send(loan);
+        }
+        sender.close();
+    });
+    r.run(RunMode::RealTime, RunFor::Forever).expect("run");
+    producer.join().expect("producer thread");
+
+    let allocs = ALLOCS.load(Ordering::Relaxed) - allocs_before;
+    let large = LARGE_ALLOCS.load(Ordering::Relaxed) - large_before;
+
+    // The sum is data-dependent on every message; keeps the pipeline honest.
+    assert!(r.value(&sum) > 0.0);
+
+    // Always visible under --nocapture, so a captured run documents itself.
+    eprintln!(
+        "steady state: {allocs} allocations for {MESSAGES} messages \
+         ({:.2}/message), {large} of payload scale (≥ {LARGE}B)",
+        allocs as f64 / MESSAGES as f64
+    );
+
+    let sizes: Vec<u64> = LARGE_SIZES
+        .iter()
+        .map(|s| s.load(Ordering::Relaxed))
+        .filter(|&s| s > 0)
+        .collect();
+    assert_eq!(
+        0, large,
+        "payload-sized allocations on the steady-state path — a book was \
+         built outside the pool ({large} allocs ≥ {LARGE}B in a {MESSAGES}-message \
+         run; first sizes: {sizes:?})"
+    );
+    let budget = MESSAGES * PER_MESSAGE_BUDGET + FIXED_SLACK;
+    assert!(
+        allocs <= budget,
+        "allocation regression: {allocs} allocs for {MESSAGES} messages \
+         (budget {budget} = {PER_MESSAGE_BUDGET}/message + {FIXED_SLACK} slack)"
+    );
+}


### PR DESCRIPTION
## What this changes

Adds the two artifacts that price and then pin the pooled channel's claims (stacked on #719):

- **`benches/pooled_channel.rs`** — the same order-book ingress pipeline (`channel → latest → weighted mid → fold`, 10k books of 2×128 levels, flat-out producer thread, realtime mode) under three payload strategies: naive owned `Book`, `Arc<Book>` (the pattern a good user writes today), and `pooled_channel` loans.
- **`tests/steady_state_allocs.rs`** — the enforcement: a counting `#[global_allocator]` around the pooled pipeline asserting **zero payload-scale allocations** (a ≥16KB payload signature no infrastructure block reaches) and a pinned small-alloc budget per message. A regression — a deep clone or fresh construction sneaking onto the path — fails loudly, with the offending allocation sizes in the message.

## Why

"Zero payload allocations at steady state" should be a regression-gated property, not prose — Criterion means hide exactly the tail behaviour (allocator p99.9 stalls) the pool exists to remove, while allocation *counts* are exact. And the strategy comparison keeps the pool honest against the `Arc` baseline rather than the naive one.

Captured numbers (shared cloud VM — read the ratios): owned **2.57µs/message**, `Arc<Book>` **3.14µs**, pooled **0.87µs** — ~3× owned, ~3.6× `Arc`. The gate measures **1.12 small allocs/message, zero payload-scale** — the documented residuals (handle `Rc` box + amortized queue blocks) and nothing else. One honest finding recorded in the README: `Arc` *loses* to owned on burst-heavy ingress — its cheap-routing-clone advantage barely fires (the `latest` clone runs per burst, and a flat-out producer makes bursts large) while its extra per-message allocation always does; `Arc` earns its keep in clone-heavy graph topologies, not at the ingress boundary.

This gate already paid for itself once: it caught the flat-out-producer wedge fixed in #719's second commit.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --test steady_state_allocs` (the new gate, green at 1.12 allocs/message) and the full `pooled_channel` integration suite on the base branch
- [x] `cargo bench --bench pooled_channel` run to completion; the captured numbers in `benches/README.md` are from that run, not invented

## Notes for the reviewer

- **Base branch is #719's** (`claude/large-structs-graph-passing-hf0zno`), not `next` — this stacks on the pool implementation and should merge after it (GitHub will retarget to `next` when the base merges).
- The gate is deliberately a *test*, per the house rule that perf gates are tests, not benches (`benches/README.md`); the README's gate paragraph now points at it.
- The alloc budget (8/message, measured 1.12) is a pinned ceiling with slack for scheduler-interleaving variance (`Burst` spill), not a target.
- One test per binary in `steady_state_allocs.rs` — the counters are process-global; noted in the file header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C5y1fmCjg5Cwgm1pp2s4f

---
_Generated by [Claude Code](https://claude.ai/code/session_015C5y1fmCjg5Cwgm1pp2s4f)_