### PR TITLE
Make accumulate a test instrument, not an output edge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,16 @@ thread panicked while holding it, and we propagate that panic deliberately.
 
 - Tests use `RunMode::HistoricalFrom(NanoTime::ZERO)` for determinism, and
   assert exact values *and* tick times (`with_time()` + `accumulate()`).
+- **`accumulate()` / `collapse_accumulate()` are test instruments, not output
+  edges.** They grow a `Vec` by one entry per tick for the whole run and clone
+  it on every tick, so they are unbounded in realtime and `O(n²)` copying in a
+  backtest. Use them where a *bounded* run's whole sequence is needed in one
+  value afterwards — asserting values and tick times, or tying two runs out
+  against each other. Everywhere else — examples included — emit as the run
+  progresses: `print()`, `logged(..)`, `for_each(..)` / `for_each_mut(..)`,
+  `inspect(..)`, or `window(..)` / `buffer(..)` for a bounded look-back. An
+  example that collects into a `Vec` only to `println!` it after the run is the
+  anti-pattern; it also stops the same wiring being pointed at a live feed.
 - Temp files in tests get unique names (pid + counter) so parallel tests
   never collide; see `crates/wingfoil/tests/lines_adapter.rs`.
 - Feature-gated tests start with `#![cfg(feature = "...")]` at file level.

--- a/crates/wingfoil/examples/adapters/kdb/round_trip/main.rs
+++ b/crates/wingfoil/examples/adapters/kdb/round_trip/main.rs
@@ -113,6 +113,10 @@ fn main() -> Result<()> {
         },
         None,
     )?
+    // `accumulate` because the tie-out below compares the *whole* read-back
+    // against the whole baseline — the assertion case it exists for, over a
+    // bounded historical run. A graph that consumes rows rather than checking
+    // them writes them out from a `for_each` sink instead.
     .collapse()
     .accumulate();
     let mut runner = g.build();

--- a/crates/wingfoil/examples/adapters/lines/README.md
+++ b/crates/wingfoil/examples/adapters/lines/README.md
@@ -31,6 +31,12 @@ let shouted = lines.map(|burst: &Burst<String>| {
 
 let _sink = shouted.write_lines(&output)?;
 
+// A second sink off the same source, printing the replay schedule live.
+let _stamped = lines.with_time().for_each(|(time, burst): &(NanoTime, Burst<String>)| {
+    println!("  {time}: {:?}", burst.iter().collect::<Vec<_>>());
+    Ok(())
+});
+
 let mut runner = g.build();
 runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
 ```

--- a/crates/wingfoil/examples/adapters/lines/main.rs
+++ b/crates/wingfoil/examples/adapters/lines/main.rs
@@ -35,16 +35,18 @@ fn main() -> anyhow::Result<()> {
             .collect::<Burst<String>>()
     });
     let _sink = shouted.write_lines(&output)?;
-    // Keep the original timestamps around to show the replay schedule.
-    let stamped = lines.with_time().accumulate();
+    // Show the replay schedule as it happens: a second sink off the same
+    // source, printing each record at the graph time it lands on.
+    let _stamped = lines
+        .with_time()
+        .for_each(|(time, burst): &(NanoTime, Burst<String>)| {
+            println!("  {time}: {:?}", burst.iter().collect::<Vec<_>>());
+            Ok(())
+        });
 
     let mut runner = g.build();
-    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
-
     println!("replayed records at their graph timestamps:");
-    for (time, burst) in runner.value(&stamped) {
-        println!("  {time}: {:?}", burst.iter().collect::<Vec<_>>());
-    }
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever)?;
 
     println!("\nwrote {}:", output.display());
     for line in fs::read_to_string(&output)?.lines() {

--- a/crates/wingfoil/examples/adapters/postgres/main.rs
+++ b/crates/wingfoil/examples/adapters/postgres/main.rs
@@ -135,6 +135,10 @@ fn main() -> Result<()> {
         },
         None,
     )?
+    // `accumulate` because the tie-out below compares the *whole* read-back
+    // against the whole baseline — the assertion case it exists for, over a
+    // bounded historical run. A graph that consumes rows rather than checking
+    // them writes them out from a `for_each` sink instead.
     .collapse()
     .accumulate();
     let mut runner = g.build();

--- a/crates/wingfoil/examples/core/async/main.rs
+++ b/crates/wingfoil/examples/core/async/main.rs
@@ -103,11 +103,25 @@ fn run(run_mode: RunMode) -> anyhow::Result<(Vec<f64>, f64)> {
         },
     );
 
-    // `collapse_accumulate` flattens the bursts and accumulates in one step —
-    // the burst-aware counterpart to `accumulate()`, so nothing is lost when a
-    // realtime cycle carries several quotes.
+    // The running mean, carried in `fold` state: sum and count every quote in
+    // every burst. O(1) per tick and bounded in a run of any length — which is
+    // what a statistic on a live feed has to be.
+    let mean = quotes
+        .fold((0.0_f64, 0u64), |st, burst: &Burst<f64>| {
+            for q in burst.iter() {
+                st.0 += *q;
+                st.1 += 1;
+            }
+        })
+        .map(|(sum, n)| if *n == 0 { 0.0 } else { sum / *n as f64 });
+
+    // `seen` exists only for this example's cross-mode tie-out below, which
+    // needs both runs' whole output as a value to compare — the one thing
+    // `accumulate` is for. `collapse_accumulate` is its burst-aware form,
+    // flattening and accumulating in one step so nothing is lost when a
+    // realtime cycle carries several quotes. The feed is bounded to `N`; a
+    // graph that *emits* rather than asserts uses the `for_each` sink above.
     let seen = quotes.collapse_accumulate();
-    let mean = seen.map(|qs| qs.iter().sum::<f64>() / qs.len().max(1) as f64);
 
     let mut runner = g.build();
     // `Forever` is bounded by the feed itself: the stream closes after N values.

--- a/crates/wingfoil/examples/core/async_source/README.md
+++ b/crates/wingfoil/examples/core/async_source/README.md
@@ -48,6 +48,10 @@ quietly bias the mean toward whichever quote happened to arrive last.
 task learns to stop. There is no separate shutdown channel and no `Drop` ordering
 to get right.
 
+The report itself is a `for_each` sink, printing each line as its quote arrives.
+A realtime feed has no end to dump a collected `Vec` at, so `accumulate()` here
+would just be an unbounded buffer.
+
 `external` is a **realtime-only** source: it is driven by wall-clock arrivals, so
 there is nothing to replay deterministically. For an async producer that *does*
 work in both modes, see [`async`](../async/), whose values carry their own
@@ -56,7 +60,7 @@ timestamps.
 ### Output
 
 ```text
-processed 20 quotes from the async feed:
+quotes from the async feed:
   burst of  1  last   99.98  mean   99.98  dev +0.00%
   burst of  1  last   97.71  mean   98.85  dev -1.15%  <-- outlier
   burst of  1  last   97.94  mean   98.55  dev -0.61%

--- a/crates/wingfoil/examples/core/async_source/main.rs
+++ b/crates/wingfoil/examples/core/async_source/main.rs
@@ -32,7 +32,7 @@ fn main() {
         })
         .map(|(sum, n)| if *n == 0 { 0.0 } else { sum / *n as f64 });
 
-    let log = quotes
+    let _printed = quotes
         .join(&mean, |burst, m| {
             let last = burst.iter().copied().last().unwrap_or(0.0);
             let dev = (last - m) / m * 100.0;
@@ -42,7 +42,12 @@ fn main() {
                 burst.len()
             )
         })
-        .accumulate();
+        // A realtime feed has no end, so the report is a sink, not a `Vec` read
+        // after the run: print each line as its quote arrives.
+        .for_each(|line: &String| {
+            println!("  {line}");
+            Ok(())
+        });
 
     // The async producer: a tokio task sleeping between sends, like a feed
     // handler would await socket reads. `send` returns false once the runner
@@ -76,11 +81,7 @@ fn main() {
 
     // Each quote wakes the kernel for one cycle: 20 quotes, then stop.
     let g_runner = &mut g.build();
+    println!("quotes from the async feed:");
     g_runner.run(RunMode::RealTime, RunFor::Cycles(20)).unwrap();
-
-    println!("processed {} quotes from the async feed:", 20);
-    for line in g_runner.value(&log) {
-        println!("  {line}");
-    }
     producer.join().expect("producer thread");
 }

--- a/crates/wingfoil/examples/core/dual_mode/main.rs
+++ b/crates/wingfoil/examples/core/dual_mode/main.rs
@@ -18,8 +18,16 @@
 //!              \     /
 //!               merge                 (recombine — at most one fires/tick)
 //!                 |
-//!               print
+//!               acc                   (accumulate — see the note below)
 //! ```
+//!
+//! The tail node is [`accumulate`](wingfoil::fluent::StreamOps::accumulate)
+//! rather than a `print`/`for_each` sink for the one reason that justifies it:
+//! this example's claim is that the two engines *agree*, and comparing them
+//! means holding both runs' whole output as a value. The run is bounded to
+//! `CYCLES`. In a graph that emits rather than asserts, the tail is a streaming
+//! sink — see [`hello_graph`](../hello_graph/) and
+//! [`ema_crossover`](../ema_crossover/).
 //!
 //! ```sh
 //! cargo run --manifest-path crates/wingfoil/Cargo.toml --release --example dual_mode

--- a/crates/wingfoil/examples/core/ema_crossover/README.md
+++ b/crates/wingfoil/examples/core/ema_crossover/README.md
@@ -25,7 +25,20 @@ let changed = signal
     .map(|st| st.0 != st.1);
 
 let events = count.join(&signal, format_event).filter(&changed);
+
+// The outbound edge: print each crossover as it happens, and let the graph
+// carry the running total.
+let printed  = events.for_each(|e: &String| { println!("  {e}"); Ok(()) });
+let n_events = printed.count();
 ```
+
+### The report is a stream, not a `Vec`
+
+Events are printed from a `for_each` sink as they are produced, not collected
+with `accumulate()` and dumped after the run. That is what makes the same wiring
+point at a live feed unchanged: an accumulator grows one entry per event for the
+whole run, which a backtest survives and a deployed graph does not. `count()` on
+the sink's tick stream gives the total without keeping the events around.
 
 `price` is read by both EMAs — a **shared node**. The topologically sorted
 scheduler runs it once per cycle and fans the tick out to both readers, rather
@@ -43,13 +56,16 @@ change" without any node needing to remember whether it has already fired:
 ### Output
 
 ```text
-backtest: 2000 ticks, fast EMA 98.15 vs slow EMA 98.69 at close — 88 crossover events:
+backtest: 2000 ticks — crossover events:
   t=   4ms  golden cross -> LONG
   t=  10ms  death cross  -> FLAT
   t=  20ms  golden cross -> LONG
   t=  61ms  death cross  -> FLAT
   t= 110ms  golden cross -> LONG
   ...
+  t=1941ms  golden cross -> LONG
+  t=1947ms  death cross  -> FLAT
+fast EMA 98.15 vs slow EMA 98.69 at close — 88 crossover events
 ```
 
 ### Run

--- a/crates/wingfoil/examples/core/ema_crossover/main.rs
+++ b/crates/wingfoil/examples/core/ema_crossover/main.rs
@@ -63,9 +63,21 @@ fn main() {
             }
         })
         .filter(&changed);
-    let log = events.accumulate();
+
+    // The outbound edge: print each crossover as it happens. A backtest report
+    // is a *stream* of events, so it belongs in a `for_each` sink — the same
+    // wiring then works unchanged against a live feed, where accumulating
+    // every event into a `Vec` would grow without bound.
+    let printed = events.for_each(|e: &String| {
+        println!("  {e}");
+        Ok(())
+    });
+    // `count` on the sink's tick stream: the running event total, carried by
+    // the graph rather than by a `Vec` length read afterwards.
+    let n_events = printed.count();
 
     let mut runner = g.build();
+    println!("backtest: 2000 ticks — crossover events:");
     runner
         .run(
             RunMode::HistoricalFrom(NanoTime::ZERO),
@@ -73,14 +85,10 @@ fn main() {
         )
         .unwrap();
 
-    let events = runner.value(&log);
     println!(
-        "backtest: 2000 ticks, fast EMA {:.2} vs slow EMA {:.2} at close — {} crossover events:",
+        "fast EMA {:.2} vs slow EMA {:.2} at close — {} crossover events",
         runner.value(&fast),
         runner.value(&slow),
-        events.len()
+        runner.value(&n_events),
     );
-    for e in &events {
-        println!("  {e}");
-    }
 }

--- a/crates/wingfoil/examples/core/hello_graph/README.md
+++ b/crates/wingfoil/examples/core/hello_graph/README.md
@@ -14,11 +14,14 @@ use wingfoil::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
 let g = GraphBuilder::new();
-let msgs = g
+let _printed = g
     .ticker(Duration::from_millis(100))
     .count()
     .map(|i| format!("tick {i}"))
-    .accumulate();
+    .for_each(|msg: &String| {
+        println!("  {msg}");
+        Ok(())
+    });
 
 let mut runner = g.build();
 runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5))?;
@@ -27,10 +30,14 @@ runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5))?;
 Three things to notice:
 
 - **`GraphBuilder` wires, `build()` freezes, `run()` executes.** You never hold a
-  node object — `Stream<T>` is a handle, and values come back through
-  `runner.value(&handle)` after the run.
-- **`accumulate()`** collects every value the stream produced, which is how an
-  example (or a test) inspects a run after the fact.
+  node object — `Stream<T>` is a handle, and a scalar like the realtime tick
+  count comes back through `runner.value(&handle)` after the run.
+- **`for_each()` is the graph's outbound edge** — a side-effecting sink that
+  runs once per tick, so output streams out *as the run progresses*. `print()`
+  is the one-call debug version (`{value:?}` per line), and `logged(..)` routes
+  through the `log` crate. Reach for `accumulate()` only in tests, where a
+  bounded run's whole sequence has to be asserted on afterwards; as an output
+  edge it grows a `Vec` for the entire run.
 - **`RunFor::Cycles(5)`** bounds the run. `RunFor::Duration(..)` and
   `RunFor::Forever` are the other two.
 

--- a/crates/wingfoil/examples/core/hello_graph/main.rs
+++ b/crates/wingfoil/examples/core/hello_graph/main.rs
@@ -14,19 +14,23 @@ use wingfoil::{NanoTime, RunFor, RunMode};
 fn main() {
     // Historical: the whole run happens instantly at simulated times.
     let g = GraphBuilder::new();
-    let msgs = g
+    // `for_each` is the graph's outbound edge: a side-effecting sink that runs
+    // per tick, so each message is printed as it is produced rather than piled
+    // into a `Vec` to be read after the run. (`.print()` is the one-call debug
+    // version, printing `{value:?}`.)
+    let _printed = g
         .ticker(Duration::from_millis(100))
         .count()
         .map(|i| format!("tick {i}"))
-        .accumulate();
+        .for_each(|msg: &String| {
+            println!("  {msg}");
+            Ok(())
+        });
     let mut runner = g.build();
+    println!("historical run (instant):");
     runner
         .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5))
         .unwrap();
-    println!("historical run (instant):");
-    for msg in runner.value(&msgs) {
-        println!("  {msg}");
-    }
 
     // Realtime: the same wiring, but the kernel waits out each 50ms tick on
     // the wall clock.

--- a/crates/wingfoil/examples/core/spawn/main.rs
+++ b/crates/wingfoil/examples/core/spawn/main.rs
@@ -33,7 +33,13 @@ fn main() {
     let scaled: Stream<Burst<u64>> =
         flat.spawn_map(|s: Stream<Burst<u64>>| s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10));
 
-    let collected = scaled.with_time().accumulate();
+    // Print each burst at its graph time, as it arrives back from the worker.
+    let _printed = scaled
+        .with_time()
+        .for_each(|(t, v): &(NanoTime, Burst<u64>)| {
+            println!("{:>3} ms: {v:?}", u64::from(*t) / 1_000_000);
+            Ok(())
+        });
     let mut runner = g.build();
 
     // Bound the run; the workers inherit this bound. Historical replay races to
@@ -44,10 +50,6 @@ fn main() {
             RunFor::Duration(period * (n + 3)),
         )
         .expect("run");
-
-    for (t, v) in runner.value(&collected) {
-        println!("{:>3} ms: {:?}", u64::from(t) / 1_000_000, v);
-    }
     // 0 ms: [10]
     // 10 ms: [20]
     // 20 ms: [30]

--- a/crates/wingfoil/examples/core/threading/README.md
+++ b/crates/wingfoil/examples/core/threading/README.md
@@ -30,7 +30,11 @@ own, so it is just an op on the receiving main graph.
   the last cycle rides one burst, so the grouping is wall-clock dependent.
 - **Historical** — the worker sends timestamped values (`send_at`) and the
   receiver replays them **deterministically** at those graph times. Same
-  topology, reproducible timeline: `[[10], [20], [30], [40], [50], [60]]`.
+  topology, reproducible timeline: `[10]`, `[20]`, … `[60]`.
+
+Each burst is printed from a `for_each` sink as the main graph receives it,
+rather than accumulated into a `Vec` and dumped afterwards — a channel-fed graph
+has no end to dump at.
 
 ## Running
 
@@ -39,9 +43,19 @@ cargo run --manifest-path crates/wingfoil/Cargo.toml --example threading
 ```
 
 ```
-realtime:   [[10], [20], [30], [40], [50], [60]]
-historical: [[10], [20], [30], [40], [50], [60]]
+realtime  : [10]
+realtime  : [20]
+realtime  : [30]
+realtime  : [40]
+realtime  : [50]
+realtime  : [60]
+historical: [10]
+historical: [20]
+historical: [30]
+historical: [40]
+historical: [50]
+historical: [60]
 ```
 
-(Under load the realtime line may coalesce consecutive values into a single
-burst, e.g. `[[10, 20], [30], ...]` — the historical line never varies.)
+(Under load the realtime run may coalesce consecutive values into a single
+burst, e.g. `realtime  : [10, 20]` — the historical run never varies.)

--- a/crates/wingfoil/examples/core/threading/main.rs
+++ b/crates/wingfoil/examples/core/threading/main.rs
@@ -32,9 +32,9 @@ use wingfoil::channel::ChannelSender;
 use wingfoil::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
-/// Run the producer-on-a-worker-thread pipeline in `run_mode` and return the
-/// scaled values the main graph collected, burst by burst.
-fn pipeline(run_mode: RunMode, period: Duration, n: u32) -> Vec<Vec<u64>> {
+/// Run the producer-on-a-worker-thread pipeline in `run_mode`, printing each
+/// burst of scaled values under `label` as the main graph receives it.
+fn pipeline(label: &str, run_mode: RunMode, period: Duration, n: u32) {
     let g = GraphBuilder::new();
 
     // The main graph's inbound edge: a channel source fed from the worker.
@@ -44,7 +44,15 @@ fn pipeline(run_mode: RunMode, period: Duration, n: u32) -> Vec<Vec<u64>> {
     // ×10 (legacy runs this on its own thread via `mapper()`; on wingfoil a stage
     // that needs no thread of its own is just an op on the receiving graph).
     let scaled = counts.map(|b: &Burst<u64>| b.iter().map(|x| x * 10).collect::<Vec<u64>>());
-    let collected = scaled.accumulate();
+
+    // Print each burst as the main graph receives it — the burst grouping *is*
+    // the thing this example shows, and a sink shows it live rather than
+    // collecting the whole run into a `Vec` first.
+    let label = label.to_string();
+    let _printed = scaled.for_each(move |burst: &Vec<u64>| {
+        println!("{label}: {burst:?}");
+        Ok(())
+    });
 
     let mut runner = g.build();
 
@@ -77,7 +85,6 @@ fn pipeline(run_mode: RunMode, period: Duration, n: u32) -> Vec<Vec<u64>> {
         .run(run_mode, RunFor::Forever)
         .expect("run main graph");
     worker.join().expect("producer worker thread");
-    runner.value(&collected)
 }
 
 fn main() {
@@ -86,11 +93,14 @@ fn main() {
 
     // Realtime: the worker paces at `period`; a cycle may carry a burst of
     // several values, so the grouping is wall-clock dependent.
-    let realtime = pipeline(RunMode::RealTime, period, n);
-    println!("realtime:   {realtime:?}");
+    pipeline("realtime  ", RunMode::RealTime, period, n);
 
     // Historical: timestamped replay — one value per instant, fully
-    // deterministic: [[10], [20], [30], [40], [50], [60]].
-    let historical = pipeline(RunMode::HistoricalFrom(NanoTime::ZERO), period, n);
-    println!("historical: {historical:?}");
+    // deterministic: [10], [20], [30], [40], [50], [60].
+    pipeline(
+        "historical",
+        RunMode::HistoricalFrom(NanoTime::ZERO),
+        period,
+        n,
+    );
 }

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -862,6 +862,19 @@ pub trait StreamOps<T>: Sized {
         F: Fn(&B, &T) -> B + 'static;
 
     /// Collect every emitted value into a `Vec`.
+    ///
+    /// **A test/inspection instrument, not an output edge.** It grows one
+    /// entry per tick for the whole run and clones the whole `Vec` on every
+    /// tick, so it is unbounded in a realtime graph. Use it where a bounded
+    /// run needs its entire sequence in one value afterwards — asserting
+    /// values *and* tick times (`with_time().accumulate()`), or tying two runs
+    /// out against each other. To emit values as the run progresses, use
+    /// [`print`](StreamOps::print), [`logged`](StreamOps::logged),
+    /// [`for_each`](StreamOps::for_each) /
+    /// [`for_each_mut`](StreamOps::for_each_mut) or
+    /// [`inspect`](StreamOps::inspect); for a bounded look-back, use
+    /// [`window`](StreamOps::window) or [`buffer`](StreamOps::buffer). See
+    /// [`ops::Accumulate`](crate::ops::Accumulate).
     fn accumulate(&self) -> Stream<Vec<T>>
     where
         T: Clone + Default + 'static;
@@ -1404,7 +1417,10 @@ impl Stream<()> {
 impl<T: Clone + Default + 'static> Stream<Burst<T>> {
     /// Accumulate every value from every burst into one `Vec`, losslessly and
     /// in order — the burst-aware counterpart to
-    /// [`accumulate`](StreamOps::accumulate).
+    /// [`accumulate`](StreamOps::accumulate), and a test/inspection instrument
+    /// for the same reasons: it grows for the whole run. To emit burst values
+    /// as they arrive, `collapse()` into a streaming edge
+    /// (`print` / `logged` / `for_each`) instead.
     pub fn collapse_accumulate(&self) -> Stream<Vec<T>> {
         self.fold(Vec::new(), |acc, burst: &Burst<T>| {
             acc.extend(burst.iter().cloned())

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -2870,6 +2870,27 @@ impl<T: 'static> Op for Count<T> {
 /// Collect every emitted value into a `Vec`, emitting the accumulated `Vec`
 /// on each tick (cloned per tick — identical to its previous fold-based
 /// desugar). Single-sourced for both layers, like [`Count`].
+///
+/// **This is a test/inspection instrument, not an output edge.** State grows
+/// by one entry per tick for the whole run and every tick clones the whole
+/// `Vec`, so it is `O(n)` memory and `O(n²)` copying over a run of `n` ticks —
+/// unbounded in realtime, and enough to park a [`pool`](crate::pool) loan
+/// forever (see the pool module docs). Use it where a run is bounded and
+/// something afterwards needs the entire sequence in one value: asserting
+/// exact values *and* tick times (`with_time().accumulate()`), or tying two
+/// runs out against each other.
+///
+/// To get values *out* of a graph, reach for the streaming edges instead —
+/// they emit as the run progresses, cost nothing per tick, and still print
+/// what was seen if a later cycle aborts the run:
+///
+/// | want | use |
+/// |---|---|
+/// | print each value | [`Print`] (`.print()`) |
+/// | log each value at a level | [`Logged`] (`.logged(..)`) |
+/// | write/send each value, fallibly | [`Sink`] (`.for_each(..)`, `.for_each_mut(..)`) |
+/// | observe in passing, infallibly | [`Inspect`] (`.inspect(..)`) |
+/// | a bounded recent window | [`Window`] / [`Buffer`] |
 pub struct Accumulate<T>(PhantomData<T>);
 
 #[op(build = accumulate, fluent)]


### PR DESCRIPTION
`accumulate()` grows a Vec by one entry per tick for the whole run and
clones it on every tick: O(n) memory and O(n^2) copying, unbounded in
realtime. It is the right tool for asserting a bounded run's values and
tick times, or tying two runs out against each other — and the wrong tool
for getting values out of a graph.

Six example mains were collecting into a Vec purely to println! it after
the run. They now emit from streaming sinks, which is what the same wiring
would have to do against a live feed:

- hello_graph, ema_crossover, async_source, lines: for_each sinks; the
  header moves ahead of run() so output still reads in order.
- ema_crossover additionally carries its event total as count() on the
  sink's tick stream instead of a Vec length read afterwards.
- threading, spawn: log each burst as the graph receives it; pipeline()
  takes a label and no longer returns a Vec.
- async: the running mean moves off the accumulated Vec into fold state
  (O(1) per tick); the accumulator stays only for the cross-mode tie-out.

Output is unchanged apart from the reordered summary lines; every README
sample was re-run and pasted from the real output.

The remaining example uses are the assertion case, now commented as such:
dual_mode (interpreted vs compiled parity — its ASCII diagram said `print`
where the wiring says accumulate) and the postgres/kdb round-trip tie-outs.
Uses in tests, doc tests and benches are unaffected.

Documented the rule where it will be read: the Accumulate op and
StreamOps::accumulate / collapse_accumulate doc comments, with a table of
the streaming edges to reach for instead, plus a working-convention bullet
in CLAUDE.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QBgifAipLzuMRELU7sXSiz