### PR TITLE
Improve nitro errors for Stream method collisions

### DIFF
--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -176,7 +176,17 @@
 //!
 //! Because dispatch is by naming convention rather than a table, a method the
 //! macro cannot dispatch surfaces as an *unresolved forwarder* rather than as a
-//! message about the method. There are two cases, and they read differently:
+//! message about the method. There are three cases, and they read differently:
+//!
+//! **A name reserved by `Stream`'s inherent interface** — `clone`, `handle`, or
+//! `wire` — is rejected with one message explaining the collision. Those names
+//! cannot identify user ops: ordinary fluent wiring would resolve the inherent
+//! method while compiled emission resolved a same-named forwarder, making the
+//! two tiers mean different things.
+//!
+//! This denylist is deliberately the small, closed inherent surface — it is not
+//! an allowlist of valid ops. New built-in and user-defined op names still need
+//! no macro-crate change.
 //!
 //! **A method that cannot be an op** — `split` (two outputs, where an `Op` has
 //! one `Out`) or `feedback` (a cycle) — is rejected with one message naming
@@ -760,11 +770,12 @@ impl ChainWalker {
         name: Ident,
         turbofish: Option<&syn::AngleBracketedGenericArguments>,
     ) -> syn::Result<usize> {
-        // Deliberately-fluent-only methods resolve on `Stream` but have no
-        // forwarders, so without this they fail as unresolved `__WF_OP_*`
-        // internals with no `no method named` error to explain them. See
-        // `fluent_only_advice`.
-        if let Some(msg) = fluent_only_advice(&method.to_string()) {
+        // Names reserved by `Stream`'s inherent interface would resolve
+        // differently in ordinary fluent wiring and compiled emission. Other
+        // deliberately-fluent-only methods resolve on `Stream` but have no
+        // forwarders, producing only unresolved `__WF_OP_*` internals. Reject
+        // both closed sets with a diagnostic at the method call.
+        if let Some(msg) = non_op_method_advice(&method.to_string()) {
             return Err(syn::Error::new(method.span(), msg));
         }
         Ok(match method.to_string().as_str() {
@@ -906,16 +917,17 @@ impl ChainWalker {
     }
 }
 
-/// Advice for a fluent method that deliberately has **no** `nitro!` forwarder,
+/// Advice for a method name that deliberately cannot identify a `nitro!` op,
 /// or `None` for anything else.
 ///
 /// This is **not** the per-op dispatch table the design removed (see
 /// `docs/decisions/macro-extensibility-decision.md`). That table listed the ops the macro
 /// *supports*, so it grew with every op added and was the thing that could
-/// drift. This list is its complement and is **closed**: it names the fluent
-/// methods that *cannot* be ops — mirroring the documented fluent-only
-/// allowlist in `tests/op_completeness.rs`. Adding an op never touches it;
-/// dispatch still resolves by naming convention alone.
+/// drift. This list is its complement and is **closed**: `Stream`'s three
+/// public op-name collisions (`clone`, `handle`, `wire`) plus the fluent
+/// methods that cannot be ops — mirroring the documented fluent-only allowlist
+/// in `tests/op_completeness.rs`. Adding an op never touches it; dispatch still
+/// resolves by naming convention alone.
 ///
 /// It is deliberately short, and got shorter: `not` and `collapse` were here
 /// until they were promoted to real ops ([`ops::Not`] / [`ops::Collapse`]) and
@@ -925,20 +937,42 @@ impl ChainWalker {
 /// `split` yields two outputs where an `Op` has one `Out`, and `feedback` is a
 /// cycle straight-line compiled emission cannot express.
 ///
-/// It exists purely for diagnostics. Without it these methods resolve fine
+/// It exists purely for diagnostics and collision hygiene. An inherent method
+/// name could otherwise mean one thing in the ordinary `wire()` function and
+/// a same-named user op in compiled emission. The other methods resolve fine
 /// fluently but have no `__wf_op_<name>_*` forwarders, so the expansion fails
 /// with two or three `cannot find value __WF_OP_<NAME>_…` errors — internal
 /// symbols, each carrying a nonsense "a constant with a similar name exists"
 /// suggestion (`.split()` → `.__WF_OP_SAMPLE_PASSIVE()`), and, because the
 /// method *does* exist on `Stream`, **no** `no method named` error to point at
-/// the real problem. That is the one case where the naming-convention design
-/// leaves a user with no usable signal at all, and it is the case we can close:
-/// the set is known and finite.
+/// the real problem. Both sets are known and finite.
 ///
 /// A genuine typo still falls through to the forwarder errors — the macro cannot
 /// know the open set of user-defined ops, which is the whole point of the
 /// design.
-fn fluent_only_advice(method: &str) -> Option<String> {
+fn non_op_method_advice(method: &str) -> Option<String> {
+    let inherent = match method {
+        "clone" => Some((
+            ".clone()",
+            "it clones the fluent stream handle rather than adding a graph node",
+        )),
+        "handle" => Some((
+            ".handle()",
+            "it exposes the interpreted runner handle rather than adding a graph node",
+        )),
+        "wire" => Some((
+            ".wire(..)",
+            "it is the low-level fluent extension hook rather than a named graph op",
+        )),
+        _ => None,
+    };
+    if let Some((call, inherent)) = inherent {
+        return Some(format!(
+            "`{call}` is reserved by `Stream`'s inherent interface and cannot be used as a \
+             `nitro!` op name: {inherent}"
+        ));
+    }
+
     let advice = match method {
         // `not` and `collapse` were here until they became real ops
         // (`ops::Not` / `ops::Collapse`) and started working in `nitro!`

--- a/crates/wingfoil/tests/trybuild/fluent_only_split.rs
+++ b/crates/wingfoil/tests/trybuild/fluent_only_split.rs
@@ -1,6 +1,6 @@
 // `split` cannot become an op: it yields two output streams where an `Op` has
 // one `Out`, and `nitro!`'s grammar binds one name to one node. Without the
-// `fluent_only_advice` check it produced two or three `cannot find value
+// `non_op_method_advice` check it produced two or three `cannot find value
 // __WF_OP_SPLIT_*` errors — internal symbols, each with a nonsense "similarly
 // named constant" suggestion — and, because `split` *does* exist on `Stream`,
 // no `no method named` error to explain them. It must be one message naming

--- a/crates/wingfoil/tests/trybuild/inherent_stream_methods.rs
+++ b/crates/wingfoil/tests/trybuild/inherent_stream_methods.rs
@@ -1,0 +1,33 @@
+// `Stream`'s inherent method names cannot also identify `nitro!` ops. The
+// ordinary fluent `wire()` function would resolve the inherent method while
+// compiled emission resolved a same-named forwarder, giving the two tiers
+// different meanings. Each collision must produce one curated diagnostic at
+// the call site rather than leaking generated `__WF_OP_*` errors.
+#![allow(unused)]
+use std::time::Duration;
+use wingfoil::prelude::*;
+
+wingfoil::nitro! {
+    fn cloning(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).clone();
+        out
+    }
+}
+
+wingfoil::nitro! {
+    fn taking_handle(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).handle();
+        out
+    }
+}
+
+wingfoil::nitro! {
+    fn raw_wiring(g: &GraphBuilder) -> Stream<u64> {
+        let out = g
+            .ticker(Duration::from_nanos(10))
+            .wire(|b, h| b.map(h, |value| *value));
+        out
+    }
+}
+
+fn main() {}

--- a/crates/wingfoil/tests/trybuild/inherent_stream_methods.stderr
+++ b/crates/wingfoil/tests/trybuild/inherent_stream_methods.stderr
@@ -1,0 +1,17 @@
+error: `.clone()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it clones the fluent stream handle rather than adding a graph node
+  --> tests/trybuild/inherent_stream_methods.rs:12:54
+   |
+12 |         let out = g.ticker(Duration::from_nanos(10)).clone();
+   |                                                      ^^^^^
+
+error: `.handle()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it exposes the interpreted runner handle rather than adding a graph node
+  --> tests/trybuild/inherent_stream_methods.rs:19:54
+   |
+19 |         let out = g.ticker(Duration::from_nanos(10)).handle();
+   |                                                      ^^^^^^
+
+error: `.wire(..)` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it is the low-level fluent extension hook rather than a named graph op
+  --> tests/trybuild/inherent_stream_methods.rs:28:14
+   |
+28 |             .wire(|b, h| b.map(h, |value| *value));
+   |              ^^^^


### PR DESCRIPTION
## What this changes

`nitro!` now rejects the `clone`, `handle`, and `wire` names before forwarder emission, with a curated call-site diagnostic explaining each `Stream` method collision. A trybuild fixture pins all three errors and verifies that generated `__WF_OP_*` failures do not leak through.

## Why

Ordinary fluent wiring resolves these names on `Stream`, while compiled emission could resolve same-named op forwarders. Reserving the closed three-name collision set keeps the two tiers unambiguous without reintroducing an allowlist of valid ops.

Closes #784.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features --lib` (321 passed)
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --test trybuild` (11 fixtures passed)
- [ ] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
  - The all-features run passed 321 library tests and 20 Aeron adapter tests, then the Docker-backed `aeron_integration` binary timed out waiting for `/dev/shm/aeron-integration-test/cnc.dat` on macOS (17 failures, 1 expected no-driver test passed). The dedicated CI workflow supplies that media driver.
- [ ] New behaviour is covered by a test asserting **values and tick times**
  - Not applicable: this changes compile-time diagnostics only; graph construction and runtime semantics are untouched.

## Notes for the reviewer

The denylist remains the issue's closed `clone` / `handle` / `wire` set. Unknown built-in or user-defined op names still take the naming-convention forwarder path unchanged.
