### PR TITLE
docs: move the supported-Python-versions badge to the Python READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Minimum supported Rust version](https://img.shields.io/crates/msrv/wingfoil?logo=rust&logoColor=white&label=rust)](Cargo.toml)
 [![Rust docs](https://img.shields.io/docsrs/wingfoil?logo=docsdotrs&logoColor=white&label=rust%20docs)](https://docs.rs/wingfoil/)
 [![PyPI - Version](https://img.shields.io/pypi/v/wingfoil?logo=pypi&logoColor=white)](https://pypi.org/project/wingfoil/)
-[![PyPI - Python versions](https://img.shields.io/pypi/pyversions/wingfoil?logo=python&logoColor=white)](https://pypi.org/project/wingfoil/)
 [![Python docs](https://img.shields.io/readthedocs/wingfoil/latest?logo=readthedocs&logoColor=white&label=python%20docs)](https://wingfoil.readthedocs.io/en/latest/)
 [![npm](https://img.shields.io/npm/v/@wingfoil/client?logo=npm&logoColor=white)](https://www.npmjs.com/package/@wingfoil/client)
 

--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -1,5 +1,9 @@
 # wingfoil-python
 
+[![PyPI - Version](https://img.shields.io/pypi/v/wingfoil?logo=pypi&logoColor=white)](https://pypi.org/project/wingfoil/)
+[![PyPI - Python versions](https://img.shields.io/pypi/pyversions/wingfoil?logo=python&logoColor=white)](https://pypi.org/project/wingfoil/)
+[![Python docs](https://img.shields.io/readthedocs/wingfoil/latest?logo=readthedocs&logoColor=white&label=python%20docs)](https://wingfoil.readthedocs.io/en/latest/)
+
 Wingfoil is a blazingly fast, highly scalable stream processing framework
 designed for latency-critical use cases such as electronic trading and
 real-time AI systems. You define a graph of transformations over streams;

--- a/legacy/wingfoil-python/README.md
+++ b/legacy/wingfoil-python/README.md
@@ -1,8 +1,8 @@
 # 🚀 Wingfoil
 
-[![PyPI - Version](https://img.shields.io/pypi/v/wingfoil.svg)](https://pypi.org/project/wingfoil/)
-[![Documentation Status](https://readthedocs.org/projects/wingfoil/badge/?version=latest)](https://wingfoil.readthedocs.io/en/latest/)
-[![CI](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust-test.yml/badge.svg)](https://github.com/wingfoil-io/wingfoil/actions/workflows/rust-test.yml)
+[![PyPI - Version](https://img.shields.io/pypi/v/wingfoil?logo=pypi&logoColor=white)](https://pypi.org/project/wingfoil/)
+[![PyPI - Python versions](https://img.shields.io/pypi/pyversions/wingfoil?logo=python&logoColor=white)](https://pypi.org/project/wingfoil/)
+[![Python docs](https://img.shields.io/readthedocs/wingfoil/latest?logo=readthedocs&logoColor=white&label=python%20docs)](https://wingfoil.readthedocs.io/en/latest/)
 
 Wingfoil is a **blazingly fast**, highly scalable
 [stream processing framework](https://github.com/wingfoil-io/wingfoil/tree/main/wingfoil/benches/)


### PR DESCRIPTION
## What this changes

The root README drops the `pyversions` badge — packages row from six badges to
five — and both Python READMEs gain a badge block of their own: PyPI version,
supported interpreters, Python docs.

## Why

Follow-up to #745. The 3.8–3.14 interpreter list is Python-package detail, and
the root README is the front door for a three-language repository. Someone
reading it wants to know a Python package exists and what version it is at;
someone who needs to know whether their 3.9 will work is already on the Python
page — where, until now, there were no badges at all.

**Both** Python READMEs, because they are two pages doing the same job at
different times:

- `crates/wingfoil-python/README.md` is the crates.io page today, and becomes
  the PyPI long description when the published name hands over at cutover.
- `legacy/wingfoil-python/README.md` is what PyPI renders **until** then.

Updating only the first would leave the badge invisible to every actual PyPI
visitor in the meantime.

## How it was verified

Docs only — no Rust, no manifests, nothing that compiles. Every badge URL is
one already in use on the root README after #745, pointed at the same published
`wingfoil` package, so nothing new needed checking beyond the placement.

## Notes for the reviewer

Two deliberate omissions in the new blocks:

**The legacy block loses its CI badge.** That is a repository fact rather than a
package one, and it is already on the root page — a PyPI visitor has no use for
the state of `rust-test.yml` on `main`.

**Neither block carries a license badge**, which a package landing page would
normally want. The two trees currently disagree — `legacy/wingfoil-python`
publishes MIT metadata while `crates/wingfoil-python` is Apache-2.0, matching
the crate — and a badge is the wrong instrument for settling that. Worth
resolving separately before the name hands over, since it is the published
metadata that users actually see.

One caveat on the badge itself: on the PyPI page it partly duplicates the
sidebar, which lists the same classifiers. It earns its place on GitHub, where
the same file is read without that sidebar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNDmhhkMmnHj6jtA5iQ6QA)_