### PR TITLE
`quoted!`: wire a node and record its closure in one step

### DIFF
--- a/crates/wingfoil/src/quote.rs
+++ b/crates/wingfoil/src/quote.rs
@@ -220,3 +220,76 @@ macro_rules! func {
         }
     };
 }
+
+/// Wire one node and record its closure in a single step.
+///
+/// The two-step form is correct but forgettable, and forgetting is **silent**:
+/// the graph runs fine interpreted, and the omission only surfaces later as a
+/// generator refusal.
+///
+/// ```
+/// use wingfoil::prelude::*;
+/// use wingfoil::{func, quoted};
+/// # let g = GraphBuilder::new();
+/// # let ticks = g.ticker(std::time::Duration::from_millis(1)).count();
+/// // Two steps, easy to half-do:
+/// let double = func!(|i: &u64| i * 2);
+/// let a = ticks.map(double.f).with_src(&double);
+///
+/// // One step, no opportunity to forget:
+/// let b = quoted!(ticks => map(|i: &u64| i * 2));
+///
+/// assert_eq!(a.src(), b.src());
+/// ```
+///
+/// Also takes a leading argument, for the ops that have one — a stream edge
+/// (`join`) or a seed (`fold`):
+///
+/// ```
+/// use wingfoil::prelude::*;
+/// use wingfoil::quoted;
+/// # let g = GraphBuilder::new();
+/// # let a = g.ticker(std::time::Duration::from_millis(1)).count();
+/// let b = quoted!(a => map(|i: &u64| i * 10));
+/// let joined = quoted!(a => join(&b, |x: &u64, y: &u64| x + y));
+/// let total = quoted!(joined => fold(0u64, |acc: &mut u64, v: &u64| *acc += v));
+/// ```
+///
+/// # Why `=>` rather than a plain method chain
+///
+/// `quoted!(ticks.map(..))` would read better, and it cannot be built. A
+/// `macro_rules!` pattern cannot destructure `receiver.method(args)` — an
+/// `expr` fragment may only be followed by `=>`, `,` or `;`, never `.`.
+///
+/// A **proc** macro can parse the chain, and that was tried first. It loses the
+/// one property that makes quotation worth having: `stringify!` recovers
+/// verbatim source only for a fragment that came straight from a user's file,
+/// and tokens re-emitted by a proc macro fall back to pretty-printing. The
+/// artifact then carries `| i : & u64 | i * 2` instead of `|i: &u64| i * 2`,
+/// and `rustfmt` will not fix it — it does not format inside a macro body.
+/// Since a generated artifact exists to be read, the syntax cost is the better
+/// trade. `Span::source_text` would settle it, but joining spans across an
+/// expression is nightly-only.
+///
+/// # What it does not do
+///
+/// Data configs still need [`with_cfg`](crate::fluent::Stream::with_cfg)
+/// explicitly — recording them here would mean either evaluating the argument
+/// twice or silently requiring `Clone` of it, and a bound that appears from
+/// inside a macro is worse than a second method call.
+///
+/// Captures still need [`func!`] with an explicit list; a capturing closure
+/// written inline here records a body that will not resolve in an artifact.
+#[macro_export]
+macro_rules! quoted {
+    // `recv => method(closure)`
+    ($recv:expr => $m:ident($f:expr)) => {{
+        let __wf_q = $crate::func!($f);
+        $recv.$m(__wf_q.f).with_src(&__wf_q)
+    }};
+    // `recv => method(arg, closure)` — a stream edge or a seed, then the body.
+    ($recv:expr => $m:ident($a:expr, $f:expr)) => {{
+        let __wf_q = $crate::func!($f);
+        $recv.$m($a, __wf_q.f).with_src(&__wf_q)
+    }};
+}

--- a/crates/wingfoil/tests/quoted_macro.rs
+++ b/crates/wingfoil/tests/quoted_macro.rs
@@ -1,0 +1,125 @@
+//! **`quoted!`**: wire one node and record its closure in a single step.
+//!
+//! The `func!` + `.with_src(..)` pair is correct but forgettable, and
+//! forgetting is silent — the graph runs fine interpreted, and the omission
+//! only surfaces later as a generator refusal. These tests pin that the
+//! shorthand produces *exactly* what the manual form produces, so it stays a
+//! convenience rather than becoming a second mechanism that can drift.
+
+use std::time::Duration;
+
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode, func, quoted};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const PERIOD: Duration = Duration::from_millis(1);
+const RUN: RunFor = RunFor::Cycles(5);
+
+#[test]
+fn quoted_records_what_the_manual_form_records() {
+    let manual = {
+        let g = GraphBuilder::new();
+        let double = func!(|i: &u64| i * 2);
+        g.ticker(PERIOD)
+            .count()
+            .map(double.f)
+            .with_src(&double)
+            .src()
+    };
+
+    let shorthand = {
+        let g = GraphBuilder::new();
+        let ticks = g.ticker(PERIOD).count();
+        quoted!(ticks => map(|i: &u64| i * 2)).src()
+    };
+
+    assert_eq!(Some("|i: &u64| i * 2"), shorthand.as_deref());
+    assert_eq!(
+        manual, shorthand,
+        "shorthand must not be a second mechanism"
+    );
+}
+
+/// **The property the whole `=>` syntax exists to protect.** Source text must
+/// survive two `macro_rules!` layers verbatim — `quoted!`'s `$f:expr` into
+/// `func!`'s `stringify!($f)` — because a generated artifact carrying
+/// `| i : & u64 | i * 2` is one `rustfmt` cannot repair (it does not format
+/// inside macro bodies).
+#[test]
+fn source_stays_verbatim_through_both_macro_layers() {
+    let g = GraphBuilder::new();
+    let ticks = g.ticker(PERIOD).count();
+    let out = quoted!(ticks => map(|i: &u64| i * 2));
+    assert_eq!(Some("|i: &u64| i * 2"), out.src().as_deref());
+    assert!(
+        !out.src().unwrap().contains(" : "),
+        "spacing was normalised: {:?}",
+        out.src()
+    );
+}
+
+/// The two-argument form: a stream edge (`join`) or a seed (`fold`) ahead of
+/// the closure.
+#[test]
+fn the_leading_argument_form_covers_join_and_fold() {
+    let g = GraphBuilder::new();
+    let a = g.ticker(PERIOD).count();
+    let b = quoted!(a => map(|i: &u64| i * 10));
+    let joined = quoted!(a => join(&b, |x: &u64, y: &u64| x + y));
+    let total = quoted!(joined => fold(0u64, |acc: &mut u64, v: &u64| *acc += v));
+
+    assert_eq!(Some("|i: &u64| i * 10"), b.src().as_deref());
+    assert_eq!(Some("|x: &u64, y: &u64| x + y"), joined.src().as_deref());
+    assert_eq!(
+        Some("|acc: &mut u64, v: &u64| *acc += v"),
+        total.src().as_deref()
+    );
+}
+
+/// Each node carries its own quotation, so a graph built out of `quoted!` calls
+/// is fully described.
+#[test]
+fn every_node_built_this_way_is_recorded() {
+    let g = GraphBuilder::new();
+    let ticks = g.ticker(PERIOD).count();
+    let doubled = quoted!(ticks => map(|i: &u64| i * 2));
+    let _big = quoted!(doubled => filter_value(|v: &u64| *v > 4));
+
+    let srcs: Vec<_> = g.describe().iter().filter_map(|n| n.src.clone()).collect();
+    assert_eq!(vec!["|i: &u64| i * 2", "|v: &u64| *v > 4"], srcs);
+}
+
+/// Recording is wiring-time only: the shorthand must not change what the graph
+/// computes.
+#[test]
+fn quoted_does_not_change_behaviour() {
+    let plain = {
+        let g = GraphBuilder::new();
+        let out = g.ticker(PERIOD).count().map(|i: &u64| i * 3).accumulate();
+        let mut runner = g.build();
+        runner.run(HISTORICAL, RUN).unwrap();
+        runner.value(out)
+    };
+
+    let shorthand = {
+        let g = GraphBuilder::new();
+        let ticks = g.ticker(PERIOD).count();
+        let out = quoted!(ticks => map(|i: &u64| i * 3)).accumulate();
+        let mut runner = g.build();
+        runner.run(HISTORICAL, RUN).unwrap();
+        runner.value(out)
+    };
+
+    assert_eq!(vec![3u64, 6, 9, 12, 15], plain);
+    assert_eq!(plain, shorthand);
+}
+
+/// It knows nothing about the catalog — it expands to an ordinary fluent call,
+/// so it works for any op with a closure config, built-in or user-defined.
+#[test]
+fn it_is_not_coupled_to_any_particular_op() {
+    let g = GraphBuilder::new();
+    let ticks = g.ticker(PERIOD).count();
+    let inspected = quoted!(ticks => inspect(|_v: &u64| ()));
+    assert_eq!(Some("|_v: &u64| ()"), inspected.src().as_deref());
+}


### PR DESCRIPTION
**Stacked on #764 → #763 → #762 → #761 → #760 → #759.** Base is `tier2-captures`; this diff is only the top commit.

## What this changes

```rust
let out = quoted!(ticks => map(|i: &u64| i * 2));
```

instead of

```rust
let double = func!(|i: &u64| i * 2);
let out = ticks.map(double.f).with_src(&double);
```

## Why

The pair was correct but forgettable, and forgetting is **silent**: the graph runs fine interpreted and the omission surfaces much later as a generator refusal. I walked into it myself writing the worked example, in the same session I'd spent predicting other people would.

## The `=>` is a concession, and it's the interesting part

`quoted!(ticks.map(..))` reads better and **cannot be built** as `macro_rules!`: an `expr` fragment may only be followed by `=>`, `,` or `;` — never `.` — so the pattern cannot destructure a method call.

A **proc** macro can parse the chain, and I built that first. It fails on the one property that makes quotation worth having:

- `stringify!` recovers verbatim source only for a fragment that came straight from a user's file. Tokens re-emitted by a proc macro fall back to pretty-printing, so the artifact carries `| i : & u64 | i * 2`.
- I checked whether `rustfmt` would repair it: **it does not format inside a macro body**, so the ugliness would ship into every generated file.
- I checked whether `Span::source_text` could recover the original: on stable it returns only the first token (`Some("|")`), because joining spans across an expression is nightly-only.

So the syntax cost buys a readable artifact — which is what a generated file exists to be. A test pins the verbatim property through both macro layers, since that is the entire reason for the shape.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` ✅ — **`cargo lint-all` not run**: `--all-features` cannot build here (aeron needs CMake ≥3.30, box has 3.28; etcd needs protoc). Documented prerequisites, unrelated to this diff; CI is the first real check on that feature set.
- [ ] `--all-features` blocked as above. Full default suite plus `bench,async,csv,cache,augurs,market,ws,redis,postgres,kafka,web,kdb,prometheus,fix,dynamic-graph,tracing` — green. Doctests green (15 passed).
- [x] New behaviour covered by tests

Six tests, including one asserting the shorthand records *byte-identically* to the manual form — so it stays a convenience rather than becoming a second mechanism that can drift.

## Notes for the reviewer

**Deliberately narrow.** Data configs still need `.with_cfg(..)` explicitly: recording them here would mean either evaluating the argument expression twice or silently requiring `Clone` of it, and a trait bound that appears from inside a macro is worse than a second method call. Captures still need `func!([name] ..)` from #764.

**It knows nothing about the catalog.** The expansion is an ordinary fluent call, so it covers user-defined ops as well as built-ins, and is not coupled to the generator's eligible set.

**Two arms only** — `recv => method(closure)` and `recv => method(arg, closure)`. That covers every closure-config op in the catalog (the leading arg being a stream edge for `join` or a seed for `fold`). A third arm is a one-line addition if an op ever needs two leading args.

**Chaining is lost** — each node is its own statement. That is the honest cost of the `=>` form; it is still one line per node against the previous two.

**Stack**: eight PRs, none reviewed, seven chained on #759.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4eojqRWBJ6uK5v5JDzmkd)_