### PR TITLE
Point the release preflight at the surviving crate; retire `next` in the docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,27 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION=$(grep -m 1 '^version' legacy/wingfoil/Cargo.toml | awk -F'"' '{print $2}')
+          # Source of truth is the surviving crate, matching release.bump. It
+          # used to be legacy's, but legacy is frozen at 8.0.0 and no longer
+          # bumps (cutover-plan 5.6) — reading it would peg every release at a
+          # version already tagged, failing the check below on every run.
+          VERSION=$(grep -m 1 '^version' crates/wingfoil/Cargo.toml | awk -F'"' '{print $2}')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Fail if the published versions disagree
+        run: |
+          # release.bump moves all three together, so a mismatch means someone
+          # edited one by hand. Catch it here rather than in the release notes,
+          # which quote this one version as the install line for all three
+          # registries — crates.io, PyPI and npm.
+          VERSION="${{ steps.version.outputs.version }}"
+          NPM_VERSION=$(node -p "require('./js/package.json').version")
+          WASM_VERSION=$(grep -m 1 '^version' crates/wingfoil-wasm/Cargo.toml | awk -F'"' '{print $2}')
+          if [ "$NPM_VERSION" != "$VERSION" ] || [ "$WASM_VERSION" != "$VERSION" ]; then
+            echo "::error::Version mismatch — wingfoil ${VERSION}, @wingfoil/client ${NPM_VERSION}, wingfoil-wasm ${WASM_VERSION}. Run release.bump to realign."
+            exit 1
+          fi
 
       - name: Fail if tag already exists
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,33 +242,30 @@ flight. The earliest instant is additionally held *out* of the map and
 refilled lazily, so a single-timer graph — and a fast timer among slow ones —
 never touches the map at all.
 
-## Branching: wingfoil work merges into `next`, not `main`
+## Branching: everything merges into `main`
 
-Everything at the root is built up on the long-lived **`next` branch** to
-stage the replacement engine in one place; when it reaches parity we delete
-the legacy tree. Until that cutover, `next` is the integration branch for all
-wingfoil work — treat it the way you would treat `main` for legacy work.
+`next` was the long-lived integration branch that staged the replacement
+engine in one place. It has landed on `main`, so **`main` is the trunk for
+every part of this repository** — the wingfoil tree at the root and the
+`legacy/` tree alike. There is no longer a second integration branch, and no
+branch rule that depends on which tree you are editing.
 
-> The branch name is the one place "next" survives as a name for this engine —
-> everything else (crates, workflows, skills, docs) is now just **wingfoil**
-> and **legacy**. Renaming the branch is a repo-admin step (branch rename +
-> re-targeting open PRs + branch protection), deliberately left for the
-> cutover; the CI `push`/`pull_request` triggers and cache `save-if` guards
-> still name it.
-
-- **NEVER edit files directly on `next` or `main`.**
-- The workflow for any change outside `legacy/`:
-  1. Cut a feature branch **from `next`**:
-     `git checkout next && git pull origin next && git checkout -b <branch-name>`.
+- **NEVER edit files directly on `main`.**
+- The workflow for any change, anywhere in the tree:
+  1. Cut a feature branch **from `main`**:
+     `git checkout main && git pull origin main && git checkout -b <branch-name>`.
   2. Do the work, commit, and push the feature branch.
-  3. Open a pull request with **base `next`** — never `main`.
+  3. Open a pull request with **base `main`**.
 - Branch naming: simple descriptive names (e.g. `add-metrics`,
   `fix-error-handling`).
-- Work under `legacy/` is cut from and merges into `main` instead — see
-  `legacy/CLAUDE.md`.
+- Work under `legacy/` follows the same rule, and always did — see
+  `legacy/CLAUDE.md` for what else is specific to that tree.
 
-`main` only ever receives the eventual next→main cutover/sync PRs; no
-day-to-day wingfoil work targets `main`.
+> **`next` is retired, not renamed.** Deleting the branch is a repo-admin step
+> (branch protection, re-targeting anything still open against it), and the CI
+> `push`/`pull_request` triggers and cache `save-if` guards still name `next`
+> alongside `main`. Those entries are inert once the branch is gone — strip
+> them when it is actually deleted, not before.
 
 ## Build Commands
 

--- a/legacy/CLAUDE.md
+++ b/legacy/CLAUDE.md
@@ -6,16 +6,16 @@ Guidance for Claude Code when working under `legacy/`.
 > shared policy — build commands, system dependencies, disk space,
 > error-handling, the pre-commit checklist — and describes Wingfoil,
 > which now occupies the repository root. This file adds what is specific to
-> the legacy engine and **overrides the branching rule**: legacy branches are
-> cut from and merge into `main`, not `next` (see [Branch
-> Management](#branch-management) below).
+> the legacy engine. It no longer overrides the branching rule: since `next`
+> landed on `main` and retired, **both trees branch from and merge into
+> `main`** (see [Branch Management](#branch-management) below).
 
 The legacy tree is the original `MutableNode` engine. It keeps shipping and
 serves as the permanent parity oracle for the port, and it is deleted
 wholesale at cutover — see `docs/cutover-plan.md` at the root. Anything shared
-between the two engines belongs in `crates/wingfoil-next/src/runtime/`, which
+between the two engines belongs in `crates/wingfoil/src/runtime/`, which
 `wingfoil` re-exports at its historical paths; never add a
-`crates/wingfoil-next` → `legacy/` dependency.
+`crates/wingfoil` → `legacy/` dependency.
 
 ## Layout
 
@@ -56,9 +56,9 @@ legacy/
   3. Create a new branch from the updated main: `git checkout -b <branch-name>`
 - Branch naming convention: use simple descriptive names (e.g., `add-metrics`,
   `fix-error-handling`)
-- **Work outside `legacy/` targets the `next` branch, not `main`** — see the
-  root `CLAUDE.md`. Only the eventual next→main cutover/sync PRs cross between
-  them.
+- **Work outside `legacy/` targets `main` too** — see the root `CLAUDE.md`.
+  The `next` integration branch is retired, so there is no second base branch
+  and no sync PR between them any more.
 
 ### Build and test — this tree is its own workspace
 


### PR DESCRIPTION
> #657 has landed (`af73401`, a merge commit — `main` and `next` ancestry
> intact). This is rebased onto it and is now a single commit against current
> `main`. The docs below assert a state that is true as of that merge.

## What this changes

Two loose ends that outlive the `next` → `main` merge: the release workflow
reads its version from the wrong crate, and the branching docs describe two
integration branches when there is now one.

## Why

**`release.yml` cannot cut a release from `main` as written.** Its preflight
does `grep -m 1 '^version' legacy/wingfoil/Cargo.toml` → `8.0.0`. Legacy is
frozen at its final release and no longer bumps (cutover-plan 5.6), and
`v8.0.0` is already tagged — so the next step, "Fail if tag already exists",
kills every run. `release.bump` migrated to `crates/wingfoil/Cargo.toml` and
carries the reasoning in a comment at `bump.yml:41-44`; `release.yml` was
missed. It now reads the same source and resolves `v9.0.0`.

Alongside it, a version-consistency check. The release notes quote one version
as the install line for crates.io, PyPI **and** npm, so a hand-edit that
desynced `js/package.json` or `wingfoil-wasm` would publish notes that lie.
`release.bump` already moves all three together — this asserts it held, in the
job named "Preflight — version check".

**The branching rule stopped being true when `next` landed.** Both `CLAUDE.md`
files now give one rule — branch from `main`, PR into `main` — for the wingfoil
tree and `legacy/` alike, replacing the split where `legacy/` overrode the root
file. Recorded as retired-not-renamed, with a note that the CI
`push`/`pull_request` triggers and cache `save-if` guards still naming `next`
are inert once the branch is deleted, so nobody strips them early.

## How it was verified

Markdown and YAML only — no Rust in the diff, so the Rust gates would report on
code this PR does not touch. What was actually run:

- `release.yml` re-parses as valid YAML; `preflight` resolves to its three
  steps in order.
- The new preflight logic, executed against the tree:
  `wingfoil=9.0.0 npm=9.0.0 wasm=9.0.0` → consistent, tag `v9.0.0`, which does
  not exist on the remote. The old logic produced `v8.0.0`, which does.

Not applicable, and left unticked deliberately:

- [ ] `cargo fmt --all`
- [ ] `cargo lint` and `cargo lint-all`
- [ ] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
- [ ] New behaviour is covered by a test asserting **values and tick times**

## Notes for the reviewer

- **The `wingfoil-next` references in legacy's Rust source and `Cargo.toml` are
  deliberate and untouched.** `wingfoil-next` is the dependency *key* —
  `wingfoil-next = { package = "wingfoil", path = "../../crates/wingfoil" }` —
  kept so legacy's whole source tree survived the rename unedited
  (cutover-plan 1.2). Only two references that were filesystem *paths* in an
  instruction were stale, and those are corrected: `crates/wingfoil-next/` →
  `crates/wingfoil/` in `legacy/CLAUDE.md`.
- **One of the same kind is left behind**, at `legacy/wingfoil/Cargo.toml:204`
  — a comment on where `cargo-husky` moved. Not folded in rather than reach
  into an otherwise-untouched file; say the word and it comes along.
- **The consistency check is the one addition, not a fix**, and is easy to drop
  if you'd rather preflight stayed minimal.
- **This does not retire the `next` branch itself** — deleting it, moving
  branch protection, and stripping `next` from the CI triggers are repo-admin
  steps. The docs describe the intended end state and say explicitly why the
  trigger entries should not be stripped before the branch is gone.