### PR TITLE
docs(fpga): rewrite the HDL-backend design against the generator as built

### DIFF
--- a/docs/fpga-hdl-backend-decision.md
+++ b/docs/fpga-hdl-backend-decision.md
@@ -3,12 +3,11 @@
 **Status: exploratory design, not scheduled.** This records the reasoning
 and the de-risk plan; nothing is committed to build.
 **Tracked as [#727](https://github.com/wingfoil-io/wingfoil/issues/727)**,
-which carries the §5 de-risk spike as a checklist. It is **gated behind**
+which carries the §7 de-risk spike as a checklist. It is **gated behind**
 the software generator of
 [`wired-graph-codegen-decision.md`](wired-graph-codegen-decision.md) — read
 that first: this document reuses its front-end (wired-graph traversal +
-`func!` quotation metadata) wholesale and adds a hardware emission backend
-behind it.
+recorded closure metadata) and adds a hardware emission backend behind it.
 
 **Question.** Could the wired-graph front-end also emit hardware — generate
 RustHDL/RHDL code that in turn generates Verilog, so a graph's hot path
@@ -16,17 +15,40 @@ RustHDL/RHDL code that in turn generates Verilog, so a graph's hot path
 same wiring backtests in software?
 
 **Answer.** Architecturally yes, and the pieces line up strikingly well —
-the Op pattern is accidentally RTL-shaped, and `func!` quotation is exactly
-the bridge RHDL's no-closures kernel subset needs. But it is a much bigger
-lift than the software generator (a restricted type dialect, per-op RTL
-twins with simulation-based parity, clock/valid semantics design) stacked
-on a pre-release one-person dependency. Position it as **backend #3** of
-the multi-front-end design, de-risked by a small hand-written spike before
-any emitter exists.
+the Op pattern is accidentally RTL-shaped. But it is a much bigger lift than
+the software generator (a restricted type dialect, per-op RTL twins with
+simulation-based parity, clock/valid semantics design) stacked on a
+pre-release one-person dependency. Position it as **backend #3** of the
+multi-front-end design, de-risked by a small hand-written spike before any
+emitter exists.
+
+> **Revision 2026-08-09 — rewritten against the generator as built.** This
+> document was written before the software generator existed
+> ([#769](https://github.com/wingfoil-io/wingfoil/pull/769)). Now that it
+> does, the central claim could be checked rather than assumed, and it did
+> not survive intact:
+>
+> - **§2 is new, and is the section to read.** It audits what the generator
+>   actually hands the hardware backend. The answer is "most of it, but not
+>   the part this document led with" — closure quotation, the advertised
+>   bridge, is the *weakest* carryover (§2b), while the unglamorous
+>   machinery (traversal, refusals, capture detection) carries cleanly.
+> - **§5.4 is new and is the load-bearing wall.** Pipeline skew was absent
+>   from the original, whose worked example (§4) is a single path and
+>   therefore cannot exhibit it.
+> - **§5.1 is corrected.** The type dialect is not a thing to introduce —
+>   wingfoil already ships fixed-point `Px`/`Qty`. They are `i128`, which is
+>   the actual problem.
+> - **§6 is new** — the host↔card interface, needed whether or not a line of
+>   HDL is ever generated.
+> - **§7's spike is amended** so it can fail. As originally written it could
+>   only succeed.
 
 ---
 
-## 1. The target crates (surveyed 2026-07)
+## 1. The target crates (surveyed 2026-07, widened 2026-08)
+
+### 1a. The two Rust-embedded candidates
 
 Both are by the same author (Samit Basu):
 
@@ -45,22 +67,143 @@ Both are by the same author (Samit Basu):
   project; the crates.io `rhdl` 0.1.0 (Sept 2023) is a name reservation —
   the real code is unreleased.
 
-**Which to target:** `rhdl`, because its kernel model lets quoted closure
-bodies splice through nearly verbatim (§3) and its frontend doubles as the
-eligibility checker — but as a *prototyping vehicle*, not a load-bearing
-production dependency, until it has releases. The shipped interface is the
-**emitted Verilog**, which is toolchain-portable: if `rhdl` stalls, the
-emitter's front half (traversal, eligibility, kernel extraction) survives
-and could retarget Chisel/Amaranth/raw Verilog templates.
-[rust-hdl](https://github.com/samitbasu/rust-hdl) ·
-[rhdl](https://github.com/samitbasu/rhdl)
+### 1b. The wider field, and why it changes the answer
 
-## 2. Why the mapping is unusually good
+The original survey compared only those two, which framed the choice as
+"which crate is the backend". That is the wrong unit. A hardware emitter has
+two separable halves, and only one of them is anybody else's problem:
+
+- **Leaf kernels** — the combinational bodies of `map` / `filter` / `join`.
+  Here a Rust-source-to-RTL compiler is irreplaceable, and `rhdl` is the only
+  game in town.
+- **Structural composition** — one module per node, valid/data along edges,
+  state registers, and (§5.4) latency balancing. This is *specific to
+  wingfoil's graph semantics*. No third party can supply it, and no third
+  party's IR makes it materially easier.
+
+Other targets, ranked by how much they would actually change the design:
+
+| | what it is | bearing on this design |
+|---|---|---|
+| **CIRCT / FIRRTL** | MLIR-based hardware compiler; `firtool` lowers FIRRTL → optimised Verilog | The most credible *emission target*. A real IR with a maintained optimiser and vendor-neutral output — emitting FIRRTL rather than Verilog buys a lowering pipeline we would otherwise own. |
+| **Spade** | Rust-inspired HDL (its own language) | Has **pipelining as a first-class construct**, with valid propagation across stages. That is precisely §5.4's problem, solved. Worth reading even if never adopted. |
+| **XLS** (Google) | HLS with an automatic scheduler; `proc`s communicating over channels | Its dataflow model is the closest existing thing to a wingfoil graph, and its scheduler does the pipelining automatically. The strongest "buy, don't build" candidate for §5.4. |
+| **Veryl** | Rust-flavoured HDL transpiling to SystemVerilog | Active and pragmatic, but a *language* — no closure-splicing story, so it loses the property that motivates this document. |
+| **Amaranth** | Python HDL (ex-nMigen) | Excellent simulator and productivity; wrong host language. |
+
+**Which to target — revised.** `rhdl` for the **leaf kernels only**.
+**wingfoil owns the structural emission**, targeting SystemVerilog directly
+or FIRRTL via CIRCT.
+
+That split is the point: it bounds the pre-release dependency to the half
+that has a fallback. If `rhdl` stalls we lose the kernel compiler — an
+inconvenience, since `map`/`filter` bodies over a fixed-point dialect are a
+small enough language to compile ourselves — rather than the backend. Under
+the original framing an `rhdl` stall took the entire emitter with it, which
+made a spare-time dependency load-bearing for the project. It is not, and
+should never have been.
+
+[rust-hdl](https://github.com/samitbasu/rust-hdl) ·
+[rhdl](https://github.com/samitbasu/rhdl) ·
+[CIRCT](https://circt.llvm.org/) ·
+[Spade](https://spade-lang.org/) ·
+[XLS](https://google.github.io/xls/)
+
+## 2. What the software generator actually carries over
+
+### 2a. The ledger
+
+The header of this document claims the hardware backend "reuses the
+front-end wholesale". With
+[#769](https://github.com/wingfoil-io/wingfoil/pull/769) landed that is
+checkable. The honest ledger:
+
+| Generator asset | Carries to hardware? | Notes |
+|---|:--:|---|
+| `NodeInfo` traversal — index, label, active/passive edges, `passive_mask`, `edges_in_call_order`, `Activation` | ✅ **fully** | This is the real inheritance. A structural HDL emitter walks exactly this, and the active/passive distinction *is* valid-gating vs plain sampling. |
+| Refusal machinery — `Ineligible` / `NotEmittable`, all reasons at once, `#[track_caller]` call sites | ✅ **fully** | The FPGA tier is a stricter instance of the same pattern. Refusing "node 12 is not synthesizable" with a wiring line number is infrastructure the hardware tier gets free. |
+| Capture detection — `free_vars` + `Probe` | ✅ **fully, and it is the sleeper asset** | The detected capture set is exactly the **runtime-parameter set** (§6c). Nothing else identifies which values a design must expose as CSRs. |
+| `check_artifact` staleness guard | ✅ **fully** | More important here, not less: a stale bitstream is worse than a stale binary, and the resynthesis cycle makes "just regenerate" expensive enough that nobody does it casually. |
+| Two-pass architecture — run the wiring, walk it, emit, compile | ✅ **fully** | Synthesis replaces pass 2. The shape is identical. |
+| `#[op(emit_cfg)]` recording configs on the node | ⚠️ **the recording, not the rendering** | That configs are *reachable at traversal time* is what matters and it transfers. `EmitLiteral` produces Rust source; hardware wants the value, for a `localparam` or a CSR reset. Needs a sibling trait, not a reuse. |
+| **Closure quotation (`#[wiring]` / `func!` recorded bodies)** | ❌ **the weakest link — see §2b** | The advertised bridge. It does not splice verbatim, and the reason is structural. |
+| `nitro!` as the sole backend | ❌ **no equivalent exists** | See §2c. This is the software generator's best architectural property and hardware does not get it. |
+| Anything about **latency** | ❌ **absent entirely** | `NodeInfo` has no notion of pipeline depth, and no way to say "these two edges must be depth-matched". §5.4 is new IR the hardware backend must add. |
+
+### 2b. Why quotation does not splice verbatim
+
+§3 of this document originally asserted that "tier-1 (closed) closures
+translate nearly verbatim" into rhdl `#[kernel]` functions. That is wrong,
+and the reason is visible in one line of `ops.rs`:
+
+```rust
+F: Fn(&A) -> B + 'static,          // map
+F: Fn(&A, &B) -> C + 'static,      // join
+F: Fn(&mut B, &A) + 'static,       // fold
+```
+
+**Every op closure in the catalog takes references.** rhdl's kernel subset
+forbids references and pointers outright. So the bodies `#[wiring]` records
+today look like
+
+```rust
+|n: &u64| (n * size) as f64
+```
+
+and the kernel they must become looks like
+
+```rust
+#[kernel] fn k0(n: b64) -> ... { ... }
+```
+
+— a signature rewrite plus deref elision throughout the body. That is
+mechanical for `map`/`filter`/`join` and a compiler pass we would have to
+write and test. It is *not* "splice through nearly verbatim", and the
+distinction matters because the verbatim claim is what made quotation look
+like the keystone.
+
+`fold`'s `Fn(&mut B, &A)` is worse than a rewrite: an `&mut` accumulator is
+a *state-update* kernel, a different shape from a combinational one, and
+maps to the register-update path rather than to a spliced expression.
+
+**Two consequences.** First, the recorded body is a `String` of normalised
+Rust (prettyplease-formatted, per `#[wiring]`'s docs) — which is *fine*,
+because it round-trips through rustc in pass 2 either way, exactly as the
+software artifact does. The string-versus-tokens question is a non-issue.
+Second, the eligibility check cannot be delegated to rhdl's frontend as §3
+hoped, because what we hand rhdl is not what the user wrote. We own the
+rewrite, so we own its failure modes.
+
+This does not sink the design. It moves quotation from "the bridge that
+makes this work" to "one of several inputs, requiring a translation pass" —
+and it means the §7 spike must exercise the rewrite rather than assume it.
+
+### 2c. The asymmetry: there is no `nitro!` for hardware
+
+The software generator's strongest architectural decision is that its
+artifact is **`nitro!` input**, not runner code. Exactly one place in the
+system knows how to turn wiring into a monomorphized runner, so the
+generator cannot drift from it, and the artifact stays reviewable plain
+Rust.
+
+Hardware has no such component. There is no macro that turns wiring into
+RTL, so the emitter must produce *structure* — modules, ports, registers,
+valid chains — directly. The parity burden the software generator
+sidestepped lands squarely here, which is why §5.2's op-twin problem and
+§7's simulation-parity discipline are not optional extras but the core of
+the work.
+
+The nearest available substitute is to make the emitted RTL's *shape* so
+regular that it is reviewable in the same way the `nitro!` artifact is: one
+module per node, one instantiation per node, edges as named wires. Readable
+output was `rust-hdl`'s stated design goal and is worth preserving as ours.
+
+## 3. Why the mapping is unusually good
 
 The wired-graph front-end already collects what a structural HDL generator
 needs — op identity, topology, active/passive edges, static `ACTIVATION`,
-and (with `func!`) closure source and explicit captures. A hardware emitter
-walks the same metadata and instantiates one module per node, wiring
+and (with `#[wiring]`) closure source and detected captures. A hardware
+emitter walks the same metadata and instantiates one module per node, wiring
 valid/data signals along the edges.
 
 The Op pattern is accidentally RTL-shaped — the legacy object graph
@@ -85,37 +228,35 @@ case where the rearchitecture is the prerequisite, not the casualty:
 That last row extends the house parity discipline unchanged: simulate the
 emitted design against the interpreted run and assert values *and* order.
 
-**`func!` is exactly the bridge RHDL needs.** rhdl kernels forbid closures
-— but the quotation design already decomposes a closure into *body tokens +
-explicit capture values*. Emit the body as a `#[kernel]` fn and the
-captures as arguments or consts, and rhdl's own compiler frontend becomes
-the validator: a quoted body outside the synthesizable subset fails
-loudly, at generation time, with the wiring call site attached — not at
-synthesis. Tier-1 (closed) closures translate nearly verbatim.
+Note what the table does **not** contain: `Burst`. See §5.5.
 
-## 3. Worked example
+## 4. Worked example
 
 The smallest graph that exercises the machinery: price feed → `delta` →
-threshold `filter` — one stateful op, one quoted closure. The RHDL layer is
-**rhdl-flavored sketch** (pre-release API; the shape, not exact syntax);
+threshold `filter` — one stateful op, one recorded closure. The RHDL layer
+is **rhdl-flavored sketch** (pre-release API; the shape, not exact syntax);
 the Verilog is idealized readable output.
 
-### 3a. What the user writes
+Read it as the *easy* case. It is a single path, so §5.4 cannot appear in
+it, and the closure is closed over a scalar, so §2b's rewrite is a
+one-liner.
 
-Fixed-width types (the FPGA dialect — `i16` ticks, not `f64`), quoted
-closure, explicit capture:
+### 4a. What the user writes
+
+Fixed-width types (the FPGA dialect — `i16` ticks, not `f64`), recorded
+closure, detected capture:
 
 ```rust
 use wingfoil::prelude::*;
-use wingfoil::func;
 
 /// Emit price deltas that exceed a threshold. FPGA-eligible:
 /// fixed-width types, kernel-subset closure bodies.
+#[wiring]
 pub fn spike_detector(g: &GraphBuilder, cfg: &Config) -> Stream<i16> {
-    let thresh: i16 = cfg.threshold;                     // frozen at generation time
-    g.channel::<i16>("price-feed")                       // -> input port in hardware
-        .delta()                                         // stateful op: has an RTL twin
-        .filter(func!([thresh] |d| d.abs() > thresh))    // quoted body -> #[kernel]
+    let thresh: i16 = cfg.threshold;                 // frozen at generation time
+    g.channel::<i16>("price-feed")                   // -> input port in hardware
+        .delta()                                     // stateful op: has an RTL twin
+        .filter(move |d: &i16| d.abs() > thresh)     // recorded body -> #[kernel]
 }
 ```
 
@@ -127,18 +268,19 @@ wingfoil::codegen::generate_hdl(|g| spike_detector(g, &config), "src/spike.gen.r
 The same graph runs interpreted in software, unchanged — that run *is* the
 parity oracle for the hardware.
 
-### 3b. What the emitter generates — RHDL (sketch)
+### 4b. What the emitter generates — RHDL (sketch)
 
-Three parts: kernels spliced from `func!` bodies, hand-written op twins
+Three parts: kernels rewritten from recorded bodies, hand-written op twins
 from a library, and the generated structural composition.
 
 ```rust
 // spike.gen.rs — GENERATED from spike_detector + desk.toml. Do not edit.
 use rhdl::prelude::*;
 
-// ---- (a) Kernel spliced from the quoted closure -------------------------
-// from wiring.rs:9: func!([thresh] |d| d.abs() > thresh), thresh = 25
-// rhdl's compiler frontend type-checks this against its synthesizable subset.
+// ---- (a) Kernel rewritten from the recorded closure ---------------------
+// from wiring.rs:9: move |d: &i16| d.abs() > thresh, thresh = 25
+// NOTE the rewrite (§2b): `&i16` parameter -> by-value `SignedBits<16>`,
+// derefs elided. The recorded text is not spliced as-is.
 #[kernel]
 pub fn filter_k0(d: SignedBits<16>) -> bool {
     let thresh = s16(25);          // capture, frozen as a literal
@@ -183,7 +325,7 @@ impl Synchronous for SpikeDetector {
 }
 ```
 
-### 3c. What rhdl emits — Verilog (idealized)
+### 4c. What rhdl emits — Verilog (idealized)
 
 ```verilog
 // spike_detector.v — generated by rhdl from SpikeDetector
@@ -229,7 +371,7 @@ The whole graph became: two registers of state, a subtractor, an
 abs/compare, and a valid chain — spike-to-output in one clock. That is the
 payoff the software engine can never touch.
 
-### 3d. The parity test (house style, extended)
+### 4d. The parity test (house style, extended)
 
 ```rust
 #[test]
@@ -239,64 +381,265 @@ fn spike_detector_hw_matches_interpreted() {
     let out = spike_detector(&g, &test_config());
     let expected = run_historical_collect(&g, out, PRICES);
 
-    // hardware: same inputs as valid strobes into rhdl's simulator
+    // hardware: same inputs as valid strobes into the simulator
     let got = rhdl::sim::run_synchronous(SpikeDetector, strobes(PRICES));
     assert_eq!(expected.values(), got.values());   // same spikes, same order
 }
 ```
 
-The example makes two properties of the design concrete: the **filter came
-through single-sourced** (the quoted body is the same tokens in software
-and in the kernel — drift-impossible, exactly as in the software
-generator), while **delta needed a twin** (`delta_update` re-states the
+The example makes two properties concrete: the **filter came through
+single-sourced** (the kernel is a mechanical rewrite of the tokens that ran,
+so drift is bounded by the rewrite's correctness rather than by a human
+re-statement), while **delta needed a twin** (`delta_update` re-states the
 semantics; simulation parity is what holds it honest).
 
-## 4. The three walls (accepted, documented)
+**Scale this test up, not out.** Verilator can run millions of cycles fast
+enough for CI, and the historical replay already produces exactly the
+stimulus and golden output a testbench needs. That is the flagship property
+worth engineering for deliberately: *the backtest is the testbench*, where
+the usual shop maintains an RTL testbench and a backtest as two artifacts
+that drift apart.
 
-1. **It's a dialect, not the full language.** `Element` admits `f64`,
-   `String`, `Vec`, `Burst`; hardware needs fixed-width `Digital` types,
-   floats mean fixed-point or FP cores, and bursts/unbounded queues need
-   explicit sized FIFOs and ready/valid backpressure that software
-   wingfoil never thinks about. FPGA-eligibility is a *third, stricter
-   tier* of the per-node eligibility pattern (loud errors listing
-   ineligible nodes with wiring call sites). Most existing graphs will not
-   qualify as-written, by design.
-2. **Ops need hardware twins — the drift problem partially returns.**
-   Catalog ops' `cycle` bodies are software (allocations, `TinyVec`,
-   `anyhow`); each FPGA-eligible op needs an RTL twin, with parity held by
-   simulation tests rather than shared code — the dual-implementation
-   drift the Op pattern eliminated in software. The mitigating hope, and
-   the flagship property if it works: for arithmetic/stateful-scalar ops
-   (`map`, `filter`, `ewma`, `delta`, …) a kernel-subset `cycle` could be
-   genuinely **single-sourced** — one body compiled by rustc for software
-   and by rhdl for hardware. Queue-y ops (`delay`, `window`, merge) will
-   need twins regardless.
-3. **Dependency maturity.** rhdl is pre-release and one person's
-   spare-time project; rust-hdl is stable but frozen and lacks the kernel
-   compiler that makes the splicing story clean. Mitigation as in §1:
-   emitted Verilog is the shipped interface; rhdl is the prototyping
-   vehicle.
+## 5. The walls (accepted, documented)
 
-## 5. The de-risk spike (the gate for going further)
+Three were recorded originally. Two more were missing, and 5.4 is the one
+most likely to sink the project.
 
-Before any emitter exists — a few days' work, entirely by hand:
+### 5.1 It is a dialect — and the problem is `i128`, not the absence of fixed-point
+
+The original text said hardware "needs fixed-width `Digital` types, floats
+mean fixed-point or FP cores". That framed fixed-point as something to
+introduce. It already exists: `adapters/market` ships `Px` and `Qty`, exact
+and orderable, and the `OrderBook` keys levels by them precisely so that
+`f64` never touches a price comparison.
+
+The real finding is their representation. They are **`i128` scaled at 1e9**,
+and deliberately so — the module records that an `i64` at nine decimals caps
+at ±9.22 × 10⁹, which makes large-notional and very-small-tick venues
+unrepresentable. That is the right call for software and the wrong width for
+fabric: 128-bit arithmetic costs several DSP slices and pipeline stages per
+operation, for range no single instrument needs.
+
+So the dialect work is **narrowing, not introducing**: a `Fixed<I, F>` with
+venue-appropriate width (typically 32 or 64 bits at that venue's tick
+scale), convertible from `Px`/`Qty` with a range check at generation time.
+That is a smaller and much better-defined job than "add fixed-point", and it
+has a software payoff on its own — narrower prices are cheaper in cache on
+the CPU path too.
+
+`Element` still admits `f64`, `String`, `Vec`, `Burst`; those stay
+ineligible. FPGA-eligibility is a **third, stricter tier** of the per-node
+eligibility pattern (loud errors listing ineligible nodes with wiring call
+sites — §2's inherited refusal machinery). Most existing graphs will not
+qualify as-written, by design.
+
+### 5.2 Ops need hardware twins — the drift problem partially returns
+
+Catalog ops' `cycle` bodies are software (allocations, `TinyVec`,
+`anyhow`); each FPGA-eligible op needs an RTL twin, with parity held by
+simulation tests rather than shared code — the dual-implementation drift the
+Op pattern eliminated in software. The mitigating hope, and the flagship
+property if it works: for arithmetic/stateful-scalar ops (`map`, `filter`,
+`ewma`, `delta`, …) a kernel-subset `cycle` could be genuinely
+**single-sourced**. Queue-y ops (`delay`, `window`, merge) will need twins
+regardless.
+
+§2c is why this matters more than it first appears: with no `nitro!`
+equivalent, twins are where *all* the parity risk concentrates.
+
+### 5.3 Dependency maturity
+
+rhdl is pre-release and one person's spare-time project; rust-hdl is stable
+but frozen and lacks the kernel compiler. §1b's split is the mitigation:
+bound the dependency to leaf kernels, own the structure.
+
+### 5.4 Pipeline skew — the wall this document was missing
+
+wingfoil's software semantics are that **a cycle is atomic**: every node
+sees one consistent time, and all upstream values settle before downstream
+fires. In hardware that holds for free only if the whole graph is
+combinational between two register stages. At the clock rates this exists
+for, it will not be — so the graph gets pipelined, and the moment it does:
+
+- **Fan-in must be latency-balanced.** A `join` whose two upstream paths
+  have different pipeline depth combines values from *different logical
+  ticks*. The emitter must compute per-node depth and insert shift-register
+  delays on the shallower leg. Mechanical — HLS tools do it — but it must be
+  designed in, and it interacts with `Tick::Silent`/`Quiet`, where a node
+  updates its slot without producing a strobe to delay.
+- **`NodeInfo` says nothing about this.** There is no per-node depth and no
+  way to express a depth-matching constraint. This is genuinely new IR, and
+  it is the one part of the hardware backend the software generator gives no
+  head start on (§2's ledger).
+- **It is the strongest argument for XLS or Spade** (§1b), both of which
+  treat scheduling/pipelining as a first-class concern rather than something
+  the emitter open-codes.
+
+Anything that reads `sample`, `join`, `merge` or a fan-out-then-recombine
+shape hits this, which is to say every non-trivial trading graph.
+
+### 5.5 `Burst`, and backpressure
+
+**`Burst` has no strobe.** Same-instant values grouped is a software
+concept; the hardware realisation is serialisation over N cycles, which
+changes latency and breaks the one-clock story that §4 sells. Either the
+dialect forbids bursts on the hardware path, or the emitter owns an explicit
+serialiser and the latency claim is stated per-burst rather than per-tick.
+Deciding this is a prerequisite for a credible number, not a detail.
+
+**Backpressure is absent from software wingfoil and mandatory in hardware.**
+The software engine has unbounded queues; a fabric design needs ready/valid
+or a proof of no-stall. For the fast path the right answer is usually *no
+backpressure at all* — fixed II=1, never drop, sized to absorb line rate —
+but `delay` and `window` need sized FIFOs with an **explicit overflow
+policy**, which software wingfoil never has to name.
+
+## 6. The host↔card interface
+
+This section is new, and it is deliberately independent of everything
+above: it applies whether the gateware is generated by this design,
+hand-written, or bought from an IP vendor. `trading-roadmap.md` item 8
+already sequences an **FPGA-sink adapter before any HDL work** for exactly
+that reason; this is the design content behind it.
+
+### 6a. PCIe discipline
+
+Three costs govern the whole interface (order-of-magnitude, not
+measurements):
+
+| operation | cost | on the hot path? |
+|---|---|---|
+| MMIO write, CPU → card (posted) | ~100–300 ns to land; the store itself is fire-and-forget | **yes** — with write-combining |
+| MMIO **read**, CPU → card → CPU (non-posted) | ~500 ns – 1.5 µs | **never** |
+| DMA card → host into a polled ring | ~500 ns – 1 µs, high bandwidth | **yes** |
+
+The rule that falls out: **the CPU writes to the card and never reads from
+it on a critical path.** A single stray register read in a hot loop costs
+more than every optimisation in the graph engine combined.
+
+### 6b. The DMA ring is already a wingfoil source
+
+The card DMAs descriptors into a pinned, huge-page host ring; the CPU spins
+on a cache line watching a sequence number or phase bit flip. No doorbell,
+no interrupt.
+
+That is `Activation::ALWAYS` + `poll` — the shape
+[#758](https://github.com/wingfoil-io/wingfoil/pull/758) made expressible in
+the compiled tiers, and which #769's `ingest` example generates. Worth
+stating plainly because it reframes a known gap: **wake-driven sources
+(`external`/`channel`) being excluded from `compiled()` (#502/#503) is not
+on the hardware ingest path at all**, because DMA rings and kernel-bypass
+NICs are polled, not woken. The gap is real for other users; it is not a
+blocker here.
+
+Two things are missing for a real ring source, both small and both useful
+before any FPGA exists:
+
+1. **Burst-aware polling.** `poll` returns `Option<T>`; every real ring API
+   returns a batch. One graph cycle per descriptor discards the
+   amortisation the API exists to provide. Maps naturally onto `Burst`.
+2. **Zero-copy handoff.** `Pooled<T>`
+   ([#719](https://github.com/wingfoil-io/wingfoil/pull/719)) is the right
+   shape for wrapping a DMA buffer whose drop returns the descriptor —
+   already named as the target in `trading-roadmap.md` item 7.
+
+### 6c. Parameter update, and what capture detection is really for
+
+Parameters reach the card over a register map (AXI4-Lite) via MMIO writes.
+The failure mode is **torn updates**: a multi-word parameter set written
+word-by-word lets the datapath observe a half-updated state. The standard
+fix is double-buffered banks plus a single commit register — write the
+shadow bank, then arm.
+
+This is where §2's "sleeper asset" pays off. `#[wiring]`'s free-variable
+analysis produces, per node, exactly the set of values the closure depends
+on. That set is the design's parameter surface. What is missing is the
+*distinction* the software generator did not need to make:
+
+- **frozen** — baked into LUTs as a constant. Fastest possible; changing it
+  means resynthesis.
+- **live** — a control register, writable at runtime through the commit
+  protocol above.
+
+`wired-graph-codegen-decision.md` §3 already names this fork ("emitting
+capture values as literals *freezes* them… the alternative — promoting
+captures to parameters — is a follow-up, not v1"). Hardware turns it from a
+follow-up into a requirement, because no trading desk resynthesises to
+change a size.
+
+**Recommendation, and it is time-sensitive:** decide the per-capture
+frozen/live distinction *now*, while #769's capture machinery is being
+written — a marker on the wiring (`param(fee)` or similar) that renders as a
+literal in the software artifact today and as a CSR in a hardware artifact
+later. It is cheap while the machinery is fresh and expensive once artifacts
+are checked in across the tree.
+
+### 6d. Timestamping
+
+Timestamp at the ingress MAC, with a PTP/PPS-disciplined clock. The two-clock
+design maps cleanly: the wire timestamp is source-driven data that becomes
+`Ctx::time()`; `Ctx::wall_time()` stays host-side telemetry. The host clock
+must stay out of the decision path — which is the same rule the engine
+already enforces in software ("never branch business logic on `wall_time`").
+
+### 6e. Observability — the decision tap
+
+The hardest operational problem in FPGA trading is knowing what the fabric
+actually did. The mitigation is a **decision tap**: a low-priority DMA
+stream carrying every trigger evaluation, reconciled against a software
+replay of the same inputs.
+
+wingfoil is unusually well placed for this, because the software graph *is*
+the same graph — the parity oracle of §4d runs in production, not only in
+CI. Design it in from the start; it is also the most saleable property of
+the whole idea.
+
+## 7. The de-risk spike (the gate for going further)
+
+Before any emitter exists — a few days' work, entirely by hand.
+
+**The original spike could only succeed.** It proposed `ticker`,
+`map`-via-kernel, `ewma`, `delta` — all single-path, all scalar, so it could
+not exhibit §5.4 and barely touches §2b. Amended so that it can fail:
 
 1. Write rhdl twins for three or four ops (`ticker`, `map`-via-kernel,
    `ewma`, `delta`).
-2. Wire one toy graph by hand, the way the emitter would.
-3. Simulate, and assert parity against the interpreted run (§3d shape).
+2. **Do the §2b rewrite by hand** on one recorded body — take the actual
+   text `#[wiring]` produces for a `Fn(&A) -> B` closure and turn it into a
+   `#[kernel]` fn. Confirm what the rewrite has to do and where it breaks.
+3. **Wire a two-input `join` whose upstream paths have deliberately unequal
+   pipeline depth**, and balance it by hand the way the emitter would.
+4. Simulate under Verilator, and assert parity against the interpreted run
+   (§4d shape) on values **and** order.
 
-This answers the two load-bearing uncertainties — *is the kernel subset
-rich enough for quoted bodies?* and *can scalar ops be single-sourced?* —
-before committing to the emitter, the twin catalog, or the dialect design.
+This answers the load-bearing uncertainties — *is the kernel subset rich
+enough for the rewritten bodies?*, *can scalar ops be single-sourced?*, and
+now *is latency balancing tractable at emitter scale?* — before committing
+to the emitter, the twin catalog, or the dialect design.
 
-## 6. Sequencing
+Step 3 is the one to run first if time is short. If latency balancing is not
+tractable, nothing else matters.
+
+## 8. Sequencing
 
 Strictly behind the software generator's own gates
-([`wired-graph-codegen-decision.md`](wired-graph-codegen-decision.md) §7–8):
-the `func!`/`OpFn`/metadata layer is shared infrastructure and lands first
-for software reasons; the §5 spike can run any time after that as a
-standalone experiment; the emitter itself is gated on the spike succeeding
-*and* a named workload (a hot path worth an FPGA, with topology/config
-cadence compatible with regenerate-and-resynthesize). Nothing here blocks
-or reorders the parity port.
+([`wired-graph-codegen-decision.md`](wired-graph-codegen-decision.md) §7–8),
+and interleaved with `trading-roadmap.md` items 7–8:
+
+1. **Now, independent of any FPGA decision** — the §6b gaps (burst-aware
+   polling, `Pooled` zero-copy handoff) and the §6c per-capture frozen/live
+   marker. All three are useful to software users and are prerequisites
+   here.
+2. **The host↔card interface (§6) before any HDL** — an FPGA-sink adapter
+   and a DMA-ring source. Useful immediately with commercial
+   feed-handler/trigger cards, needs no HDL work, and is an ordinary
+   wingfoil adapter. This is `trading-roadmap.md` item 8's first half and
+   the highest-value, lowest-risk piece of the entire hardware story.
+3. **The §7 spike**, amended — runnable any time after the generator lands.
+4. **The emitter**, gated on the spike succeeding *and* a named workload (a
+   hot path worth an FPGA, with topology/config cadence compatible with
+   regenerate-and-resynthesize).
+
+Nothing here blocks or reorders the parity port. Do not reorder gate 2 ahead
+of gate 3's findings *into* gate 4 — the interface work is safe to do early
+precisely because it is independent of whether the emitter is ever built.


### PR DESCRIPTION
## What this changes

`docs/fpga-hdl-backend-decision.md` was written *before* the software generator existed. Now that #769 has built it, the document's central claim — that a hardware backend reuses the codegen front-end wholesale — could be checked rather than assumed. It did not survive intact. This rewrites the doc around what actually carries over, and adds the two walls it was missing.

Docs only; no code changes.

## Why

Refs #727 (this doc's tracking issue). Follows #769.

The question that prompted it: *now that lightning-codegen has landed, is it actually useful for the Verilog work?* The answer is yes, substantially — but not through the part the document led with.

**The headline claim was wrong.** §3 asserted that `func!` quotation is "exactly the bridge RHDL's no-closures kernel subset needs" and that tier-1 closures "translate nearly verbatim". One line of `ops.rs` settles it:

```rust
F: Fn(&A) -> B + 'static,          // map
F: Fn(&A, &B) -> C + 'static,      // join
F: Fn(&mut B, &A) + 'static,       // fold
```

Every op closure in the catalog takes references; rhdl forbids them. So a recorded body — `|n: &u64| (n * size) as f64` — needs a signature rewrite and deref elision to become a `#[kernel]` fn, not a splice. `fold`'s `&mut` accumulator isn't a rewrite at all: it's a state-update kernel, a different shape. The knock-on matters more than the rewrite — §3 hoped rhdl's frontend would double as the eligibility checker, and it can't, because what we hand rhdl isn't what the user wrote.

The clean carryovers turn out to be the unglamorous ones: `NodeInfo` traversal (active/passive edges *are* valid-gating vs plain sampling), the refusal machinery with `#[track_caller]` call sites, capture detection, and `check_artifact`.

## The changes

**New §2 — the carryover ledger.** Per-asset audit of what the generator hands the hardware backend, including §2b (why quotation doesn't splice) and §2c: there is no `nitro!` equivalent for RTL, so the parity burden the software generator sidestepped lands squarely on the op twins.

**New §5.4 — pipeline skew, the load-bearing wall.** Absent from the original, whose worked example is a single path and therefore cannot exhibit it. Fan-in across paths of unequal pipeline depth combines values from *different logical ticks*, and `NodeInfo` carries no depth information to balance against. The one part of the backend the generator gives no head start on.

**§5.1 corrected.** Fixed-point is not something to introduce — `adapters/market` already ships `Px`/`Qty`. Their `i128` width is the actual obstacle, and it's deliberate (an `i64` at nine decimals caps at ±9.22 × 10⁹, making large-notional venues unrepresentable). The work is *narrowing* to a venue-scaled `Fixed<I, F>`, which has a software payoff of its own.

**New §5.5** — `Burst` has no strobe (it serialises, which breaks the one-clock claim), and backpressure is mandatory in fabric while absent from software wingfoil.

**New §6 — the host↔card interface.** PCIe posted-vs-non-posted discipline (never read across it on a hot path), the DMA ring as an `Activation::ALWAYS` poll source, torn-parameter avoidance, wire timestamping, and the decision tap. Deliberately independent of everything else: it applies whether the gateware is generated, hand-written, or bought, which is why `trading-roadmap.md` item 8 already sequences it first.

**§1 widened, and the backend split.** Beyond rust-hdl/rhdl: CIRCT/FIRRTL, Spade, XLS, Veryl, Amaranth. Recommendation is rhdl for **leaf kernels only**, with wingfoil owning structural emission — which bounds the pre-release one-person dependency to the half that has a fallback. Under the original framing, an rhdl stall took the whole emitter with it.

**§7's spike amended so it can fail.** As written it was all single-path and scalar, so it could only succeed. Now includes doing the §2b rewrite by hand and wiring an unequal-depth `join`, with a note that the latter runs first if time is short.

## How it was verified

Docs only — no Rust changed, so the code checklist doesn't apply. What was checked:

- [x] Every claim about the current tree verified against source, not memory — the `Fn(&A)` bounds in `ops.rs`/`fluent.rs`, `Px`/`Qty` as `i128` at `SCALE = 1e9` in `adapters/market.rs`, `poll`'s `Option<T>` return, and the `NodeInfo` fields the ledger cites
- [x] Cross-references checked: no other doc links to this one by section number, so the renumbering is contained
- [x] Heading sequence and internal `§` references consistent after renumbering

## Notes for the reviewer

**Read §2 first** — it is the section that answers "was the codegen work useful here", and the rest follows from it.

**The doc keeps a revision note at the top** recording what changed and why, rather than silently rewriting. §2b in particular contradicts the original §3, and the audit trail seemed worth more than a clean read.

**#727's checklist is now stale** — it cites "doc §5" and "doc §4" for the spike and the walls, both of which have moved (§7 and §5), and its three-item spike is the version that could only succeed. Not updated here; happy to do it in a follow-up.

**Not folded in, deliberately:** the review findings on #769 itself. The one I'd call a should-fix-before-merge is that `#[wiring]` and the `Probe` expansion hardcode `::wingfoil`, which breaks for anyone renaming the dependency (`wf = { package = "wingfoil" }`) — `proc-macro-crate` is the usual fix. That belongs on #769, not here.

**Time-sensitive item raised in §6c:** capture detection already produces, per node, the exact set of values a closure depends on — which for hardware splits into *frozen* (baked into LUTs) and *live* (a control register). `wired-graph-codegen-decision.md` §3 names that fork as "a follow-up, not v1"; hardware makes it a requirement, since nobody resynthesises to change a size. Cheap to decide while #769's capture machinery is fresh, expensive once artifacts are checked in across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9wTP8Gyd9jFWpi6awakVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9wTP8Gyd9jFWpi6awakVP)_