### PR TITLE
Refusal messages taught the old API

### DIFF
--- a/crates/wingfoil/src/codegen.rs
+++ b/crates/wingfoil/src/codegen.rs
@@ -125,8 +125,10 @@ impl fmt::Display for NotEmittable {
         }
         write!(
             f,
-            "quote closures with `func!(..)` and record them with `.with_src(..)`; \
-             record data configs with `.with_cfg(..)`"
+            "Every closure a generated graph contains has to be quoted, because \
+             the engine erases closures and no traversal can recover one. Data \
+             configs mostly look after themselves — only `fold`/`scan` seeds, \
+             whose type is generic, still need `.with_cfg(&seed)`."
         )
     }
 }
@@ -315,7 +317,9 @@ pub fn ineligible(nodes: &[NodeInfo]) -> Vec<Ineligible> {
                 label: n.label,
                 reason: format!(
                     "`{build}`'s closure was not quoted, so the engine erased it. \
-                     Wrap it in `func!(..)` and record it with `.with_src(..)`."
+                     Write `quoted!(<upstream> => {build}(..))` — or, if it \
+                     captures, declare what it captures: \
+                     `{build}([threshold] move |v| ..)`."
                 ),
             });
         }
@@ -366,8 +370,15 @@ mod tests {
         assert!(text.contains("node 2 (Map)"), "{text}");
         assert!(text.contains("node 5 (MergeN)"), "{text}");
         assert!(
-            text.contains("func!"),
-            "the message says what to do: {text}"
+            text.contains("quoted"),
+            "the footer says what to do about it: {text}"
+        );
+        // Concrete data configs record themselves now (`#[op(emit_cfg)]`), so
+        // blanket `.with_cfg(..)` advice would send a reader to fix something
+        // that is not broken. Only the generic-seed case is still named.
+        assert!(
+            text.contains("fold"),
+            "the remaining `with_cfg` case is scoped, not blanket: {text}"
         );
     }
 }

--- a/crates/wingfoil/tests/codegen_emission.rs
+++ b/crates/wingfoil/tests/codegen_emission.rs
@@ -206,7 +206,7 @@ fn an_erased_closure_is_refused_not_silently_emitted() {
     let err = refusals(&nodes);
     assert_eq!(1, err.len(), "only the map is ineligible: {err:?}");
     assert_eq!(2, err[0].index);
-    assert!(err[0].reason.contains("func!"), "{:?}", err[0]);
+    assert!(err[0].reason.contains("quoted!"), "{:?}", err[0]);
 }
 
 /// The other half of the same property: a config-free op is **not** flagged, so
@@ -397,7 +397,7 @@ fn generate_reports_all_reasons_it_cannot_emit() {
 
     let text = err.to_string();
     assert!(text.contains("2 node(s)"), "both reported at once: {text}");
-    assert!(text.contains("func!"), "message says what to do: {text}");
+    assert!(text.contains("quoted!"), "message says what to do: {text}");
 }
 
 /// The artifact header is not decoration: a **stale** generated file is the


### PR DESCRIPTION
**Stacked on #767 → #766 → #765 → #764 → #763 → #762 → #761 → #760 → #759.**

## What this changes

The refusal text is the **teaching surface** — the one thing a user reads at the moment they're confused — and it was written before both `quoted!` (#765) and `#[op(emit_cfg)]` (#767) landed, so it taught neither.

It recommended the manual two-step `func!` + `.with_src(..)` form rather than `quoted!`, said nothing about declaring captures (the case most likely to have caused the refusal), and advised recording data configs — which concrete ones now do themselves, so following it would send a reader to fix something that isn't broken.

Now:

```
- node 2 (Map): `map`'s closure was not quoted, so the engine erased it.
  Write `quoted!(<upstream> => map(..))` — or, if it captures, declare
  what it captures: `map([threshold] move |v| ..)`.

Every closure a generated graph contains has to be quoted, because the
engine erases closures and no traversal can recover one. Data configs
mostly look after themselves — only `fold`/`scan` seeds, whose type is
generic, still need `.with_cfg(&seed)`.
```

The op's own build name is interpolated, so the suggestion names the method the user actually called rather than a generic `map`.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` ✅ — `cargo lint-all` not run (`--all-features` needs CMake ≥3.30 for aeron and protoc for etcd; documented prerequisites, unrelated to this diff).
- [ ] `--all-features` blocked as above. Full default suite plus the broad feature set — green. Doctests green.
- [x] Covered by tests

Assertions updated across three tests. The unit test now also asserts the footer does **not** carry blanket `with_cfg` advice — the specific way it was wrong, pinned so it can't drift back.

## Notes for the reviewer — and a finding that outranks this PR

While writing this I tested something I'd asserted earlier without checking, and I was wrong about it. **`quoted!`'s `=>` syntax buys nothing.**

I'd justified the `=>` form on the grounds that a proc macro loses verbatim source. That part holds. But I never checked whether a **concrete `QuotedFn<F>` parameter** preserves closure inference — the `map_q(func!(..))` shape. Measured:

| Form | Unannotated closure | Chainable |
|---|---|---|
| `.map(\|i\| i*2)` — no quotation | ✅ | ✅ |
| `quoted!(ticks => map(\|i\| i*2))` | ❌ `Fn is not general enough` | ❌ |
| `.map_q(func!(\|i: &u64\| i*2))` | ❌ same error | ✅ |

Both quotation forms need the annotation **equally** — `func!` binds the closure with no expected type in sight, so `quoted!` inherits the same HRTB failure. So the `=>` grammar costs chainability and buys nothing over a `_q` method twin.

`#[op(fluent)]` already generates the fluent method, so generating a `_q` twin is a derive flag plus one trait-declaration line per closure-config op — mechanical, and it would let `func!` be the only vocabulary:

```rust
let out = ticks.map_q(func!(|i: &u64| i * 2))
               .filter_value_q(func!(|v: &u64| *v > 4));
```

That deprecates `quoted!` — which #765 and #766 introduce. I have **not** built it, because it invalidates two open PRs in this stack and that's a call for the repo owner, not something to do unilaterally on top of nine unreviewed layers.

**Stack**: eleven PRs, none reviewed, ten chained on #759.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4eojqRWBJ6uK5v5JDzmkd)_