### PR TITLE
Make busy-poll sources expressible in `nitro!`, and correct the compiled-tier IO classification

### DIFF
--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -119,9 +119,21 @@
 //!
 //! Limitations (v1): wiring itself must be straight-line (no wiring inside
 //! loops/conditionals — the DAG must be static; use `.map_n` / `.fan` for
-//! regular repeated topologies); IO-edge sources and sinks
-//! (`external`, `poll`, `for_each`) are not expressible — IO lives at the
-//! fluent layer, feeding compiled islands through their inputs.
+//! regular repeated topologies); and the **wake-driven** IO sources
+//! `external` / `channel` (`Activation::THREADED`) are not expressible — a
+//! compiled graph builds its `Kernel` without a ready receiver, so nothing can
+//! set their dirty bit. Those live at the fluent layer, feeding compiled
+//! islands through their inputs.
+//!
+//! Two things this list used to name are no longer limitations. The
+//! `for_each` **sink** is an ordinary op (`ops::Sink`) and always emitted here
+//! — the compiled expansion explicitly accounts for a side-effect-only node
+//! whose value locals are write-only. And the busy-poll source `poll`
+//! (`Activation::ALWAYS`) now works in both compiled tiers: the expansion
+//! const-folds "does this graph spin" out of its ops' `ACTIVATION` consts and
+//! calls `Kernel::set_spin`, and an island declares `always` outward so the
+//! *outer* engine spins. Both are pinned by `tests/op_completeness.rs` and
+//! `tests/poll_all_tiers.rs`.
 //!
 //! # When a method name doesn't resolve
 //!

--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -3037,6 +3037,26 @@ fn node_dispatch(def: &NitroDef, target: Target, i: usize) -> TokenStream2 {
 
 fn expand_compiled(def: &NitroDef) -> TokenStream2 {
     let n = def.nodes.len();
+    // Whether the graph holds a busy-poll (`Activation::ALWAYS`) source — the
+    // OR of every op's `ACTIVATION` const, folded at compile time exactly like
+    // the island's `callback_activated` flag below.
+    //
+    // The dispatch condition in `node_dispatch` already cycles an `always` node
+    // unconditionally, but that is only half of what a poll source needs: a
+    // realtime `begin_cycle` *parks* until the next scheduled callback, so a
+    // graph whose only source polls would sleep instead of spinning. The
+    // interpreted `Runner` sets this from its `has_always` flag; the compiled
+    // tier had no equivalent, which is why `poll` was not expressible here.
+    let act_consts: Vec<Ident> = def
+        .nodes
+        .iter()
+        .filter(|node| !node.is_input())
+        .map(|node| node.op_const("ACTIVATION"))
+        .collect();
+    // Parenthesised: this is an `||` chain spliced into larger conditions, and
+    // `&&` binds tighter — without the parens `#spins && cond` would parse as
+    // `.. || (last.always && cond)` and fire whenever *any* op is `always`.
+    let spins = quote! { (false #(|| #act_consts.always)*) };
     let setup = interleaved_setup(def);
     let mut starts = Vec::new();
     let mut body = Vec::new();
@@ -3066,7 +3086,20 @@ fn expand_compiled(def: &NitroDef) -> TokenStream2 {
             run_mode: ::wingfoil::RunMode,
             run_for: ::wingfoil::RunFor,
         ) -> ::wingfoil::anyhow::Result<( #(#out_types,)* )> {
+            // A busy-poll source is wall-clock and realtime-only, exactly as in
+            // the interpreted `Runner` — a reachable caller error, so `bail!`
+            // rather than `assert!` (see CLAUDE.md's error-handling rules).
+            if #spins && !::core::matches!(run_mode, ::wingfoil::RunMode::RealTime) {
+                ::wingfoil::anyhow::bail!(
+                    "graphs with poll sources require RunMode::RealTime — there is \
+                     nothing to busy-poll in a deterministic historical replay"
+                );
+            }
             let mut __k = ::wingfoil::Kernel::new(run_mode, run_for);
+            // Busy-spin: never park, so the poll closure runs every cycle.
+            if #spins {
+                __k.set_spin(true);
+            }
             #(#setup)*
             // Cleanup (stop/teardown) must run even when `start` or a cycle
             // aborts, so the run phase is an immediately-invoked closure whose
@@ -3122,6 +3155,12 @@ fn expand_nested(def: &NitroDef) -> TokenStream2 {
         .collect();
     let callback_activated = quote! {
         false #(|| #act_consts.callback_activated())*
+    };
+    // Whether the island holds a busy-poll op, declared outward so the outer
+    // engine cycles the composite every cycle and its kernel spins rather than
+    // parks. Parenthesised for the same precedence reason as `expand_compiled`.
+    let island_spins = quote! {
+        (false #(|| #act_consts.always)*)
     };
     let setup = interleaved_setup(def);
     let mut starts = Vec::new();
@@ -3213,7 +3252,7 @@ fn expand_nested(def: &NitroDef) -> TokenStream2 {
                     __passive.push(#ix_ids);
                 }
             )*
-            __g.__composite(__active, __passive, #callback_activated, move |__ctx, __phase| {
+            __g.__composite(__active, __passive, #callback_activated, #island_spins, move |__ctx, __phase| {
                 let __now = __ctx.time();
                 // The outer cycle's wall snap, taken once and shared by every
                 // inner node's `Ctx`. Per-node `NanoTime::now()` reads used to

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -138,14 +138,18 @@ impl GraphBuilder {
         active_ups: Vec<usize>,
         passive_ups: Vec<usize>,
         callback_activated: bool,
+        always: bool,
         node: impl FnMut(&mut crate::op::Ctx, crate::op::CompositePhase) -> Result<crate::op::Tick<T>>
         + 'static,
     ) -> Stream<T> {
         self.assert_not_built();
-        let handle =
-            self.inner
-                .borrow_mut()
-                .composite(active_ups, passive_ups, callback_activated, node);
+        let handle = self.inner.borrow_mut().composite(
+            active_ups,
+            passive_ups,
+            callback_activated,
+            always,
+            node,
+        );
         self.wrap(handle)
     }
 

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -2249,6 +2249,7 @@ impl Builder {
         active_ups: Vec<usize>,
         passive_ups: Vec<usize>,
         callback_activated: bool,
+        always: bool,
         node: F,
     ) -> Handle<T>
     where
@@ -2265,10 +2266,18 @@ impl Builder {
         let cell_start = cell.clone();
         let cell_stop = cell.clone();
         let cell_teardown = cell.clone();
+        // An island holding a busy-poll (`Activation::ALWAYS`) op must say so
+        // outward: the composite is one node to the outer engine, so unless it
+        // declares `always` the outer dispatch never cycles it (a source island
+        // has no upstream edge to be activated by) and the outer kernel parks
+        // instead of spinning. Mirrors `Builder::poll` setting the same flag.
+        if always {
+            self.has_always = true;
+        }
         let caps = Activation {
             schedules: callback_activated,
             threaded: false,
-            always: false,
+            always,
         };
         self.push_node(
             active_ups,

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -2898,6 +2898,12 @@ impl<T: Clone + 'static> Op for Sample<T> {
 /// mutating captures (see [`Map`] for why).
 pub struct Poll<T, F>(PhantomData<(T, F)>);
 
+// `no_builder`: the interpreted [`Builder::poll`](crate::interp::Builder::poll)
+// is hand-written because a poll source also sets the builder-level
+// `has_always` / `re_runnable` flags, which a generated method cannot reach.
+// The attribute is still needed for the `nitro!` forwarders — without them a
+// busy-poll source has no compiled dispatch and cannot appear in `nitro!`.
+#[op(build = poll, no_builder)]
 impl<T, F> Op for Poll<T, F>
 where
     T: Clone + 'static,

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -41,11 +41,28 @@
 //! `surface_stats_*` blocks. Category 2b is down to `logged` alone.
 //!
 //! **1. IO / cycle — not expressible by design** (capability matrix `❌`):
-//!   * `external`, `channel`, `poll` — IO / threaded / busy-poll sources; the
-//!     compiled path runs its own loop with no external wake.
+//!   * `external`, `channel` — wake-driven (`Activation::THREADED`) sources.
+//!     A compiled graph builds its `Kernel` *without* a ready receiver, so
+//!     nothing can ever set their dirty bit. Lifting this needs more than a
+//!     kernel flag: a producer handle must escape to the caller before the run
+//!     starts, and `compiled()` returns only when the run ends.
 //!   * `feedback` (source + the `feedback` close method) — a cycle in the DAG,
 //!     which straight-line compiled emission cannot express (v1 out-of-scope).
-//!   * `for_each` — a fallible IO sink; lives at the runtime boundary.
+//!
+//!     **`poll` and `for_each` were both in this list and have since left it**
+//!     — the same trajectory `not`, `collapse`, `count` and `merge_all` took
+//!     out of category 2. Neither is exercised in *this* file's `nitro!`
+//!     blocks, so both are recorded here rather than left "silently in
+//!     neither":
+//!     - `for_each` is an ordinary op (`ops::Sink`) and has been dual-mode for
+//!       some time; the classification above simply went stale. It is spelled
+//!       in `surface_lifecycle` below, alongside the other side-effect nodes.
+//!     - `poll` (`Activation::ALWAYS`) is dual-mode as of the busy-spin work in
+//!       `port-plan.md` footnote 17, but is **realtime-only** — it cannot ride
+//!       this file's `HISTORICAL` blocks, which is the whole point of the
+//!       three-engine parity harness below. It is pinned instead by
+//!       `tests/poll_all_tiers.rs`, the same way `merge_n.rs` and
+//!       `combine_n.rs` pin the two variadic ops' hand-written forwarders.
 //!
 //! **2. Sugar over a primitive — spell the primitive in `nitro!`:**
 //!   * `split` → two `map`s. It is the only one left, and it is left because it
@@ -262,14 +279,18 @@ wingfoil::nitro! {
 }
 
 // Lifecycle / passthrough surface: `print` (a plain per-tick pass-through
-// since deviation D8 dropped its teardown buffer) and `timed` (passes values
+// since deviation D8 dropped its teardown buffer), `timed` (passes values
 // through unchanged while carrying the start/stop hooks the compiled path
-// emits).
+// emits), and `for_each` (the fallible sink — a side-effect-only node with no
+// downstream, whose value/state locals the compiled expansion leaves
+// write-only).
 wingfoil::nitro! {
     fn surface_lifecycle(g: &GraphBuilder) -> Stream<Vec<u64>> {
         let count = g.ticker(P).count();
         let printed = count.print();
         let timed = printed.timed();
+        // Not part of the tail: a pure sink, exercising the terminal-node path.
+        let sunk = timed.for_each(|_v: &u64| Ok(()));
         let out = timed.accumulate();
         out
     }

--- a/crates/wingfoil/tests/poll_all_tiers.rs
+++ b/crates/wingfoil/tests/poll_all_tiers.rs
@@ -1,0 +1,85 @@
+//! **A busy-poll source across all three tiers.** `poll` is the first
+//! `Activation::ALWAYS` op to reach `nitro!`, and `always` is the one
+//! activation the compiled tiers could not previously honour: `node_dispatch`
+//! already cycles such a node unconditionally, but a realtime `begin_cycle`
+//! *parks* until the next scheduled callback, so a graph whose only source
+//! polls would sleep rather than spin. The interpreted `Runner` sets
+//! `Kernel::set_spin` from its `has_always` flag; the compiled expansion now
+//! derives the same fact from the OR of its ops' `ACTIVATION` consts, and a
+//! `nested()` island declares it outward so the *outer* engine spins.
+//!
+//! The parity assertion is what pins all three: an island that failed to
+//! declare `always` outward is never cycled at all (the composite is one node
+//! with no upstream edge to activate it), which shows up here as a zero.
+
+use std::cell::Cell;
+
+use wingfoil::prelude::*;
+use wingfoil::{RunFor, RunMode};
+
+thread_local! {
+    static NEXT: Cell<u64> = const { Cell::new(0) };
+}
+
+fn reset() {
+    NEXT.with(|c| c.set(0));
+}
+
+wingfoil::nitro! {
+    fn polled(g: &GraphBuilder) -> Stream<u64> {
+        // Ticks every cycle with a monotonically increasing value.
+        let src = g.poll(|| {
+            NEXT.with(|c| {
+                let v = c.get() + 1;
+                c.set(v);
+                Some(v)
+            })
+        });
+        let doubled = src.map(|v: &u64| v * 2);
+        doubled
+    }
+}
+
+#[test]
+fn poll_source_runs_in_all_three_tiers() {
+    // Interpreted — the reference.
+    reset();
+    let (mut runner, out) = polled::interpreted();
+    runner
+        .run(RunMode::RealTime, RunFor::Cycles(5))
+        .expect("interpreted run");
+    let interpreted = runner.value(out);
+    assert_eq!(10, interpreted, "interpreted: 5 polls, doubled");
+
+    // Compiled — standalone, owns its own kernel and run loop.
+    reset();
+    let (compiled,) = polled::compiled(RunMode::RealTime, RunFor::Cycles(5)).expect("compiled run");
+    assert_eq!(interpreted, compiled, "compiled must match interpreted");
+
+    // Nested — the same graph mounted as one island in an interpreted graph.
+    reset();
+    let g = GraphBuilder::new();
+    let island = polled::nested(&g);
+    let mut runner = g.build();
+    runner
+        .run(RunMode::RealTime, RunFor::Cycles(5))
+        .expect("nested run");
+    let nested = runner.value(island);
+    assert_eq!(interpreted, nested, "nested must match interpreted");
+}
+
+/// A poll source is wall-clock, so a historical run must be rejected — the same
+/// contract the interpreted `Runner` enforces.
+#[test]
+fn poll_in_compiled_rejects_historical() {
+    reset();
+    let err = polled::compiled(
+        RunMode::HistoricalFrom(wingfoil::NanoTime::ZERO),
+        RunFor::Cycles(5),
+    )
+    .expect_err("historical must be rejected");
+    assert!(
+        err.to_string().contains("require RunMode::RealTime"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/wingfoil/tests/trybuild/unknown_combinator.stderr
+++ b/crates/wingfoil/tests/trybuild/unknown_combinator.stderr
@@ -1,20 +1,3 @@
-error[E0425]: cannot find value `__WF_OP_FROBNICATE_PASSIVE` in this scope
-  --> tests/trybuild/unknown_combinator.rs:12:62
-   |
-12 |         let out = g.ticker(Duration::from_nanos(10)).count().frobnicate();
-   |                                                              ^^^^^^^^^^
-   |
-  ::: src/ops.rs
-   |
-   | #[op(build = accumulate, fluent)]
-   | --------------------------------- similarly named constant `__WF_OP_ACCUMULATE_PASSIVE` defined here
-   |
-help: a constant with a similar name exists
-   |
-12 -         let out = g.ticker(Duration::from_nanos(10)).count().frobnicate();
-12 +         let out = g.ticker(Duration::from_nanos(10)).count().__WF_OP_ACCUMULATE_PASSIVE();
-   |
-
 error[E0425]: cannot find value `__WF_OP_FROBNICATE_ACTIVATION` in this scope
   --> tests/trybuild/unknown_combinator.rs:12:62
    |
@@ -30,6 +13,23 @@ help: a constant with a similar name exists
    |
 12 -         let out = g.ticker(Duration::from_nanos(10)).count().frobnicate();
 12 +         let out = g.ticker(Duration::from_nanos(10)).count().__WF_OP_ACCUMULATE_ACTIVATION();
+   |
+
+error[E0425]: cannot find value `__WF_OP_FROBNICATE_PASSIVE` in this scope
+  --> tests/trybuild/unknown_combinator.rs:12:62
+   |
+12 |         let out = g.ticker(Duration::from_nanos(10)).count().frobnicate();
+   |                                                              ^^^^^^^^^^
+   |
+  ::: src/ops.rs
+   |
+   | #[op(build = accumulate, fluent)]
+   | --------------------------------- similarly named constant `__WF_OP_ACCUMULATE_PASSIVE` defined here
+   |
+help: a constant with a similar name exists
+   |
+12 -         let out = g.ticker(Duration::from_nanos(10)).count().frobnicate();
+12 +         let out = g.ticker(Duration::from_nanos(10)).count().__WF_OP_ACCUMULATE_PASSIVE();
    |
 
 error[E0599]: no method named `frobnicate` found for struct `wingfoil::fluent::Stream<T>` in the current scope

--- a/docs/port-plan.md
+++ b/docs/port-plan.md
@@ -94,7 +94,7 @@ today's interpreted engine.
 | Split + glitch-free recombine (single-fire) | ✅ | ✅ | ✅ | ✅ |
 | Delay & self-scheduling (`SCHEDULES`) | ✅ | ✅ | ✅ | ✅ |
 | Feedback / cycles | ✅ | ✅¹ | ❌ | ❌ |
-| Busy-poll ingest (`ALWAYS`) | ✅ | ✅ | ❌ | ❌ |
+| Busy-poll ingest (`ALWAYS`) | ✅ | ✅ | ✅¹⁷ | ✅¹⁷ |
 | External / channel / async sources (`THREADED`) | ✅ | ✅ | ❌ | ❌ |
 | Bursts (never latest-wins) | ✅ | ✅ | ❌² | ❌² |
 | Historical replay | ✅ | ✅ | ✅³ | ✅ |
@@ -112,10 +112,17 @@ today's interpreted engine.
 
 ¹ Fluent layer only (engine-level `+1` edge); not expressible inside `nitro!`.
 ² No burst *sources* exist in the macro vocabulary; the pattern is about IO
-  ingestion, which the compiled path excludes anyway. Lifting this (with
-  busy-poll ingest) is deferred post-v1 — see "Deferred / post-v1 work".
-³ Compiled runs its own loop with no external wake, so realtime is
-  timer-driven only; historical/timer + data-via-consts is full.
+  ingestion via `external`/`channel`, which the compiled path still excludes
+  (see ³). Busy-poll ingest, which this footnote used to be bracketed with, has
+  since landed — see ¹⁷.
+³ Compiled runs its own loop with no external *wake*: it constructs its
+  `Kernel` without a ready receiver, so a `THREADED` source
+  (`external`/`channel`) can never set its dirty bit. Realtime is therefore
+  timer- or poll-driven (see ¹⁷), not wake-driven; historical/timer +
+  data-via-consts is full. Lifting the wake path needs more than a kernel
+  flag — a producer handle has to escape to the caller *before* the run, and
+  `compiled()` returns only when the run ends — so it wants a scoped entry
+  point rather than a signature tweak.
 ⁴ **Full lifecycle, all three engines** (this footnote previously read
   "`start` emitted; `stop`/`teardown` emitted once a macro-expressible op needs
   them (none do yet)" — that is stale). `#[op]` emits `_stop`/`_teardown`
@@ -188,6 +195,19 @@ today's interpreted engine.
   By design the compiled/island paths stay uninstrumented: they exist to be a
   monomorphized loop with no engine indirection, and legacy has no compiled
   path for them to be at parity with.
+¹⁷ **Landed.** `poll` is `#[op(build = poll, no_builder)]`, so it dispatches
+  through the ordinary forwarders; the hand-written `Builder::poll` stays
+  because it also sets the builder-level `has_always` / `re_runnable` flags.
+  `node_dispatch` already cycled an `ALWAYS` node unconditionally — what was
+  missing was the kernel side. `expand_compiled` now derives "this graph
+  spins" from the OR of its ops' `ACTIVATION` consts (the same const-fold the
+  island used for `callback_activated`), calls `Kernel::set_spin`, and rejects
+  a historical run with the interpreted `Runner`'s message. An island declares
+  `always` outward through `Builder::composite`, without which the outer engine
+  never cycles the composite at all — a source island has no upstream edge to
+  be activated by — and the outer kernel parks instead of spinning. Pinned by
+  `tests/poll_all_tiers.rs`. This is ingest, not full IO: `external`/`channel`
+  (`THREADED`) remain excluded per ³.
 ## Phase 0 — design spikes
 
 Four contract questions, each resolved with a spike + parity test before any


### PR DESCRIPTION
## What this changes

`poll` (`Activation::ALWAYS`) now works in `compiled()` and `nested()`, not just interpreted. Three docs that claimed `poll` and `for_each` cannot reach `nitro!` are corrected — one claim made stale by this PR, the other stale already.

## Why

`nitro!`'s excluded-op list read as a structural property of the compiled tier. Investigating it, most of the barrier turned out to be narrow:

- `node_dispatch` **already** emits an unconditional cycle for an `ALWAYS` node, and `Kernel` already owns the whole spin/park/wake machinery (`set_spin`, `with_ready`, `recv_timeout` parking). What was missing was only the *kernel construction* side of `compiled()`.
- `ops::Poll` was already a complete `Op` — right `Cfg`, `State`, `In`, `Out`, `ACTIVATION` — with no `#[op(build = …)]`, so it had no forwarders to dispatch through.
- `for_each` was **already** dual-mode before this branch: `ops::Sink` carries `#[op(build = for_each, fluent)]`, it is absent from the macro's `fluent_only_advice` rejection list, and the compiled expansion explicitly accounts for a side-effect-only node. Only the classification was stale.

Three changes:

1. `#[op(build = poll, no_builder)]` on `Poll` — `no_builder` keeps the hand-written `Builder::poll`, which also sets the builder-level `has_always` / `re_runnable` flags a generated method cannot reach.
2. `expand_compiled` derives "this graph spins" from the OR of its ops' `ACTIVATION` consts — the same const-fold the island already used for `callback_activated` — then calls `Kernel::set_spin` and rejects a historical run with the interpreted `Runner`'s message.
3. `Builder::composite` hardcoded `always: false`, so an island holding a poll source could not declare it outward. The outer engine therefore never cycled the composite at all (a source island has no upstream edge to activate it) and its kernel parked instead of spinning. Now threaded through `GraphBuilder::__composite` from the nested expansion.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` ✅ — **`cargo lint-all` not run**: `--all-features` cannot build in this environment (aeron needs CMake ≥3.30, box has 3.28; etcd needs protoc). Both are the documented prerequisites in `CLAUDE.md` and unrelated to this diff, but CI is the first real check on that feature set.
- [ ] `--all-features` blocked as above. Ran the full default suite plus `bench,async,csv,cache,augurs,market,ws,redis,postgres,kafka,web,kdb,prometheus,fix,dynamic-graph,tracing` — all green.
- [x] New behaviour is covered by a test asserting values across all three tiers

`tests/poll_all_tiers.rs` pins value parity across interpreted / compiled / nested plus the historical-mode rejection. `for_each` is now spelled in `op_completeness.rs::surface_lifecycle`, which is the two-sided guard proving both fluent method and forwarder exist.

The `tick times` half of that checklist item does not apply here — a busy-spin graph is realtime-only and has no deterministic tick schedule to assert against, which is also why `poll` cannot ride `op_completeness.rs`'s `HISTORICAL` blocks.

## Notes for the reviewer

**The `unknown_combinator.stderr` snapshot is regenerated.** The new `__WF_OP_POLL_*` constants reorder rustc's two "similarly named constant" suggestions. I verified against a stashed tree that clean `main` passes, so the churn is genuinely from this diff, and confirmed the change is a pure swap of the two `E0425` blocks with identical content. Any new op will do this — worth capturing in the `/new-op` skill, which I have not done here.

**An operator-precedence trap worth knowing about.** `spins` expands to an `||` chain, and `&&` binds tighter, so `#spins && !realtime` first parsed as `… || (last.always && !realtime)` and rejected *realtime* runs. It is parenthesised with a comment now. The same trap is waiting for anyone splicing `callback_activated` into a larger condition.

**Scope deliberately stops short of full IO.** `external`/`channel` (`THREADED`) remain excluded, and the reason is now recorded in `port-plan.md` footnote 3: the barrier is not the run loop but the *signature* — a producer handle must escape to the caller before the run starts, and `compiled()` returns only when the run ends. Lifting it wants a scoped entry point (`std::thread::scope`-shaped), not a kernel flag. `feedback` stays out for the original reason: straight-line emission cannot express a cycle.

**No benchmark.** The motivating case is kernel-bypass ingress (`trading-roadmap.md` item 7 specifies an `Activation::ALWAYS` spin node draining an RX ring), where the existing tier numbers suggest ~24 ns/cycle against ~288 ns interpreted. This PR proves correctness, not that figure — no poll graph is measured. Happy to add a bench if the perf claim should be load-bearing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4eojqRWBJ6uK5v5JDzmkd)_