### PR TITLE
docs: polish README badges, add Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+# Dependabot **version** updates.
+#
+# Dependabot *security* updates (the alerts raised against advisories in an
+# existing tree, and the fix PRs that follow) are a repository setting and need
+# no entry here — they cover every ecosystem Dependabot can parse, including
+# `legacy/wingfoil-python/uv.lock`, whether or not it is listed below. This file
+# only decides where routine version bumps are proposed, and how noisily.
+#
+# The complementary gate is `.github/workflows/security-audit.yml`, which fails
+# CI on a dependency with a known advisory (`cargo audit`, `pnpm audit`,
+# `dependency-review`). Dependabot proposes the upgrade; the audit workflow is
+# what stops a vulnerable dep landing in the first place.
+#
+# Everything is grouped and weekly on purpose: this tree carries two Cargo
+# workspaces and ~45 workflows, so ungrouped daily updates would open dozens of
+# PRs a week. Minor and patch bumps ride together in one PR per ecosystem;
+# majors come through individually, because they are the ones that need reading.
+version: 2
+
+updates:
+  # The wingfoil workspace at the repository root.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo:
+        update-types: [minor, patch]
+
+  # `legacy/` is a separate workspace with its own lockfile, so it needs its own
+  # entry — a root-directory cargo update never sees it. Retires with the
+  # legacy tree at cutover, along with every `legacy-*` workflow.
+  - package-ecosystem: cargo
+    directory: /legacy
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      cargo-legacy:
+        update-types: [minor, patch]
+
+  # `js/` — the @wingfoil/client npm package (pnpm lockfile v9).
+  - package-ecosystem: npm
+    directory: /js
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm:
+        update-types: [minor, patch]
+
+  # The workflows themselves. Stale action versions are a supply-chain surface
+  # of their own, and several files still pin v3 of actions Dependabot can move.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        update-types: [minor, patch]

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,9 @@
 * `security-audit.yml` — fails on dependencies with known advisories
   (`cargo audit` for Cargo, `pnpm audit` for `wingfoil-js`, and
   `dependency-review` to block newly introduced vulnerable deps on PRs).
-  Also runs weekly to catch advisories disclosed against pinned deps.
+  Also runs weekly to catch advisories disclosed against pinned deps. Its
+  counterpart is [`../dependabot.yml`](../dependabot.yml), which opens the
+  upgrade PRs — this workflow is the gate, Dependabot is the fix.
 * `rust-fmt.yml` — `cargo fmt` check (manual dispatch).
 
 ## Integration tests

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-[![CI](https://img.shields.io/github/actions/workflow/status/wingfoil-io/wingfoil/rust-test.yml?branch=main&label=CI)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust-test.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/wingfoil-io/wingfoil/rust-test.yml?branch=main&label=CI&logo=githubactions&logoColor=white)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust-test.yml)
+[![Security audit](https://img.shields.io/github/actions/workflow/status/wingfoil-io/wingfoil/security-audit.yml?branch=main&label=security%20audit&logo=githubactions&logoColor=white)](https://github.com/wingfoil-io/wingfoil/actions/workflows/security-audit.yml)
 [![codecov](https://codecov.io/gh/wingfoil-io/wingfoil/graph/badge.svg)](https://codecov.io/gh/wingfoil-io/wingfoil)
-[![Crates.io Version](https://img.shields.io/crates/v/wingfoil.svg)](https://crates.io/crates/wingfoil)
+[![Dependabot](https://img.shields.io/badge/dependabot-enabled-025E8C?logo=dependabot&logoColor=white)](.github/dependabot.yml)
+
+[![Crates.io Version](https://img.shields.io/crates/v/wingfoil?logo=rust&logoColor=white)](https://crates.io/crates/wingfoil)
+[![MSRV](https://img.shields.io/crates/msrv/wingfoil?logo=rust&logoColor=white&label=msrv)](Cargo.toml)
 [![Docs.rs](https://docs.rs/wingfoil/badge.svg)](https://docs.rs/wingfoil/)
-[![PyPI - Version](https://img.shields.io/pypi/v/wingfoil.svg)](https://pypi.org/project/wingfoil/)
-[![npm](https://img.shields.io/npm/v/@wingfoil/client.svg)](https://www.npmjs.com/package/@wingfoil/client)
+[![PyPI - Version](https://img.shields.io/pypi/v/wingfoil?logo=pypi&logoColor=white)](https://pypi.org/project/wingfoil/)
+[![PyPI - Python versions](https://img.shields.io/pypi/pyversions/wingfoil?logo=python&logoColor=white)](https://pypi.org/project/wingfoil/)
+[![npm](https://img.shields.io/npm/v/@wingfoil/client?logo=npm&logoColor=white)](https://www.npmjs.com/package/@wingfoil/client)
 [![Documentation Status](https://readthedocs.org/projects/wingfoil/badge/?version=latest)](https://wingfoil.readthedocs.io/en/latest/)
+
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE.txt)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/rfGqf3Ff)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,17 @@ Out of scope:
 
 ## Dependency vulnerabilities
 
-Dependency advisories are picked up by `cargo audit`
-([`security-audit.yml`](.github/workflows/security-audit.yml)) and Dependabot.
-You are welcome to open a normal public issue for those — they are already
-public by definition.
+Dependency advisories are caught two ways, and the difference matters:
+
+- [`security-audit.yml`](.github/workflows/security-audit.yml) **fails CI** on a
+  dependency with a known advisory — `cargo audit` against RustSec for both
+  Cargo workspaces, `pnpm audit` for `js/`, and `dependency-review` to block a
+  pull request that *introduces* a vulnerable dep. It also runs weekly, so an
+  advisory disclosed against an already-pinned dependency surfaces without a
+  code change.
+- **Dependabot** opens the upgrade PRs: security updates automatically against
+  the GitHub Advisory Database, and routine version bumps on the weekly
+  schedule in [`dependabot.yml`](.github/dependabot.yml).
+
+You are welcome to open a normal public issue for a dependency advisory — they
+are already public by definition.

--- a/crates/wingfoil-python/pyproject.toml
+++ b/crates/wingfoil-python/pyproject.toml
@@ -9,8 +9,21 @@ description = "Python interop prototype for wingfoil (the Op-pattern engine)"
 readme = "README.md"
 requires-python = ">=3.8"
 license = "Apache-2.0"
+# The `Python :: X.Y` entries are what PyPI (and the README's
+# `pypi/pyversions` badge) read to report supported interpreters — neither
+# looks at `requires-python`. Keep this list in step with the build matrix in
+# `.github/workflows/pypi-publish.yml`: a version built there but missing here
+# is invisible to users, and one listed here but not built is a wheel that
+# does not exist.
 classifiers = [
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
 ]


### PR DESCRIPTION
## What this changes

The README badge block gains four badges — security-audit status, Dependabot,
crates.io MSRV, and PyPI supported Python versions — and is grouped into
status / packages / project rows with consistent logos. `.github/dependabot.yml`
is new: weekly grouped version updates for both Cargo workspaces, `js/`, and the
GitHub Actions the workflows pin.

## Why

The badge row said nothing about security posture, and nothing about which
Python interpreters the wheels support — the thing people actually check before
`pip install`. Dependabot was already referenced in `SECURITY.md` but had no
config file, so only its automatic *security* updates were in play; routine
version bumps were never proposed.

Adding the pyversions badge turned up a real gap. It reads
`Programming Language :: Python :: X.Y` classifiers, **not** `requires-python`,
and only `legacy/wingfoil-python` carries them. `crates/wingfoil-python` — the
package that inherits the published name at cutover — had none, so the badge
would have gone blank the moment the name handed over. Its classifier list now
matches the `pypi-publish.yml` build matrix (3.8–3.14), with a comment tying the
two together so they stay in step.

## How it was verified

No Rust changed, so the usual gates have nothing to bite on. What was checked
instead:

- Both new data-driven badges were verified against their upstream source
  rather than by eye: crates.io reports `rust_version = 1.88` for the published
  crate (matches root `Cargo.toml`), and PyPI reports classifiers 3.8–3.14 for
  the published `wingfoil` package, so `crates/msrv` and `pypi/pyversions`
  both have real data behind them.
- `.github/dependabot.yml` parses as YAML and resolves to the four intended
  ecosystem entries; `crates/wingfoil-python/pyproject.toml` still parses and
  carries the full classifier set.
- The `js/` lockfile is pnpm v9, which the npm ecosystem entry supports.

## Notes for the reviewer

**Grouping is deliberate.** Two Cargo workspaces and ~45 workflows would open
dozens of PRs a week ungrouped. Minor and patch bumps ride together in one PR
per ecosystem; majors come through individually, because those are the ones that
need reading.

**`legacy/wingfoil-python/uv.lock` is deliberately not listed**, and that costs
nothing security-wise. Dependabot *security* updates are a repository setting
that needs no config file and already covers every ecosystem it can parse,
including that lockfile. This config only decides where routine version bumps get
proposed — and that tree is dev-only, is deleted at cutover, and its one known
advisory (the pytest one already waived in `security-audit.yml`) cannot be
resolved by upgrading while the floor is 3.8. That gate-versus-fix split is now
written down in `SECURITY.md` and the workflows README.

**The Dependabot badge is static** and links to the config. There is no live
Dependabot status endpoint; the honest live signal is the security-audit badge
next to it.

Two things noticed and left alone: the push to this branch triggered GitHub's
open-Dependabot-alerts notice for the default branch, which is worth a look
independently of this PR; and an **OpenSSF Scorecard** badge would give a real
posture score rather than pass/fail, but it needs its own workflow with
`id-token: write` and publishes results publicly, so it seemed like a call to
make separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNDmhhkMmnHj6jtA5iQ6QA)_