### PR TITLE
Point the op/adapter skills at `main`, not the retired `next`

### DIFF
--- a/.claude/commands/bind-adapter.md
+++ b/.claude/commands/bind-adapter.md
@@ -55,13 +55,14 @@ ideally in the same PR.
 
 ## 1. Branch
 
-Cut from `next`, never `main` (see `CLAUDE.md`):
+Never edit files directly on `main` — cut the feature branch from it (see
+`CLAUDE.md`):
 
 ```bash
-git checkout next && git pull origin next && git checkout -b bind-$ARGUMENTS-python
+git checkout main && git pull origin main && git checkout -b bind-$ARGUMENTS-python
 ```
 
-The PR targets base `next`.
+The PR targets base `main`.
 
 ## 2. Feature gate — `crates/wingfoil-python/Cargo.toml`
 
@@ -507,7 +508,7 @@ cargo clippy --manifest-path crates/wingfoil-python/Cargo.toml --features all-ad
 
 Before opening the PR, run a clean-context review pass as a subagent:
 
-1. Re-read this file, then walk `git diff next...HEAD` against steps 1–8 and
+1. Re-read this file, then walk `git diff main...HEAD` against steps 1–8 and
    produce a present / missing / diverged checklist.
 2. Diff the binding against legacy `py_$ARGUMENTS.rs` one more time: every
    entry point, argument, and default → equivalent or a numbered deviation in

--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -195,15 +195,14 @@ signature, several natural call sites (see `AugursForecastConfig`'s
 
 ## 1. Branch
 
-**All wingfoil work cuts from and merges into `next`, never `main`** (see
-`CLAUDE.md`). Cut the feature branch from `next`:
+**Never edit files directly on `main`** (see `CLAUDE.md`). `main` is the trunk
+for every part of this repository — cut the feature branch from it:
 
 ```bash
-git checkout next && git pull origin next && git checkout -b $ARGUMENTS-next
+git checkout main && git pull origin main && git checkout -b $ARGUMENTS-adapter
 ```
 
-When you open the PR, its **base branch must be `next`** — not `main`. Only the
-eventual next→main cutover PRs target `main`.
+When you open the PR, its **base branch is `main`**.
 
 ## 2. Choose the adapter shape
 
@@ -1015,11 +1014,11 @@ CI where aeron's deps are present. Note it in the PR if you substituted.
 Before opening a PR, run a clean-context review pass as a subagent (so the
 parent context stays clean) with these tasks:
 
-1. **Re-read this skill file end to end**, then walk `git diff next...HEAD`
+1. **Re-read this skill file end to end**, then walk `git diff main...HEAD`
    against steps 1–14 and produce a checklist: present / missing / diverged.
    Flag every divergence, even intentional ones.
-2. **Validate the artifacts exist**: branch cut from `next` and the PR targets
-   base `next`, not `main` (step 1); feature flags (step 3); both
+2. **Validate the artifacts exist**: branch cut from `main` and the PR targets
+   base `main` (step 1); feature flags (step 3); both
    `mod.rs` edits — gate *and* doc bullet (step 4); module docs with the
    Layering section (step 6); factory returns `Result` for wiring-time I/O
    and the trait is out of the prelude (steps 7–8); a realtime-only sink

--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -57,14 +57,14 @@ actually add ops is a bug.
 
 ## 1. Branch
 
-**All wingfoil work cuts from and merges into `next`, never `main`** (see
-`CLAUDE.md`). Cut the feature branch from `next`:
+**Never edit files directly on `main`** (see `CLAUDE.md`). `main` is the trunk
+for every part of this repository — cut the feature branch from it:
 
 ```bash
-git checkout next && git pull origin next && git checkout -b $ARGUMENTS-op-next
+git checkout main && git pull origin main && git checkout -b $ARGUMENTS-op
 ```
 
-When you open the PR, its **base branch must be `next`** — not `main`.
+When you open the PR, its **base branch is `main`**.
 
 ## 2. Classify the op shape — the load-bearing decision
 
@@ -629,10 +629,10 @@ Note the substitution in the PR; the full workspace `lint-all` runs in CI.
 
 Before opening a PR, run a clean-context review pass as a subagent:
 
-1. **Re-read this skill end to end**, then walk `git diff next...HEAD` against
+1. **Re-read this skill end to end**, then walk `git diff main...HEAD` against
    steps 1–9 and produce a present / missing / diverged checklist. Flag every
    divergence, even intentional ones.
-2. **Validate the artifacts**: branch cut from `next`, PR base `next` (step 1);
+2. **Validate the artifacts**: branch cut from `main`, PR base `main` (step 1);
    the `Op` impl with correct `ACTIVATION` and `Tick` variants (steps 2–3);
    closure configs are `Fn` not `FnMut`; `State: Default` (or `init_arg`); a
    `no_builder` is justified by a signature that differs from the shape, not by


### PR DESCRIPTION
## What this changes

The branch step and the self-review step in all three contributor recipes — `/new-op`, `/new-adapter`, `/bind-adapter` — now cut from and target `main` instead of `next`.

Docs only. No Rust touched.

## Why

`next` is retired and deleted (`git branch -a` shows only `main`), but every skill still opened with:

```bash
git checkout next && git pull origin next && git checkout -b <name>-op-next
```

So anyone following a recipe end to end failed on its first command. The same drift ran through the step-10 self-review instructions, which diffed against `next...HEAD`.

This surfaced while splitting #459 into per-combinator issues (#797–#803). Those issues are a contributor on-ramp that points at `/new-op` as the recipe, so a broken first step is a broken first PR — the reason to fix it now rather than at the next skill edit.

`CLAUDE.md` already rules on this: the skills are living documents, and "a skill that has drifted from how we actually build ops/adapters is a bug; treat updating it as part of 'done'."

## How it was verified

Docs-only change, so the code checklist doesn't apply — the pre-commit hook ran `fmt` and `clippy` over an unchanged workspace.

- Confirmed `next` no longer exists: `git branch -a` → `main` plus this branch.
- Re-read the three branch steps and the two self-review steps against `CLAUDE.md`'s "Branching: everything merges into `main`" section.
- Checked the remaining `next` occurrences in each file are incidental prose ("the next reader", "next to `ticker`", "its next loop turn") and left them alone.

## Notes for the reviewer

Scope was kept deliberately narrow — only instructions that name a branch. Worth a follow-up sweep for the same drift elsewhere: `CONTRIBUTING.md`, the issue templates, and the `legacy/*` workflows (`CLAUDE.md` notes those last ones retire wholesale at cutover, so they may be fine to leave).

One naming call: the `new-adapter` branch suffix became `-adapter` rather than the old `-next`, since the suffix existed to mark the integration branch. Same for `-op` in `new-op`. Cosmetic, easy to change if you'd rather they stay bare.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vVXnzZdkC4pD2yu1sVAa8)_