### PR TITLE
Add 9.0.0 release notes and update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,8 +169,19 @@ jobs:
           [PyPI](https://pypi.org/project/wingfoil/$VERSION/) and
           [npm](https://www.npmjs.com/package/@wingfoil/client/v/$VERSION).
 
+          EOF
+
+          # Link the curated notes for this version when there is a page for
+          # it, and the index otherwise — every release gets a working link,
+          # and one that carries a page points straight at it.
+          if [ -f "docs/release-notes/${VERSION}.md" ]; then
+            NOTES_PATH="docs/release-notes/${VERSION}.md"
+          else
+            NOTES_PATH="docs/release-notes/"
+          fi
+          cat >> notes.md <<EOF
           What changed and how to upgrade:
-          [release notes](https://github.com/${GITHUB_REPOSITORY}/blob/$TAG/docs/release-notes.md).
+          [release notes](https://github.com/${GITHUB_REPOSITORY}/blob/$TAG/${NOTES_PATH}).
 
           EOF
           gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,9 @@ jobs:
           [PyPI](https://pypi.org/project/wingfoil/$VERSION/) and
           [npm](https://www.npmjs.com/package/@wingfoil/client/v/$VERSION).
 
+          What changed and how to upgrade:
+          [release notes](https://github.com/${GITHUB_REPOSITORY}/blob/$TAG/docs/release-notes.md).
+
           EOF
           gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
             -f "tag_name=$TAG" --jq .body >> notes.md

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ latency tracing across processes.
 ## Links
 
 - Explore the [examples](crates/wingfoil/examples/)
+- Upgrading from 8.x? Read the [release notes](docs/release-notes.md) — 9.0
+  replaces the engine
 - Compare the field: [stream processing, dataflow and trading frameworks](docs/comparison.md)
 - Browse the [crates](crates/)
 - Read the [benchmarks](crates/wingfoil/benches/)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ latency tracing across processes.
 ## Links
 
 - Explore the [examples](crates/wingfoil/examples/)
-- Upgrading from 8.x? Read the [release notes](docs/release-notes.md) — 9.0
+- Upgrading from 8.x? Read the [release notes](docs/release-notes/) — 9.0
   replaces the engine
 - Compare the field: [stream processing, dataflow and trading frameworks](docs/comparison.md)
 - Browse the [crates](crates/)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,302 @@
+# Release notes
+
+Curated, human-written notes for each release: what changed, why, and what you
+have to do about it. The commit-level changelog is generated per tag on the
+[GitHub releases page](https://github.com/wingfoil-io/wingfoil/releases) — this
+file is the part a generated changelog cannot write.
+
+---
+
+## 9.0.0 — the engine cutover
+
+**Wingfoil 9.0.0 replaces the engine.** Same project, same crate and package
+names, same registries — a different engine underneath. The `MutableNode` engine
+that shipped through the 8.x line is superseded by the `Op` engine, and this is a
+deliberate breaking change: there is no compatibility facade.
+
+If you are on 8.x, nothing you have installed stops working. 8.0.0 stays on
+crates.io, PyPI and npm permanently and existing lockfiles keep resolving. The
+break happens when you choose to bump.
+
+- **Rust migration guide:** [`migration.md`](migration.md)
+- **Python migration guide:** [`../crates/wingfoil-python/docs/migration.rst`](../crates/wingfoil-python/docs/migration.rst)
+
+### What ships at 9.0.0
+
+Every published artifact moves together, over the top of the 8.x line:
+
+| Artifact | Registry | Notes |
+|---|---|---|
+| `wingfoil` | crates.io | The engine |
+| `wingfoil-derive` | crates.io | `nitro!`, `#[op]`, `latency_stages!` — shares no API with 8.0.0, which held only `#[node]` |
+| `wingfoil-python` | PyPI (`pip install wingfoil`) | |
+| `wingfoil-wire-types` | crates.io | Wire format shared with the browser client |
+| `@wingfoil/client` | npm | |
+
+Nothing is orphaned: the new crates took over the published names rather than
+starting a new line beside them, so all four crates continue at 9.0.0 instead of
+three continuing and one stopping dead. MSRV is 1.88.
+
+The 9.0 engine is a **superset** of 8.x — every op, every adapter, both run
+modes, the examples, the benchmarks and both language bindings — with exactly
+one public API removed ([below](#what-is-gone)). That was the governing
+constraint of the whole port, audited adapter by adapter in
+[`deviation-register.md`](deviation-register.md).
+
+### Why the engine was replaced
+
+The 8.x node fused three concerns into one object. A node was its *computation*,
+its *storage* (`RefCell` fields), and its *input plumbing* (peeking upstream
+`Rc<dyn Stream>` handles it held itself). That works, and it shipped for years —
+but it fixes the execution strategy at the point where semantics are written.
+Because a node owns its own state and reaches for its own inputs, the engine can
+only ever walk a list of trait objects and call them. There is nothing to
+monomorphize, and any second way of executing a graph means a second copy of the
+cycle logic, free to drift from the first.
+
+The `Op` trait separates the three. An op declares only what it *computes* —
+`cycle(cfg, state, input, ctx)`, with `Cfg` for construction-time config, `State`
+engine-owned, `In<'a>` typed inputs handed in per cycle, and `Activation`
+declaring its scheduling statically. The engine owns everything else.
+
+That one change is what the release buys, and it pays in four places:
+
+- **Three execution tiers from one definition.** Interpreted, the whole graph
+  monomorphized into a single function (`compiled()`), or a compiled island
+  mounted as one node of an interpreted graph (`nested()`). Semantics live once,
+  in each op's `cycle`; the tiers differ only in how the engine reaches it, so
+  they cannot drift apart. Compiled runs **4.4×–37×** faster than interpreted;
+  an island, **2.2×–10.2×**.
+- **The interpreted tier got faster too.** The port beats the engine it replaces
+  on all eight benchmark workloads — **0.56×–0.84×** of legacy's time. Replacing
+  an engine usually costs something on the path everyone is already on; this one
+  did not, and that was a gate on the cutover rather than a hope.
+- **Extensibility without a registry.** `#[op(build = name)]` derives the
+  interpreted builder method *and* the forwarders the compiled paths dispatch
+  through, from the declared shape. Your op and a built-in op take the identical
+  path — there is no per-op match arm to add, and no fork needed to get compiled
+  coverage for your own node.
+- **Failure became expressible.** Every lifecycle function returns
+  `anyhow::Result`, a producer thread can push an error into the graph with
+  `send_error`, and the marshaling helpers that used to default their way past
+  bad input now abort the run naming the field. `Tick` gained a third state,
+  `Silent(v)` — "update my value, do not tick downstream" — which the two-state
+  `Ok(true)`/`Ok(false)` could not say at all.
+
+**Why no compatibility facade.** It was considered and ruled out. A facade over
+the `MutableNode` wiring path would have to be *maintained* across exactly the
+refactors this cutover exists to enable, and it would keep the fused
+node/state/inputs shape alive as a supported surface — the shape the release
+exists to remove. The Python binding made the same call independently ("a
+replacement engine with its own binding, not a compatibility facade over the old
+one"), and having the two languages disagree about how hard the break is would
+be worse than the break. The major version bump is the signal, the migration
+guides are the answer, and 8.0.0 staying installable forever is the safety net.
+
+### Performance
+
+Read the ratios, not the absolute times — these were captured on shared 4-core
+cloud VMs, each comparison measured back to back in one run. Full method and
+caveats: [`benches/README.md`](../crates/wingfoil/benches/README.md).
+
+| Workload | Nodes | legacy | interpreted | compiled | nested | interp/legacy |
+|---|---|---|---|---|---|---|
+| `dense_chain` | 37 | 7.9491 ms | 6.6387 ms | 187.08 µs | 930.81 µs | **0.84×** |
+| `fanout` | 103 | 17.052 ms | 11.993 ms | 324.26 µs | 1.4309 ms | **0.70×** |
+| `fan_in_16` | 20 | 4.7610 ms | 2.6683 ms | 174.44 µs | 854.77 µs | **0.56×** |
+| `fan_in_64` | 68 | 10.722 ms | 6.4710 ms | 258.57 µs | 938.48 µs | **0.60×** |
+| `fan_in_256` | 260 | 38.079 ms | 31.599 ms | 2.5496 ms | 3.0954 ms | **0.83×** |
+| `accumulate` | 3 | 2.0837 ms | 1.4268 ms | 326.31 µs | 1.4033 ms | **0.68×** |
+| `sparse` | 205 | 2.5036 ms | 2.1139 ms | 310.63 µs | 751.34 µs | **0.84×** |
+| `sparse_wide` | 781 | 3.0716 ms | 2.0145 ms | 355.15 µs | 895.66 µs | **0.66×** |
+
+The legacy column is only measurable while both engines are in the tree, so a
+second, independent capture was banked as the cutover's pass/fail record before
+the tree is deleted — [`cutover-plan.md` gate 6.4](cutover-plan.md#gate-64--the-legacy-vs-wingfoil-reading-captured-before-deletion).
+It agrees: interpreted ahead of legacy in all eight groups.
+
+---
+
+## Upgrading — the short version
+
+### Rust
+
+**1. Bump the dependency.**
+
+```toml
+[dependencies]
+wingfoil = "9.0"
+```
+
+**2. Build the graph on a builder.** Sources are no longer free functions and
+`run` is no longer a method on a stream:
+
+```rust
+// 8.x
+let count = ticker(Duration::from_millis(10)).count();
+count.run(RunMode::RealTime, RunFor::Cycles(100))?;
+
+// 9.0
+let g = GraphBuilder::new();
+let count = g.ticker(Duration::from_millis(10)).count();
+let mut runner = g.build();
+runner.run(RunMode::RealTime, RunFor::Cycles(100))?;
+```
+
+`Rc<dyn Stream<T>>` becomes `Stream<T>`, a cheap `Clone` handle;
+`node.peek_value()` becomes `runner.value(&handle)`. `RunMode`, `RunFor` and
+`NanoTime` are **unchanged** — literally the same types, since both engines
+share one runtime core.
+
+**3. Rewrite custom nodes from `#[node]` to `Op`.** State and config become
+associated types, inputs arrive as parameters, and scheduling is declared:
+
+```rust
+// 8.x — state in fields, inputs peeked from stored upstreams
+#[node(active = [upstream], output = value: f64)]
+impl MutableNode for ScaleStream {
+    fn cycle(&mut self, _state: &mut GraphState) -> anyhow::Result<bool> {
+        self.value = self.upstream.peek_value() * self.factor;
+        Ok(true)
+    }
+}
+
+// 9.0 — config, state and inputs are parameters; the return says what to do
+#[op(build = scale, fluent)]
+impl Op for Scale {
+    type Cfg = f64;
+    type State = ();
+    type In<'a> = (&'a f64,);
+    type Out = f64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(cfg: &mut f64, _state: &mut (), input: (&f64,), _ctx: &mut Ctx<'_>)
+        -> Result<Tick<f64>>
+    {
+        Ok(Tick::Value(input.0 * *cfg))
+    }
+}
+```
+
+The item-by-item mapping table is in [`migration.md`](migration.md#writing-a-node-node--op).
+
+**4. Check every node that used to return `Ok(false)`.** If you ported it
+mechanically to `Tick::Quiet` and its downstream now fires when it should not,
+you want `Tick::Silent(v)` — update the value without ticking.
+
+**5. Adapters: one trait method, not a free-fn/operator pair.** Sinks are
+extension-trait methods on `Stream<T>`; sources are free functions taking
+`&GraphBuilder` first. They stay out of the prelude — opt in per adapter.
+
+```rust
+use wingfoil::adapters::zmq::{ZeroMqPub, zmq_sub};
+
+let (data, status) = zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, "tcp://host:5556")?;
+let sink = stream.zmq_pub(5556, ());
+```
+
+Two behavioural changes to expect when you run it: **connections are established
+at `start()`, not at wiring**, so a connection error surfaces during the run with
+node context rather than during construction; and **live sources reject
+`RunMode::HistoricalFrom` at wiring**, with an error naming the bounded reader
+instead of the deadlock 8.x would have given you.
+
+**6. Handle the errors.** Every lifecycle function returns `anyhow::Result` —
+propagate with `?` and `.context("…")` at I/O boundaries. Production code does
+not call `.unwrap()`.
+
+### Python
+
+```sh
+pip install -U wingfoil
+```
+
+Six changes cover almost every upgrade; the complete list is
+[`migration.rst`](../crates/wingfoil-python/docs/migration.rst).
+
+1. **The graph is explicit.** `g = wf.Graph()`, sources built on it, and `run`
+   is a graph method taking nanosecond integers — `g.run(cycles=3)` replays
+   historically by default, `g.run(realtime=True, duration_nanos=D)` runs live.
+2. **`peek_value()` → `value()`.**
+3. **`filter` changed meaning** — it now gates on another *stream*'s value,
+   matching the Rust engine. The predicate form is **`filter_value`**. Passing a
+   function raises `TypeError` rather than misbehaving quietly.
+4. **Sources yield a `list` per tick.** 8.x kept only the last row of any
+   timestamp and dropped the rest silently; reads are lossless now, so index or
+   iterate where you used to read a single dict.
+5. **Conversion failures abort the run**, naming the field. Missing values,
+   wrong-typed keys and malformed CSV timestamps used to default silently — a
+   bad timestamp became `NanoTime::ZERO` and quietly reordered your replay. If
+   you were relying on a default, make it explicit in your `map`.
+6. **Adapter selectors are plain strings**, not enum classes, and live-only
+   sources take `realtime=True` at wiring, which must match the eventual `run`.
+
+Windowed statistics need **no change** — the same eight methods with the same
+`Window` / `Weighting` / `EwmaSpan` arguments.
+
+### TypeScript
+
+```sh
+npm install @wingfoil/client@9
+```
+
+The wire types moved with the engine and the version tracks it; the client API
+is unchanged.
+
+### You do not have to move everything at once
+
+The **ZeroMQ wire format is byte-compatible between 8.x and 9.0**, in both
+directions, including through the Python bindings — covered by cross-engine
+tests specifically so a staged rollout is safe. A publisher on the old engine
+can feed a subscriber on the new one while you migrate process by process.
+
+---
+
+## What is gone
+
+**`Graph::export`** — the GML topology dump. It is the only public 8.x API with
+no replacement in 9.0, and the drop is deliberate: we want a designed
+introspection and visualisation story rather than a same-shape port of a
+debug-only helper. Nothing in the engine blocks bringing it back — the builder
+holds the full topology plus debug labels — so if you depend on it, say so and
+it can come back as part of that work.
+
+If you find anything else 8.x did that 9.0 cannot, that is a bug in the port,
+not an intended break. Please
+[open an issue](https://github.com/wingfoil-io/wingfoil/issues).
+
+## Deliberately not in 9.0
+
+Four limits, all of them on capability the new engine *adds* rather than
+anything 8.x had, so none is a regression — 8.x has no compiled tier at all:
+
+- Compiled realtime is timer-driven, with no external wake. I/O stays at the
+  interpreted boundary, with compiled islands inside.
+- Islands are single-output; interpreted multi-output works today
+  (`Builder::demux`).
+- Dynamic graph editing inside an island is partial; the interpreted surface is
+  complete.
+- Compiled sparse gating is per-node `if` checks rather than region gating. The
+  `sparse` benchmarks measure those checks cheap enough that compiled still
+  beats the dirty-list on a ~97%-quiet graph.
+
+Each was ruled explicitly at cutover rather than left implicit —
+[`cutover-plan.md` §2](cutover-plan.md#2-rulings-owed--no-code-but-they-gate-the-swap).
+
+## Where the legacy tree stands
+
+The 8.x engine is **still in this repository, under `legacy/`**, frozen at 8.0.0
+and outside the cargo workspace. It is not part of anything 9.0.0 publishes: the
+only edge from `crates/` to it is a dev-dependency, used by the parity tests and
+the comparison benchmarks above, so the shipped library graph never leaves the
+new tree.
+
+It stays for as long as it is useful as the parity oracle. Deleting it is the
+last mechanical step of the cutover and it is purely subtractive — the layout
+was arranged so that removal is a `git rm`, not a re-organisation. The sequence,
+including what is and is not recoverable afterwards, is
+[`cutover-runbook.md`](cutover-runbook.md).
+
+Its publish jobs are already retired, so `legacy/` will not produce another
+release. 8.0.0 remains on crates.io and PyPI permanently regardless — crates.io
+does not delete, and nothing a downstream user has today stops working.

--- a/docs/release-notes/9.0.0.md
+++ b/docs/release-notes/9.0.0.md
@@ -1,13 +1,4 @@
-# Release notes
-
-Curated, human-written notes for each release: what changed, why, and what you
-have to do about it. The commit-level changelog is generated per tag on the
-[GitHub releases page](https://github.com/wingfoil-io/wingfoil/releases) — this
-file is the part a generated changelog cannot write.
-
----
-
-## 9.0.0 — the engine cutover
+# Wingfoil 9.0.0 — the engine cutover
 
 **Wingfoil 9.0.0 replaces the engine.** Same project, same crate and package
 names, same registries — a different engine underneath. The `MutableNode` engine
@@ -18,10 +9,10 @@ If you are on 8.x, nothing you have installed stops working. 8.0.0 stays on
 crates.io, PyPI and npm permanently and existing lockfiles keep resolving. The
 break happens when you choose to bump.
 
-- **Rust migration guide:** [`migration.md`](migration.md)
-- **Python migration guide:** [`../crates/wingfoil-python/docs/migration.rst`](../crates/wingfoil-python/docs/migration.rst)
+- **Rust migration guide:** [`migration.md`](../migration.md)
+- **Python migration guide:** [`migration.rst`](../../crates/wingfoil-python/docs/migration.rst)
 
-### What ships at 9.0.0
+## What ships at 9.0.0
 
 Every published artifact moves together, over the top of the 8.x line:
 
@@ -41,9 +32,9 @@ The 9.0 engine is a **superset** of 8.x — every op, every adapter, both run
 modes, the examples, the benchmarks and both language bindings — with exactly
 one public API removed ([below](#what-is-gone)). That was the governing
 constraint of the whole port, audited adapter by adapter in
-[`deviation-register.md`](deviation-register.md).
+[`deviation-register.md`](../deviation-register.md).
 
-### Why the engine was replaced
+## Why the engine was replaced
 
 The 8.x node fused three concerns into one object. A node was its *computation*,
 its *storage* (`RefCell` fields), and its *input plumbing* (peeking upstream
@@ -93,11 +84,11 @@ one"), and having the two languages disagree about how hard the break is would
 be worse than the break. The major version bump is the signal, the migration
 guides are the answer, and 8.0.0 staying installable forever is the safety net.
 
-### Performance
+## Performance
 
 Read the ratios, not the absolute times — these were captured on shared 4-core
 cloud VMs, each comparison measured back to back in one run. Full method and
-caveats: [`benches/README.md`](../crates/wingfoil/benches/README.md).
+caveats: [`benches/README.md`](../../crates/wingfoil/benches/README.md).
 
 | Workload | Nodes | legacy | interpreted | compiled | nested | interp/legacy |
 |---|---|---|---|---|---|---|
@@ -112,7 +103,7 @@ caveats: [`benches/README.md`](../crates/wingfoil/benches/README.md).
 
 The legacy column is only measurable while both engines are in the tree, so a
 second, independent capture was banked as the cutover's pass/fail record before
-the tree is deleted — [`cutover-plan.md` gate 6.4](cutover-plan.md#gate-64--the-legacy-vs-wingfoil-reading-captured-before-deletion).
+the tree is deleted — [`cutover-plan.md` gate 6.4](../cutover-plan.md#gate-64--the-legacy-vs-wingfoil-reading-captured-before-deletion).
 It agrees: interpreted ahead of legacy in all eight groups.
 
 ---
@@ -178,7 +169,7 @@ impl Op for Scale {
 }
 ```
 
-The item-by-item mapping table is in [`migration.md`](migration.md#writing-a-node-node--op).
+The item-by-item mapping table is in [`migration.md`](../migration.md#writing-a-node-node--op).
 
 **4. Check every node that used to return `Ok(false)`.** If you ported it
 mechanically to `Tick::Quiet` and its downstream now fires when it should not,
@@ -212,7 +203,7 @@ pip install -U wingfoil
 ```
 
 Six changes cover almost every upgrade; the complete list is
-[`migration.rst`](../crates/wingfoil-python/docs/migration.rst).
+[`migration.rst`](../../crates/wingfoil-python/docs/migration.rst).
 
 1. **The graph is explicit.** `g = wf.Graph()`, sources built on it, and `run`
    is a graph method taking nanosecond integers — `g.run(cycles=3)` replays
@@ -281,7 +272,7 @@ anything 8.x had, so none is a regression — 8.x has no compiled tier at all:
   beats the dirty-list on a ~97%-quiet graph.
 
 Each was ruled explicitly at cutover rather than left implicit —
-[`cutover-plan.md` §2](cutover-plan.md#2-rulings-owed--no-code-but-they-gate-the-swap).
+[`cutover-plan.md` §2](../cutover-plan.md#2-rulings-owed--no-code-but-they-gate-the-swap).
 
 ## Where the legacy tree stands
 
@@ -295,7 +286,7 @@ It stays for as long as it is useful as the parity oracle. Deleting it is the
 last mechanical step of the cutover and it is purely subtractive — the layout
 was arranged so that removal is a `git rm`, not a re-organisation. The sequence,
 including what is and is not recoverable afterwards, is
-[`cutover-runbook.md`](cutover-runbook.md).
+[`cutover-runbook.md`](../cutover-runbook.md).
 
 Its publish jobs are already retired, so `legacy/` will not produce another
 release. 8.0.0 remains on crates.io and PyPI permanently regardless — crates.io

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,24 @@
+# Release notes
+
+One page per release: what changed, why, and what you have to do about it.
+
+These are the curated, human-written half of a release. The commit-level
+changelog is generated per tag on the
+[GitHub releases page](https://github.com/wingfoil-io/wingfoil/releases), and
+the release body links here for the part a generated changelog cannot write —
+rationale, upgrade steps, and what was deliberately left out.
+
+| Version | |
+|---|---|
+| [**9.0.0**](9.0.0.md) | The engine cutover — the `Op` engine replaces `MutableNode`. Breaking; [Rust](../migration.md) and [Python](../../crates/wingfoil-python/docs/migration.rst) migration guides |
+
+Releases before 9.0.0 have no page here — the practice starts with the cutover,
+which is the first release that needed one.
+
+## Adding a page
+
+Name the file after the version (`9.1.0.md`), add a row to the table above
+(newest first), and lead with what the release *is* before what it contains. A
+release that breaks something owes three things: the reasoning behind the break,
+the shortest upgrade path that actually works, and an honest list of what is
+gone or deferred. A release that breaks nothing can be short.


### PR DESCRIPTION
## What this changes

Adds comprehensive release notes for 9.0.0 documenting the engine cutover from `MutableNode` to `Op`, including rationale, performance comparisons, and migration guides for Rust and Python. Updates the release workflow to link to curated release notes when available.

## Why

The 9.0.0 release is a major breaking change that replaces the entire execution engine. Users need clear documentation of:
- Why the engine was replaced and what problems it solves
- Performance improvements across all execution tiers
- Step-by-step migration paths for Rust and Python
- What was deliberately removed vs. deferred

The release workflow update ensures GitHub release bodies link directly to the curated notes rather than relying solely on auto-generated commit logs, which cannot capture rationale or upgrade guidance.

## How it was verified

- [ ] `cargo fmt --all`
- [ ] `cargo lint` and `cargo lint-all`
- [ ] Documentation structure follows conventions (release notes index, per-version pages)
- [ ] Links in release notes point to existing migration guides and deviation register
- [ ] Workflow logic correctly selects between version-specific notes and index

## Notes for the reviewer

The release notes document the complete cutover story:
- **9.0.0.md** (293 lines): Full rationale, performance data, upgrade steps, and what is gone/deferred
- **README.md**: Index of release notes with guidance for adding future pages
- **release.yml**: Conditional logic to link version-specific notes when they exist, falling back to the index

The performance table captures the legacy vs. interpreted vs. compiled vs. nested tiers, with the legacy column measured before deletion (per cutover-plan.md gate 6.4). All eight benchmarks show interpreted ahead of legacy, validating the port's performance claim.

The upgrade sections are intentionally short and actionable — full detail lives in `docs/migration.md` and `crates/wingfoil-python/docs/migration.rst`, which are linked from the release notes.

https://claude.ai/code/session_01FYMWw57Jb3YRFmTfL5qYi2