### PR TITLE
Extend inherent method denylist to all Stream public methods

### DIFF
--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -178,18 +178,27 @@
 //! macro cannot dispatch surfaces as an *unresolved forwarder* rather than as a
 //! message about the method. There are three cases, and they read differently:
 //!
-//! **A name reserved by `Stream`'s inherent interface** — `clone`, `handle`, or
-//! `wire` — is rejected with one message explaining the collision. Those names
-//! cannot identify user ops: ordinary fluent wiring would resolve the inherent
-//! method while compiled emission resolved a same-named forwarder, making the
-//! two tiers mean different things.
+//! **A name reserved by `Stream`'s inherent interface** — `clone`, `handle`,
+//! `graph`, `wire`, `value_slot`, `build` or `upstream` — is rejected with one
+//! message explaining the collision. Those names cannot identify user ops:
+//! ordinary fluent wiring would resolve the inherent method while compiled
+//! emission resolved a same-named forwarder, making the two tiers mean
+//! different things.
+//!
+//! ```text
+//! error: `.build()` is reserved by `Stream`'s inherent interface and cannot be
+//!        used as a `nitro!` op name: it consumes the whole graph into a
+//!        `Runner` rather than adding a graph node — a `nitro!` block wires the
+//!        graph, and the caller builds and runs it
+//! ```
 //!
 //! This denylist is deliberately the small, closed inherent surface — it is not
 //! an allowlist of valid ops. New built-in and user-defined op names still need
-//! no macro-crate change.
+//! no macro-crate change; a new method on `impl<T> Stream<T>` does.
 //!
 //! **A method that cannot be an op** — `split` (two outputs, where an `Op` has
-//! one `Out`) or `feedback` (a cycle) — is rejected with one message naming
+//! one `Out`), `feedback` (a cycle), or `collapse_accumulate` / `filter_none`
+//! (sugar over `fold` / `map_filter`) — is rejected with one message naming
 //! what to write instead:
 //!
 //! ```text
@@ -923,19 +932,29 @@ impl ChainWalker {
 /// This is **not** the per-op dispatch table the design removed (see
 /// `docs/decisions/macro-extensibility-decision.md`). That table listed the ops the macro
 /// *supports*, so it grew with every op added and was the thing that could
-/// drift. This list is its complement and is **closed**: `Stream`'s three
-/// public op-name collisions (`clone`, `handle`, `wire`) plus the fluent
-/// methods that cannot be ops — mirroring the documented fluent-only allowlist
-/// in `tests/op_completeness.rs`. Adding an op never touches it; dispatch still
-/// resolves by naming convention alone.
+/// drift. This list is its complement and is **closed**: `Stream`'s inherent
+/// op-name collisions — every public method of its `impl<T> Stream<T>` plus
+/// `clone` — and the fluent methods that cannot be ops, mirroring the
+/// documented fluent-only allowlist in `tests/op_completeness.rs`. Adding an op
+/// never touches it; dispatch still resolves by naming convention alone.
 ///
-/// It is deliberately short, and got shorter: `not` and `collapse` were here
-/// until they were promoted to real ops ([`ops::Not`] / [`ops::Collapse`]) and
-/// began working in `nitro!` outright — the same move `count`, `accumulate` and
-/// `merge_all` made before them. **Promoting is the preferred fix; this list is
-/// for what is left**, which is the two that have no promotion available:
-/// `split` yields two outputs where an `Op` has one `Out`, and `feedback` is a
-/// cycle straight-line compiled emission cannot express.
+/// The inherent half is closed **only while it tracks `fluent.rs`**: it shipped
+/// naming `clone` / `handle` / `wire` alone, which left `graph`, `value_slot`,
+/// `build` and `upstream` falling through to exactly the leaked `__WF_OP_*`
+/// failure described below. `.build()` was the costly omission — `Stream::build`
+/// is the documented way to close a fluent chain (`.print().build().run(..)`),
+/// so it is the one a user is most likely to carry into a `nitro!` block by
+/// habit. Add a method to `impl<T> Stream<T>` and it belongs here too.
+///
+/// The fluent-only half is deliberately short, and got shorter: `not` and
+/// `collapse` were here until they were promoted to real ops ([`ops::Not`] /
+/// [`ops::Collapse`]) and began working in `nitro!` outright — the same move
+/// `count`, `accumulate` and `merge_all` made before them. **Promoting is the
+/// preferred fix; this list is for what is left**: `split` yields two outputs
+/// where an `Op` has one `Out`, `feedback` is a cycle straight-line compiled
+/// emission cannot express, and `collapse_accumulate` / `filter_none` are
+/// one-liners over `fold` / `map_filter`, both already ops — so the primitive
+/// is what a compiled graph should spell.
 ///
 /// It exists purely for diagnostics and collision hygiene. An inherent method
 /// name could otherwise mean one thing in the ordinary `wire()` function and
@@ -951,6 +970,10 @@ impl ChainWalker {
 /// know the open set of user-defined ops, which is the whole point of the
 /// design.
 fn non_op_method_advice(method: &str) -> Option<String> {
+    // Every public method of `impl<T> Stream<T>` in `fluent.rs`, plus the
+    // `Clone` impl. Kept in that order so the two can be diffed by eye when a
+    // method is added there — an addition that is *not* mirrored here reopens
+    // the leaked-`__WF_OP_*` failure this closes.
     let inherent = match method {
         "clone" => Some((
             ".clone()",
@@ -960,9 +983,27 @@ fn non_op_method_advice(method: &str) -> Option<String> {
             ".handle()",
             "it exposes the interpreted runner handle rather than adding a graph node",
         )),
+        "graph" => Some((
+            ".graph()",
+            "it returns the `GraphBuilder` this stream belongs to rather than adding a graph node",
+        )),
         "wire" => Some((
             ".wire(..)",
             "it is the low-level fluent extension hook rather than a named graph op",
+        )),
+        "value_slot" | "__slot" => Some((
+            ".value_slot()",
+            "it hands out the stream's value slot for a `custom_node` to read, rather than \
+             adding a graph node",
+        )),
+        "build" => Some((
+            ".build()",
+            "it consumes the whole graph into a `Runner` rather than adding a graph node — a \
+             `nitro!` block wires the graph, and the caller builds and runs it",
+        )),
+        "upstream" => Some((
+            ".upstream()",
+            "it erases the stream to a `custom_node` edge rather than adding a graph node",
         )),
         _ => None,
     };
@@ -977,10 +1018,22 @@ fn non_op_method_advice(method: &str) -> Option<String> {
         // `not` and `collapse` were here until they became real ops
         // (`ops::Not` / `ops::Collapse`) and started working in `nitro!`
         // outright. What is left is what *cannot* be promoted: `split` has two
-        // outputs where an `Op` has one, and `feedback` is a cycle.
+        // outputs where an `Op` has one, `feedback` is a cycle, and the last
+        // two are one-liners over a primitive that is already an op.
         "split" => {
             "it is sugar over two `map`s — bind them separately: \
              `let a = pairs.map(|t| t.0.clone()); let b = pairs.map(|t| t.1.clone());`"
+        }
+        "collapse_accumulate" => {
+            "it is sugar over `fold` — spell the primitive: \
+             `.fold(Vec::new(), |acc, burst| acc.extend(burst.iter().cloned()))`. Like \
+             `accumulate`, it grows for the whole run, so it is a test instrument rather \
+             than an output edge"
+        }
+        "filter_none" => {
+            "it is sugar over `map_filter` — spell the primitive: \
+             `.map_filter(|opt| match opt.clone() { Some(v) => (v, true), None => \
+             (Default::default(), false) })`"
         }
         "feedback" => {
             "it closes a cycle in the DAG, which straight-line compiled emission \

--- a/crates/wingfoil/examples/core/dual_mode/README.md
+++ b/crates/wingfoil/examples/core/dual_mode/README.md
@@ -128,10 +128,28 @@ let chained = count.map_n(n, |i| i + 1);
 ### When a method is rejected
 
 Dispatch is by naming convention, not a table, so a method `nitro!` cannot
-dispatch shows up as an unresolved *forwarder*. Two cases:
+dispatch shows up as an unresolved *forwarder*. Three cases:
+
+**A name reserved by `Stream`'s inherent interface** — `clone`, `handle`,
+`graph`, `wire`, `value_slot`, `build` or `upstream`. These are not combinators
+at all, so they cannot identify an op: fluent wiring would resolve the inherent
+method while compiled emission resolved a same-named forwarder, and the two
+tiers would mean different things. One message, at your call site:
+
+```text
+error: `.build()` is reserved by `Stream`'s inherent interface and cannot be
+       used as a `nitro!` op name: it consumes the whole graph into a `Runner`
+       rather than adding a graph node — a `nitro!` block wires the graph, and
+       the caller builds and runs it
+```
+
+`.build()` is the one worth knowing about: it is how you close a *fluent* chain
+(`.print().build().run(..)`), so it is easy to carry into a `nitro!` block by
+habit. A `nitro!` block only wires — the caller builds and runs what it returns.
 
 **A method that cannot be an op** — `split` (two outputs, where an `Op` has one
-`Out`) or `feedback` (a cycle). One message, naming the replacement:
+`Out`), `feedback` (a cycle), or `collapse_accumulate` / `filter_none` (sugar
+over `fold` / `map_filter`). One message, naming the replacement:
 
 ```text
 error: `.split(..)` has no `nitro!` forwarder, so it cannot appear in a compiled

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -77,13 +77,24 @@
 //!       value is a handle, and `compiled()` is outputs-only).
 //!
 //! **2. Sugar over a primitive — spell the primitive in `nitro!`:**
-//!   * `split` → two `map`s. It is the only one left, and it is left because it
-//!     **cannot** be promoted: it yields two output streams where an `Op` has
-//!     one `Out`, and `nitro!`'s grammar binds one name to one node.
+//!   * `split` → two `map`s. It **cannot** be promoted: it yields two output
+//!     streams where an `Op` has one `Out`, and `nitro!`'s grammar binds one
+//!     name to one node.
 //!     (`map_n` / `fan` / `merge_all` are the *exception* — the macro
 //!     recognises them, unrolling the first two as repetition sugar and
 //!     emitting the last two through the variadic `merge_n`; covered in
 //!     `surface_sugar` below and in `merge_n.rs`.)
+//!   * `collapse_accumulate` → `fold`, and `filter_none` → `map_filter`. Both
+//!     are inherent one-liners on a *specialised* `Stream` (`Stream<Burst<T>>`
+//!     and `Stream<Option<T>>`), which is how they stayed out of this list
+//!     until now: the guard was written against the `StreamOps` surface, the
+//!     same blind spot that swallowed `combine` and all 36 of `StatisticsOps`.
+//!     Neither needs promoting — `Fold` and `MapFilter` are already ops and
+//!     already dual-mode, so the primitive is what a compiled graph spells.
+//!     `collapse_accumulate` additionally inherits `accumulate`'s status as a
+//!     *test instrument* (it grows for the whole run), which is its own reason
+//!     not to want it in a compiled kernel. Both are rejected by name in
+//!     `nitro!`, pinned by `tests/trybuild/fluent_only_sugar.rs`.
 //!
 //!     **`not` and `collapse` were here and have since been promoted** to real
 //!     ops (`ops::Not` / `ops::Collapse`), so both are dual-mode now and are

--- a/crates/wingfoil/tests/trybuild/fluent_only_sugar.rs
+++ b/crates/wingfoil/tests/trybuild/fluent_only_sugar.rs
@@ -1,0 +1,25 @@
+// `collapse_accumulate` and `filter_none` are inherent one-liners over `fold`
+// and `map_filter` — both already ops — so neither has forwarders of its own.
+// Like `split`, they resolve fine fluently, which is what makes the untreated
+// failure so poor: the expansion dies on `__WF_OP_*` internals with no `no
+// method named` error to explain them. Each must name the primitive to spell
+// instead. See `fluent_only_split.rs` for the same shape on `split`.
+#![allow(unused)]
+use std::time::Duration;
+use wingfoil::prelude::*;
+
+wingfoil::nitro! {
+    fn collapsing(g: &GraphBuilder, bursts: &Stream<Burst<u64>>) -> Stream<Vec<u64>> {
+        let out = bursts.collapse_accumulate();
+        out
+    }
+}
+
+wingfoil::nitro! {
+    fn dropping_none(g: &GraphBuilder, opts: &Stream<Option<u64>>) -> Stream<u64> {
+        let out = opts.filter_none();
+        out
+    }
+}
+
+fn main() {}

--- a/crates/wingfoil/tests/trybuild/fluent_only_sugar.stderr
+++ b/crates/wingfoil/tests/trybuild/fluent_only_sugar.stderr
@@ -1,0 +1,11 @@
+error: `.collapse_accumulate(..)` has no `nitro!` forwarder, so it cannot appear in a compiled graph: it is sugar over `fold` — spell the primitive: `.fold(Vec::new(), |acc, burst| acc.extend(burst.iter().cloned()))`. Like `accumulate`, it grows for the whole run, so it is a test instrument rather than an output edge
+  --> tests/trybuild/fluent_only_sugar.rs:13:26
+   |
+13 |         let out = bursts.collapse_accumulate();
+   |                          ^^^^^^^^^^^^^^^^^^^
+
+error: `.filter_none(..)` has no `nitro!` forwarder, so it cannot appear in a compiled graph: it is sugar over `map_filter` — spell the primitive: `.map_filter(|opt| match opt.clone() { Some(v) => (v, true), None => (Default::default(), false) })`
+  --> tests/trybuild/fluent_only_sugar.rs:20:24
+   |
+20 |         let out = opts.filter_none();
+   |                        ^^^^^^^^^^^

--- a/crates/wingfoil/tests/trybuild/inherent_stream_methods.rs
+++ b/crates/wingfoil/tests/trybuild/inherent_stream_methods.rs
@@ -3,6 +3,10 @@
 // compiled emission resolved a same-named forwarder, giving the two tiers
 // different meanings. Each collision must produce one curated diagnostic at
 // the call site rather than leaking generated `__WF_OP_*` errors.
+//
+// One block per public method of `impl<T> Stream<T>` in `fluent.rs`, plus
+// `clone`. The set shipped as `clone` / `handle` / `wire` alone, which left the
+// other four leaking `__WF_OP_*`; these blocks are what keeps the two in step.
 #![allow(unused)]
 use std::time::Duration;
 use wingfoil::prelude::*;
@@ -22,10 +26,40 @@ wingfoil::nitro! {
 }
 
 wingfoil::nitro! {
+    fn reaching_the_builder(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).graph();
+        out
+    }
+}
+
+wingfoil::nitro! {
     fn raw_wiring(g: &GraphBuilder) -> Stream<u64> {
         let out = g
             .ticker(Duration::from_nanos(10))
             .wire(|b, h| b.map(h, |value| *value));
+        out
+    }
+}
+
+wingfoil::nitro! {
+    fn taking_slot(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).value_slot();
+        out
+    }
+}
+
+// The likeliest of the seven to be typed by habit: `Stream::build` is the
+// documented way to close a *fluent* chain (`.print().build().run(..)`).
+wingfoil::nitro! {
+    fn closing_the_chain(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).build();
+        out
+    }
+}
+
+wingfoil::nitro! {
+    fn erasing_to_an_edge(g: &GraphBuilder) -> Stream<u64> {
+        let out = g.ticker(Duration::from_nanos(10)).upstream();
         out
     }
 }

--- a/crates/wingfoil/tests/trybuild/inherent_stream_methods.stderr
+++ b/crates/wingfoil/tests/trybuild/inherent_stream_methods.stderr
@@ -1,17 +1,41 @@
 error: `.clone()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it clones the fluent stream handle rather than adding a graph node
-  --> tests/trybuild/inherent_stream_methods.rs:12:54
+  --> tests/trybuild/inherent_stream_methods.rs:16:54
    |
-12 |         let out = g.ticker(Duration::from_nanos(10)).clone();
+16 |         let out = g.ticker(Duration::from_nanos(10)).clone();
    |                                                      ^^^^^
 
 error: `.handle()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it exposes the interpreted runner handle rather than adding a graph node
-  --> tests/trybuild/inherent_stream_methods.rs:19:54
+  --> tests/trybuild/inherent_stream_methods.rs:23:54
    |
-19 |         let out = g.ticker(Duration::from_nanos(10)).handle();
+23 |         let out = g.ticker(Duration::from_nanos(10)).handle();
    |                                                      ^^^^^^
 
-error: `.wire(..)` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it is the low-level fluent extension hook rather than a named graph op
-  --> tests/trybuild/inherent_stream_methods.rs:28:14
+error: `.graph()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it returns the `GraphBuilder` this stream belongs to rather than adding a graph node
+  --> tests/trybuild/inherent_stream_methods.rs:30:54
    |
-28 |             .wire(|b, h| b.map(h, |value| *value));
+30 |         let out = g.ticker(Duration::from_nanos(10)).graph();
+   |                                                      ^^^^^
+
+error: `.wire(..)` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it is the low-level fluent extension hook rather than a named graph op
+  --> tests/trybuild/inherent_stream_methods.rs:39:14
+   |
+39 |             .wire(|b, h| b.map(h, |value| *value));
    |              ^^^^
+
+error: `.value_slot()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it hands out the stream's value slot for a `custom_node` to read, rather than adding a graph node
+  --> tests/trybuild/inherent_stream_methods.rs:46:54
+   |
+46 |         let out = g.ticker(Duration::from_nanos(10)).value_slot();
+   |                                                      ^^^^^^^^^^
+
+error: `.build()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it consumes the whole graph into a `Runner` rather than adding a graph node — a `nitro!` block wires the graph, and the caller builds and runs it
+  --> tests/trybuild/inherent_stream_methods.rs:55:54
+   |
+55 |         let out = g.ticker(Duration::from_nanos(10)).build();
+   |                                                      ^^^^^
+
+error: `.upstream()` is reserved by `Stream`'s inherent interface and cannot be used as a `nitro!` op name: it erases the stream to a `custom_node` edge rather than adding a graph node
+  --> tests/trybuild/inherent_stream_methods.rs:62:54
+   |
+62 |         let out = g.ticker(Duration::from_nanos(10)).upstream();
+   |                                                      ^^^^^^^^

--- a/docs/decisions/macro-extensibility-decision.md
+++ b/docs/decisions/macro-extensibility-decision.md
@@ -197,7 +197,17 @@ nobody reading the tracker would find it. The three live items were filed on
 |---|---|
 | `#[op]` out-of-crate — emit `::wingfoil::` paths + an extension trait, so a user op is `impl Op` + `#[op(build = name)]` + a 3-line fluent method rather than ~40 hand-written lines | [#782](https://github.com/wingfoil-io/wingfoil/issues/782) |
 | `nitro!` / `compiled()` never call the generated `_stop` / `_teardown` forwarders — the forwarders exist, the emission side does not | [#783](https://github.com/wingfoil-io/wingfoil/issues/783) |
-| Collision hygiene: denylist `Stream`'s inherent methods (`clone`, `handle`, `wire`) so typos there keep a curated error | [#784](https://github.com/wingfoil-io/wingfoil/issues/784) |
+| ~~Collision hygiene: denylist `Stream`'s inherent methods so typos there keep a curated error~~ ✅ **done** ([#794](https://github.com/wingfoil-io/wingfoil/pull/794), extended in follow-up) | [#784](https://github.com/wingfoil-io/wingfoil/issues/784) |
+
+The collision-hygiene row is worth one line of record, because it landed in two
+steps and the first was short. It shipped naming `clone` / `handle` / `wire` —
+the three this section had listed — which left `graph`, `value_slot`, `build`
+and `upstream` still leaking `__WF_OP_*` internals, `.build()` most costly of
+them: it is the documented way to close a *fluent* chain, so it is the one a
+user carries into a `nitro!` block by habit. The denylist is now every public
+method of `impl<T> Stream<T>` plus `clone`, pinned method-for-method by
+`tests/trybuild/inherent_stream_methods.rs`. **The set is closed only while it
+tracks `fluent.rs`** — a new inherent method on `Stream` belongs in both.
 
 The fourth item is done and stays here as the record:
 


### PR DESCRIPTION
## What this changes

Extends the collision-hygiene denylist from three inherent methods (`clone`, `handle`, `wire`) to all seven public methods of `impl<T> Stream<T>` — adding `graph`, `value_slot`, `build` and `upstream`. Also rejects the two fluent-only sugar methods that have no forwarders of their own (`collapse_accumulate`, `filter_none`). All six were leaking `__WF_OP_*` internals; each now produces one curated diagnostic at the call site.

## Why

[#794](https://github.com/wingfoil-io/wingfoil/pull/794) curated the diagnostic for three of the seven names `Stream` actually reserves. The other four still fell through to the generated forwarder path and failed on `__WF_OP_*` internals — with no `no method named` error to explain them, because the methods *do* exist on `Stream`. That is the exact failure the denylist exists to close.

`.build()` was the costly omission: `Stream::build` is the documented way to close a *fluent* chain (`.print().build().run(..)`), so it is the one a user carries into a `nitro!` block by habit. Before this change, on `main`:

```text
error[E0425]: cannot find value `__WF_OP_BUILD_ACTIVATION` in this scope
error[E0425]: cannot find value `__WF_OP_BUILD_PASSIVE` in this scope
error[E0308]: mismatched types
error[E0425]: cannot find function `__wf_op_build_cycle` in this scope

help: a function with a similar name exists
  -         let out = g.ticker(Duration::from_nanos(10)).build();
  +         let out = g.ticker(Duration::from_nanos(10)).__wf_op_map_cycle();
```

Four errors, every symbol macro-internal, and a suggestion that is actively wrong. After: one message, at the call site, naming the real problem.

`collapse_accumulate` and `filter_none` are inherent one-liners over `fold` / `map_filter` — already ops, already dual-mode — so they take the "spell the primitive" advice `split` gets rather than being promoted.

Closes #784.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features` — 323 lib tests, 20 Aeron adapter tests and all 12 trybuild fixtures pass. The Docker-backed `aeron_integration` binary fails 17/18 on `failed to initialize a docker client: Socket not found: /var/run/docker.sock` — no Docker in the dev sandbox, the same environmental gap #794 reported from macOS. The dedicated CI workflow supplies that driver.
- [ ] New behaviour is covered by a test asserting **values and tick times**
  - Not applicable: compile-time diagnostics only. Graph construction and runtime semantics are untouched, which is why the coverage is trybuild fixtures — a rejected program has no values or tick times to assert on.

## Notes for the reviewer

The denylist is deliberately closed and minimal — it is not an allowlist of valid ops. **Adding an op still needs no macro-crate change; adding an inherent method to `Stream` does.** That is the invariant this PR turns from a claim into something pinned: one trybuild block per method, so `fluent.rs` and the denylist can be diffed by eye.

Being inherent methods on a *specialised* `Stream` (`Stream<Burst<T>>`, `Stream<Option<T>>`) is how the two sugar methods escaped `tests/op_completeness.rs` until now — that guard is written against the `StreamOps` surface, the same blind spot that swallowed `combine` and all 36 of `StatisticsOps`. Both are now classified there, so neither is left "silently in neither".

Docs updated where the taxonomy is spelled out and had gone stale: `examples/core/dual_mode/README.md` still said "Two cases", and the decision record still carried #784 as open work.

Two environment prerequisites surfaced while running `lint-all` and the full test suite in a clean sandbox, both undocumented in `CLAUDE.md`: the Aeron adapter also needs **`libbsd-dev`** (link fails with `rust-lld: error: unable to find library -lbsd`), and `protoc` is needed for `cargo lint-all`, not only for builds. Left out of this diff as unrelated; happy to fold into the dev-setup docs separately.
