### PR TITLE
Pin nanoid past GHSA-2v37-7h3g-55p8, unblocking `security.audit` on main

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -80,6 +80,7 @@
       "esbuild": ">=0.25.0",
       "@babel/core": ">=7.29.6",
       "postcss": ">=8.5.18",
+      "nanoid": "^3.3.17",
       "seroval": ">=1.5.3",
       "seroval-plugins": ">=1.5.3"
     }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   esbuild: '>=0.25.0'
   '@babel/core': '>=7.29.6'
   postcss: '>=8.5.18'
+  nanoid: ^3.3.17
   seroval: '>=1.5.3'
   seroval-plugins: '>=1.5.3'
 
@@ -763,8 +764,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1609,7 +1610,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-releases@2.0.38: {}
 
@@ -1629,7 +1630,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## What this changes

Adds `"nanoid": "^3.3.17"` to `js/`'s existing `pnpm.overrides` block and regenerates the lockfile: `nanoid` 3.3.16 → 3.3.18.

## Why

`security.audit` has been red on `main` since `32ff98c`. The failing job is `pnpm audit`, not anything Rust:

```
high  nanoid: custom generators can loop indefinitely when size is zero
      Vulnerable versions  <3.3.17
      Patched versions     >=3.3.17
      Paths                . > vite > postcss > nanoid
      More info            https://github.com/advisories/GHSA-2v37-7h3g-55p8
```

**Newly disclosed rather than newly introduced.** `main` was green at `442c0e8` on 2026-08-07 and red at `32ff98c` on 2026-08-08, and nothing in between touched `js/` — the advisory was published in the interval. So this is not a regression from any recent change, it is a pinned transitive dependency that an advisory caught up with.

## Notes for the reviewer

**The caret is deliberate, and differs from its neighbours.** Every other entry in that overrides block uses `>=`. Using `>=3.3.17` here resolves to **nanoid 6.0.1** — three majors up — and nanoid 4+ is ESM-only while postcss 8 expects `^3.3.x`. That would very likely break the bundle rather than patch it. `^3.3.17` keeps the fix inside the 3.x line, which is what the advisory actually asks for (`Patched versions: >=3.3.17`, and 3.3.18 is the current 3.x release).

If the repo would rather the block stay uniformly `>=`, the alternative is bumping `vite`/`postcss` until the transitive pin moves on its own — a larger change with real breakage risk, for the same outcome.

## How it was verified

- [x] `pnpm audit --audit-level moderate` → **No known vulnerabilities found** (was `1 high`)
- [x] `pnpm install` clean, lockfile regenerated and committed
- [x] `pnpm test` — **unchanged by this diff**: 15 tests pass before and after

On that last point, so it is not mistaken for a regression: two of the three test *files* fail both before and after, identically, with `Failed to load url ./wasm/wingfoil_wasm.js`. They need the WASM artifact built first, which this environment has not done. I confirmed by stashing the change and re-running against clean `main` — same failure, same counts.

No Rust code is touched, so the Rust legs are unaffected.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4eojqRWBJ6uK5v5JDzmkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4eojqRWBJ6uK5v5JDzmkd)_