### PR TITLE
Correct two stale claims in the 9.0.0 release notes

### DIFF
--- a/docs/release-notes/9.0.0.md
+++ b/docs/release-notes/9.0.0.md
@@ -20,13 +20,15 @@ Every published artifact moves together, over the top of the 8.x line:
 |---|---|---|
 | `wingfoil` | crates.io | The engine |
 | `wingfoil-derive` | crates.io | `nitro!`, `#[op]`, `latency_stages!` — shares no API with 8.0.0, which held only `#[node]` |
-| `wingfoil-python` | PyPI (`pip install wingfoil`) | |
+| `wingfoil-python` | crates.io + PyPI (`pip install wingfoil`) | |
+| `wingfoil-python-derive` | crates.io | `#[pyop]`, `#[pyadapter]` — new in 9.0, no 8.x counterpart |
 | `wingfoil-wire-types` | crates.io | Wire format shared with the browser client |
 | `@wingfoil/client` | npm | |
 
 Nothing is orphaned: the new crates took over the published names rather than
-starting a new line beside them, so all four crates continue at 9.0.0 instead of
-three continuing and one stopping dead. MSRV is 1.88.
+starting a new line beside them, so every name 8.x published — `wingfoil`,
+`wingfoil-derive`, `wingfoil-python` — continues at 9.0.0 rather than stopping
+dead beside a new line. MSRV is 1.88.
 
 The 9.0 engine is a **superset** of 8.x — every op, every adapter, both run
 modes, the examples, the benchmarks and both language bindings — with exactly
@@ -261,8 +263,11 @@ not an intended break. Please
 Four limits, all of them on capability the new engine *adds* rather than
 anything 8.x had, so none is a regression — 8.x has no compiled tier at all:
 
-- Compiled realtime is timer-driven, with no external wake. I/O stays at the
-  interpreted boundary, with compiled islands inside.
+- Compiled realtime has no *wake-driven* ingest. `external` and `channel`
+  (`Activation::THREADED`) stay at the interpreted boundary, with compiled
+  islands inside — a compiled graph builds its `Kernel` without a ready
+  receiver, so nothing can ever set their dirty bit. Busy-poll ingest is not
+  affected: `poll` reaches both compiled tiers, realtime-only.
 - Islands are single-output; interpreted multi-output works today
   (`Builder::demux`).
 - Dynamic graph editing inside an island is partial; the interpreted surface is


### PR DESCRIPTION
## What this changes

Two corrections to `docs/release-notes/9.0.0.md`, which landed in #774. One file, +10/-5. No Rust touched.

> **Rebased.** This PR originally carried the notes themselves — #774 merged them from the original branch while this was in flight, so the duplicated commits are dropped and only the corrections remain.

## Why

Both claims were made stale by **#758**, which landed the *same afternoon* the notes were written — an hour either side of the two notes commits. They were wrong on arrival rather than having drifted.

**1. The compiled-realtime limit.** "Deliberately not in 9.0" said compiled realtime is timer-driven with no external wake, and that I/O stays at the interpreted boundary. #758 made busy-poll sources expressible in the compiled and nested tiers — `expand_compiled` now derives `spins` from the OR of its ops' `ACTIVATION` consts — so `poll` reaches both, realtime-only.

Reworded to the exclusion that actually survives: wake-driven `THREADED` ingest (`external`, `channel`), which a compiled `Kernel` built without a ready receiver can never mark dirty. This now matches the category-1 list in `tests/op_completeness.rs`, which #758 corrected in the same commit and the notes never caught up with.

**2. The shipped-artifacts table** omitted `wingfoil-python-derive`, which `crates-publish.yml` publishes at 9.0.0 alongside the other four. Added it, and marked `wingfoil-python` as going to crates.io as well as PyPI. That made the following sentence's "all four crates" count wrong, so it now states the claim it was making — every name 8.x published continues at 9.0.0 — rather than a count that breaks whenever the set changes.

## How it was verified

No Rust changed, so fmt/clippy/tests have nothing to say about this diff. What was checked is that the rest of the page is still true of `main`:

- [x] Every cross-reference target exists — `migration.md`, `migration.rst`, `deviation-register.md`, `benches/README.md`, `cutover-plan.md`, `cutover-runbook.md`
- [x] Both deep anchors resolve — `cutover-plan.md` gate 6.4 and §2
- [x] MSRV claim matches the workspace (`rust-version = "1.88"`)
- [x] Every API in the upgrade samples still exists: `Runner::value`, `GraphBuilder::new`, `Builder::demux`, `zmq_sub`, `#[op(build = …, fluent)]`, Python `filter_value`
- [x] Published-crate list read from `crates-publish.yml`, not assumed
- [x] Benchmark table left alone — no bench file has changed since the notes were written

## Notes for the reviewer

**One thing I deliberately did not change, for you to rule on.** `tests/op_completeness.rs` lists `feedback` as a compiled-tier exclusion too — a cycle in the DAG that straight-line emission cannot express. "Deliberately not in 9.0" doesn't mention it, and adding it would turn "Four limits" into five and change the section's shape. That reads as an author's call about what belongs in release notes versus a test's classification comment, not a correctness fix. One line to add if you want it.

**Still outstanding, beyond this PR.** There is no `v9.0.0` tag and no published GitHub release — the releases page is empty — so nothing links to these notes yet, and the `release.yml` block #774 added has not had a chance to fire. Separately, `UPGRADING.md` is unmerged on `claude/release-notes-upgrade-guide-0oxhc3` (131 lines, the fluent `GraphBuilder` API) and overlaps this page's "Upgrading — the short version"; worth settling whether those are one document or two.