### PR TITLE
docs: point contributors at next rather than main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,26 @@
 
+## ⚠️ Read this first: branch your work off `next`, not `main`
+
+Active development happens on **[`next`](https://github.com/wingfoil-io/wingfoil/tree/next)**.
+`main` is the previous generation of the codebase, kept only until the two are
+swapped — it still builds and ships, but it is not where new work goes.
+
+The two trees are laid out differently (`next` moved the crates under
+`crates/`), so a change written against `main` does not port across as a rebase.
+Please save yourself the rework:
+
+```bash
+git clone https://github.com/wingfoil-io/wingfoil.git
+cd wingfoil
+git checkout next
+git checkout -b my-change
+```
+
+and open your pull request against `next`.
+
+If you have already started against `main`, open the PR anyway and say so — we
+would much rather help you move it than have you drop it.
+
 ## We're looking for contributors!
 
 Hi! Thanks for your interest in contributing to **wingfoil** — we'd love to have your participation! 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Short code snippets for each adapter live in the [examples README](https://githu
 
 ## Get Involved!
 
+> **Contributing?** Branch off [`next`](https://github.com/wingfoil-io/wingfoil/tree/next),
+> not `main` — that is where active development happens, and the two trees are
+> laid out differently. See
+> [CONTRIBUTING.md](https://github.com/wingfoil-io/wingfoil/blob/main/CONTRIBUTING.md).
+
 We want to hear from you!  Especially if you:
 - are interested in [contributing](https://github.com/wingfoil-io/wingfoil/blob/main/CONTRIBUTING.md)
 - know of a project that wingfoil would be well-suited for


### PR DESCRIPTION
## Why

`main` is the default branch, so it is what a contributor lands on, clones and builds against. Nothing in the repository said that active development had moved to `next` — not `CONTRIBUTING.md`, not the README.

#733 was written against `main` for exactly this reason, and there are 26 forks all pointed at the same tree.

The cost is not small: `next` moved the crates under `crates/`, so a change written against `main` does not port across as a rebase.

## What

- A redirect block at the top of `CONTRIBUTING.md`, above everything else, with the clone/checkout commands.
- A short callout in the README's **Get Involved** section.

Both invite someone who has already started against `main` to open the PR anyway rather than drop it — the goal is to save rework, not to turn contributions away.

## Note on the follow-up merge

This commit lands on `main`, which breaks the ancestry that #735 just established (`main` was an ancestor of `next`, making the cutover swap a fast-forward).

**A follow-up `main` → `next` merge is needed to restore it.** I'll open that once this lands; it should be a trivial one, since `CONTRIBUTING.md` and `README.md` both exist unchanged on `next`.

This is the general rule now: every commit to `main` costs a re-sync. That is an argument for this being close to the last one.

## Verification

Docs-only. `cargo fmt --all -- --check` and `cargo lint` both pass.

> The repo's cargo-husky hooks were installed from the `next` tree in this working copy and call `scripts/disk.sh`, which does not exist on `main` — so the hooks were bypassed and their checks (`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`) run by hand instead. Harmless here, but worth knowing if you switch trees in one clone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLAUVMurYnUzdZF224z4Xm)_