### PR TITLE
README example tables, and pin the parity oracle so it survives the deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 [![codecov](https://codecov.io/gh/wingfoil-io/wingfoil/graph/badge.svg)](https://codecov.io/gh/wingfoil-io/wingfoil)
 
 [![Crates.io Version](https://img.shields.io/crates/v/wingfoil?logo=rust&logoColor=white)](https://crates.io/crates/wingfoil)
-[![Minimum supported Rust version](https://img.shields.io/crates/msrv/wingfoil?logo=rust&logoColor=white&label=rust)](Cargo.toml)
 [![Rust docs](https://img.shields.io/docsrs/wingfoil?logo=docsdotrs&logoColor=white&label=rust%20docs)](https://docs.rs/wingfoil/)
 [![PyPI - Version](https://img.shields.io/pypi/v/wingfoil?logo=pypi&logoColor=white)](https://pypi.org/project/wingfoil/)
-[![Python docs](https://img.shields.io/readthedocs/wingfoil/latest?logo=readthedocs&logoColor=white&label=python%20docs)](https://wingfoil.readthedocs.io/en/latest/)
 [![npm](https://img.shields.io/npm/v/@wingfoil/client?logo=npm&logoColor=white)](https://www.npmjs.com/package/@wingfoil/client)
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE.txt)
@@ -22,9 +20,13 @@ into a single monomorphized function, or as compiled islands inside an
 interpreted graph. Backtest it over history, then run it live without changing
 the wiring.
 
-It ships with sixteen production-ready adapters covering tick stores, message
-buses, market protocols and observability backends, so graphs plug into real
-data sources and sinks in a line.
+It ships with production-ready adapters covering tick stores, message buses,
+market protocols and observability backends, so graphs plug into real data
+sources and sinks in a line.
+
+> **9.0 replaces the engine.** Coming from 8.x, start with the
+> [release notes](docs/release-notes/9.0.0.md) and the
+> [migration guide](docs/migration.md).
 
 
 ## Features
@@ -39,10 +41,23 @@ data sources and sinks in a line.
   deterministically off source-driven engine time, then run the identical graph
   live. Same-instant values ride a single burst — never coalesced, never
   latest-wins, never dropped, in either mode.
-- **Adapters**: [PostgreSQL, KDB+, Kafka, Redis, etcd, Fluvio, ZeroMQ, FIX 4.4,
-  iceoryx2, Aeron, WebSocket, Prometheus, OpenTelemetry, CSV, augurs and
-  line-oriented files](crates/wingfoil/examples/adapters/) — one runnable
-  example each.
+- **Adapters**: production-ready integrations for
+  [KDB+](crates/wingfoil/examples/adapters/kdb/),
+  [PostgreSQL](crates/wingfoil/examples/adapters/postgres/),
+  [Kafka](crates/wingfoil/examples/adapters/kafka/),
+  [Redis](crates/wingfoil/examples/adapters/redis/),
+  [Fluvio](crates/wingfoil/examples/adapters/fluvio/),
+  [etcd](crates/wingfoil/examples/adapters/etcd/),
+  [ZeroMQ](crates/wingfoil/examples/adapters/zmq/),
+  [FIX 4.4](crates/wingfoil/examples/adapters/fix/),
+  [iceoryx2](crates/wingfoil/examples/adapters/iceoryx2/),
+  [Aeron](crates/wingfoil/examples/adapters/aeron/),
+  [WebSocket](crates/wingfoil/examples/adapters/web/),
+  [Prometheus](crates/wingfoil/examples/adapters/prometheus/),
+  [OpenTelemetry](crates/wingfoil/examples/adapters/otlp/),
+  [CSV](crates/wingfoil/examples/adapters/csv/),
+  [augurs](crates/wingfoil/examples/adapters/augurs/) and
+  [more](#adapters) — one runnable example each.
 - **Latency tracing**: [per-hop wall-clock stamps](crates/wingfoil/examples/showcase/)
   aggregating into one report, across shared memory and the wire.
 - **Multi-language**: a [Rust crate](https://crates.io/crates/wingfoil/), a
@@ -181,7 +196,7 @@ deliberately *not* claimed — is in
 
 ## Examples
 
-46 runnable examples, each in its own directory with a README covering what it
+44 runnable examples, each in its own directory with a README covering what it
 teaches, the wiring, and its expected output. Full index:
 [`examples/README.md`](crates/wingfoil/examples/README.md).
 
@@ -194,18 +209,66 @@ cargo run --manifest-path crates/wingfoil/Cargo.toml --example ema_crossover # f
 cargo run --manifest-path crates/wingfoil/Cargo.toml --features csv --example order_book
 ```
 
-Then pick a direction: [`adapters/`](crates/wingfoil/examples/adapters/) to plug
-in real data, [`core/dual_mode`](crates/wingfoil/examples/core/dual_mode/) for
-the execution tiers, [`core/run_mode`](crates/wingfoil/examples/core/run_mode/)
-to backtest, or [`showcase/`](crates/wingfoil/examples/showcase/) for end-to-end
-latency tracing across processes.
+### Core concepts
+
+No services, no feature flags — these run with a plain `cargo run`.
+
+| Example | Description |
+|---|---|
+| [`hello_graph`](crates/wingfoil/examples/core/hello_graph/) | The smallest complete program: wire, build, run. |
+| [`ema_crossover`](crates/wingfoil/examples/core/ema_crossover/) | A backtest-shaped graph — fold, join, map and filter over a price series. |
+| [`order_book`](crates/wingfoil/examples/core/order_book/) | Load NASDAQ AAPL limit orders from CSV, maintain an order book, derive trades and two-way prices, write both back out. |
+| [`run_mode`](crates/wingfoil/examples/core/run_mode/) | Swap `RunMode::RealTime` and `RunMode::HistoricalFrom` over the same wiring, for backtesting. |
+| [`dual_mode`](crates/wingfoil/examples/core/dual_mode/) | One wiring, three execution tiers — interpreted, compiled, and a compiled island — proven to agree. |
+| [`topological_sort`](crates/wingfoil/examples/core/topological_sort/) | Why topologically sorted execution avoids the O(2^N) node explosion of naive per-path propagation. |
+| [`dynamism`](crates/wingfoil/examples/core/dynamism/) | Add and remove nodes on a running graph — one price book, four wirings. |
+| [`feedback`](crates/wingfoil/examples/core/feedback/) | Close a loop between two nodes with `feedback` — a proportional control loop a plain DAG cannot express. |
+| [`statistics`](crates/wingfoil/examples/core/statistics/) | Streaming statistics: EWMA, cumulative and rolling mean/variance/std/min/max/median, over sample- and time-based windows. |
+| [`async`](crates/wingfoil/examples/core/async/) | Tokio async/await at the graph's edges, with the core graph staying synchronous. |
+| [`async_source`](crates/wingfoil/examples/core/async_source/) | An async quote feed driving the graph through an `external` source. |
+| [`threading`](crates/wingfoil/examples/core/threading/) | Distribute graph execution across worker threads, with no locks on the execution path. |
+| [`spawn`](crates/wingfoil/examples/core/spawn/) | Offload slow work off the graph thread with `spawn` / `spawn_map`. |
+| [`tracing`](crates/wingfoil/examples/core/tracing/) | Observability: the `logged` debug tap and the engine's own spans. |
+| [`introspect`](crates/wingfoil/examples/core/introspect/) | Read back the graph you wired — text, Mermaid, DOT, JSON or GML. |
+
+### Adapters
+
+One directory per adapter, each behind its cargo feature. See each README for
+the service to start and the command to run.
+
+| Example | Description |
+|---|---|
+| [`kdb`](crates/wingfoil/examples/adapters/kdb/) | KDB+ in three parts: time-sliced reads, LRU-cached reads, and a round-trip write/read/validate. |
+| [`postgres`](crates/wingfoil/examples/adapters/postgres/) | PostgreSQL — time-sliced historical reads and streaming writes, round-tripped and asserted to tie out. |
+| [`kafka`](crates/wingfoil/examples/adapters/kafka/) | Consume a Kafka topic, transform each record, produce to another. |
+| [`fluvio`](crates/wingfoil/examples/adapters/fluvio/) | Fluvio — seed a topic, consume it, transform, write to a second topic, from one `GraphBuilder`. |
+| [`redis`](crates/wingfoil/examples/adapters/redis/) | Redis Pub/Sub end to end: publish, subscribe, transform, republish. |
+| [`etcd`](crates/wingfoil/examples/adapters/etcd/) | Watch an etcd key prefix, transform the values, write them back under another. |
+| [`zmq`](crates/wingfoil/examples/adapters/zmq/) | ZeroMQ pub/sub, with direct addressing or etcd service discovery. |
+| [`fix`](crates/wingfoil/examples/adapters/fix/) | FIX 4.4 — an acceptor and an initiator in one process, over a loopback session. |
+| [`iceoryx2`](crates/wingfoil/examples/adapters/iceoryx2/) | Zero-copy IPC over shared memory, in spin, threaded and signaled polling modes. |
+| [`aeron`](crates/wingfoil/examples/adapters/aeron/) | Low-latency Aeron UDP/IPC transport — publish and subscribe over `aeron:ipc`. |
+| [`web`](crates/wingfoil/examples/adapters/web/) | Stream a synthetic mid-price to a browser over WebSocket, and take UI events back in. |
+| [`ws`](crates/wingfoil/examples/adapters/ws/) | A reconnecting WebSocket *client* feeding a graph — the transport half of a venue adapter. |
+| [`prometheus`](crates/wingfoil/examples/adapters/prometheus/) | Serve `GET /metrics` in the Prometheus text format for a scraper or Grafana. |
+| [`otlp`](crates/wingfoil/examples/adapters/otlp/) | Push stream values to an OpenTelemetry backend over OTLP. |
+| [`telemetry`](crates/wingfoil/examples/adapters/telemetry/) | The two exporters side by side — pull-based scraping vs push — with a Grafana stack. |
+| [`csv`](crates/wingfoil/examples/adapters/csv/) | Replay a CSV as a deterministic historical burst stream, transform it, write it back. The one to read first — it needs no server. |
+| [`lines`](crates/wingfoil/examples/adapters/lines/) | Line-oriented files in both directions — the smallest complete I/O edge. |
+| [`augurs`](crates/wingfoil/examples/adapters/augurs/) | On-graph time-series analysis with Grafana's augurs: forecasting, outliers, changepoints, seasonality, DTW, clustering. |
+
+### Showcase
+
+| Example | Description |
+|---|---|
+| [`latency`](crates/wingfoil/examples/showcase/latency/) | A two-process pipeline over iceoryx2 with per-hop stamping and an end-of-run report. |
+| [`trading_e2e`](crates/wingfoil/examples/showcase/trading_e2e/) | Browser to live venue and back: WebSocket in, shared memory across processes, FIX/TLS out, with Grafana dashboards over the whole path. |
 
 
 ## Links
 
 - Explore the [examples](crates/wingfoil/examples/)
-- Upgrading from 8.x? Read the [release notes](docs/release-notes/) — 9.0
-  replaces the engine
+- Read the [release notes](docs/release-notes/)
 - Compare the field: [stream processing, dataflow and trading frameworks](docs/comparison.md)
 - Browse the [crates](crates/)
 - Read the [benchmarks](crates/wingfoil/benches/)

--- a/crates/wingfoil/tests/engine_semantics.rs
+++ b/crates/wingfoil/tests/engine_semantics.rs
@@ -105,27 +105,49 @@ fn for_each_observes_every_tick() {
     assert_eq!(vec![1, 2, 3], *seen.borrow());
 }
 
+/// What the legacy engine counts for this graph, **captured from it** on
+/// 2026-08-12 while it was still here to ask (see the test below).
+const LEGACY_DURATION_BOUND_COUNT: u64 = 6;
+
 /// The duration bound must terminate exactly like the legacy engine's —
 /// both engines run the same trailing-cycle semantics (a 100ns ticker under
 /// a 305ns bound runs cycles at 0..=500: the bound is checked against the
 /// *previous* cycle's time, then one marked-last cycle still runs).
+///
+/// **The expectation is pinned, not just compared.** This was a pairwise
+/// `assert_eq!(legacy, wingfoil)`, which has two problems: it passes if both
+/// engines drift the same way, and it cannot outlive the oracle — so the
+/// cutover runbook had the whole file down as a deletion. Asserting each
+/// engine against the captured constant is strictly stronger *and* leaves the
+/// legacy half as a clearly-marked block to lift out. Every other test in this
+/// file already works this way, citing the legacy test it mirrors.
 #[test]
 fn duration_bound_matches_legacy_engine() {
-    use legacy_wingfoil::NodeOperators;
     let period = Duration::from_nanos(100);
     let bound = Duration::from_nanos(305);
 
-    let legacy = legacy_wingfoil::ticker(period).count();
-    legacy
-        .run(HISTORICAL, RunFor::Duration(bound))
-        .expect("legacy run");
+    // --- legacy oracle: lift this block out with `legacy/` (runbook step 2),
+    // --- along with the `legacy_wingfoil` dev-dependency. The rest stands.
+    {
+        use legacy_wingfoil::NodeOperators;
+        let legacy = legacy_wingfoil::ticker(period).count();
+        legacy
+            .run(HISTORICAL, RunFor::Duration(bound))
+            .expect("legacy run");
+        assert_eq!(
+            LEGACY_DURATION_BOUND_COUNT,
+            legacy.peek_value(),
+            "the captured constant no longer describes the legacy engine"
+        );
+    }
+    // --- end legacy oracle ---
 
     let g = GraphBuilder::new();
     let next = g.ticker(period).count();
     let mut r = g.build();
     r.run(HISTORICAL, RunFor::Duration(bound)).unwrap();
 
-    assert_eq!(legacy.peek_value(), r.value(&next));
+    assert_eq!(LEGACY_DURATION_BOUND_COUNT, r.value(&next));
 }
 
 /// The activation contract is `const`, so it can be checked at compile time

--- a/docs/planning/cutover-runbook.md
+++ b/docs/planning/cutover-runbook.md
@@ -113,12 +113,21 @@ With legacy gone there is nothing to alias.
 | `iceoryx2` feature | `"legacy_wingfoil/iceoryx2"` | drop from the list |
 | `zmq-cross-engine-test` feature | `"zmq", "legacy_wingfoil/zmq"` | delete the whole feature |
 
-**Three files use it, and all three are deletions, not rewrites** — each exists
-to compare against an engine that no longer exists:
+**Three files use it. Only one is a deletion** — the other two keep most of
+their value once the comparison arm is lifted out:
 
-- `crates/wingfoil/tests/engine_semantics.rs` — the parity oracle.
-- `crates/wingfoil/tests/zmq_cross_engine_integration.rs` — proved the two
-  engines agree on the wire. Its sibling
+- `crates/wingfoil/tests/engine_semantics.rs` — **keep the file; lift one
+  block.** This was listed as a deletion, which was wrong: of its eight tests
+  only `duration_bound_matches_legacy_engine` ever linked legacy, and the
+  other seven pin legacy's expected values as constants, each citing the legacy
+  test it mirrors. They are ordinary regression tests that happen to encode
+  legacy semantics, and they outlive the tree. The one live test has since been
+  restructured around a captured constant (`LEGACY_DURATION_BOUND_COUNT`, taken
+  from the legacy engine on 2026-08-12) with its legacy half fenced in a
+  marked block: delete the block, keep the test.
+- `crates/wingfoil/tests/zmq_cross_engine_integration.rs` — **the one genuine
+  deletion.** It proved the two engines agree on the wire, which is not a
+  question that survives having one engine. Its sibling
   `zmq_cross_lang_integration.rs` **stays**: that one tests Rust ↔ Python,
   which survives the cutover.
 - `crates/wingfoil/benches/tiers.rs` — the `legacy` arm of each group only.
@@ -126,8 +135,10 @@ to compare against an engine that no longer exists:
   interpreted / compiled / nested. Also drop its `[[bench]]`-adjacent legacy
   references and the `legacy` group labels.
 
-Do not delete `tiers.rs` wholesale — the three surviving tiers are still the
-tier-comparison benchmark.
+Do not delete `tiers.rs` or `engine_semantics.rs` wholesale. The general rule,
+learned from both: a file that *compares* the engines dies with the tree, but a
+file that *records what legacy did* is the reason the comparison was worth
+running — capture the value, fence the legacy half, keep the assertion.
 
 ## Step 3 — revert the package-selection workaround
 


### PR DESCRIPTION
## What this changes

Two independent commits, both follow-ons from the legacy-deletion readiness audit in #787.

### `f52ebba` — README

The adapter and example lists take the **legacy README's shape**, which read better than what replaced it. The features bullet names each adapter as its own link again, and `## Examples` carries three tables — Core concepts, Adapters, Showcase — one row per example with a line of description. All 35 example directories appear in exactly one row; descriptions are written from each example's own README rather than invented. The three-command "start here" block stays above the tables: those answer different questions.

Also:

- **Badges trimmed** — the MSRV and Python-docs (readthedocs) rows are gone.
- **The release-notes link moves to the top**, as a callout under the intro rather than the seventh bullet of `## Links` at the bottom of a 280-line file. 9.0 replaces the engine, so an 8.x reader should meet that before the feature list. It points at `9.0.0.md` directly and pairs with the migration guide; the `## Links` entry stays, reworded.
- **Two pre-existing inaccuracies corrected**: "46 runnable examples" → 44 (what `check-example-docs.sh` counts), and the claim of "sixteen production-ready adapters" — 17 have example directories and `src/adapters/` has 19 modules, so the number is dropped rather than restated wrongly. Worth settling which count to claim.

### `8258f9a` — the parity oracle

`docs/planning/cutover-runbook.md` listed `tests/engine_semantics.rs` as a **deletion** at cutover, on the grounds that it exists to compare against an engine that will not exist. That was wrong about the file. Of its eight tests only `duration_bound_matches_legacy_engine` ever linked `legacy_wingfoil`; the other seven pin legacy's expected values as constants, each citing the legacy test it mirrors. They are ordinary regression tests that happen to encode legacy semantics, and they outlive the tree — deleting them discards seven working assertions to remove one dependency.

The one live test is restructured rather than left to die with the oracle. It was a pairwise `assert_eq!(legacy.peek_value(), r.value(&next))`, which is weaker than it looks: it passes if both engines drift the same way, and it cannot outlive the comparison. Now **both sides assert against `LEGACY_DURATION_BOUND_COUNT`** — captured from the legacy engine while it is still here to ask — with the legacy half fenced in a marked block. Deleting that block at cutover leaves a test that still means what it meant.

This is a one-way door, which is why it is worth doing now rather than in the deletion PR: once `legacy/` is gone there is nothing left to capture the value from. The runbook's step 2 is corrected to match, with the rule the two cases share — a file that *compares* the engines dies with the tree, but a file that *records what legacy did* is the reason the comparison was worth running.

## Why

Both came out of reviewing the cutover plan against the tree rather than from an issue. The README half is presentation; the oracle half prevents a small, permanent loss of test coverage at the cutover.

## How it was verified

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --test engine_semantics` — 8/8, including the cross-engine test. First time this has been run rather than assumed green
- [x] **The deletion was simulated**: the fenced legacy block was actually removed and the remaining test compiled and passed, rather than the claim being made by inspection
- [x] Every relative link in `README.md` resolved against the tree, and every example directory checked for a table row; the anchor the features bullet points at is the one GitHub generates
- [ ] `cargo lint-all` / full `--all-features` test run — not run locally; CI covers both. The only Rust change is one test file

## Notes for the reviewer

- The README's adapter count is left unstated deliberately — say which definition you want (adapters with a runnable example: 17; modules in `src/adapters/`: 19) and I'll put a number back.
- The oracle commit **contradicts a line in the runbook that #787 shipped**, and corrects it in the same commit — that is intentional, not a merge artifact.
- Not included, and mentioned only so it isn't a surprise: moving `stats` to `adapters::statistics` behind a feature gate is in progress separately, and blocked on one decision about the `nitro!` prelude.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPnmCFPUJE6Ew1g523fzdu)_