### PR TITLE
docs: point every Discord link at the invite that does not expire

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/wingfoil-io/wingfoil/discussions
     about: Ask how to wire something, or float an idea before it becomes an issue.
   - name: Chat on Discord
-    url: https://discord.gg/rfGqf3Ff
+    url: https://discord.gg/WfZwpQnZUA
     about: The fastest way to get a question answered.
   - name: Security vulnerability
     url: https://github.com/wingfoil-io/wingfoil/security/advisories/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Wingfoil
 
-We'd love your help. Say hi on [Discord](https://discord.gg/rfGqf3Ff), open a
+We'd love your help. Say hi on [Discord](https://discord.gg/WfZwpQnZUA), open a
 [discussion](https://github.com/wingfoil-io/wingfoil/discussions), or comment
 on any issue you fancy.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![npm](https://img.shields.io/npm/v/@wingfoil/client?logo=npm&logoColor=white)](https://www.npmjs.com/package/@wingfoil/client)
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE.txt)
-[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/rfGqf3Ff)
+[![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/WfZwpQnZUA)
 
 # Wingfoil
 
@@ -221,7 +221,7 @@ We want to hear from you! Especially if you:
 - have any feedback
 
 Please do get in touch:
-- ping us on [discord](https://discord.gg/rfGqf3Ff)
+- ping us on [discord](https://discord.gg/WfZwpQnZUA)
 - email us at [hello@wingfoil.io](mailto:hello@wingfoil.io)
 - submit an [issue](https://github.com/wingfoil-io/wingfoil/issues)
 - get involved in the [discussion](https://github.com/wingfoil-io/wingfoil/discussions/)

--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -958,6 +958,6 @@ love your input — especially if you:
 - have any feedback.
 
 Email us at [hello@wingfoil.io](mailto:hello@wingfoil.io), ping us on
-[discord](https://discord.gg/rfGqf3Ff), open a
+[discord](https://discord.gg/WfZwpQnZUA), open a
 [GitHub discussion](https://github.com/wingfoil-io/wingfoil/discussions/), or
 browse the [issue tracker](https://github.com/wingfoil-io/wingfoil/issues).

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -138,7 +138,7 @@ We want to hear from you!  Especially if you:
 - have any feedback
 
 Please do get in touch:
-- ping us on [discord](https://discord.gg/rfGqf3Ff)
+- ping us on [discord](https://discord.gg/WfZwpQnZUA)
 - email us at [hello@wingfoil.io](mailto:hello@wingfoil.io)
 - submit an [issue](https://github.com/wingfoil-io/wingfoil/issues)
 - get involved in the [discussion](https://github.com/wingfoil-io/wingfoil/discussions/)


### PR DESCRIPTION
## What this changes

Every `discord.gg` link in the tree now uses the same, non-expiring invite code.
Six references across five files:

- `README.md` — the Discord badge, and the "ping us on discord" line
- `.github/ISSUE_TEMPLATE/config.yml` — the "Chat on Discord" entry in the
  new-issue chooser
- `CONTRIBUTING.md`
- `crates/wingfoil-python/README.md`
- `legacy/README.md`

## Why

`discord.gg/rfGqf3Ff` was dead — every one of those links landed on "Invalid
Invite", including the badge on the front page and the issue-template chooser,
which is the path someone takes when they have a question and are trying *not*
to open an issue.

The cause is a default worth knowing: **Discord invites expire after seven
days** unless you open "Edit invite link" and set Expire After to Never. A link
pasted into documentation therefore dies a week later while the server itself is
perfectly healthy.

The replacement, `WfZwpQnZUA`, was generated with Expire After set to Never —
and it turned out to be a code **already in the tree**, in
`legacy/CONTRIBUTING.md`. Asking Discord for a never-expiring invite returns the
existing invite matching those settings rather than minting a duplicate, which
is decent evidence it has been live the whole time. So the repository was
carrying two codes, one working and one dead, and the working one was in the
single file least likely to be read. All six now agree.

## How it was verified

A literal find-and-replace of the invite code, confirmed by grep: no occurrence
of the old code remains anywhere in the tree, and all seven `discord.gg` links
(the six changed plus the already-correct `legacy/CONTRIBUTING.md`) now carry
the same code.

The link itself was **not** fetched from CI — `discord.gg` is unreachable from
the sandbox this was authored in. It rests on the invite having been generated
interactively with Expire After: Never, and on the corroboration above. Worth
one manual click before merge, ideally in a logged-out or private window, which
is what a first-time visitor sees.

## Notes for the reviewer

This is the kind of breakage nothing currently catches: no test or lint reads
documentation links, so the badge could sit dead indefinitely. If it seems worth
it, a link-check step over `*.md` in CI would catch the next one — happy to add
it separately, though it needs care around rate-limited and login-walled hosts
to avoid becoming a flaky job that people learn to ignore.

The `legacy/CONTRIBUTING.md` link is unchanged — it was already correct.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNDmhhkMmnHj6jtA5iQ6QA)_