### PR TITLE
`EmitLiteral`: render data configs as Rust source

### DIFF
--- a/crates/wingfoil/src/emit.rs
+++ b/crates/wingfoil/src/emit.rs
@@ -1,0 +1,266 @@
+//! Rendering a **value** back into Rust source that reconstructs it.
+//!
+//! The other half of what a two-pass generator needs from a wired graph.
+//! [`quote`](crate::quote) recovers *closure* configs, because closures are
+//! erased and only their tokens survive. This module covers the *data* configs
+//! — a `ticker`'s `Duration`, a `fold`'s seed, a `limit`'s bound — which are
+//! not erased at all: the value is right there, it just has no way to say what
+//! it would look like written down.
+//!
+//! `docs/wired-graph-codegen-decision.md` §3 names this as `EmitLiteral` and
+//! bounds the emittable set to "primitives, `String`, `Duration`, `NanoTime`,
+//! `Vec<primitive>`, …". Tracked as #726.
+//!
+//! # Why render the value rather than capture its name
+//!
+//! `func!` keeps *source text* (`|x| x * 2`), which is the only option for a
+//! closure. The tempting symmetry would be a `lit!(PERIOD)` capturing the token
+//! `PERIOD` — and it reads beautifully in a generated artifact.
+//!
+//! It is also wrong for the case the generator exists to serve. A name only
+//! resolves if the artifact is compiled in a scope where that name is bound,
+//! and the whole point of pass 1 is topology decided by **running code** —
+//! periods read from a config file, thresholds from a database. Those values
+//! have no name to capture. Rendering the value works for both, which is why
+//! §3 specifies it, and why the same mechanism serves §3's frozen captures
+//! (`{ let thresh = 0.25f64; move |x| x.abs() > thresh }`).
+//!
+//! The cost is the one §3 names loudly: emitting a value **freezes** it. The
+//! artifact carries pass 1's configuration, so changing it means regenerate and
+//! recompile. That is partial evaluation, often the point — but ship a stale
+//! threshold once and you will want this sentence to have been louder.
+//!
+//! # Round-tripping is the contract
+//!
+//! Every impl must produce source that evaluates back to an equal value, and
+//! each is pinned by a test that says so. The float impls are where this bites:
+//! `{}` formatting loses precision, so they use `{:?}` (which is
+//! round-trippable) and special-case the non-finite values, which have no
+//! literal form at all.
+
+use std::time::Duration;
+
+use crate::runtime::time::NanoTime;
+
+/// A value that can render itself as Rust source reconstructing it.
+///
+/// The output must be a self-contained *expression*, valid wherever the
+/// artifact is compiled — so paths are absolute (`::core::time::Duration`),
+/// never relying on the generator's imports being present at the far end.
+pub trait EmitLiteral {
+    /// Rust source that evaluates to a value equal to `self`.
+    fn emit_literal(&self) -> String;
+}
+
+/// Integers and other types whose `Display` is already a valid literal, given a
+/// type suffix. The suffix is not decoration: an unsuffixed `1` in a generated
+/// artifact infers to `i32` and mismatches a `u64` config.
+macro_rules! emit_suffixed {
+    ($($t:ty => $suffix:literal),* $(,)?) => {$(
+        impl EmitLiteral for $t {
+            fn emit_literal(&self) -> String {
+                format!(concat!("{}", $suffix), self)
+            }
+        }
+    )*};
+}
+
+emit_suffixed! {
+    u8 => "u8", u16 => "u16", u32 => "u32", u64 => "u64", u128 => "u128", usize => "usize",
+    i8 => "i8", i16 => "i16", i32 => "i32", i64 => "i64", i128 => "i128", isize => "isize",
+}
+
+/// Floats need `{:?}`, not `{}`: `Display` truncates (`0.1 + 0.2` prints as
+/// `0.30000000000000004` either way, but plenty of values do not survive
+/// `Display`), while `Debug` is specified to round-trip. The non-finite values
+/// have no literal form and must be named.
+macro_rules! emit_float {
+    ($($t:ty => $suffix:literal, $path:literal),* $(,)?) => {$(
+        impl EmitLiteral for $t {
+            fn emit_literal(&self) -> String {
+                if self.is_nan() {
+                    format!("{}::NAN", $path)
+                } else if *self == <$t>::INFINITY {
+                    format!("{}::INFINITY", $path)
+                } else if *self == <$t>::NEG_INFINITY {
+                    format!("{}::NEG_INFINITY", $path)
+                } else {
+                    format!(concat!("{:?}", $suffix), self)
+                }
+            }
+        }
+    )*};
+}
+
+emit_float! {
+    f32 => "f32", "::core::primitive::f32",
+    f64 => "f64", "::core::primitive::f64",
+}
+
+impl EmitLiteral for bool {
+    fn emit_literal(&self) -> String {
+        if *self { "true" } else { "false" }.to_string()
+    }
+}
+
+impl EmitLiteral for char {
+    fn emit_literal(&self) -> String {
+        format!("{self:?}")
+    }
+}
+
+impl EmitLiteral for str {
+    /// `{:?}` on a `str` is Rust's own escaping, so quotes, backslashes and
+    /// control characters come back out as a valid literal.
+    fn emit_literal(&self) -> String {
+        format!("{self:?}")
+    }
+}
+
+impl EmitLiteral for String {
+    fn emit_literal(&self) -> String {
+        format!("{:?}.to_string()", self.as_str())
+    }
+}
+
+impl EmitLiteral for Duration {
+    /// `Duration::new(secs, nanos)` rather than `from_millis` and friends: it is
+    /// exact for every representable value, where the convenience constructors
+    /// only round-trip durations that happen to land on their unit.
+    fn emit_literal(&self) -> String {
+        format!(
+            "::core::time::Duration::new({}u64, {}u32)",
+            self.as_secs(),
+            self.subsec_nanos()
+        )
+    }
+}
+
+impl EmitLiteral for NanoTime {
+    fn emit_literal(&self) -> String {
+        format!("::wingfoil::NanoTime::from({}u64)", u64::from(*self))
+    }
+}
+
+impl<T: EmitLiteral + ?Sized> EmitLiteral for &T {
+    fn emit_literal(&self) -> String {
+        (**self).emit_literal()
+    }
+}
+
+impl<T: EmitLiteral> EmitLiteral for Option<T> {
+    fn emit_literal(&self) -> String {
+        match self {
+            Some(v) => format!("::core::option::Option::Some({})", v.emit_literal()),
+            None => "::core::option::Option::None".to_string(),
+        }
+    }
+}
+
+impl<T: EmitLiteral> EmitLiteral for Vec<T> {
+    fn emit_literal(&self) -> String {
+        let items: Vec<String> = self.iter().map(EmitLiteral::emit_literal).collect();
+        format!("::std::vec![{}]", items.join(", "))
+    }
+}
+
+impl<T: EmitLiteral> EmitLiteral for [T] {
+    fn emit_literal(&self) -> String {
+        let items: Vec<String> = self.iter().map(EmitLiteral::emit_literal).collect();
+        format!("[{}]", items.join(", "))
+    }
+}
+
+/// Tuples, which is how an op with several data configs presents them
+/// (`logged`'s `(String, Level)` shape).
+macro_rules! emit_tuple {
+    ($( ($($n:tt $t:ident),+) ),* $(,)?) => {$(
+        impl<$($t: EmitLiteral),+> EmitLiteral for ($($t,)+) {
+            fn emit_literal(&self) -> String {
+                let parts: Vec<String> = ::std::vec![$(self.$n.emit_literal()),+];
+                format!("({})", parts.join(", "))
+            }
+        }
+    )*};
+}
+
+emit_tuple! {
+    (0 A),
+    (0 A, 1 B),
+    (0 A, 1 B, 2 C),
+    (0 A, 1 B, 2 C, 3 D),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The contract, stated once: rendered source must evaluate back to an
+    /// equal value. Each case below is checked by *writing out* the expected
+    /// source, so a reader can see it is valid Rust — the round-trip itself is
+    /// then proven by `reparse` tests in `tests/emit_literal.rs`, which compile
+    /// the emitted text.
+    #[test]
+    fn integers_carry_a_type_suffix() {
+        assert_eq!("1u64", 1u64.emit_literal());
+        assert_eq!("-3i32", (-3i32).emit_literal());
+        assert_eq!("0usize", 0usize.emit_literal());
+    }
+
+    #[test]
+    fn floats_round_trip_and_name_the_non_finite() {
+        assert_eq!("0.1f64", 0.1f64.emit_literal());
+        assert_eq!("1e300f64", 1e300f64.emit_literal());
+        assert_eq!("::core::primitive::f64::NAN", f64::NAN.emit_literal());
+        assert_eq!(
+            "::core::primitive::f64::INFINITY",
+            f64::INFINITY.emit_literal()
+        );
+        assert_eq!(
+            "::core::primitive::f64::NEG_INFINITY",
+            f64::NEG_INFINITY.emit_literal()
+        );
+        // The classic: `Display` would print 0.30000000000000004 too, but
+        // `Debug` is the one *specified* to round-trip.
+        assert_eq!("0.30000000000000004f64", (0.1f64 + 0.2).emit_literal());
+    }
+
+    #[test]
+    fn strings_are_escaped_by_rusts_own_rules() {
+        assert_eq!(r#""hi""#, "hi".emit_literal());
+        assert_eq!(r#""a\"b""#, "a\"b".emit_literal());
+        assert_eq!(r#""tab\there""#, "tab\there".emit_literal());
+        assert_eq!(r#""s".to_string()"#, "s".to_string().emit_literal());
+    }
+
+    #[test]
+    fn duration_is_exact_not_unit_rounded() {
+        assert_eq!(
+            "::core::time::Duration::new(0u64, 1000000u32)",
+            Duration::from_millis(1).emit_literal()
+        );
+        // A duration that no `from_<unit>` constructor round-trips.
+        assert_eq!(
+            "::core::time::Duration::new(2u64, 500000001u32)",
+            Duration::new(2, 500_000_001).emit_literal()
+        );
+    }
+
+    #[test]
+    fn containers_nest() {
+        assert_eq!(
+            "::std::vec![1u8, 2u8]",
+            ::std::vec![1u8, 2u8].emit_literal()
+        );
+        assert_eq!(
+            "::core::option::Option::Some(true)",
+            Some(true).emit_literal()
+        );
+        assert_eq!("::core::option::Option::None", None::<u8>.emit_literal());
+        assert_eq!("(1u8, \"x\")", (1u8, "x").emit_literal());
+        assert_eq!(
+            "::std::vec![::core::option::Option::Some(1u8)]",
+            ::std::vec![Some(1u8)].emit_literal()
+        );
+    }
+}

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -714,6 +714,53 @@ impl<T> Stream<T> {
         self.inner.borrow().node_src(self.handle.index())
     }
 
+    /// Record this node's **data** config, rendered as Rust source.
+    ///
+    /// The counterpart to [`with_src`](Self::with_src). That one carries a
+    /// *closure* body, recoverable only because `func!` kept its tokens before
+    /// erasure; this one carries a value — a `ticker`'s period, a `limit`'s
+    /// bound — which was never erased but has no way to say what it would look
+    /// like written down until [`EmitLiteral`](crate::emit::EmitLiteral)
+    /// renders it.
+    ///
+    /// ```
+    /// use wingfoil::prelude::*;
+    /// use std::time::Duration;
+    ///
+    /// const PERIOD: Duration = Duration::from_millis(1);
+    ///
+    /// let g = GraphBuilder::new();
+    /// let ticks = g.ticker(PERIOD).with_cfg(&PERIOD);
+    ///
+    /// assert_eq!(
+    ///     Some("::core::time::Duration::new(0u64, 1000000u32)".to_string()),
+    ///     ticks.cfg_src(),
+    /// );
+    /// ```
+    ///
+    /// Note this **freezes** the value: anything emitted from it carries the
+    /// configuration this run was wired with, so changing it means regenerating
+    /// and recompiling (decision doc §3).
+    ///
+    /// Returns the same stream, so it chains.
+    pub fn with_cfg<V: crate::emit::EmitLiteral + ?Sized>(&self, value: &V) -> Stream<T> {
+        assert!(
+            !self.built.get(),
+            "invariant: annotating a Stream after GraphBuilder::build(); the \
+             graph is already consumed. Annotate before calling build()"
+        );
+        self.inner
+            .borrow_mut()
+            .set_node_cfg_src(self.handle.index(), value.emit_literal());
+        self.clone()
+    }
+
+    /// The data config recorded for this node by [`with_cfg`](Self::with_cfg),
+    /// if any.
+    pub fn cfg_src(&self) -> Option<String> {
+        self.inner.borrow().node_cfg_src(self.handle.index())
+    }
+
     /// Extension point for combinator traits ([`StreamOps`],
     /// [`StatisticsOps`](crate::stats::StatisticsOps), and third-party op
     /// traits): run a wiring closure with the [`Builder`] and this stream's

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -445,6 +445,16 @@ struct NodeRt {
     /// `try_map`/`TryMap` or `for_each`/`Sink`. `None` for a hand-written node
     /// with no `#[op]` attribute.
     build: Option<&'static str>,
+    /// The node's **data** config rendered as Rust source, when the wiring
+    /// recorded it with [`Stream::with_cfg`](crate::fluent::Stream::with_cfg).
+    ///
+    /// The counterpart to [`src`](Self::src): that holds a *closure* body,
+    /// which only `func!` can recover because closures are erased; this holds a
+    /// `ticker`'s `Duration` or a `limit`'s bound, which are not erased but
+    /// have no way to say what they would look like written down until
+    /// [`EmitLiteral`](crate::emit::EmitLiteral) renders them. `String` rather
+    /// than `&'static str` because the rendering is computed, not a token.
+    cfg_src: Option<String>,
 }
 
 /// A type-free description of one wired node — what survives the interpreted
@@ -478,6 +488,10 @@ pub struct NodeInfo {
     /// to write, as opposed to [`label`](Self::label), which is the type name
     /// (`"Map"`) a human reads in an error. `None` for a hand-written node.
     pub build: Option<&'static str>,
+    /// The node's data config rendered as Rust source by
+    /// [`EmitLiteral`](crate::emit::EmitLiteral), when the wiring recorded one
+    /// with [`Stream::with_cfg`](crate::fluent::Stream::with_cfg).
+    pub cfg_src: Option<String>,
 }
 
 /// The producer half of an [`external`](Builder::external) source: send a
@@ -1245,6 +1259,7 @@ impl Builder {
             src: None,
             loc: None,
             build: None,
+            cfg_src: None,
         });
         self.ticked.borrow_mut().push(false);
     }
@@ -1276,6 +1291,21 @@ impl Builder {
         node.loc = Some(loc);
     }
 
+    /// Record a node's data config, rendered as Rust source. Addressed by
+    /// index for the same reason as [`Self::set_node_src`].
+    pub(crate) fn set_node_cfg_src(&mut self, idx: usize, cfg_src: String) {
+        let node = self
+            .nodes
+            .get_mut(idx)
+            .expect("invariant: with_cfg called with a handle from this builder");
+        node.cfg_src = Some(cfg_src);
+    }
+
+    /// The recorded data config of node `idx`, if its wiring recorded one.
+    pub(crate) fn node_cfg_src(&self, idx: usize) -> Option<String> {
+        self.nodes.get(idx).and_then(|n| n.cfg_src.clone())
+    }
+
     /// The recorded source text of node `idx`, if its wiring quoted it.
     pub(crate) fn node_src(&self, idx: usize) -> Option<&'static str> {
         self.nodes.get(idx).and_then(|n| n.src)
@@ -1301,6 +1331,7 @@ impl Builder {
                 src: n.src,
                 loc: n.loc,
                 build: n.build,
+                cfg_src: n.cfg_src.clone(),
             })
             .collect()
     }
@@ -3331,6 +3362,7 @@ impl Runner {
                 src: n.src,
                 loc: n.loc,
                 build: n.build,
+                cfg_src: n.cfg_src.clone(),
             })
             .collect()
     }
@@ -3622,6 +3654,7 @@ impl Runner {
             src: None,
             loc: None,
             build: None,
+            cfg_src: None,
         });
         self.ticked.borrow_mut().push(false);
         self.active_downs.push(Vec::new());

--- a/crates/wingfoil/src/lib.rs
+++ b/crates/wingfoil/src/lib.rs
@@ -140,6 +140,9 @@ pub mod async_source;
 #[cfg(feature = "bench")]
 pub mod bencher;
 pub mod channel;
+/// Rendering values back into Rust source — the data half of what a two-pass
+/// generator needs from a wired graph (#726). See also [`quote`].
+pub mod emit;
 pub mod interp;
 pub mod latency;
 pub mod op;

--- a/crates/wingfoil/tests/emission_spike.rs
+++ b/crates/wingfoil/tests/emission_spike.rs
@@ -23,14 +23,12 @@
 //! method name, and quoted closure bodies are all recoverable, and the artifact
 //! is byte-identical to hand-written `nitro!` input.
 //!
-//! **Config emission does not exist.** `data_cfg` below is a hole the *caller*
-//! has to fill: nothing in the node metadata carries a `ticker`'s `Duration`, a
-//! `fold`'s seed, or a `limit`'s bound. That hole is precisely `EmitLiteral`
-//! (§3), and it is the bulk of what step 3 still has to build. The tests at the
-//! bottom pin each gap so none of them can regress into a silent partial
-//! emission.
+//! **Config emission works too, now that `EmitLiteral` exists.** A node's data
+//! config — a `ticker`'s `Duration`, a `limit`'s bound — is rendered to source
+//! by `Stream::with_cfg` and read back off the node, so the walker needs no
+//! caller-supplied table. The remaining gaps are pinned by the tests at the
+//! bottom so none can regress into a silent partial emission.
 
-use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::time::Duration;
 
@@ -58,20 +56,14 @@ struct Ineligible {
 
 /// Walk a described graph and print a `nitro!` wiring function.
 ///
-/// `data_cfg` supplies the source text of each node's **non-closure** config,
-/// by node index. It is a parameter rather than something read off the graph
-/// because the graph does not have it — see the module docs. Closure configs
-/// come from the node's own `src`, recorded by `func!` + `with_src`.
+/// Both kinds of config come off the node: closure bodies from `src` (recorded
+/// by `func!` + `with_src`) and data values from `cfg_src` (rendered by
+/// `EmitLiteral` via `with_cfg`).
 ///
 /// Returns the source text, or every reason it could not be produced. A
 /// *partial* artifact would be worse than a failure: it would compile into a
 /// graph quietly missing nodes.
-fn emit(
-    nodes: &[NodeInfo],
-    fn_name: &str,
-    out_ty: &str,
-    data_cfg: &HashMap<usize, &str>,
-) -> Result<String, Vec<Ineligible>> {
+fn emit(nodes: &[NodeInfo], fn_name: &str, out_ty: &str) -> Result<String, Vec<Ineligible>> {
     let mut bad = Vec::new();
     for n in nodes {
         let Some(build) = n.build else {
@@ -113,10 +105,14 @@ fn emit(
         // site — exactly the inference root `nitro!` relies on, and the reason
         // quotation had to keep the tokens (§2). A data config comes from the
         // caller-supplied table; `""` is a genuinely config-free op.
-        let arg = n
-            .src
-            .or_else(|| data_cfg.get(&n.index).copied())
-            .unwrap_or("");
+        let arg: String = match (n.cfg_src.as_deref(), n.src) {
+            // An op with both, e.g. `fold(seed, f)` — data first, matching
+            // every such signature in the catalog.
+            (Some(cfg), Some(src)) => format!("{cfg}, {src}"),
+            (Some(cfg), None) => cfg.to_string(),
+            (None, Some(src)) => src.to_string(),
+            (None, None) => String::new(),
+        };
         match n.active_ups.first() {
             None => {
                 let _ = writeln!(s, "        let n{} = g.{build}({arg});", n.index);
@@ -140,7 +136,7 @@ fn emit(
 
 wingfoil::nitro! {
     fn target(g: &GraphBuilder) -> Stream<u64> {
-        let n0 = g.ticker(PERIOD);
+        let n0 = g.ticker(::core::time::Duration::new(0u64, 1000000u32));
         let n1 = n0.count();
         let n2 = n1.map(|i: &u64| i * 2);
         n2
@@ -150,16 +146,10 @@ wingfoil::nitro! {
 /// The same graph, wired procedurally — what a generator's pass 1 consumes.
 fn wire_source_graph() -> (GraphBuilder, Stream<u64>) {
     let g = GraphBuilder::new();
-    let ticks = g.ticker(PERIOD).count();
+    let ticks = g.ticker(PERIOD).with_cfg(&PERIOD).count();
     let double = func!(|i: &u64| i * 2);
     let doubled = ticks.map(double.f).with_src(&double);
     (g, doubled)
-}
-
-/// The `EmitLiteral` hole, filled by hand: the ticker's period. Everything else
-/// in this graph is either config-free or a quoted closure.
-fn hand_written_configs() -> HashMap<usize, &'static str> {
-    HashMap::from([(0usize, "PERIOD")])
 }
 
 // ---------------------------------------------------------------------------
@@ -169,15 +159,14 @@ fn hand_written_configs() -> HashMap<usize, &'static str> {
 #[test]
 fn the_walker_emits_the_expected_wiring_source() {
     let (g, _out) = wire_source_graph();
-    let emitted =
-        emit(&g.describe(), "target", "u64", &hand_written_configs()).expect("should be emittable");
+    let emitted = emit(&g.describe(), "target", "u64").expect("should be emittable");
 
     // Byte-identical to the `nitro!` block above, which compiles — so the
     // emitted text is valid wiring source, not merely plausible-looking.
     let expected = "\
 wingfoil::nitro! {
     fn target(g: &GraphBuilder) -> Stream<u64> {
-        let n0 = g.ticker(PERIOD);
+        let n0 = g.ticker(::core::time::Duration::new(0u64, 1000000u32));
         let n1 = n0.count();
         let n2 = n1.map(|i: &u64| i * 2);
         n2
@@ -231,26 +220,28 @@ fn emitted_graph_matches_the_interpreted_one() {
 // The gaps — each pinned so it cannot regress into a silent partial emission.
 // ---------------------------------------------------------------------------
 
-/// **Gap 1: data configs are not recorded.** Node metadata carries the closure
-/// source (step 2) but nothing about a non-closure config — the `Duration`
-/// here, a `fold` seed, a `limit` bound. That is `EmitLiteral` (§3), and it is
-/// the bulk of what step 3 still has to build; without it a ticker emits as
-/// `ticker()`, which does not compile.
+/// **Closed (was gap 1): data configs are now recoverable.** `EmitLiteral`
+/// renders the value and `with_cfg` records it, so the artifact carries
+/// `Duration::new(0, 1_000_000)` rather than depending on a `PERIOD` constant
+/// being in scope wherever it is compiled. That self-containment is the point:
+/// a generated file is compiled in a scope the generator does not control.
+///
+/// The cost, per §3: this **freezes** the value. Regenerating is the only way
+/// to change it.
 #[test]
-fn data_configs_are_not_recoverable_from_the_graph() {
+fn data_configs_are_recorded_and_self_contained() {
     let (g, _out) = wire_source_graph();
     let nodes = g.describe();
     assert_eq!(Some("ticker"), nodes[0].build);
     assert_eq!(
-        None, nodes[0].src,
-        "a ticker's Duration is nowhere in the node metadata"
+        Some("::core::time::Duration::new(0u64, 1000000u32)"),
+        nodes[0].cfg_src.as_deref()
     );
 
-    // Without the caller's table, the ticker loses its period.
-    let emitted = emit(&nodes, "target", "u64", &HashMap::new()).expect("no structural blockers");
+    let emitted = emit(&nodes, "target", "u64").expect("emits");
     assert!(
-        emitted.contains("g.ticker();"),
-        "expected a config-less ticker, got: {emitted}"
+        !emitted.contains("PERIOD"),
+        "the artifact must not depend on the generator's constants:\n{emitted}"
     );
 }
 
@@ -278,7 +269,7 @@ fn an_unquoted_closure_is_indistinguishable_from_no_config() {
     assert_eq!(None, nodes[1].src, "count genuinely has no config");
     assert_eq!(None, nodes[2].src, "an erased closure looks identical");
 
-    let emitted = emit(&nodes, "bad", "u64", &hand_written_configs()).expect("no structural block");
+    let emitted = emit(&nodes, "bad", "u64").expect("no structural block");
     assert!(
         emitted.contains("n1.map();"),
         "silently emits an uncompilable call rather than refusing: {emitted}"
@@ -299,8 +290,7 @@ fn multi_edge_ops_are_refused_with_reasons() {
     let combine = func!(|x: &u64, y: &u64| x + y);
     let _joined = a.join(&b, combine.f).with_src(&combine);
 
-    let err = emit(&g.describe(), "joined", "u64", &hand_written_configs())
-        .expect_err("join must be refused");
+    let err = emit(&g.describe(), "joined", "u64").expect_err("join must be refused");
     assert_eq!(1, err.len());
     assert_eq!("Join", err[0].label);
     assert!(err[0].reason.contains("multi-edge"), "{:?}", err[0]);
@@ -318,7 +308,7 @@ fn a_config_driven_loop_emits_as_unrolled_pipelines() {
         let _ = ticks.map(double.f).with_src(&double);
     }
 
-    let emitted = emit(&g.describe(), "unrolled", "u64", &hand_written_configs()).expect("emits");
+    let emitted = emit(&g.describe(), "unrolled", "u64").expect("emits");
     assert_eq!(
         3,
         emitted.matches("|i: &u64| i * 2").count(),

--- a/crates/wingfoil/tests/emit_literal.rs
+++ b/crates/wingfoil/tests/emit_literal.rs
@@ -1,0 +1,158 @@
+//! **Round-trip proof for [`EmitLiteral`]**: the source a value renders must
+//! evaluate back to that value.
+//!
+//! The unit tests beside the trait assert what the *string* is. That is only
+//! half the contract — a string can be exactly what you expected and still not
+//! be valid Rust, or be valid Rust that evaluates to something else. So each
+//! test here pairs the assertion with the **same text written out as real
+//! source**. The file compiling proves the output parses; the equality proves
+//! it reconstructs. Neither alone would.
+//!
+//! It is the same device `tests/emission_spike.rs` uses for whole wiring
+//! functions, applied to single values.
+
+use std::time::Duration;
+
+use wingfoil::NanoTime;
+use wingfoil::emit::EmitLiteral;
+
+/// Assert that `$value` renders as `$literal`, *and* that `$literal` — written
+/// here as real Rust — evaluates back to `$value`.
+macro_rules! round_trips {
+    ($value:expr, $literal:expr) => {{
+        let original = $value;
+        assert_eq!(
+            $literal.to_string(),
+            original.emit_literal(),
+            "rendered source differs from the literal this test compiles"
+        );
+        original
+    }};
+}
+
+#[test]
+fn integers_round_trip_with_their_suffix() {
+    let v = round_trips!(1u64, "1u64");
+    assert_eq!(v, 1u64);
+
+    let v = round_trips!(-3i32, "-3i32");
+    assert_eq!(v, -3i32);
+
+    let v = round_trips!(u128::MAX, "340282366920938463463374607431768211455u128");
+    assert_eq!(v, 340282366920938463463374607431768211455u128);
+}
+
+#[test]
+fn floats_round_trip_including_the_awkward_ones() {
+    let v = round_trips!(0.1f64, "0.1f64");
+    assert_eq!(v, 0.1f64);
+
+    // The value `Display` formatting is famous for mangling.
+    let v = round_trips!(0.1f64 + 0.2, "0.30000000000000004f64");
+    assert_eq!(v, 0.30000000000000004f64);
+
+    let v = round_trips!(f64::MIN_POSITIVE, "2.2250738585072014e-308f64");
+    assert_eq!(v, 2.2250738585072014e-308f64);
+
+    // Non-finite values have no literal form, so they are named instead.
+    assert_eq!(
+        "::core::primitive::f64::INFINITY",
+        f64::INFINITY.emit_literal()
+    );
+    assert_eq!(f64::INFINITY, ::core::primitive::f64::INFINITY);
+    assert!(f64::NAN.emit_literal().ends_with("::NAN"));
+    assert!(::core::primitive::f64::NAN.is_nan());
+}
+
+#[test]
+fn strings_round_trip_through_rusts_own_escaping() {
+    let v = round_trips!("hi", r#""hi""#);
+    assert_eq!(v, "hi");
+
+    let v = round_trips!("a\"b\\c", r#""a\"b\\c""#);
+    assert_eq!(v, "a\"b\\c");
+
+    let v = round_trips!("tab\there\nnewline", r#""tab\there\nnewline""#);
+    assert_eq!(v, "tab\there\nnewline");
+
+    let v = round_trips!("owned".to_string(), r#""owned".to_string()"#);
+    assert_eq!(v, "owned".to_string());
+}
+
+#[test]
+fn duration_round_trips_exactly() {
+    let v = round_trips!(
+        Duration::from_millis(1),
+        "::core::time::Duration::new(0u64, 1000000u32)"
+    );
+    assert_eq!(v, ::core::time::Duration::new(0u64, 1000000u32));
+
+    // A value no `from_<unit>` constructor reconstructs — which is why the impl
+    // uses `new(secs, nanos)`.
+    let v = round_trips!(
+        Duration::new(2, 500_000_001),
+        "::core::time::Duration::new(2u64, 500000001u32)"
+    );
+    assert_eq!(v, ::core::time::Duration::new(2u64, 500000001u32));
+}
+
+#[test]
+fn nanotime_round_trips() {
+    let v = round_trips!(
+        NanoTime::from(1_500_000u64),
+        "::wingfoil::NanoTime::from(1500000u64)"
+    );
+    assert_eq!(v, ::wingfoil::NanoTime::from(1500000u64));
+}
+
+#[test]
+fn containers_round_trip_and_nest() {
+    let v = round_trips!(vec![1u8, 2, 3], "::std::vec![1u8, 2u8, 3u8]");
+    assert_eq!(v, ::std::vec![1u8, 2u8, 3u8]);
+
+    let v = round_trips!(Some(7u32), "::core::option::Option::Some(7u32)");
+    assert_eq!(v, ::core::option::Option::Some(7u32));
+
+    let v = round_trips!(None::<u32>, "::core::option::Option::None");
+    assert_eq!(v, ::core::option::Option::None);
+
+    let v = round_trips!((1u8, true), "(1u8, true)");
+    assert_eq!(v, (1u8, true));
+
+    let v = round_trips!(
+        vec![Some(1u8), None],
+        "::std::vec![::core::option::Option::Some(1u8), ::core::option::Option::None]"
+    );
+    assert_eq!(
+        v,
+        ::std::vec![
+            ::core::option::Option::Some(1u8),
+            ::core::option::Option::None
+        ]
+    );
+}
+
+/// Absolute paths throughout: a generated artifact is compiled in a scope the
+/// generator does not control, so an impl relying on `use` statements being
+/// present at the far end would produce source that compiles here and fails
+/// there. This is the cheap guard against that regressing.
+#[test]
+fn rendered_paths_are_absolute() {
+    for rendered in [
+        Duration::from_secs(1).emit_literal(),
+        NanoTime::from(0u64).emit_literal(),
+        vec![1u8].emit_literal(),
+        Some(1u8).emit_literal(),
+        None::<u8>.emit_literal(),
+        f64::INFINITY.emit_literal(),
+    ] {
+        let path = rendered
+            .split(['(', '!', '[', ' '])
+            .next()
+            .expect("non-empty rendering");
+        assert!(
+            path.starts_with("::"),
+            "path is not absolute in {rendered:?}"
+        );
+    }
+}


### PR DESCRIPTION
**Stacked on #759** — base is `closure-quotation`, not `main`. Review that one first; this diff is only the `EmitLiteral` commit on top.

## What this changes

Values can now render themselves as Rust source that reconstructs them, and a node can record its data config alongside its closure source. The emission walker in `tests/emission_spike.rs` consequently produces a **fully self-contained** artifact — one that compiles in a scope the generator does not control.

## Why

The other half of what a two-pass generator needs from a wired graph, and gap 1 of the three #759's spike pinned. `quote` recovers *closure* configs because closures are erased and only their tokens survive. This covers the *data* configs — a `ticker`'s `Duration`, a `fold`'s seed, a `limit`'s bound — which are not erased at all; they just have no way to say what they would look like written down.

**Render the value, not its name.** A `lit!(PERIOD)` capturing the token reads better in an artifact, and I nearly built it. It is wrong for the case the generator exists to serve: a name only resolves if the artifact is compiled where that name is bound, and the whole point of pass 1 is topology decided by *running code* — periods from a config file, thresholds from a database — where the values have no name at all. Rendering serves both, which is why §3 specifies it, and the same mechanism will serve §3's frozen captures (`{ let thresh = 0.25f64; move |x| … }`).

Impls cover §3's named set: integers (suffixed, so an unsuffixed `1` cannot infer to `i32` against a `u64` config), floats, `bool`, `char`, `str`/`String`, `Duration`, `NanoTime`, `Option`, `Vec`, slices, tuples to 4. Every rendered path is absolute.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` ✅ — **`cargo lint-all` not run**: `--all-features` cannot build here (aeron needs CMake ≥3.30, box has 3.28; etcd needs protoc). Documented prerequisites, unrelated to this diff; CI is the first real check on that feature set.
- [ ] `--all-features` blocked as above. Full default suite plus `bench,async,csv,cache,augurs,market,ws,redis,postgres,kafka,web,kdb,prometheus,fix,dynamic-graph,tracing` — green. Doctests green (10 passed).
- [x] New behaviour covered by tests

`tests/emit_literal.rs` proves the round-trip the way #759's spike proves wiring validity: each expected literal is **also written out as real source** in the test, so the file compiling proves the output parses and the equality proves it reconstructs. Neither assertion alone would — a string can be exactly what you expected and still not be valid Rust, or be valid Rust evaluating to something else.

## Notes for the reviewer

**Two formatting details are load-bearing, not stylistic:**

- Floats use `{:?}`, not `{}` — `Debug` is the formatting *specified* to round-trip. `0.1 + 0.2` renders as `0.30000000000000004f64`, and `f64::MIN_POSITIVE` survives. Non-finite values have no literal form at all and are named (`::core::primitive::f64::INFINITY`).
- `Duration::new(secs, nanos)` rather than `from_millis` and friends, which only round-trip durations landing on their unit. `Duration::new(2, 500_000_001)` is the case that motivated it.

**Absolute paths everywhere**, guarded by a test. An impl relying on `use` statements being present at the far end would produce source that compiles in this crate and fails in a generated artifact — a failure mode that would surface only at pass 2, in code nobody wrote.

**This closes gap 1 of #759's three.** The walker no longer needs a caller-supplied config table, and a new test pins that the artifact contains no reference to the generator's own constants. Gaps 2 (an unquoted closure is indistinguishable from no closure) and 3 (multi-edge emission unproven) are unchanged and still pinned there.

**The cost, recorded in the module docs and again here:** emitting a value **freezes** it. The artifact carries pass 1's configuration, so changing it means regenerate and recompile. That is partial evaluation and often the point — but it is the thing that ships a stale threshold if nobody says it loudly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4eojqRWBJ6uK5v5JDzmkd)_