### PR TITLE
Guard the compiled/island `Op::stop` emission, and correct #783's record

### DIFF
--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -428,7 +428,38 @@ another family, wrap it — do not add a field only one family reads.
 Compiled-specific stateful/lifecycle behaviour has its own suites
 (`tests/compiled_stateful_ops.rs`, `tests/compiled_lifecycle_ops.rs`,
 `tests/nested_islands.rs`) — extend the relevant one if your op is stateful or
-has `start`/`stop` hooks.
+has `start`/`stop`/`teardown` hooks.
+
+**A lifecycle hook is only covered when its *effect* is observed on all three
+tiers.** `#[op]` emits the `_start` / `_stop` / `_teardown` forwarders for every
+op, and `nitro!` calls one per node — but a test that merely runs the graph and
+checks the output value passes whether or not the hook ran. That is how the
+`stop`/`teardown` emission stayed missing from `compiled()` / `nested()` long
+after the forwarders existed (#783), and how the `stop` half then stayed
+unguarded after it landed: the only catalog op with a real `stop` is `timed`,
+whose hook *prints*. So for an op with an end-of-run hook, add a case to
+`tests/compiled_lifecycle_ops.rs` that:
+
+- records the hook firing into a thread-local log (a counter for "exactly
+  once", an ordered `Vec` for ordering), and asserts the log after
+  `interpreted()`, `compiled()` **and** `nested()`;
+- records the op's **state** as the hook saw it, not just that it fired — that
+  is what pins the hook against the node's real accumulated state rather than a
+  fresh seed;
+- pins the ordering the interpreted `Runner` defines and the other two must
+  mirror: every node's `stop` in node order, then every node's `teardown` in
+  node order, with cleanup running even after a `start`/`cycle` abort (first
+  error wins). `finally` is the ready-made teardown probe; a `stop` probe has to
+  be a purpose-built op.
+- **Sanity-check the guard by breaking the thing it guards.** Delete the
+  emission (the `#(#stops)*` / `#(#teardowns)*` splice in `expand_compiled` /
+  `expand_nested`), confirm your test — and ideally *only* your test — fails,
+  then restore. A lifecycle test that passes both ways is worth nothing.
+
+For a probe op keep the `Cfg` equal to the call-site argument type (a
+`&'static str` label, not an owned `String`): the compiled emission uses
+call-site types verbatim, so an "ergonomic" config makes the op fluent-only and
+it never reaches the tiers you are trying to test (step 5's gotcha).
 
 ### Python bindings — see step 7
 

--- a/crates/wingfoil/tests/compiled_lifecycle_ops.rs
+++ b/crates/wingfoil/tests/compiled_lifecycle_ops.rs
@@ -6,17 +6,29 @@
 //! with the *same* contract the interpreted engine honours: cleanup always
 //! runs (even after a cycle aborts), in node order, first error wins.
 //!
-//! `finally` is the cleanly observable probe: its whole purpose is a
-//! teardown closure. A shared thread-local counter lets each test assert the
-//! closure fires **exactly once**, at run end, on all three engines — and a
-//! shared order log asserts multiple lifecycle ops tear down in the same order
-//! everywhere. `print` / `timed` are asserted through value pass-through parity
-//! and clean completion (their diagnostics go to std{out,err}).
+//! `finally` is the cleanly observable probe for the **teardown** half: its
+//! whole purpose is a teardown closure. A shared thread-local counter lets each
+//! test assert the closure fires **exactly once**, at run end, on all three
+//! engines — and a shared order log asserts multiple lifecycle ops tear down in
+//! the same order everywhere. `print` / `timed` are asserted through value
+//! pass-through parity and clean completion (their diagnostics go to
+//! std{out,err}).
+//!
+//! The **stop** half needs its own probe, and no catalog op provides one:
+//! `timed` is the only op with a real `Op::stop`, and its hook prints rather
+//! than yielding anything a test can read. So [`Bookend`] below is a user op
+//! (hand-written forwarders, the `tests/custom_op.rs` pattern) whose entire
+//! observable behaviour *is* its `stop` hook, wired next to a `finally` so one
+//! log pins both hooks *and* the ordering between them — every node's `stop`,
+//! then every node's `teardown`, which is the interpreted `Runner`'s contract.
+//! Until it existed, deleting the compiled/island `stop` emission left the
+//! whole suite green.
 
 use std::cell::{Cell, RefCell};
 use std::time::Duration;
 
-use wingfoil::anyhow::bail;
+use wingfoil::anyhow::{Result, bail};
+use wingfoil::op::Op;
 use wingfoil::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
@@ -26,13 +38,13 @@ const PERIOD: Duration = Duration::from_millis(1);
 thread_local! {
     /// How many times a `finally` teardown closure has fired this run.
     static FINALLY_HITS: Cell<u32> = const { Cell::new(0) };
-    /// The labels lifecycle hooks record as they tear down, in fire order.
-    static TEARDOWN_ORDER: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
+    /// The labels lifecycle hooks record as they fire, in fire order.
+    static LIFECYCLE_ORDER: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
 }
 
 fn reset() {
     FINALLY_HITS.with(|c| c.set(0));
-    TEARDOWN_ORDER.with(|o| o.borrow_mut().clear());
+    LIFECYCLE_ORDER.with(|o| o.borrow_mut().clear());
 }
 fn hits() -> u32 {
     FINALLY_HITS.with(Cell::get)
@@ -40,11 +52,11 @@ fn hits() -> u32 {
 fn bump_hits() {
     FINALLY_HITS.with(|c| c.set(c.get() + 1));
 }
-fn record(label: &'static str) {
-    TEARDOWN_ORDER.with(|o| o.borrow_mut().push(label));
+fn record(label: impl Into<String>) {
+    LIFECYCLE_ORDER.with(|o| o.borrow_mut().push(label.into()));
 }
-fn order() -> Vec<&'static str> {
-    TEARDOWN_ORDER.with(|o| o.borrow().clone())
+fn order() -> Vec<String> {
+    LIFECYCLE_ORDER.with(|o| o.borrow().clone())
 }
 
 // ---------------------------------------------------------------------------
@@ -216,4 +228,173 @@ fn compiled_cleanup_runs_after_cycle_abort() {
         "compiled surfaces the cycle error"
     );
     assert_eq!(1, hits(), "compiled: teardown runs despite the cycle abort");
+}
+
+// ---------------------------------------------------------------------------
+// `Op::stop` — the other end-of-run hook, and the one no catalog op exposes
+// observably. A user op with hand-written forwarders, exactly as
+// `tests/custom_op.rs` writes them (`#[op]`'s generated `Builder` method names
+// `crate::interp::Builder`, so the attribute is in-crate tooling).
+// ---------------------------------------------------------------------------
+
+/// Pass-through op whose observable behaviour lives entirely in
+/// [`Op::stop`]: at end of run it records `<label>:stop:<last value cycled>`.
+///
+/// Recording the *state* — not just the fact of the call — is deliberate: it
+/// pins that the hook is handed the node's real, accumulated state, as the
+/// interpreted engine hands its cycle and its stop the same cfg+state cell.
+///
+/// `Cfg` is the label as a `&'static str` so the `nitro!` call-site argument
+/// type **is** the `Cfg` (the compiled emission uses call-site types verbatim);
+/// an owned `String` config would make the op fluent-only.
+pub struct Bookend;
+
+impl Op for Bookend {
+    type Cfg = &'static str;
+    type State = u64;
+    type In<'a> = (&'a u64,);
+    type Out = u64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut &'static str,
+        state: &mut u64,
+        input: (&u64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<u64>> {
+        *state = *input.0;
+        Ok(Tick::Value(*state))
+    }
+
+    fn stop(cfg: &mut &'static str, state: &mut u64, _ctx: &mut Ctx<'_>) -> Result<()> {
+        record(format!("{cfg}:stop:{state}"));
+        Ok(())
+    }
+}
+
+pub const __WF_OP_BOOKEND_ACTIVATION: Activation = Bookend::ACTIVATION;
+pub const __WF_OP_BOOKEND_PASSIVE: u32 = 0;
+
+pub fn __wf_op_bookend_cycle(
+    cfg: &mut <Bookend as Op>::Cfg,
+    state: &mut <Bookend as Op>::State,
+    input: ((&u64, bool),),
+    ctx: &mut Ctx<'_>,
+) -> Result<Tick<<Bookend as Op>::Out>> {
+    <Bookend as Op>::cycle(cfg, state, (input.0.0,), ctx)
+}
+
+/// Erased no-op: `Bookend` does not override `Op::start`, so op generics must
+/// not appear here (they would dangle at the call site).
+pub fn __wf_op_bookend_start<C, S>(_cfg: &mut C, _state: &mut S, _ctx: &mut Ctx<'_>) -> Result<()> {
+    Ok(())
+}
+
+pub fn __wf_op_bookend_seed_state<P>(_cfg: &P) -> u64 {
+    0
+}
+pub fn __wf_op_bookend_seed_value<P>(_cfg: &P) -> u64 {
+    0
+}
+
+/// The **real** stop forwarder — mirroring the cycle forwarder's signature
+/// (the input is ignored, present only to anchor inference the same way).
+pub fn __wf_op_bookend_stop(
+    cfg: &mut <Bookend as Op>::Cfg,
+    state: &mut <Bookend as Op>::State,
+    input: ((&u64, bool),),
+    ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    let _ = input;
+    <Bookend as Op>::stop(cfg, state, ctx)
+}
+pub fn __wf_op_bookend_teardown(
+    cfg: &mut <Bookend as Op>::Cfg,
+    state: &mut <Bookend as Op>::State,
+    input: ((&u64, bool),),
+    ctx: &mut Ctx<'_>,
+) -> Result<()> {
+    let _ = input;
+    <Bookend as Op>::teardown(cfg, state, ctx)
+}
+
+trait BookendOps {
+    fn bookend(&self, label: &'static str) -> Stream<u64>;
+}
+
+impl BookendOps for Stream<u64> {
+    fn bookend(&self, label: &'static str) -> Stream<u64> {
+        // `register_op1_with_stop` is the public interpreted primitive for the
+        // "op with an end-of-run hook" shape — the interpreted twin of the
+        // `_stop` forwarder the monomorphized tiers call.
+        self.wire(|b, h| {
+            b.register_op1_with_stop(
+                h,
+                "bookend",
+                Bookend::ACTIVATION,
+                label,
+                || 0u64,
+                |c, s, a, ctx| <Bookend as Op>::cycle(c, s, (a,), ctx),
+                <Bookend as Op>::stop,
+            )
+        })
+    }
+}
+
+wingfoil::nitro! {
+    fn stop_then_teardown(g: &GraphBuilder) -> Stream<u64> {
+        let count = g.ticker(PERIOD).count();
+        // `bookend`'s effect is in `Op::stop`, `finally`'s in `Op::teardown`,
+        // so one log covers both hooks and the boundary between them.
+        let watched = count.bookend("bookend");
+        let done = watched.finally(|v: &u64| {
+            record(format!("finally:teardown:{v}"));
+            Ok(())
+        });
+        watched
+    }
+}
+
+/// `Op::stop` fires **exactly once, with the node's real state, before any
+/// node's `teardown`** — on all three engines.
+///
+/// This is the regression guard for the `stop` half of the `nitro!` end-of-run
+/// emission: with the compiled or island `stop` calls removed, the two
+/// monomorphized engines log only `finally:teardown:5` and this test fails
+/// where every other test still passes.
+#[test]
+fn stop_then_teardown_ordering_matches_across_engines() {
+    let run_for = RunFor::Cycles(5);
+    let expected = vec!["bookend:stop:5", "finally:teardown:5"];
+
+    // Interpreted — the oracle: every node's `stop`, then every node's
+    // `teardown`, each in node order.
+    reset();
+    let (mut runner, out) = stop_then_teardown::interpreted();
+    runner.run(HISTORICAL, run_for).unwrap();
+    assert_eq!(5, runner.value(out));
+    let interpreted_order = order();
+    assert_eq!(expected, interpreted_order);
+
+    reset();
+    let (compiled,) = stop_then_teardown::compiled(HISTORICAL, run_for).unwrap();
+    assert_eq!(5, compiled, "compiled pass-through");
+    assert_eq!(
+        interpreted_order,
+        order(),
+        "compiled: stop must run (with real state) before teardown"
+    );
+
+    reset();
+    let g = GraphBuilder::new();
+    let island = stop_then_teardown::nested(&g);
+    let handle = island.handle();
+    let mut runner = g.build();
+    runner.run(HISTORICAL, run_for).unwrap();
+    assert_eq!(5, runner.value(handle), "nested pass-through");
+    assert_eq!(
+        interpreted_order,
+        order(),
+        "nested: the island's inner stop then teardown, driven by the outer run"
+    );
 }

--- a/docs/decisions/macro-extensibility-decision.md
+++ b/docs/decisions/macro-extensibility-decision.md
@@ -117,16 +117,19 @@ expression". The two approximations both exist in this repo's history:
 
 ## 3. `OpInfo`, field by field: trait-derivable vs token-bound
 
-(Note: the current table has no `has_stop`/`has_teardown` fields — `compiled()`
-today emits no stop/teardown for *any* op. The fallback inherits that
-pre-existing gap; forwarder-based `_stop`/`_teardown` emission is the same
-mechanical follow-up for both paths.)
+(Note: the table never grew `has_stop`/`has_teardown` fields, and does not need
+them — the same "call it unconditionally, let the default no-op fold away"
+convention that eliminated `has_start` covers the end-of-run hooks too. It was
+written when `compiled()` emitted no stop/teardown for *any* op; that gap is
+[#783](https://github.com/wingfoil-io/wingfoil/issues/783), closed the same
+mechanical way for the fallback and the derive alike.)
 
 | Field | Verdict | How |
 |---|---|---|
 | `op_type` | **eliminated** | forwarder naming convention; inference names the type |
 | `callback_activated` | **derived** (implemented) | `ACTIVATION` re-emitted as const by `#[op]`; guard folds post-mono |
 | `has_start` / `state_in_start` | **derived** (implemented) | call `_start` unconditionally through forwarders; the default no-op inlines away |
+| `has_stop` / `has_teardown` | **eliminated** (implemented) | `_stop` / `_teardown` are emitted for *every* op and always forward the real hook, so the cleanup tail calls one per node unconditionally; the trait defaults fold away |
 | `owned_closure` | **derived** (implemented) | call-site syntactic fact (literal closure vs other expr) — decided generically from tokens |
 | `cfg_init` | **convention** (implemented) | the single call argument *is* the `Cfg` value; unification handles literals. (`NanoTimeFrom` convenience rows stay table/sugar) |
 | `state_init` | **convention** (implemented) | `Default::default()`, type inferred — same contract as `register_op1`. `fold`'s call-arg seed stays a table row |
@@ -196,7 +199,7 @@ nobody reading the tracker would find it. The three live items were filed on
 | Work | Issue |
 |---|---|
 | `#[op]` out-of-crate — emit `::wingfoil::` paths + an extension trait, so a user op is `impl Op` + `#[op(build = name)]` + a 3-line fluent method rather than ~40 hand-written lines | [#782](https://github.com/wingfoil-io/wingfoil/issues/782) |
-| `nitro!` / `compiled()` never call the generated `_stop` / `_teardown` forwarders — the forwarders exist, the emission side does not | [#783](https://github.com/wingfoil-io/wingfoil/issues/783) |
+| ~~`nitro!` / `compiled()` never call the generated `_stop` / `_teardown` forwarders — the forwarders exist, the emission side does not~~ ✅ **done** — `node_lifecycle` emits both hooks for the `Compiled` and `Nested` targets; see below | [#783](https://github.com/wingfoil-io/wingfoil/issues/783) |
 | ~~Collision hygiene: denylist `Stream`'s inherent methods so typos there keep a curated error~~ ✅ **done** ([#794](https://github.com/wingfoil-io/wingfoil/pull/794), extended in follow-up) | [#784](https://github.com/wingfoil-io/wingfoil/issues/784) |
 
 The collision-hygiene row is worth one line of record, because it landed in two
@@ -208,6 +211,23 @@ user carries into a `nitro!` block by habit. The denylist is now every public
 method of `impl<T> Stream<T>` plus `clone`, pinned method-for-method by
 `tests/trybuild/inherent_stream_methods.rs`. **The set is closed only while it
 tracks `fluent.rs`** — a new inherent method on `Stream` belongs in both.
+
+The stop/teardown row is worth its own line of record, because what it settled
+is a *contract*, not just an emission. The interpreted `Runner` is the oracle:
+every node's `stop` in node order, then every node's `teardown` in node order,
+and **cleanup always runs** — a `start` or `cycle` error is captured, not
+returned early, so an aborted run still flushes and the first error wins. Both
+monomorphized targets now say exactly that. `compiled()` wraps its start+cycle
+phase in an immediately-invoked closure whose `?` lands in `__first_err`, then
+runs the two tails; the island answers the same phases outward, because
+end-of-run for an island is the **outer** run's end — the outer engine drives
+the composite node's own `stop`/`teardown`, which the closure receives as
+`CompositePhase::Stop` / `Teardown`. (That is not the `is_last_cycle` /
+`run_mode` deviation: those are per-*cycle* facts the island is never told, and
+they stay undelivered. End-of-run reaches it through a hook, not through the
+context.) Guarded by `tests/compiled_lifecycle_ops.rs`, which needs **both**
+probes — `finally` for teardown, and a user op whose only effect is its `stop`
+hook, since the one catalog op with a real `stop` (`timed`) only prints.
 
 The fourth item is done and stays here as the record:
 
@@ -267,9 +287,10 @@ with overlapping confidence intervals on a host drifting ±5% between runs
 
 **Option 2, adopted and built.** Migration path: (a) fallback + forwarders +
 const guards + multi-input convention; (b) absorb the residue and delete the
-table — both **done** (§5). (c) `#[op]` out-of-crate and (d) stop/teardown
-emission are [#782](https://github.com/wingfoil-io/wingfoil/issues/782) and
-[#783](https://github.com/wingfoil-io/wingfoil/issues/783). The escape hatch
+table — both **done** (§5); (d) stop/teardown emission — **done**
+([#783](https://github.com/wingfoil-io/wingfoil/issues/783), §4). Only (c)
+`#[op]` out-of-crate remains open, as
+[#782](https://github.com/wingfoil-io/wingfoil/issues/782). The escape hatch
 (`nested()` islands for interpreted-only ops) remains for everything the
 residue still excludes.
 

--- a/docs/planning/port-plan.md
+++ b/docs/planning/port-plan.md
@@ -147,8 +147,12 @@ today's interpreted engine.
   node's `stop` then `teardown` still runs after an abort, first error wins,
   mirroring the interpreted `Runner`. The `_owned` forwarder variant threads a
   literal-closure config through by value so a `finally` closure reaches its
-  own `teardown`. Pinned by `tests/compiled_lifecycle_ops.rs::
-  finally_teardown_fires_once_on_all_three_engines`. The one *structural*
+  own `teardown`. Pinned by `tests/compiled_lifecycle_ops.rs`, which needs one
+  probe per hook: `finally_teardown_fires_once_on_all_three_engines` for
+  `teardown`, and `stop_then_teardown_ordering_matches_across_engines` for
+  `stop` — the latter carrying its own user op, because the only catalog op with
+  a real `Op::stop` (`timed`) merely prints, so nothing observable was asserting
+  that half. The one *structural*
   difference from legacy remains: no separate `setup` phase, because wingfoil's
   ops are constructed at wiring time (register **D14**).
 ⁵ Only the declared output tuple is returned — no runner, no peeking


### PR DESCRIPTION
## What this changes

`tests/compiled_lifecycle_ops.rs` gains the missing half of #783's regression
guard: a probe for **`Op::stop`** under `compiled()` and `nested()`. The
emitter change #783 asks for is already on `main` — this PR verifies it,
guards the unguarded half, and corrects the three documents that still say it
is outstanding.

## Why

Closes #783.

**Scope item 1 (emitter) was already done, before this PR.** `nitro!`'s
`node_lifecycle` (`crates/wingfoil-derive/src/lib.rs`) emits `stop` and
`teardown` for both `Target::Compiled` and `Target::Nested`; `expand_compiled`
runs the two tails after an IIFE that captures `?` into `__first_err`, and
`expand_nested` answers `CompositePhase::Stop` / `Teardown`. I re-read all
three call sites of `node_start` before touching anything and found the
`node_stop` / `node_teardown` equivalents present and correct, so **no emitter
change was needed and none is in this diff**. What had drifted was the record:
the decision record §3/§4/§6 still asserted "`compiled()` today emits no
stop/teardown for *any* op", which is false of `main` (the port-plan footnote
⁴ had already been corrected — the two disagreed).

**Scope item 2 was half done, and the missing half mattered.** Every existing
probe observes `teardown`, through `finally`. Nothing observed `stop`: the only
catalog op with a real `Op::stop` is `timed`, and its hook *prints*. So the
`stop` emission was carried by no assertion at all.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`
- [x] `cargo lint-all` — passes in full; this sandbox has the aeron toolchain
      (cmake 3.31, clang 18, libuuid), so no substitution was needed
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
      — every unit/adapter/parity target green. The nine `*_integration`
      targets (aeron, etcd, fluvio, kafka, otlp, postgres, redis, and the two
      zmq cross-*) fail on `failed to initialize a docker client: Socket not
      found: /var/run/docker.sock` — the live-service tier, unrelated to this
      diff and unreachable without Docker here
- [x] New behaviour is covered by a test that asserts ordering and state

### The new test fails against unfixed code — measured, not asserted

Because the emitter fix is already on `main`, "against `main`" is not the
meaningful control; the meaningful control is *without the emission the test
guards*. Deleting the `#(#stops)*` splice from `expand_compiled` and from
`expand_nested`'s `CompositePhase::Stop` arm, and running the **whole**
default-feature suite with `--no-fail-fast`, produces exactly one failure —
the new test:

```
test stop_then_teardown_ordering_matches_across_engines ... FAILED

thread 'stop_then_teardown_ordering_matches_across_engines' panicked at
crates/wingfoil/tests/compiled_lifecycle_ops.rs:382:5:
assertion `left == right` failed: compiled: stop must run (with real state) before teardown
  left: ["bookend:stop:5", "finally:teardown:5"]
 right: ["finally:teardown:5"]
```

Every other test in the suite — including the four that already lived in this
file — stayed green, which is precisely the hole being closed. The splices were
then restored; the emitter is byte-identical to `main` in this branch.

## What the test does

`Bookend` is a pass-through user op with hand-written forwarders (the
`tests/custom_op.rs` pattern — `#[op]`'s generated builder names
`crate::interp::Builder`, so it is in-crate tooling) whose entire observable
behaviour is its `stop` hook. It is wired next to a `finally`, so one ordered
thread-local log covers both hooks *and* the boundary between them, on
`interpreted()`, `compiled()` and `nested()`.

Two details are deliberate. The hook records the op's **state**, not just that
it fired, which pins that the node's real accumulated state reaches the hook
rather than a fresh seed. And `Cfg` is a `&'static str` label rather than a
`String`: the compiled emission uses call-site argument types verbatim, so an
"ergonomic" owned config would make the probe fluent-only and it would never
reach the tiers under test.

## Semantics, established from the interpreted engine

`Runner::run` (`interp.rs`) is the oracle and both monomorphized tiers already
agree with it: **every node's `stop` in node order, then every node's
`teardown` in node order**, cleanup always running — a `start`/`cycle` error is
captured rather than returned early, and the first error wins. The test pins the
ordering; the pre-existing `compiled_cleanup_runs_after_cycle_abort` pins the
error-safety.

### The island end-of-run answer (asked explicitly in the brief)

**End-of-run for an island is the *outer* run's end, and the island observes it
correctly — there is no residual deviation, so nothing was added to
`deviation-register.md`.** `Builder::composite` sets the composite node's own
`stop` and `teardown` hooks, so when the outer `Runner` reaches its cleanup
passes it calls them, and the closure receives `CompositePhase::Stop` /
`Teardown` and runs every inner node's hook (error-safe, first error wins).

This is not in tension with the documented island deviations. `is_last_cycle`
and `run_mode` are per-**cycle** facts the island is never told, and they stay
undelivered; end-of-run reaches the island through a *hook*, not through the
context. The new test asserts the island's log is identical to the interpreted
one, so the claim is executable rather than argued.

## Notes for the reviewer

- **No engine or emitter code changed.** The diff is one test file and three
  documents. If you expected an emitter diff for #783, the reason there is none
  is in "Why" above — please sanity-check that reading, since it is the load-
  bearing claim of this PR.
- Doc corrections: `macro-extensibility-decision.md` §3 (the stale note, plus a
  `has_stop`/`has_teardown` row that says why the field was eliminated rather
  than added), §4 (the row struck through and marked done, with a paragraph of
  record covering the contract and the island answer) and §6 (the migration path
  now has only `#[op]` out-of-crate, #782, open); `port-plan.md` footnote ⁴ now
  names both probes rather than only the teardown one.
- `/new-op` gains the rule this surfaced, per the skill's own "living document"
  clause: a lifecycle hook is covered only when its *effect* is asserted on all
  three tiers, and the guard is worth only what deleting the emission proves —
  including the `Cfg`-equals-call-site-type trap for probe ops.
- Not Python-exposed and not intended to be: `Bookend` is a test fixture, not
  catalog surface.
- The cargo-husky hooks are not installed in this checkout (`.git/hooks` holds
  only the samples), so nothing pre-commit ran automatically; the four gates
  above were run by hand instead, and `--no-verify` was not used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_019E9ZYUCcabdMAZVz1dF7Yd)_