### PR TITLE
Document realtime channel grouping by arrival, not timestamp

### DIFF
--- a/crates/wingfoil/src/adapters/etcd.rs
+++ b/crates/wingfoil/src/adapters/etcd.rs
@@ -223,6 +223,14 @@ pub struct EtcdEvent {
 /// keeps only the burst's **last** event and silently drops the rest, which on
 /// a watch stream loses updates (see [`Collapse`](crate::ops::Collapse)).
 ///
+/// **The snapshot is not guaranteed to arrive in one burst.** All of its events
+/// share one timestamp (one consistent read), but this is a realtime-only
+/// source and the realtime channel receiver groups a burst by *arrival*, not by
+/// timestamp — so a multi-key snapshot may be split across cycles. Nothing is
+/// lost; only the cycle boundaries vary. Bound such a run by
+/// [`RunFor::Duration`](crate::RunFor::Duration) (or `Forever`) and accumulate —
+/// never by `RunFor::Cycles(n)`, which can end the run mid-snapshot.
+///
 /// # Errors
 ///
 /// Returns an error at **wiring time** if `run_mode` is
@@ -284,14 +292,24 @@ pub fn etcd_sub(
             // 4. Return the combined snapshot + live stream. `watch_stream` is moved
             //    in and kept alive for the stream's lifetime so the watch stays open.
             Ok(async_stream::stream! {
-                // Phase 1: emit the snapshot as a single atomic burst. Every
-                // snapshot KV shares ONE timestamp so they are grouped into one
-                // burst (never latest-wins, never split across cycles) — matching
-                // legacy's single `HistoricalValue` snapshot burst. Stamping each
-                // event with its own `NanoTime::now()` would scatter them across
-                // distinct instants, so a bounded run (e.g. `RunFor::Cycles(1)`)
-                // could observe only the first key — an intermittent "missing key"
-                // under load.
+                // Phase 1: emit the snapshot. Every snapshot KV shares ONE
+                // timestamp — the whole GET is one consistent read at
+                // `snapshot_rev`, so stamping each event with its own
+                // `NanoTime::now()` would invent instants the data does not
+                // have, and scatter one atomic read across them. This matches
+                // legacy's single `HistoricalValue` snapshot burst.
+                //
+                // It does NOT mean the consumer sees the snapshot as one burst.
+                // `etcd_sub` is realtime-only, and the realtime channel receiver
+                // groups by **arrival** — a cycle emits whatever is queued at
+                // that moment — not by timestamp; only the historical receiver
+                // groups on the stamp (`Builder::channel`). The producer sends
+                // one value per `send_at` and the first send already wakes the
+                // kernel, so a multi-key snapshot may still be split across
+                // cycles. Nothing is lost (the rest ride the next cycle), but a
+                // consumer must not bound the run by cycle count and expect the
+                // whole snapshot: use `RunFor::Duration`/`Forever` and
+                // accumulate.
                 let snapshot_time = NanoTime::now();
                 for event in snapshot {
                     yield Ok((snapshot_time, event));

--- a/crates/wingfoil/src/adapters/etcd/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/etcd/CLAUDE.md
@@ -48,6 +48,19 @@ Config types: `EtcdConnection` (`new` / `with_endpoints`, plus `From<&str>` /
   redis Streams reader mirrors it with stream IDs. Do not reorder.
 - **Everything is stamped `NanoTime::now()`.** It is a live wall-clock stream;
   there is no historical timeline.
+- **The snapshot shares one timestamp, but that does not make it one burst.**
+  The stamp is right (one consistent GET at `snapshot_rev`), yet this source is
+  realtime-only and the *realtime* channel receiver groups by **arrival** — a
+  cycle emits whatever `try_recv` drains right then — while only the historical
+  receiver groups by timestamp. The producer sends one value per `send_at` and
+  the first send already wakes the kernel, so a multi-key snapshot can be split
+  across cycles. Nothing is lost, but **never bound an `etcd_sub` test or
+  consumer with `RunFor::Cycles(n)`** when it must see every event: use
+  `RunFor::Duration` and `collapse_accumulate`. This flaked the integration
+  suite twice — once "fixed" by giving the snapshot a single timestamp, which
+  cannot help in the only run mode this adapter supports. `Cycles(n)` is also a
+  **hang** risk here: if events coalesce into fewer bursts than `n`, a realtime
+  run with nothing scheduled parks on the ready channel indefinitely.
 - **The producer task spawns in `start()`**, deferred via `source_at_start`, so
   the connect + watch happen at run start with node context, not at wiring
   (register A1/A4).

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -672,6 +672,15 @@ impl Builder {
     ///
     /// - **Realtime**: each `send` wakes the kernel; a cycle emits a burst of
     ///   all values that arrived since the last one (wall-clock paced).
+    ///   Grouping here is by **arrival**, not by timestamp — a `send_at` stamp
+    ///   is ignored in this mode, so values sharing one instant are *not*
+    ///   guaranteed to ride one burst (the first `send` already wakes the
+    ///   kernel, so the graph may cycle mid-group). Nothing is dropped; only
+    ///   the cycle a value lands on varies. A realtime consumer that must see
+    ///   every value therefore bounds its run by [`RunFor::Duration`] or
+    ///   `Forever` and accumulates — never by `RunFor::Cycles(n)`, which can
+    ///   stop the run mid-group. Pinned by `tests/channel.rs`
+    ///   (`channel_realtime_groups_by_arrival_not_by_timestamp`).
     /// - **Historical**: the producer sends timestamped values
     ///   ([`ChannelSender::send_at`]) then [`close`](ChannelSender::close);
     ///   the receiver collects them at `start`, groups same-timestamp values

--- a/crates/wingfoil/tests/channel.rs
+++ b/crates/wingfoil/tests/channel.rs
@@ -108,6 +108,57 @@ fn channel_historical_same_time_values_ride_one_burst() {
     );
 }
 
+/// The **realtime** counterpart of the test above, and deliberately the
+/// opposite result: a realtime burst groups by **arrival**, not by timestamp.
+/// Two values stamped at the same instant land in two separate bursts if the
+/// graph cycles between the sends — the timestamp is ignored entirely in this
+/// mode (`Message::ValueAt` is treated as `Message::Value`).
+///
+/// Pinned because the asymmetry is easy to forget and expensive to rediscover:
+/// an `etcd_sub` snapshot stamps every key with one instant, and the etcd
+/// integration suite flaked intermittently on the assumption that this made it
+/// one burst. It does not — nothing is lost, but the cycle a value lands on is
+/// wall-clock luck, so a realtime consumer that must see every value bounds its
+/// run by `RunFor::Duration`/`Forever` and accumulates, never by
+/// `RunFor::Cycles(n)`.
+///
+/// Deterministic despite being a race in the wild: the producer waits for the
+/// graph to *tell it* the first burst was delivered before sending the second.
+#[test]
+fn channel_realtime_groups_by_arrival_not_by_timestamp() {
+    let g = GraphBuilder::new();
+    let (values, sender) = g.channel::<u64>();
+    // The graph signals the producer from inside the cycle that delivers a
+    // burst, which is what makes the split below happen every time rather than
+    // only under load.
+    let (delivered_tx, delivered_rx) = std::sync::mpsc::channel::<()>();
+    let bursts = values
+        .map(move |b: &Burst<u64>| {
+            let _ = delivered_tx.send(());
+            b.iter().copied().collect::<Vec<u64>>()
+        })
+        .accumulate();
+    let mut r = g.build();
+
+    let producer = std::thread::spawn(move || {
+        sender.send_at(1, NanoTime::new(100));
+        delivered_rx.recv().expect("first burst delivered");
+        // Same timestamp as the first — and still a burst of its own.
+        sender.send_at(2, NanoTime::new(100));
+        sender.close();
+    });
+    // Terminates on the producer's `close()` (and its dropped sender), so the
+    // bound only has to be "long enough": `Forever` is exact here.
+    r.run(RunMode::RealTime, RunFor::Forever).unwrap();
+    producer.join().expect("producer thread");
+
+    assert_eq!(
+        vec![vec![1], vec![2]],
+        r.value(&bursts),
+        "same-time realtime values split by arrival (contrast the historical test above)"
+    );
+}
+
 /// A producer that sends `Message::Error` aborts the receiving graph's run,
 /// surfaced through the channel node's context — the channel layer leaning on
 /// Phase 0.1's fallible cycle.

--- a/crates/wingfoil/tests/etcd_integration.rs
+++ b/crates/wingfoil/tests/etcd_integration.rs
@@ -47,6 +47,27 @@ fn realtime(cycles: u32) -> RunParams {
     }
 }
 
+/// The bound for a source test that must observe *every* event of a multi-value
+/// snapshot or watch sequence: a fixed realtime window, never `RunFor::Cycles(n)`.
+///
+/// `etcd_sub` is realtime-only, and the realtime channel receiver groups a burst
+/// by **arrival** — a cycle emits whatever `try_recv` drains at that moment —
+/// not by the producer's timestamp (only the *historical* receiver groups by
+/// timestamp; see `Builder::channel`). The producer sends one value per
+/// `send_at`, and the first send already wakes the kernel, so a two-key snapshot
+/// stamped at one instant can still be split: cycle 1 takes key A, and key B
+/// rides cycle 2. Bounding by cycle count then ends the run holding only key A —
+/// exactly the intermittent "concurrent key missing" failure this suite hit.
+///
+/// A window bound is immune: `collapse_accumulate` gathers across cycles, so it
+/// does not matter how the events are distributed over them. Sized generously
+/// against a slow CI container (the events themselves land in milliseconds); a
+/// realtime run with nothing scheduled parks on the ready channel until the
+/// bound, so this is the cost only when the graph is genuinely idle.
+fn observe_window() -> RunFor {
+    RunFor::Duration(Duration::from_secs(2))
+}
+
 /// Seed key-value pairs directly into etcd via the client.
 fn seed_keys(endpoint: &str, pairs: &[(&str, &str)]) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
@@ -123,7 +144,9 @@ fn test_sub_empty_snapshot_then_live_write() -> anyhow::Result<()> {
 
 #[test]
 fn test_sub_snapshot_with_existing_keys() -> anyhow::Result<()> {
-    // Pre-seeded keys appear as Put events in the snapshot phase (one burst).
+    // Pre-seeded keys appear as Put events in the snapshot phase. Bounded by a
+    // window, not a cycle count — the realtime receiver may split the snapshot
+    // across cycles (see `observe_window`).
     let rt = tokio::runtime::Runtime::new()?;
     let (_container, endpoint) = start_etcd()?;
     seed_keys(&endpoint, &[("/snap/a", "1"), ("/snap/b", "2")])?;
@@ -138,7 +161,7 @@ fn test_sub_snapshot_with_existing_keys() -> anyhow::Result<()> {
     .collapse_accumulate();
 
     let mut runner = g.build();
-    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+    runner.run(RunMode::RealTime, observe_window())?;
 
     let events: Vec<EtcdEvent> = runner.value(&events);
     assert_eq!(events.len(), 2);
@@ -198,7 +221,10 @@ fn test_sub_delete_events() -> anyhow::Result<()> {
     });
 
     let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
-    // Cycles(2): 1 snapshot Put + 1 live Delete.
+    // 1 snapshot Put + 1 live Delete. A window, not `Cycles(2)`: if the delete
+    // lands fast enough to ride the *same* burst as the snapshot Put, a
+    // two-cycle bound would wait forever for a second cycle that never comes
+    // (a realtime run with nothing scheduled parks until an external wake).
     let events = etcd_sub(
         &g,
         realtime(2).run_mode,
@@ -208,7 +234,7 @@ fn test_sub_delete_events() -> anyhow::Result<()> {
     .collapse_accumulate();
 
     let mut runner = g.build();
-    runner.run(RunMode::RealTime, RunFor::Cycles(2))?;
+    runner.run(RunMode::RealTime, observe_window())?;
     writer.join().unwrap();
 
     let events: Vec<EtcdEvent> = runner.value(&events);
@@ -222,7 +248,10 @@ fn test_sub_delete_events() -> anyhow::Result<()> {
 #[test]
 fn test_sub_no_race_between_snapshot_and_watch() -> anyhow::Result<()> {
     // A pre-seeded key and a second key written just before the graph starts
-    // must each appear exactly once — no missed events, no duplicates.
+    // must each appear exactly once — no missed events, no duplicates. Both
+    // land before the run, so both come from the snapshot; the assertion that
+    // bites is `keys.len() == 2`, i.e. the watch does not replay what the
+    // snapshot already carried.
     let rt = tokio::runtime::Runtime::new()?;
     let (_container, endpoint) = start_etcd()?;
     seed_keys(&endpoint, &[("/race/existing", "old")])?;
@@ -243,7 +272,7 @@ fn test_sub_no_race_between_snapshot_and_watch() -> anyhow::Result<()> {
     .collapse_accumulate();
 
     let mut runner = g.build();
-    runner.run(RunMode::RealTime, RunFor::Cycles(1))?;
+    runner.run(RunMode::RealTime, observe_window())?;
 
     let events: Vec<EtcdEvent> = runner.value(&events);
     let keys: std::collections::HashSet<String> =


### PR DESCRIPTION
## What this changes

Adds comprehensive documentation and a test case clarifying that the realtime channel receiver groups values by **arrival** (cycle boundaries), not by timestamp. Values sharing the same `send_at` timestamp are not guaranteed to arrive in the same burst; the timestamp is ignored entirely in realtime mode. This affects how `etcd_sub` snapshots and other realtime sources must be bounded.

## Why

The etcd integration test suite flaked intermittently with "concurrent key missing" failures. The root cause: a multi-key snapshot stamped at one instant (one consistent read) can be split across cycles because the realtime receiver groups by arrival, not timestamp. Tests bounded by `RunFor::Cycles(n)` could end mid-snapshot. The fix is to bound realtime runs by `RunFor::Duration` and accumulate, never by cycle count when every event must be observed.

This is a subtle asymmetry between historical and realtime modes that is easy to forget and expensive to rediscover in production. The changes document it thoroughly and pin it with a deterministic test.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
- [x] New behaviour is covered by a test asserting **values and tick times**

The new test `channel_realtime_groups_by_arrival_not_by_timestamp` is deterministic despite being a race: the producer waits for the graph to signal delivery of the first burst before sending the second, ensuring the split happens every time. It asserts that two values with the same timestamp land in separate bursts when they arrive in different cycles.

All three etcd integration tests that were using `RunFor::Cycles(n)` have been updated to use `observe_window()` (a 2-second duration bound) and now pass reliably.

## Notes for the reviewer

The changes are purely documentation and test coverage — no runtime behavior changes. The realtime channel already grouped by arrival; this PR documents that fact and fixes tests that were written under the incorrect assumption that timestamp grouping applied in realtime mode.

Key additions:
- New test `channel_realtime_groups_by_arrival_not_by_timestamp` in `tests/channel.rs` with detailed comments explaining the asymmetry
- New helper `observe_window()` in `tests/etcd_integration.rs` with extensive documentation on why duration bounds are required
- Updated doc comments in `src/adapters/etcd.rs` and `src/interp.rs` explaining the grouping behavior
- Updated `adapters/etcd/CLAUDE.md` with guidance on avoiding this pitfall in future code

The test is pinned (marked with a comment explaining why) because the asymmetry between historical and realtime grouping is a footgun that has already caused production flakes.

https://claude.ai/code/session_018jNSgHmxs5bFuQJ3SgUDm8