### PR TITLE
README: name the markets the engine actually serves today

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 # Wingfoil
 
 Wingfoil is a [blazingly fast](crates/wingfoil/benches/) stream processing
-engine for latency-critical systems such as electronic trading and real-time AI.
+engine for latency-critical systems: electronic trading, real-time decisioning
+and streaming ML features.
 
 Wire a graph of calculations once and Wingfoil runs it — interpreted, compiled
 into a single monomorphized function, or as compiled islands inside an

--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -5,9 +5,9 @@
 [![Python docs](https://img.shields.io/readthedocs/wingfoil/latest?logo=readthedocs&logoColor=white&label=python%20docs)](https://wingfoil.readthedocs.io/en/latest/)
 
 Wingfoil is a blazingly fast, highly scalable stream processing framework
-designed for latency-critical use cases such as electronic trading and
-real-time AI systems. You define a graph of transformations over streams;
-Wingfoil drives their execution in a tightly scheduled
+designed for latency-critical use cases: electronic trading, real-time
+decisioning and streaming ML features. You define a graph of transformations
+over streams; Wingfoil drives their execution in a tightly scheduled
 [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph), either against
 live data or replayed history.
 

--- a/crates/wingfoil/README.md
+++ b/crates/wingfoil/README.md
@@ -1,8 +1,8 @@
 # wingfoil
 
 The Wingfoil engine: a dual-mode stream-processing library for building
-DAGs of data transformations, for latency-critical use cases such as electronic
-trading and real-time AI systems.
+DAGs of data transformations, for latency-critical use cases: electronic
+trading, real-time decisioning and streaming ML features.
 
 You describe your graph once, in a single fluent wiring, and choose how to run
 it. Every tier is derived from the same definition, so they cannot drift — there


### PR DESCRIPTION
## What this changes

The opening line of the root, `crates/wingfoil` and `crates/wingfoil-python` READMEs:

> **before** — …for latency-critical systems such as electronic trading and **real-time AI**.
> **after** — …for latency-critical systems: **electronic trading, real-time decisioning and streaming ML features**.

Docs only.

## Why

The trading half of the old claim is true and demonstrated. The AI half is aspiration: there is no AI example in the tree, no tensor type, no inference adapter — and the engine's headline advantage, ~27 ns of per-node overhead, does not count in a pipeline dominated by a millisecond forward pass, let alone an LLM call. Someone arriving from that world checks, finds nothing, and reads the rest of the page as overclaiming. That is an expensive first impression for the claim that is least defensible.

The replacement names markets the existing differentiators genuinely serve. "Streaming ML features" in particular is not a promise about models — it points at the rolling and time-weighted aggregate catalog in `stats.rs`, which is what a feature pipeline is made of and which already ships today.

## How it was verified

Docs-only, so the code checklist doesn't apply.

- `grep -ri "real-time ai"` across the tree outside `legacy/` returns nothing after this change.
- The `Cargo.toml` `description` fields that feed crates.io never mentioned AI — checked and left untouched.
- Reflowed the `wingfoil-python` paragraph so the surrounding lines stay inside the file's wrap width.

## Notes for the reviewer

Purely a positioning change; no capability claim is added, only one removed. `legacy/` is untouched, since it retires at cutover.

Two places still carry the old framing and are **deliberately** left for a separate change: the GitHub repository description (not in the tree) and `docs/comparison.md`, whose Wingfoil row lists "no trading domain model" as a con — arguably it should read as a domain-neutral core with domain vocabulary in sibling crates, but that is a rewrite of a public-facing comparison and deserves its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vVXnzZdkC4pD2yu1sVAa8)_