### PR TITLE
Record whether an op's config is a closure, so eligibility is decidable

### DIFF
--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -2070,6 +2070,31 @@ fn expand_builder(args: &OpArgs, b: &BuilderShape<'_>) -> syn::Result<TokenStrea
     // The `build = <name>` token as a string literal, recorded on the node so a
     // graph traversal can recover the method an emitter would have to write.
     let build_name = name.to_string();
+    // Does this op's `Cfg` hold a **closure**? True when `Cfg` is one of the
+    // impl's own type parameters and that parameter carries an `Fn`-family
+    // bound — `map`'s `F: Fn(&A) -> B`, and not `ticker`'s `Cfg = Duration`.
+    //
+    // Recorded on the node because a traversal cannot otherwise tell an op that
+    // takes no config from one whose closure the engine erased: both leave
+    // `NodeInfo::src` empty. Without it an emitter cannot say which nodes are
+    // ineligible, and silently prints a call with a missing argument.
+    let takes_closure_cfg = {
+        let cfg_name = quote! { #cfg_ty }.to_string();
+        let is_param = b.type_params.iter().any(|p| *p == cfg_name);
+        is_param
+            && b.preds.iter().any(|pr| {
+                // Whitespace-insensitive: `quote!` spaces tokens out
+                // (`F : Fn (& A) -> B`) and the exact placement is not a
+                // stable contract, so normalise before matching.
+                let pr: String = pr
+                    .to_string()
+                    .chars()
+                    .filter(|c| !c.is_whitespace())
+                    .collect();
+                pr.starts_with(&format!("{cfg_name}:"))
+                    && (pr.contains("Fn(") || pr.contains("FnMut(") || pr.contains("FnOnce("))
+            })
+    };
     let n = shape.edge_ref_tys.len();
     if n > 26 {
         return Err(syn::Error::new(
@@ -2322,8 +2347,9 @@ fn expand_builder(args: &OpArgs, b: &BuilderShape<'_>) -> syn::Result<TokenStrea
                 // wiring-time values (see `ResetFn`).
                 // The op's *method* name, alongside the type name `push_node`
                 // recorded as the label. An emitter walking the wired graph
-                // needs `map`, not `Map`.
-                self.set_node_build(#build_name);
+                // needs `map`, not `Map` — plus whether its config is a closure,
+                // which is what distinguishes "no config" from "erased closure".
+                self.set_node_build(#build_name, #takes_closure_cfg);
                 self.set_reset(::std::boxed::Box::new(move || {
                     __cs_reset.borrow_mut().1 = #state_reseed;
                     *__out_reset.borrow_mut() = #out_reseed;

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -455,6 +455,14 @@ struct NodeRt {
     /// [`EmitLiteral`](crate::emit::EmitLiteral) renders them. `String` rather
     /// than `&'static str` because the rendering is computed, not a token.
     cfg_src: Option<String>,
+    /// Whether this op's `Cfg` is a **closure** (`map`'s `F: Fn(&A) -> B`)
+    /// rather than data (`ticker`'s `Duration`).
+    ///
+    /// The fact that makes [`src`](Self::src) interpretable. Without it a
+    /// traversal cannot tell `count` — which genuinely has no config — from a
+    /// `map` whose closure the engine erased: both leave `src` empty. An
+    /// emitter needs the difference to know which nodes it must refuse.
+    takes_closure_cfg: bool,
 }
 
 /// A type-free description of one wired node — what survives the interpreted
@@ -492,6 +500,12 @@ pub struct NodeInfo {
     /// [`EmitLiteral`](crate::emit::EmitLiteral), when the wiring recorded one
     /// with [`Stream::with_cfg`](crate::fluent::Stream::with_cfg).
     pub cfg_src: Option<String>,
+    /// Whether this op takes a **closure** config. Read together with
+    /// [`src`](Self::src): `takes_closure_cfg && src.is_none()` is the precise
+    /// statement "this node has a closure the engine erased and the wiring did
+    /// not quote" — the one an emitter must refuse on. Neither field alone says
+    /// it, because a config-free op also reports `src: None`.
+    pub takes_closure_cfg: bool,
 }
 
 /// The producer half of an [`external`](Builder::external) source: send a
@@ -1260,6 +1274,7 @@ impl Builder {
             loc: None,
             build: None,
             cfg_src: None,
+            takes_closure_cfg: false,
         });
         self.ticked.borrow_mut().push(false);
     }
@@ -1267,11 +1282,13 @@ impl Builder {
     /// Record the op's `#[op(build = …)]` method name against the node most
     /// recently pushed. Called by the generated `Builder` method right after
     /// `push_node`, in the same style as `set_reset`.
-    pub(crate) fn set_node_build(&mut self, build: &'static str) {
-        self.nodes
+    pub(crate) fn set_node_build(&mut self, build: &'static str, takes_closure_cfg: bool) {
+        let node = self
+            .nodes
             .last_mut()
-            .expect("invariant: set_node_build called immediately after push_node")
-            .build = Some(build);
+            .expect("invariant: set_node_build called immediately after push_node");
+        node.build = Some(build);
+        node.takes_closure_cfg = takes_closure_cfg;
     }
 
     /// Record the source text of a node's closure config — the quotation half
@@ -1332,6 +1349,7 @@ impl Builder {
                 loc: n.loc,
                 build: n.build,
                 cfg_src: n.cfg_src.clone(),
+                takes_closure_cfg: n.takes_closure_cfg,
             })
             .collect()
     }
@@ -3363,6 +3381,7 @@ impl Runner {
                 loc: n.loc,
                 build: n.build,
                 cfg_src: n.cfg_src.clone(),
+                takes_closure_cfg: n.takes_closure_cfg,
             })
             .collect()
     }
@@ -3655,6 +3674,7 @@ impl Runner {
             loc: None,
             build: None,
             cfg_src: None,
+            takes_closure_cfg: false,
         });
         self.ticked.borrow_mut().push(false);
         self.active_downs.push(Vec::new());

--- a/crates/wingfoil/tests/emission_spike.rs
+++ b/crates/wingfoil/tests/emission_spike.rs
@@ -26,8 +26,19 @@
 //! **Config emission works too, now that `EmitLiteral` exists.** A node's data
 //! config — a `ticker`'s `Duration`, a `limit`'s bound — is rendered to source
 //! by `Stream::with_cfg` and read back off the node, so the walker needs no
-//! caller-supplied table. The remaining gaps are pinned by the tests at the
-//! bottom so none can regress into a silent partial emission.
+//! caller-supplied table.
+//!
+//! **Eligibility is decidable.** `#[op]` records whether an op's `Cfg` is a
+//! closure, so `takes_closure_cfg && src.is_none()` states exactly "this node
+//! has a closure the engine erased and the wiring did not quote" — the case an
+//! emitter must refuse. Neither field alone says it, because a config-free op
+//! like `count` also reports `src: None`.
+//!
+//! What is left: emission covers **single-edge chains only**. Multi-edge
+//! (`join`) and passive-edge (`sample`) ops are refused rather than emitted,
+//! and the refusals name node indices rather than the *call sites*
+//! `#[track_caller]` would give. Both are pinned by tests at the bottom so
+//! neither can regress into a silent partial emission.
 
 use std::fmt::Write as _;
 use std::time::Duration;
@@ -86,6 +97,19 @@ fn emit(nodes: &[NodeInfo], fn_name: &str, out_ty: &str) -> Result<String, Vec<I
                 index: n.index,
                 label: n.label,
                 reason: format!("`{build}` is multi-edge; receiver/argument split unproven"),
+            });
+        }
+        // The precise statement of "erased closure": the op takes one, and the
+        // wiring did not quote it. Neither field alone says this — a
+        // config-free op like `count` also reports `src: None`.
+        if n.takes_closure_cfg && n.src.is_none() {
+            bad.push(Ineligible {
+                index: n.index,
+                label: n.label,
+                reason: format!(
+                    "`{build}`'s closure was not quoted; wrap it in `func!` and \
+                     record it with `.with_src(..)` to make this node emittable"
+                ),
             });
         }
     }
@@ -245,35 +269,49 @@ fn data_configs_are_recorded_and_self_contained() {
     );
 }
 
-/// **Gap 2: an unquoted closure is indistinguishable from no closure.** Both
-/// report `src: None`, so the walker cannot tell `count()` (genuinely
-/// config-free) from `map(move |i| i * factor)` (a capturing closure the engine
-/// erased). It therefore emits `map()` — which does not compile — instead of
-/// refusing.
+/// **Closed (was gap 2): an unquoted closure is now distinguishable from no
+/// closure at all.** `#[op]` knows whether an op's `Cfg` is a closure — it can
+/// see the `Fn` bound on the config type parameter — and records it, so
+/// `takes_closure_cfg && src.is_none()` states exactly "this node has a closure
+/// the engine erased and the wiring did not quote".
 ///
-/// §4.1 wants a loud error naming every non-emittable node *and its call site*.
-/// That needs metadata this spike does not have: a per-node "takes a closure
-/// config" flag (`#[op]` knows it) plus the `#[track_caller]` location the
-/// design specifies. Cheap to add; currently absent.
+/// The walker refuses such a node instead of printing `map()`, which is the
+/// "loud, precise failure" §4.1 asks for. What it still lacks is the *call
+/// site*: `#[track_caller]` on the wiring methods would name the line the user
+/// wrote, rather than the node index.
 #[test]
-fn an_unquoted_closure_is_indistinguishable_from_no_config() {
+fn an_erased_closure_is_refused_not_silently_emitted() {
     let g = GraphBuilder::new();
     let factor = 3u64;
     let _out = g
         .ticker(PERIOD)
+        .with_cfg(&PERIOD)
         .count()
         // Captures `factor` — erased, unrecoverable.
         .map(move |i: &u64| i * factor);
 
     let nodes = g.describe();
-    assert_eq!(None, nodes[1].src, "count genuinely has no config");
-    assert_eq!(None, nodes[2].src, "an erased closure looks identical");
+    assert!(!nodes[1].takes_closure_cfg, "count has no closure config");
+    assert!(nodes[2].takes_closure_cfg, "map does");
+    assert_eq!(None, nodes[2].src, "and it was not quoted");
 
-    let emitted = emit(&nodes, "bad", "u64").expect("no structural block");
-    assert!(
-        emitted.contains("n1.map();"),
-        "silently emits an uncompilable call rather than refusing: {emitted}"
-    );
+    let err = emit(&nodes, "bad", "u64").expect_err("must refuse the erased closure");
+    assert_eq!(1, err.len(), "only the map is ineligible: {err:?}");
+    assert_eq!(2, err[0].index);
+    assert!(err[0].reason.contains("func!"), "{:?}", err[0]);
+}
+
+/// The other half of the same property: a config-free op is **not** flagged, so
+/// refusing an erased closure does not also refuse every `count` in the graph.
+#[test]
+fn config_free_ops_are_not_mistaken_for_erased_closures() {
+    let (g, _out) = wire_source_graph();
+    let nodes = g.describe();
+    assert!(!nodes[0].takes_closure_cfg, "ticker's Cfg is a Duration");
+    assert!(!nodes[1].takes_closure_cfg, "count takes no config");
+    assert!(nodes[2].takes_closure_cfg, "map takes a closure");
+
+    emit(&nodes, "target", "u64").expect("a fully quoted graph still emits");
 }
 
 /// **Gap 3: multi-edge and passive-edge ops are refused.** `active_ups`
@@ -285,13 +323,17 @@ fn an_unquoted_closure_is_indistinguishable_from_no_config() {
 #[test]
 fn multi_edge_ops_are_refused_with_reasons() {
     let g = GraphBuilder::new();
-    let a = g.ticker(PERIOD).count();
-    let b = a.map(|i: &u64| i * 10);
+    let a = g.ticker(PERIOD).with_cfg(&PERIOD).count();
+    let scale = func!(|i: &u64| i * 10);
+    let b = a.map(scale.f).with_src(&scale);
     let combine = func!(|x: &u64, y: &u64| x + y);
     let _joined = a.join(&b, combine.f).with_src(&combine);
 
+    // Everything else in this graph is quoted or config-free, so the join is
+    // the *only* refusal — which is what makes this a test of the multi-edge
+    // rule rather than of eligibility in general.
     let err = emit(&g.describe(), "joined", "u64").expect_err("join must be refused");
-    assert_eq!(1, err.len());
+    assert_eq!(1, err.len(), "only the join is ineligible: {err:?}");
     assert_eq!("Join", err[0].label);
     assert!(err[0].reason.contains("multi-edge"), "{:?}", err[0]);
 }


### PR DESCRIPTION
**Stacked on #760**, which is stacked on #759. Base is `emit-literal`; this diff is only the top commit. Review order: #759 → #760 → this.

## What this changes

`NodeInfo` now says whether an op takes a **closure** config. That makes emission eligibility decidable, and the walker in `tests/emission_spike.rs` refuses erased-closure nodes instead of printing calls that don't compile.

## Why

Gap 2 of the three #759's emission spike pinned. A traversal could not tell `count` — which genuinely has no config — from a `map` whose closure the engine erased: **both report `src: None`**. So a walker had no way to refuse the second without also refusing the first, and emitted `map()` instead.

`#[op]` already knows the difference and simply never recorded it. It can see that the op's `Cfg` is one of the impl's own type parameters *and* that the parameter carries an `Fn`-family bound — `map`'s `F: Fn(&A) -> B`, and not `ticker`'s `Cfg = Duration`. Recorded now alongside the build name, which makes the statement precise:

```rust
takes_closure_cfg && src.is_none()
// => "a closure the engine erased and the wiring did not quote"
```

The walker refuses exactly those, with a reason naming `func!` and `with_src` — the "loud, precise failure" §4.1 asks for.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` ✅ — **`cargo lint-all` not run**: `--all-features` cannot build here (aeron needs CMake ≥3.30, box has 3.28; etcd needs protoc). Documented prerequisites, unrelated to this diff; CI is the first real check on that feature set.
- [ ] `--all-features` blocked as above. Full default suite plus `bench,async,csv,cache,augurs,market,ws,redis,postgres,kafka,web,kdb,prometheus,fix,dynamic-graph,tracing` — green.
- [x] New behaviour covered by tests

Two tests pin **both** directions, which is the part that matters: an erased closure is refused, and a config-free op is *not* swept up with it. A one-directional test would pass for a flag that was simply always true.

## Notes for the reviewer

**The bound match is deliberately whitespace-insensitive.** `quote!` renders the predicate as `F : Fn (& A) -> B`, and the exact spacing is not a stable contract — matching it literally is the kind of thing that breaks on a proc-macro2 bump for no visible reason. Normalising first costs nothing.

**It also caught a real bug in my own test.** Tightening `multi_edge_ops_are_refused_with_reasons` revealed that its graph contained an unquoted `map` alongside the join, so the walker now (correctly) reported two refusals. The test asserted one. Fixed by quoting the `map`, which makes it a genuine test of the multi-edge rule rather than of eligibility in general.

**Still missing from §4.1: the call site.** Refusals name node indices, where `#[track_caller]` would name the line the user actually wrote. That is plumbing rather than discovery, and it has one wrinkle worth recording: the closure passed to `Stream::wire` breaks caller propagation, so the location has to be captured in the *generated fluent method* and recorded against the node the way `with_src` does — not simply annotated onto the builder method.

**Remaining after this**: emission covers single-edge chains only. Multi-edge (`join`) and passive-edge (`sample`) ops are refused rather than emitted. `active_ups` preserves receiver-first order so `join` is probably recoverable, but nothing yet distinguishes a receiver from an argument, and `sample`'s passive leg is absent from `active_ups` entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4eojqRWBJ6uK5v5JDzmkd)_