### PR TITLE
docs: single-threaded contract, docs/RELEASING.md, and missing_docs enabled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ cargo test --manifest-path crates/wingfoil/Cargo.toml
 cargo run  --manifest-path crates/wingfoil/Cargo.toml --example hello_graph
 ```
 
-A few adapters need more (Aeron wants clang, libuuid and CMake ≥ 3.20; some
-adapter tests want a server) — [`CLAUDE.md`](CLAUDE.md) has the details, and
-none of it is needed to work on the engine.
+A few adapters need more (Aeron wants clang, libuuid and CMake ≥ 3.30; some
+adapter tests want a live service) — [`CLAUDE.md`](CLAUDE.md) has the details,
+and none of it is needed to work on the engine.
 
 **Where to start:** the
 [`good first issue`](https://github.com/wingfoil-io/wingfoil/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
@@ -44,15 +44,13 @@ Wingfoil is a ground-up rebuild of the legacy engine
 [`README.md`](README.md) for the design objectives and
 [`docs/planning/port-plan.md`](docs/planning/port-plan.md) for the roadmap.
 
-Two trees, two workflows, and it matters which one you are in:
+**Everything branches from and merges into `main`**, whichever tree you are in.
+`next` was the integration branch that staged the replacement engine; it has
+landed and is retired, so there is no second base branch any more.
 
-| You are changing | Branch from | PR targets |
-|---|---|---|
-| Anything outside `legacy/` | `next` | `next` |
-| Anything under `legacy/` | `main` | `main` |
-
-Never commit directly to `next` or `main`. Branch names are simple and
-descriptive — `add-metrics`, `fix-error-handling`.
+Never commit directly to `main`. Cut a branch, push it, open a PR with base
+`main`. Branch names are simple and descriptive — `add-metrics`,
+`fix-error-handling`.
 
 ## What contributions look like here
 
@@ -97,10 +95,63 @@ cargo fmt --all
 cargo lint && cargo lint-all          # workspace clippy aliases, mirror CI
 ```
 
-`legacy/` is **not** in this workspace — it is its own, so none of the above
-reaches it and `--manifest-path crates/wingfoil/Cargo.toml` does not resolve here. See
+`legacy/` is **not** in this workspace — it is its own, rooted at
+`legacy/Cargo.toml`, so none of the above reaches it and the git hooks do not
+cover it either. Use `cargo lint-legacy` / `cargo test-legacy`, and see
 [`legacy/CONTRIBUTING.md`](legacy/CONTRIBUTING.md#pre-pr-check-matches-ci) if
 you are changing that tree.
 
-The default feature set is dependency-free; `--all-features` adds the
-`async` (tokio/futures), `csv` and `augurs` adapters.
+The default feature set is empty (`default = []`) and dependency-free — every
+adapter is behind its own feature. Run `cargo lint-all` before pushing:
+feature-gated code is the easiest thing to break without noticing, and it is
+what CI runs.
+
+### Tests that need a live service
+
+Adapter tests come in two files. `tests/<name>_adapter.rs` needs nothing
+running and is part of the ordinary `cargo test` suite.
+`tests/<name>_integration.rs` needs a real service or real sockets, and is
+**compiled but not run** by the normal job — CI's `test` job filters it out
+with `-E 'not binary(/_integration$/)'`, so the `_integration` filename suffix
+is the only thing keeping it out. Each one runs in its own workflow instead
+(see [`.github/workflows/README.md`](.github/workflows/README.md)).
+
+To run one locally you need its feature *and* whatever it talks to. Every
+`*_integration.rs` file opens with the exact command and prerequisites — read
+that header first. The three shapes:
+
+- **Docker, brought up by the test.** etcd, redis, postgres, kafka, fluvio,
+  otlp and aeron use [`testcontainers`](https://crates.io/crates/testcontainers)
+  and start their own container, so a running Docker daemon is the whole
+  prerequisite:
+
+  ```bash
+  cargo test --manifest-path crates/wingfoil/Cargo.toml \
+    --features redis-integration-test -- --test-threads=1 --nocapture
+  ```
+
+  Without Docker these fail with `Socket not found: /var/run/docker.sock`.
+
+- **Docker, brought up by you.** Prometheus scrapes a live exporter, so bring
+  the stack up first (`docker compose -f
+  legacy/wingfoil/src/adapters/prometheus/docker/docker-compose.yml up -d`);
+  the test skips itself with a printed notice if Prometheus is unreachable.
+  KDB+ has no freely-licensed image at all — start a `q -p 5000` yourself
+  (`KDB_TEST_HOST` / `KDB_TEST_PORT` to point elsewhere), and it likewise
+  skips rather than fails when there is nothing there.
+
+- **No service at all**, just real sockets or shared memory: `web` (in-process
+  server over loopback), `zmq` (needs `libzmq`), `fix` (in-process
+  acceptor + initiator) and `iceoryx2` (a writable `/dev/shm`). These are
+  tier-2 only because they are slow and timing-sensitive, not because they
+  need infrastructure — the feature flag is all they want.
+
+Because they run against a live wall clock, integration tests generally assert
+*values* rather than exact tick times; the deterministic
+`HistoricalFrom(NanoTime::ZERO)` value-and-tick-time assertions belong in the
+`_adapter.rs` half.
+
+## Releasing
+
+Maintainers only, and both steps are manual dispatches — see
+[`docs/RELEASING.md`](docs/RELEASING.md).

--- a/crates/wingfoil-wire-types/src/lib.rs
+++ b/crates/wingfoil-wire-types/src/lib.rs
@@ -8,6 +8,10 @@
 //! so wire compatibility is enforced at compile time.
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// This crate *is* the wire contract, so an undocumented public item is a gap
+// in the protocol spec. `cargo lint` runs with `-D warnings`, making this a
+// deny in CI.
+#![warn(missing_docs)]
 
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -61,9 +65,15 @@ pub enum ControlMessage {
         version: u16,
     },
     /// Sent by the client to subscribe to one or more topics.
-    Subscribe { topics: Vec<String> },
+    Subscribe {
+        /// The topic names to start receiving frames for.
+        topics: Vec<String>,
+    },
     /// Sent by the client to unsubscribe from one or more topics.
-    Unsubscribe { topics: Vec<String> },
+    Unsubscribe {
+        /// The topic names to stop receiving frames for.
+        topics: Vec<String>,
+    },
     /// Sent by the server when a publish `topic`'s stream has ended and no
     /// further frames will arrive on it — for example when a historical
     /// replay (or any finite `RunFor`) reaches the end of its source.
@@ -73,7 +83,10 @@ pub enum ControlMessage {
     /// can use it to render "replay finished" and to stop reconnecting
     /// (the server is done, not merely dropped). Real-time streams with an
     /// unbounded `RunFor::Forever` source never emit it.
-    Complete { topic: String },
+    Complete {
+        /// The topic whose stream has ended.
+        topic: String,
+    },
 }
 
 /// The serialization format used for envelope payloads and envelopes.
@@ -82,8 +95,11 @@ pub enum ControlMessage {
 /// for debugging in browser devtools.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub enum CodecKind {
+    /// Compact binary framing via `bincode`. The default.
     #[default]
     Bincode,
+    /// JSON. Larger and slower, but readable in browser devtools — an
+    /// escape hatch for debugging, not for production traffic.
     Json,
 }
 

--- a/crates/wingfoil/src/adapters/aeron/aeron_rs_backend.rs
+++ b/crates/wingfoil/src/adapters/aeron/aeron_rs_backend.rs
@@ -70,11 +70,16 @@ where
 // Connection handle
 // ---------------------------------------------------------------------------
 
+/// A connected `aeron-rs` client, and the factory every subscriber and
+/// publisher on this backend is derived from. One per media driver.
 pub struct AeronRsHandle {
     aeron: Arc<Mutex<Aeron>>,
 }
 
 impl AeronRsHandle {
+    /// Connect to the media driver, honouring `AERON_DIR` for its directory
+    /// (the same variable the C driver reads). The driver must already be
+    /// running — this does not start one.
     #[allow(clippy::arc_with_non_send_sync)]
     pub fn connect() -> anyhow::Result<Self> {
         let mut ctx = Context::new();
@@ -88,6 +93,10 @@ impl AeronRsHandle {
         })
     }
 
+    /// Add a subscription on `channel` / `stream_id` and poll the driver until
+    /// it is available, giving up after `timeout`. Uses the default fragment
+    /// limit; override it with
+    /// [`with_fragment_limit`](AeronRsSubscriber::with_fragment_limit).
     pub fn subscription(
         &self,
         channel: &str,
@@ -110,6 +119,8 @@ impl AeronRsHandle {
         })
     }
 
+    /// Add a publication on `channel` / `stream_id` and poll the driver until
+    /// it is available, giving up after `timeout`.
     pub fn publication(
         &self,
         channel: &str,
@@ -134,6 +145,10 @@ impl AeronRsHandle {
 // Subscriber
 // ---------------------------------------------------------------------------
 
+/// An `aeron-rs` subscription, as an
+/// [`AeronSubscriberBackend`]. Each `poll` locks the shared `Subscription` —
+/// see the module-level warning about that lock landing on the graph thread in
+/// [`AeronMode::Spin`](crate::adapters::aeron::AeronMode::Spin).
 pub struct AeronRsSubscriber {
     sub: Arc<Mutex<Subscription>>,
     /// Cap on fragments delivered per [`AeronSubscriberBackend::poll`] call.
@@ -230,6 +245,8 @@ impl AeronSubscriberBackend for AeronRsSubscriber {
 // Publisher
 // ---------------------------------------------------------------------------
 
+/// An `aeron-rs` publication, as an [`AeronPublisherBackend`]. There is no
+/// threaded mode for publishing, so every `offer` locks on the calling thread.
 pub struct AeronRsPublisher {
     publication: Arc<Mutex<Publication>>,
 }

--- a/crates/wingfoil/src/adapters/aeron/rusteron_backend.rs
+++ b/crates/wingfoil/src/adapters/aeron/rusteron_backend.rs
@@ -119,6 +119,9 @@ impl AeronHandle {
 // Subscriber
 // ---------------------------------------------------------------------------
 
+/// A rusteron (C++ FFI) subscription, as an [`AeronSubscriberBackend`] — the
+/// production backend. Unlike the `aeron-rs` one it takes no lock to poll, so
+/// it is safe on the graph thread.
 pub struct RusteronSubscriber {
     sub: AeronSubscription,
     /// Cap on fragments delivered per [`AeronSubscriberBackend::poll`] call.
@@ -231,6 +234,10 @@ impl AeronSubscriberBackend for RusteronSubscriber {
 // Publisher
 // ---------------------------------------------------------------------------
 
+/// A rusteron (C++ FFI) publication, as an [`AeronPublisherBackend`] — the
+/// production backend. Lock-free to `offer`. Construct one through
+/// [`AeronHandle::publication`], or wrap an existing publication with
+/// [`RusteronPublisher::new`].
 pub struct RusteronPublisher {
     publication: AeronPublication,
 }

--- a/crates/wingfoil/src/adapters/cache.rs
+++ b/crates/wingfoil/src/adapters/cache.rs
@@ -85,7 +85,10 @@ impl CacheKey {
 /// ```
 #[derive(Debug, Clone)]
 pub struct CacheConfig {
+    /// Directory holding the `.cache` files, one per [`CacheKey`].
     pub folder: PathBuf,
+    /// Total on-disk budget for `folder`'s `.cache` files. Writing past it
+    /// evicts least-recently-used files first; `u64::MAX` disables eviction.
     pub max_size_bytes: u64,
 }
 
@@ -158,6 +161,9 @@ pub struct FileCache<T> {
 }
 
 impl<T> FileCache<T> {
+    /// A cache over `config.folder`. Purely a handle — nothing touches the
+    /// filesystem until a `get` or `put`, and the folder is expected to exist
+    /// by then.
     pub fn new(config: CacheConfig) -> Self {
         Self {
             config,

--- a/crates/wingfoil/src/adapters/common.rs
+++ b/crates/wingfoil/src/adapters/common.rs
@@ -94,6 +94,9 @@ pub struct WindowFilter {
 }
 
 impl WindowFilter {
+    /// A filter for one slice/batch. `label` names the adapter in the summary
+    /// warning [`finish`](WindowFilter::finish) emits; `window` is the
+    /// half-open range rows must fall in.
     pub fn new(label: &'static str, window: TimeWindow) -> Self {
         Self {
             label,

--- a/crates/wingfoil/src/adapters/etcd.rs
+++ b/crates/wingfoil/src/adapters/etcd.rs
@@ -170,7 +170,11 @@ impl From<&String> for EtcdConnection {
 /// A single key-value pair from etcd.
 #[derive(Debug, Clone, Default)]
 pub struct EtcdEntry {
+    /// The full etcd key, prefix included.
     pub key: String,
+    /// The raw value bytes — etcd is byte-oriented, so decoding is the
+    /// caller's. [`value_str`](EtcdEntry::value_str) for UTF-8. Empty on a
+    /// [`Delete`](EtcdEventKind::Delete) event.
     pub value: Vec<u8>,
 }
 
@@ -201,7 +205,10 @@ pub enum EtcdEventKind {
 /// Subsequent watch events reflect the actual change type from etcd.
 #[derive(Debug, Clone, Default)]
 pub struct EtcdEvent {
+    /// Whether the key was put or deleted. Always
+    /// [`Put`](EtcdEventKind::Put) for the initial snapshot.
     pub kind: EtcdEventKind,
+    /// The key, and the value where there is one.
     pub entry: EtcdEntry,
     /// The etcd cluster revision at which this event was observed.
     pub revision: i64,

--- a/crates/wingfoil/src/adapters/fix.rs
+++ b/crates/wingfoil/src/adapters/fix.rs
@@ -495,9 +495,13 @@ impl<'a> FixGroup<'a> {
 /// FIX session lifecycle state.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum FixSessionStatus {
+    /// No transport: never connected, or the socket has dropped. An initiator
+    /// in this state is between reconnect attempts.
     #[default]
     Disconnected,
+    /// Connected, `Logon` (MsgType A) sent, awaiting the counterparty's.
     LoggingIn,
+    /// Logon complete — the session is up and application messages flow.
     LoggedIn,
     /// Server sent a Logout (MsgType 5). Contains the `Text` field (tag 58) if present.
     LoggedOut(Option<String>),
@@ -510,9 +514,16 @@ pub enum FixSessionStatus {
     /// flow a gap is a business event: between `expected` and `received` there
     /// may be fills you have not seen.
     SequenceGap {
+        /// The `MsgSeqNum` (34) the session was expecting next.
         expected: u64,
+        /// The `MsgSeqNum` that actually arrived. Everything in
+        /// `expected..received` was missed.
         received: u64,
     },
+    /// A transport or protocol failure, carrying its message — a refused
+    /// connect, a malformed frame, a rejected logon. Reported as a status
+    /// event rather than failing the run, so the graph can react to a session
+    /// problem the way it reacts to any other value.
     Error(String),
 }
 
@@ -522,7 +533,11 @@ pub enum FixSessionStatus {
 /// messages around it.
 #[derive(Debug, Clone)]
 pub enum FixEvent {
+    /// An inbound application message.
     Data(FixMessage),
+    /// A session lifecycle transition. Interleaved with `Data` on the one
+    /// transport precisely so its ordering against surrounding messages is
+    /// preserved.
     Status(FixSessionStatus),
 }
 
@@ -600,7 +615,12 @@ pub enum FixMessageStore {
     /// Capacity is a message count, not bytes. Size it against the reconnect
     /// window you care about: a session sending 100 orders/second that must
     /// survive a 30-second drop wants ~3,000.
-    Memory { capacity: usize },
+    Memory {
+        /// How many sent messages to retain, as a **count** — size it against
+        /// the reconnect window you care about, per the note above. Older
+        /// entries are dropped and degrade to gap fill if requested.
+        capacity: usize,
+    },
 }
 
 /// One sent application message, kept so it can be replayed on request.

--- a/crates/wingfoil/src/async_source.rs
+++ b/crates/wingfoil/src/async_source.rs
@@ -137,8 +137,14 @@ impl GraphRuntime {
 /// receiver stop at end-of-stream.
 #[derive(Clone, Copy, Debug)]
 pub struct RunParams {
+    /// Which clock the run is being driven against — the flag a producer
+    /// branches on to pick a historical source over a live one.
     pub run_mode: RunMode,
+    /// The run's bound. Prefer ending the producer's stream and letting the
+    /// receiver stop at end-of-stream over reading this.
     pub run_for: RunFor,
+    /// Engine time at graph start: `now()` in realtime, the replay start in a
+    /// historical run — the instant to stamp the first value relative to.
     pub start_time: NanoTime,
 }
 

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -55,9 +55,9 @@ use crate::pool::{Pooled, PooledSender};
 /// The shared `Rc<RefCell<Builder>>` makes this type — and every [`Stream`]
 /// wired from it, and the [`Runner`] it builds — **`!Send` and `!Sync`**.
 /// Wiring, [`build`](GraphBuilder::build) and [`Runner::run`] all happen on one
-/// thread, and passing a `GraphBuilder` to `std::thread::spawn` fails to
-/// compile with ``` `Rc<RefCell<Builder>>` cannot be sent between threads
-/// safely ```.
+/// thread, and a closure capturing a `GraphBuilder` fails `std::thread::spawn`'s
+/// `Send` bound with `` `Rc<RefCell<wingfoil::interp::Builder>>` cannot be sent
+/// between threads safely ``.
 ///
 /// The engine takes **no locks on the graph execution path**, which is what
 /// this buys. Producers on other threads reach the graph through the channel

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -19,6 +19,16 @@
 //!
 //! This layer is *wiring-time only* — it adds nothing to execution (the built
 //! [`Runner`] is identical).
+//!
+//! # Single-threaded
+//!
+//! [`GraphBuilder`] and [`Stream<T>`] are **`!Send` and `!Sync`** — they share
+//! an `Rc<RefCell<Builder>>` — so a graph is wired, built and run on one
+//! thread. Cross-thread work goes through the channel layer instead:
+//! [`SourceOps::channel`] / [`SourceOps::pooled_channel`] hand out a `Send`
+//! sender, and [`SourceOps::spawn`] / [`StreamOps::spawn_map`] run a whole
+//! sub-graph on a worker thread for you. See the crate docs' *"Threading: a
+//! graph lives on one thread"* for the full table and a worked example.
 
 use std::cell::{Cell, RefCell};
 use std::fmt::Debug;
@@ -40,6 +50,24 @@ use crate::pool::{Pooled, PooledSender};
 /// A graph under construction. Cheap to clone; all clones share the same
 /// underlying builder.
 ///
+/// # Not `Send`, by design
+///
+/// The shared `Rc<RefCell<Builder>>` makes this type — and every [`Stream`]
+/// wired from it, and the [`Runner`] it builds — **`!Send` and `!Sync`**.
+/// Wiring, [`build`](GraphBuilder::build) and [`Runner::run`] all happen on one
+/// thread, and passing a `GraphBuilder` to `std::thread::spawn` fails to
+/// compile with ``` `Rc<RefCell<Builder>>` cannot be sent between threads
+/// safely ```.
+///
+/// The engine takes **no locks on the graph execution path**, which is what
+/// this buys. Producers on other threads reach the graph through the channel
+/// layer instead — [`SourceOps::channel`] and
+/// [`SourceOps::pooled_channel`] return a `Send` sender to move across, and
+/// [`SourceOps::spawn`] wires and runs an entire producer sub-graph on a
+/// worker thread. Running several *separate* graphs on several threads is
+/// fine; sharing one is what the bound rules out. The crate-level docs carry
+/// the full table of crossings and a runnable example.
+///
 /// [`build`](GraphBuilder::build) **consumes** the wired graph, so it may be
 /// called only once: the `built` flag (shared with every [`Stream`] wired from
 /// this builder) poisons the builder afterwards, turning a second `build()` —
@@ -53,6 +81,8 @@ pub struct GraphBuilder {
 }
 
 impl GraphBuilder {
+    /// An empty graph, ready to wire. The entry point for everything in this
+    /// module.
     pub fn new() -> Self {
         Self::default()
     }
@@ -638,6 +668,15 @@ impl SourceOps for GraphBuilder {
 /// [`StreamOps`] extension trait (and others), so `use`ing the trait enables
 /// chaining: `g.ticker(p).count().map(|i| i * 2)`. [`build`](Stream::build)
 /// closes the chain, so wiring, building and running can be one expression.
+///
+/// Like the [`GraphBuilder`] it came from, a `Stream` is **`!Send` and
+/// `!Sync`** (it holds the same `Rc<RefCell<Builder>>`), so it cannot be moved
+/// to another thread — see [`GraphBuilder`]'s *"Not `Send`, by design"* for
+/// why, and for the channel-layer crossings to use instead. A closure passed
+/// to a combinator runs on the graph thread and so needs no `Send` bound
+/// either; the ones that *do* require `Send` ([`StreamOps::spawn_map`],
+/// [`SourceOps::spawn`]) say so in their signatures, because those are exactly
+/// the ones that cross.
 pub struct Stream<T> {
     inner: Rc<RefCell<Builder>>,
     /// Shared with the owning [`GraphBuilder`]: set once the graph is built, so
@@ -968,6 +1007,21 @@ pub trait StreamOps<T>: Sized {
         T: Clone + Default + 'static;
 
     /// Merge with another stream; the earliest-supplied ticked input wins.
+    ///
+    /// **Lossy on a same-cycle tie.** A merge emits at most one value per
+    /// cycle, so when both inputs tick in the same cycle this stream's value is
+    /// emitted and `other`'s is *dropped* — not queued, not emitted next cycle.
+    /// `other`'s own slot still holds the value, so anything reading *that*
+    /// stream sees it; nothing downstream of the merge does. Same shape as
+    /// [`collapse`](StreamOps::collapse)'s loss: fine for a
+    /// latest-value-wins signal, wrong for an event stream where every value
+    /// must arrive — and load-dependent, so the ties (and the loss) may not
+    /// appear until a producer speeds up. There is no merge variant that keeps
+    /// both — [`merge_all`](StreamOps::merge_all) and
+    /// [`MergeN`](crate::ops::MergeN) have the same one-winner rule. Where
+    /// nothing may be dropped, use [`join`](StreamOps::join) instead: it ticks
+    /// when either input ticks and its closure is handed *both* values, so a
+    /// tie is something you handle rather than something you lose.
     fn merge(&self, other: &Stream<T>) -> Stream<T>
     where
         T: Clone + Default + 'static;

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -2719,9 +2719,10 @@ pub enum Dispatch {
 ///
 /// A `Runner` owns the node state and value slots as `Rc`s, so it is **`!Send`
 /// and `!Sync`**: [`run`](Runner::run) must be called on the thread that wired
-/// and [`built`](crate::fluent::GraphBuilder::build) the graph, and the runner
-/// cannot be handed to `std::thread::spawn` (`Rc<...> cannot be sent between
-/// threads safely`). Feed it from other threads through the channel layer
+/// and [`built`](crate::fluent::GraphBuilder::build) the graph, and a closure
+/// capturing a `Runner` cannot satisfy `std::thread::spawn`'s `Send` bound
+/// (`Rc<…> cannot be sent between threads safely`). Feed it from other threads
+/// through the channel layer
 /// instead — see [`GraphBuilder`](crate::fluent::GraphBuilder) and the crate
 /// docs' *"Threading: a graph lives on one thread"*.
 pub struct Runner {

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -32,6 +32,18 @@
 //! see the port plan). `run` is fallible — it returns the first
 //! `start`/`cycle`/`stop`/`teardown` error (with node context) and still runs
 //! cleanup afterwards, matching the legacy engine.
+//!
+//! # Single-threaded
+//!
+//! Those `Rc<RefCell<..>>` slots are also the reason [`Builder`] and
+//! [`Runner`] are **`!Send` and `!Sync`**: a graph is wired, built and run on
+//! one thread, and nothing on the execution path takes a lock. Threads reach a
+//! running graph through the channel layer — a `Send`
+//! [`ChannelSender`](crate::channel::ChannelSender) from
+//! [`SourceOps::channel`](crate::fluent::SourceOps::channel), or a whole
+//! sub-graph offloaded with
+//! [`SourceOps::spawn`](crate::fluent::SourceOps::spawn). The crate docs'
+//! *"Threading: a graph lives on one thread"* section has the full table.
 
 use std::any::Any;
 use std::cell::{Cell, Ref, RefCell, RefMut};
@@ -110,6 +122,8 @@ macro_rules! cycle_node_span {
 /// Anything that identifies a node's typed output — a raw [`Handle`] or a
 /// fluent [`Stream`](crate::fluent::Stream).
 pub trait AsHandle<T> {
+    /// The typed handle this refers to — the index the engine wires and reads
+    /// values through.
     fn as_handle(&self) -> Handle<T>;
 }
 
@@ -620,6 +634,8 @@ impl Default for Builder {
 }
 
 impl Builder {
+    /// An empty graph. Most code reaches this through
+    /// [`GraphBuilder`](crate::fluent::GraphBuilder) rather than directly.
     pub fn new() -> Self {
         Self::default()
     }
@@ -2527,6 +2543,9 @@ impl Builder {
     // Wingfoil's counterpart of legacy's `Graph::initialise` — the one-shot pass
     // that turns wiring into the dispatch topology. Named `initialise` in the
     // span so a subscriber (or a dashboard) reads the same across both engines.
+    /// Turn the wired graph into a [`Runner`]: the one-shot pass that computes
+    /// the reverse adjacency lists, the `layer` sort keys and the seed set the
+    /// sparse dispatch loop needs. Consumes the builder — wiring is over.
     #[cfg_attr(
         feature = "instrument-initialise",
         tracing::instrument(skip_all, name = "initialise")
@@ -2695,6 +2714,16 @@ pub enum Dispatch {
 /// once after everything it reads — glitch-free, single-fire, and
 /// byte-identical to the previous full-index sweep, which index order alone
 /// already satisfied on a static graph.
+///
+/// # Not `Send`
+///
+/// A `Runner` owns the node state and value slots as `Rc`s, so it is **`!Send`
+/// and `!Sync`**: [`run`](Runner::run) must be called on the thread that wired
+/// and [`built`](crate::fluent::GraphBuilder::build) the graph, and the runner
+/// cannot be handed to `std::thread::spawn` (`Rc<...> cannot be sent between
+/// threads safely`). Feed it from other threads through the channel layer
+/// instead — see [`GraphBuilder`](crate::fluent::GraphBuilder) and the crate
+/// docs' *"Threading: a graph lives on one thread"*.
 pub struct Runner {
     nodes: Vec<NodeRt>,
     slots: Vec<Rc<dyn Any>>,

--- a/crates/wingfoil/src/latency.rs
+++ b/crates/wingfoil/src/latency.rs
@@ -452,7 +452,10 @@ where
 /// Construction config for a [`LatencyReport`] sink: the shared stats
 /// accumulator plus whether to print a summary at [`stop`](Op::stop).
 pub struct LatencyReportCfg<L: Latency> {
+    /// The accumulator the sink folds each observation into. Shared, so the
+    /// caller can read the numbers out after the run.
     pub stats: Rc<RefCell<LatencyStats<L>>>,
+    /// Print the per-stage summary to stdout when the run stops.
     pub print_on_teardown: bool,
 }
 

--- a/crates/wingfoil/src/lib.rs
+++ b/crates/wingfoil/src/lib.rs
@@ -99,6 +99,83 @@
 //! For how the pieces fit together, and why, see
 //! `docs/wingfoil-architecture.md`.
 //!
+//! # Threading: a graph lives on one thread
+//!
+//! **[`GraphBuilder`](fluent::GraphBuilder), [`Stream<T>`](fluent::Stream) and
+//! [`Runner`](interp::Runner) are `!Send` and `!Sync`.** They hold `Rc`
+//! internally, so wiring, [`build`](fluent::GraphBuilder::build) and
+//! [`run`](interp::Runner::run) all have to happen on the same thread, and
+//! moving any of them into `std::thread::spawn` is a compile error along the
+//! lines of:
+//!
+//! ```text
+//! error[E0277]: `Rc<RefCell<Builder>>` cannot be sent between threads safely
+//!    = note: required because it appears within the type `GraphBuilder`
+//! note: required by a bound in `std::thread::spawn`
+//! ```
+//!
+//! That is a deliberate contract, not a missing impl. Node state is
+//! `RefCell`-owned by the engine and read back through `Rc` slots precisely so
+//! that **no lock is ever taken on the graph execution path** — a mutex inside
+//! `cycle` would be a correctness problem as much as a cost one. Making the
+//! wiring types `Send` would only move the synchronisation somewhere less
+//! visible.
+//!
+//! Nothing stops you running *several* graphs, one per thread. What you cannot
+//! do is share one.
+//!
+//! ## Crossing the thread boundary
+//!
+//! Every supported crossing hands you a `Send` half while the graph stays
+//! where it is:
+//!
+//! | You want to… | Wire | The `Send` half to move |
+//! |---|---|---|
+//! | feed a graph from a thread, socket or async task | [`channel`](fluent::SourceOps::channel) | [`ChannelSender<T>`](channel::ChannelSender) |
+//! | …the same, with recycled buffers and no payload allocation | [`pooled_channel`](fluent::SourceOps::pooled_channel) | [`PooledSender<T>`](pool::PooledSender) |
+//! | …the same, but connect at run start rather than at wiring | [`source_at_start`](fluent::SourceOps::source_at_start) | `ChannelSender<T>`, handed to your `setup` |
+//! | run a whole producer sub-graph on a worker thread | [`spawn`](fluent::SourceOps::spawn) | nothing — the worker wires its own graph |
+//! | offload one stage of an existing pipeline | [`spawn_map`](fluent::StreamOps::spawn_map) | nothing — ditto, in lock-step |
+//! | push values in from realtime code, minimal envelope | [`external`](fluent::SourceOps::external) | [`ExternalSource<T>`](interp::ExternalSource) |
+//!
+//! [`channel`](fluent::SourceOps::channel) is the general answer, and the one
+//! the I/O adapters are built on. The sender is `Send` and clonable, each
+//! `send` wakes the realtime kernel, and
+//! [`send_at`](channel::ChannelSender::send_at) stamps a value so a historical
+//! replay stays deterministic:
+//!
+//! ```
+//! use std::thread;
+//! use std::time::Duration;
+//! use wingfoil::prelude::*;
+//! use wingfoil::{NanoTime, RunFor, RunMode};
+//!
+//! let g = GraphBuilder::new();
+//! // The `Stream` stays on this thread; the `ChannelSender` is the `Send` half.
+//! let (values, sender) = g.channel::<u64>();
+//! let total = values
+//!     .map(|b: &Burst<u64>| b.iter().sum::<u64>())
+//!     .fold(0u64, |acc, v| *acc += v);
+//! let mut runner = g.build();
+//!
+//! let producer = thread::spawn(move || {
+//!     for i in 1..=3u64 {
+//!         sender.send_at(i, NanoTime::from(Duration::from_secs(i)));
+//!     }
+//!     // End-of-stream: the receiving graph winds down once it has drained.
+//!     sender.close();
+//! });
+//!
+//! runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Forever).unwrap();
+//! producer.join().unwrap();
+//! assert_eq!(runner.value(&total), 1 + 2 + 3);
+//! ```
+//!
+//! Note what did *not* cross: `g`, `values`, `total` and `runner` all stayed on
+//! the calling thread. If the producer is itself a wingfoil graph, reach for
+//! [`spawn`](fluent::SourceOps::spawn) instead and it will wire and run one on
+//! the worker for you — see `examples/core/threading` and `examples/core/spawn`.
+//!
 //! # Tracing and instrumentation
 //!
 //! The engine can emit `tracing` spans around its own execution. Every span
@@ -132,6 +209,13 @@
 //! dirty list is drained rather than topologically ordered; and `compiled()`
 //! is a closed box — static topology, outputs only, no I/O or live inputs, by
 //! design. See `docs/planning/port-plan.md` "Deferred / post-v1 work".
+
+// Every public item carries rustdoc, and CI keeps it that way: `cargo lint`
+// runs clippy with `-D warnings`, so this warn is effectively a deny. Adding a
+// public item without a doc comment breaks the build — which is the point.
+// Write a real sentence; a comment restating the item's name silences the lint
+// and tells the reader nothing.
+#![warn(missing_docs)]
 
 // Lets this crate refer to itself as `wingfoil`, so the paths that
 // `nitro!`-generated code emits (`::wingfoil::...`) resolve when the

--- a/crates/wingfoil/src/lib.rs
+++ b/crates/wingfoil/src/lib.rs
@@ -109,10 +109,16 @@
 //! lines of:
 //!
 //! ```text
-//! error[E0277]: `Rc<RefCell<Builder>>` cannot be sent between threads safely
-//!    = note: required because it appears within the type `GraphBuilder`
-//! note: required by a bound in `std::thread::spawn`
+//! error[E0277]: `Rc<RefCell<wingfoil::interp::Builder>>` cannot be sent
+//!               between threads safely
+//!   = help: within `{closure@...}`, the trait `Send` is not implemented for
+//!           `Rc<RefCell<wingfoil::interp::Builder>>`
+//! note: required because it appears within the type
+//!       `wingfoil::fluent::GraphBuilder`
 //! ```
+//!
+//! (Whichever of the three you moved: `Stream<T>` names the same `Rc`, and
+//! `Runner` names the `Rc` slots it owns.)
 //!
 //! That is a deliberate contract, not a missing impl. Node state is
 //! `RefCell`-owned by the engine and read back through `Rc` slots precisely so

--- a/crates/wingfoil/src/op.rs
+++ b/crates/wingfoil/src/op.rs
@@ -39,21 +39,31 @@ pub struct Activation {
 }
 
 impl Activation {
+    /// Purely reactive: the op fires only when an upstream ticks. The default
+    /// for every stateless combinator (`map`, `filter`, `join`, …).
     pub const NONE: Activation = Activation {
         schedules: false,
         threaded: false,
         always: false,
     };
+    /// The op wakes *itself* through the kernel's time queue — a `ticker`,
+    /// a `delay` popping a due value, a `feedback` source. Sets
+    /// [`schedules`](Activation::schedules).
     pub const SCHEDULES: Activation = Activation {
         schedules: true,
         threaded: false,
         always: false,
     };
+    /// The op is woken by another thread or async task through the channel
+    /// layer. Realtime only. Sets [`threaded`](Activation::threaded).
     pub const THREADED: Activation = Activation {
         schedules: false,
         threaded: true,
         always: false,
     };
+    /// The op is cycled unconditionally, every cycle — a busy-poll socket or
+    /// ring-buffer reader. Turns a realtime run into a busy-spin loop, and is
+    /// rejected in historical mode. Sets [`always`](Activation::always).
     pub const ALWAYS: Activation = Activation {
         schedules: false,
         threaded: false,
@@ -83,9 +93,13 @@ impl Activation {
 /// engine handle it generically.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Tick<T> {
+    /// Update the value slot **and** tick downstream — the ordinary "this node
+    /// produced something" outcome.
     Value(T),
     /// Update the value slot, but do not tick downstream.
     Silent(T),
+    /// Produce nothing: the slot keeps its previous value and no downstream
+    /// node is activated. The hot path for a `filter` that rejects.
     Quiet,
 }
 
@@ -145,6 +159,14 @@ enum Sink<'a> {
 }
 
 impl<'a> Ctx<'a> {
+    /// The per-cycle context for graph node `node`, scheduling straight to the
+    /// run's `kernel`. Built once per node per cycle by every engine — the
+    /// interpreted runner and `nitro!`'s `compiled()` alike.
+    ///
+    /// It copies the kernel's cheap scalars but deliberately **not** the
+    /// wall-clock snap: `wall_time` is left `None` and resolved lazily on
+    /// first [`wall_time`](Ctx::wall_time) call, so a cycle in which nothing
+    /// stamps reads the clock zero times.
     pub fn new(kernel: &'a mut Kernel, node: usize) -> Self {
         Self {
             time: kernel.time(),
@@ -294,12 +316,31 @@ impl<'a> Ctx<'a> {
 /// op the `Ok(..)` is constant-folded away after monomorphization, leaving
 /// no branch in the binary.
 pub trait Op: 'static {
+    /// Construction-time configuration, closures included — a `map`'s `F`
+    /// *is* its `Cfg`. Built at wiring, owned by the engine, handed to every
+    /// lifecycle function by `&mut`. `()` for an op that needs none.
     type Cfg: 'static;
+    /// Per-node mutable state carried between cycles: boxed by the
+    /// interpreted engine, a stack local in a compiled runner. `()` for a
+    /// stateless op.
     type State: 'static;
+    /// The typed inputs for one cycle — upstream values by reference, plus a
+    /// `bool` tick flag wherever the op needs to know *which* input fired
+    /// (`(&T, bool)`). A tuple for a fixed-arity op, a slice for a variadic
+    /// one, `()` for a source. The engine assembles it; ops never reach
+    /// upstream themselves.
     type In<'a>;
+    /// The value this op produces, i.e. what its downstream sees.
     type Out: Clone + 'static;
+    /// How this op is scheduled, declared statically so the engines can read
+    /// it at wiring time rather than infer it. See [`Activation`].
     const ACTIVATION: Activation;
 
+    /// Run one cycle: the op's whole semantics, and the only function that
+    /// must be written. Returns [`Tick::Value`] to produce and propagate,
+    /// [`Tick::Silent`] to update the value slot without waking downstream,
+    /// or [`Tick::Quiet`] to do neither. `Err` aborts the run with node
+    /// context.
     fn cycle(
         cfg: &mut Self::Cfg,
         state: &mut Self::State,

--- a/crates/wingfoil/src/runtime/kernel.rs
+++ b/crates/wingfoil/src/runtime/kernel.rs
@@ -180,6 +180,10 @@ pub struct Kernel {
 }
 
 impl Kernel {
+    /// A kernel driving a run in `run_mode`, bounded by `run_for`, with no
+    /// external wake-up channel — the right constructor for a graph whose
+    /// sources are all timers or replayed values. Use
+    /// [`with_ready`](Kernel::with_ready) when another thread must wake it.
     pub fn new(run_mode: RunMode, run_for: RunFor) -> Self {
         Self::build(run_mode, run_for, None)
     }

--- a/crates/wingfoil/src/runtime/latency.rs
+++ b/crates/wingfoil/src/runtime/latency.rs
@@ -60,8 +60,12 @@ pub trait Stage<L: Latency> {
 /// Implemented automatically for [`Traced<T, L>`]. Hand-roll if you embed a
 /// latency record as a sub-field of a richer payload.
 pub trait HasLatency {
+    /// The embedded latency record's type — the stage layout this payload
+    /// carries.
     type L: Latency;
+    /// The embedded record, for reading stamps.
     fn latency(&self) -> &Self::L;
+    /// The embedded record, for writing a stage's stamp.
     fn latency_mut(&mut self) -> &mut Self::L;
 }
 
@@ -79,7 +83,10 @@ pub trait HasLatency {
     Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct Traced<T, L> {
+    /// The value being carried. First, so the `#[repr(C)]` layout above holds.
     pub payload: T,
+    /// The per-stage timestamps accumulated as this value crossed the
+    /// pipeline.
     pub latency: L,
 }
 
@@ -240,9 +247,16 @@ const fn bucket_bounds(i: usize) -> (u64, u64) {
 /// deltas below 32 ns); see [`HISTOGRAM_BUCKETS`].
 #[derive(Clone, Copy, Debug)]
 pub struct StageStats {
+    /// Number of observations recorded for this stage. Exact.
     pub count: u64,
+    /// Total of every recorded delta, in nanoseconds; saturating. Exact.
+    /// Divide by `count` for the mean.
     pub sum_ns: u64,
+    /// Smallest delta seen, in nanoseconds. Exact. `u64::MAX` before the
+    /// first observation.
     pub min_ns: u64,
+    /// Largest delta seen, in nanoseconds. Exact. Zero before the first
+    /// observation.
     pub max_ns: u64,
     /// Sub-bucketed delta counts; see [`HISTOGRAM_BUCKETS`] for the layout.
     /// Read quantiles out of it with [`StageStats::quantile_ns`] rather than
@@ -263,6 +277,9 @@ impl Default for StageStats {
 }
 
 impl StageStats {
+    /// Fold one stage delta in: bumps `count`/`sum_ns`, widens the min/max,
+    /// and increments the histogram bucket it falls in. Allocation-free, so
+    /// it is safe on the graph path.
     #[inline]
     pub fn record(&mut self, delta_ns: u64) {
         self.count += 1;
@@ -399,6 +416,7 @@ impl<L: Latency> Default for LatencyStats<L> {
 }
 
 impl<L: Latency> LatencyStats<L> {
+    /// Zeroed statistics for every stage `L` declares.
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/wingfoil/src/runtime/mod.rs
+++ b/crates/wingfoil/src/runtime/mod.rs
@@ -19,5 +19,12 @@ pub mod burst;
 pub mod kernel;
 pub mod latency;
 pub mod run;
+/// Engine time: [`NanoTime`](time::NanoTime), a strictly-monotonic nanosecond
+/// instant, plus its conversions to and from `Duration`, `NaiveDateTime` and
+/// KDB+ timestamps. Re-exported at the crate root.
 pub mod time;
+/// The scheduled-callback queue: [`TimeQueue<T>`](time_queue::TimeQueue),
+/// which backs the graph scheduler, `delay` and `feedback`. Deduplicates
+/// `(value, time)` pairs by design — see its module docs before changing it.
+/// Re-exported at the crate root.
 pub mod time_queue;

--- a/crates/wingfoil/src/runtime/run.rs
+++ b/crates/wingfoil/src/runtime/run.rs
@@ -14,12 +14,19 @@ use crate::runtime::time::NanoTime;
 /// Defaults to [`RunMode::RealTime`], the production deployment mode.
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum RunMode {
+    /// Engine time follows the wall clock, and the kernel parks between
+    /// cycles. Threaded and busy-poll sources are only legal here.
     #[default]
     RealTime,
+    /// Deterministic replay from the given start time: engine time is pure
+    /// logic — each cycle advances to the earliest scheduled callback, never
+    /// consulting a clock — so a run is reproducible cycle for cycle.
     HistoricalFrom(NanoTime),
 }
 
 impl RunMode {
+    /// The engine time the run begins at: `now()` in realtime, the supplied
+    /// instant in a historical replay.
     pub fn start_time(&self) -> NanoTime {
         match self {
             RunMode::RealTime => NanoTime::now(),
@@ -34,13 +41,22 @@ impl RunMode {
 /// Defaults to [`RunFor::Forever`].
 #[derive(Clone, Copy, Debug, Default)]
 pub enum RunFor {
+    /// Stop once *engine* time has advanced this far past the start time —
+    /// wall-clock elapsed in realtime, replayed time in a historical run.
     Duration(Duration),
+    /// Stop after this many engine cycles. Exact and deterministic in a
+    /// historical replay; in realtime, burst coalescing makes the number of
+    /// cycles a poor proxy for the number of values, so prefer `Duration`.
     Cycles(u32),
+    /// Run until something else ends it — a source signalling end-of-stream,
+    /// a `stop` handle, or an error.
     #[default]
     Forever,
 }
 
 impl RunFor {
+    /// Whether the run has reached its bound, given the cycle just completed
+    /// and the engine time elapsed since the start.
     pub fn done(&self, cycle: u32, elapsed: NanoTime) -> bool {
         match self {
             RunFor::Cycles(cycles) => cycle > *cycles,

--- a/crates/wingfoil/src/runtime/time.rs
+++ b/crates/wingfoil/src/runtime/time.rs
@@ -54,19 +54,36 @@ static EPOCH_OFFSET_NANOS: LazyLock<u64> = LazyLock::new(|| {
 pub struct NanoTime(RawTime);
 
 impl NanoTime {
+    /// The Unix epoch, and the conventional start time for a deterministic
+    /// historical run (`RunMode::HistoricalFrom(NanoTime::ZERO)`).
     pub const ZERO: Self = Self(0);
+    /// The largest representable instant. Used as "never" when comparing
+    /// scheduled times, so an empty queue loses every `min`.
     pub const MAX: Self = Self(RawTime::MAX);
+    /// Nanoseconds in a second — the unit conversion for the raw count.
     pub const NANOS_PER_SECOND: RawTime = 1_000_000_000;
+    /// Seconds in a nanosecond, i.e. the multiplier that turns the raw count
+    /// into fractional seconds for display.
     pub const SECONDS_PER_NANO: f64 = 1e-9;
 
     /// KDB epoch is 2000-01-01, Unix epoch is 1970-01-01
     /// Difference: 946684800 seconds = 946684800000000000 nanoseconds
     const KDB_EPOCH_OFFSET_NANOS: i64 = 946_684_800_000_000_000;
 
+    /// The current wall-clock instant, as nanoseconds since the Unix epoch.
+    ///
+    /// Reads a coarse-corrected TSC clock, so it costs ~24 ns rather than a
+    /// syscall — which is why the kernel still caches one snap per cycle
+    /// instead of calling this per node. **Business logic should not call it:**
+    /// use [`Ctx::time`](crate::op::Ctx::time), which is source-driven and
+    /// replays deterministically.
     pub fn now() -> Self {
         Self(CLOCK.now().as_u64() + *EPOCH_OFFSET_NANOS)
     }
 
+    /// This instant as fractional **seconds** since the epoch, grouped for
+    /// readability. For logs and `Display`; lossy, so do not round-trip
+    /// through it.
     pub fn pretty(&self) -> String {
         (self.0 as f64 * Self::SECONDS_PER_NANO).formato("#,###.000_000")
     }

--- a/crates/wingfoil/src/runtime/time_queue.rs
+++ b/crates/wingfoil/src/runtime/time_queue.rs
@@ -156,6 +156,7 @@ impl<T> Default for TimeQueue<T> {
 }
 
 impl<T> TimeQueue<T> {
+    /// An empty queue.
     pub fn new() -> Self {
         Self::default()
     }
@@ -171,6 +172,8 @@ impl<T> TimeQueue<T> {
         }
     }
 
+    /// Whether nothing is scheduled — checked every cycle, so it must not
+    /// touch the map beyond `is_empty`.
     pub fn is_empty(&self) -> bool {
         self.front.is_none() && self.buckets.is_empty()
     }
@@ -204,6 +207,8 @@ impl<T> TimeQueue<T> {
         }
     }
 
+    /// Drop every pending entry, at every instant. Used when a run ends or a
+    /// scheduling node is torn down, so a stale schedule cannot resurrect it.
     pub fn clear(&mut self) {
         self.front = None;
         self.buckets.clear();

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ engine, the one decision everything else follows from, and the rules that bite.
 | [**python-interop.md**](python-interop.md) | The plugin SDK — authoring ops, graphs and adapters in Rust, then composing them from Python |
 | [**comparison.md**](comparison.md) | Wingfoil against other stream processing, dataflow and trading frameworks |
 | [**release-notes/**](release-notes/) | One page per version — what changed, why, and what you have to do about it |
+| [**RELEASING.md**](RELEASING.md) | Maintainer-facing: how a release is cut, the two dispatches, and what to do when a publish fails halfway |
 
 ## [`decisions/`](decisions/) — why the engine is the way it is
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,11 +20,14 @@ because nothing in the tree fails without them until a release run does:
    `pypi-publish.yml`, and **no environment** (leave the environment field
    blank — it must match the workflow, and `upload-pypi` declares no
    `environment:`). TestPyPI matters as much as PyPI: without it the rehearsal
-   in step 2 fails at the last step, after ~2 hours of wheel builds.
+   in step 2 fails at its very last step, after the whole wheel matrix has
+   built.
 2. **Dispatch `pypi-publish.yml` once with `pypi-target: test`.** That is the
    only way to exercise the whole PyPI path — sdist repair, five wheels, the
    `upload-pypi` job's OIDC mint — without burning a version number on the real
-   index. Do it after any change to that workflow, not just once ever.
+   index. `test` is the default for a manual dispatch, so this is also what you
+   get if you dispatch that workflow without thinking; only `release.yml` passes
+   `prod`. Do it after any change to that workflow, not just once ever.
 
 npm and crates.io are already set up: npm publishes over OIDC too (trusted
 publisher for `wingfoil-io/wingfoil` + `npm-publish.yml` on `@wingfoil/client`),
@@ -92,8 +95,9 @@ ZMQ integration tests run alongside as their own job.
 - `npm-publish.yml` — builds the wasm bundle and the TypeScript, lints, runs
   `vitest` as a publish preflight, checks the pack tarball actually contains
   `dist/wasm/wingfoil_wasm_bg.wasm`, then `npm publish --access public` over
-  OIDC. npm is pinned to the 11.x line; 12.0.0 cannot resolve `sigstore` for
-  `--provenance`.
+  OIDC (provenance is emitted automatically). It publishes with the **npm**
+  CLI, not pnpm, which has no OIDC trusted publishing — and pins npm to the
+  11.x line, because 12.0.0's bundle cannot resolve `sigstore`.
 - `pypi-publish.yml` with `pypi-target: prod` — one sdist plus five abi3 wheels
   (linux x86_64 + aarch64 in `manylinux_2_28` containers, macOS arm64 + x86_64,
   windows x64), then one `upload-pypi` job over OIDC. The Linux wheels carry

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,146 @@
+# Releasing
+
+How a wingfoil release is cut, what has to be true before you start, and what
+to do when a publish fails halfway. Maintainer-facing; the workflows in
+[`.github/workflows/`](../.github/workflows/) are the source of truth and this
+page explains them.
+
+A release ships **one version to three registries** — crates.io, PyPI and npm —
+and the tag is cut only once all three have the artifacts.
+
+## Before the first release from a fresh setup
+
+Two things are configured outside this repository and are easy to forget,
+because nothing in the tree fails without them until a release run does:
+
+1. **Trusted publishers must be registered on both PyPI *and* TestPyPI.**
+   `pypi-publish.yml` uploads over OIDC — there is no `*_PYPI_API_TOKEN`
+   secret. Register a GitHub publisher on each of the two indexes for the
+   project `wingfoil`, owner `wingfoil-io`, repository `wingfoil`, workflow
+   `pypi-publish.yml`, and **no environment** (leave the environment field
+   blank — it must match the workflow, and `upload-pypi` declares no
+   `environment:`). TestPyPI matters as much as PyPI: without it the rehearsal
+   in step 2 fails at the last step, after ~2 hours of wheel builds.
+2. **Dispatch `pypi-publish.yml` once with `pypi-target: test`.** That is the
+   only way to exercise the whole PyPI path — sdist repair, five wheels, the
+   `upload-pypi` job's OIDC mint — without burning a version number on the real
+   index. Do it after any change to that workflow, not just once ever.
+
+npm and crates.io are already set up: npm publishes over OIDC too (trusted
+publisher for `wingfoil-io/wingfoil` + `npm-publish.yml` on `@wingfoil/client`),
+and crates.io uses the `CRATES_IO_API_TOKEN` secret.
+
+## The release, end to end
+
+Two manual dispatches, in this order.
+
+### 1. `release.bump`
+
+Dispatch [`bump.yml`](../.github/workflows/bump.yml) with `major` / `minor` /
+`patch`. It computes the next version from the highest of the three version
+strings it tracks, then moves them all together and pushes the commit **straight
+to `main`**:
+
+- every root-workspace crate (`cargo set-version`);
+- `crates/wingfoil-wasm/Cargo.toml`, which is excluded from the workspace and so
+  is bumped by `sed`, along with its `wingfoil-wire-types` pin;
+- `js/package.json` (`@wingfoil/client`);
+- `crates/wingfoil-python/docs/conf.py`;
+- the `esm.sh/@wingfoil/client@<version>` importmap pins in the `trading_e2e`
+  examples;
+- `legacy/wingfoil`'s `wingfoil-wire-types` requirement — legacy itself is
+  frozen at 8.0.0 and deliberately not bumped, but it still has to resolve.
+
+The commit message is `bump: <type> version to <x.y.z>`, and that exact shape is
+what the heavy CI legs skip on (see
+[`.github/workflows/README.md`](../.github/workflows/README.md)).
+
+Write the [release-notes page](release-notes/) for the new version before step 2
+if the release needs one — `github-release` links `docs/release-notes/<version>.md`
+when it exists and the index otherwise, so a page added later is not linked from
+the release body.
+
+### 2. `release`
+
+Dispatch [`release.yml`](../.github/workflows/release.yml). One run, in this
+order:
+
+```
+preflight ─> all tests ─┬─> crates.io ─┐
+            legacy zmq  ├─> npm        ├─> tag ─> GitHub release
+                        └─> PyPI       ┘
+```
+
+**Preflight** reads the version from `crates/wingfoil/Cargo.toml` (the surviving
+crate — legacy is frozen and reading it would peg every release at a version
+already tagged), and fails if `js/package.json` or `wingfoil-wasm` disagree with
+it, or if the tag already exists.
+
+**All tests** is `all-tests.yml`: `rust-test.yml` + `python-test.yml` +
+`legacy-python-test.yml` + the whole `integration-tests.yml` fan-out. The legacy
+ZMQ integration tests run alongside as their own job.
+
+**The three publishes run in parallel**, each a reusable workflow:
+
+- `crates-publish.yml` — six crates to crates.io in dependency order, with
+  `sleep 30` waits for the index between tiers: `wingfoil-derive`,
+  `wingfoil-python-derive`, `wingfoil-wire-types` → `wingfoil`, `wingfoil-wasm`
+  → `wingfoil-python`. `wingfoil-wasm` is verified against
+  `wasm32-unknown-unknown` (the target is installed in the job for exactly
+  that), and every step passes `--registry crates-io` because these crates list
+  two registries in `package.publish`.
+- `npm-publish.yml` — builds the wasm bundle and the TypeScript, lints, runs
+  `vitest` as a publish preflight, checks the pack tarball actually contains
+  `dist/wasm/wingfoil_wasm_bg.wasm`, then `npm publish --access public` over
+  OIDC. npm is pinned to the 11.x line; 12.0.0 cannot resolve `sigstore` for
+  `--provenance`.
+- `pypi-publish.yml` with `pypi-target: prod` — one sdist plus five abi3 wheels
+  (linux x86_64 + aarch64 in `manylinux_2_28` containers, macOS arm64 + x86_64,
+  windows x64), then one `upload-pypi` job over OIDC. The Linux wheels carry
+  every adapter (`--features extension-module,all-adapters`); macOS and Windows
+  take the pyproject feature list, which excludes aeron and iceoryx2. The upload
+  job refuses to publish fewer than 5 wheels or anything other than exactly 1
+  sdist.
+
+`release.yml` grants `id-token: write` on the `publish-npm` and `publish-pypi`
+jobs itself. A reusable workflow's permissions are capped by its caller, so the
+grant has to be at the call site or the upload job cannot mint an OIDC token.
+
+**Then the tag**, and only then. This ordering is the fix for a real failure
+mode: the tag used to come first, so a publish failure left a pushed tag that
+made preflight's "tag already exists" check block every re-run, and the only way
+forward was deleting a tag by hand. Nothing consumes the tag — each publish job
+checks out the dispatched commit, not the tag — so moving it last costs nothing.
+
+**Finally the GitHub release**, which needs the tag to exist
+(`gh release create --verify-tag`). Its body is an install block for all three
+registries, a link to the release notes, and GitHub's generated changelog
+appended underneath.
+
+## When a publish fails
+
+The recoverable-but-not-idempotent case is a **partial** publish. If crates.io
+succeeds and npm fails, re-dispatching `release.yml` re-runs the crates job,
+which dies on *crate version already uploaded*.
+
+That state is still clean in the ways that matter — **no tag was pushed and no
+GitHub release exists**, so there is nothing to hand-delete and the version is
+not yet announced. The way out is to dispatch the *remaining* registries
+individually rather than re-running `release.yml`:
+
+- `crates-publish.yml`, `npm-publish.yml`, `pypi-publish.yml` are each
+  dispatchable on their own. That is what they are for outside a release run.
+- Then push the tag by hand and create the release, or re-dispatch
+  `release.yml` only once every registry is done — its publish jobs will still
+  fail on "already uploaded", so hand-tagging is usually the shorter path.
+
+None of the three registries lets you overwrite a published version, so a bad
+release is fixed by bumping again, not by republishing.
+
+## Related
+
+| | |
+|---|---|
+| [`.github/workflows/README.md`](../.github/workflows/README.md) | Every workflow in the repo, what triggers it, and the CI/integration split |
+| [`release-notes/`](release-notes/) | The curated half of a release — one page per version |
+| [`../SECURITY.md`](../SECURITY.md) | Dependency policy, and why Dependabot version updates are off |

--- a/docs/wingfoil-architecture.md
+++ b/docs/wingfoil-architecture.md
@@ -172,6 +172,17 @@ state; the channel layer to talk to background threads; `ArcSwap` where a
 background thread needs an occasional read. A mutex in `cycle` is a
 correctness problem, not just a performance one.
 
+**A graph lives on one thread, and the types say so.** `GraphBuilder`,
+`Stream<T>` and `Runner` hold `Rc`, so all three are `!Send`/`!Sync` — wiring,
+`build()` and `run()` happen on the same thread, and moving any of them into
+`thread::spawn` is a compile error. That is the *enforcement* of the rule
+above, not a separate one. Everything that crosses a thread boundary crosses at
+the channel layer, which hands out a `Send` half — `channel` /
+`pooled_channel` / `source_at_start` return a sender to move; `spawn` and
+`spawn_map` wire and run a whole sub-graph on a worker for you. Several
+separate graphs on several threads is fine; sharing one is what is ruled out.
+The rustdoc on `GraphBuilder` carries the table and a runnable example.
+
 **I/O is established at `start()`, not at wiring.** Wiring stays pure — parse,
 validate, reject the wrong run mode — so it is testable without a live
 service, and connection errors surface during the run with node context.

--- a/legacy/CONTRIBUTING.md
+++ b/legacy/CONTRIBUTING.md
@@ -7,14 +7,17 @@ Drop a comment on any issue, open a new one, or say hi on [Discord](https://disc
 
 We're actively looking for help on the following:
 
-- 🔧 [ZMQ service discovery](https://github.com/wingfoil-io/wingfoil/issues/103) — dynamic node registration
-- 🗄 [KDB+ caching](https://github.com/wingfoil-io/wingfoil/issues/90) — faster replay and snapshot support
 - 📦 [Binary file I/O](https://github.com/wingfoil-io/wingfoil/issues/104) — Arrow, Parquet, and more
-- 🛢 [SQL I/O](https://github.com/wingfoil-io/wingfoil/issues/105) — stream to/from relational databases
-- ⚡ [Kafka I/O](https://github.com/wingfoil-io/wingfoil/issues/23) — streaming integration
 - 🐍 [wingfoil-python full parity](https://github.com/wingfoil-io/wingfoil/issues/106) — every node and adapter exposed to Python
 - 🐍 [Python showcase](https://github.com/wingfoil-io/wingfoil/issues/107) — Rust pipeline, results in pandas + scikit-learn + plotly
-- 🌐 [JS/TS browser integration](https://github.com/wingfoil-io/wingfoil/issues/110) — wingfoil in-browser via WASM
+
+Shipped since this list was written, and no longer open:
+[ZMQ service discovery](https://github.com/wingfoil-io/wingfoil/issues/103),
+[KDB+ caching](https://github.com/wingfoil-io/wingfoil/issues/90),
+[SQL I/O](https://github.com/wingfoil-io/wingfoil/issues/105) (the postgres
+adapter), [Kafka I/O](https://github.com/wingfoil-io/wingfoil/issues/23) and
+[JS/TS browser integration](https://github.com/wingfoil-io/wingfoil/issues/110)
+(`wingfoil-wasm` + `@wingfoil/client`).
 
 We're especially keen to hear from specialists in:
 
@@ -24,10 +27,12 @@ We're especially keen to hear from specialists in:
 
 ## Good First Issues
 
-New to open source or Rust? These are a great starting point:
-
-- 🧮 [Add EWMA stream](https://github.com/wingfoil-io/wingfoil/issues/111)
-- 🔍 [Python binding for inspect & throttle](https://github.com/wingfoil-io/wingfoil/issues/112)
+New to open source or Rust? Browse the
+[`good first issue`](https://github.com/wingfoil-io/wingfoil/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+label, or anything labelled `size: small`. **New work belongs on the wingfoil
+tree at the repository root, not here** — see the root
+[`CONTRIBUTING.md`](../CONTRIBUTING.md). This tree is frozen at 8.0.0 and is
+deleted at cutover.
 
 
 ## Building and Testing


### PR DESCRIPTION
## What this changes

Three of the four remaining items on #458, and a fourth verified rather than
assumed.

**The single-threaded contract is documented on the types users hold.**
`GraphBuilder`, `Stream<T>` and `Runner` are `!Send`/`!Sync` — they share an
`Rc<RefCell<Builder>>` — but nothing in the rustdoc said so, so the first thing
a new 9.0 user meets is `Rc<RefCell<Builder>> cannot be sent between threads
safely` from a `thread::spawn` they had no reason to expect would fail, and
they have to infer the channel layer from scratch. Now:

- a crate-level **"Threading: a graph lives on one thread"** section with the
  compiler error it produces, why the bound is deliberate, a table of the six
  supported crossings (`channel`, `pooled_channel`, `source_at_start`, `spawn`,
  `spawn_map`, `external`) with the `Send` half each hands back, and a
  **runnable doc-test** that moves a `ChannelSender` onto a worker thread while
  the graph stays put;
- `GraphBuilder` gets a *"Not `Send`, by design"* section; `Stream<T>`,
  `Runner`, and the `fluent` / `interp` module docs point at it;
- the same rule joins `docs/wingfoil-architecture.md`'s "rules that bite",
  directly under the "no locks on the graph execution path" invariant it is the
  enforcement of.

**`docs/RELEASING.md`.** New, and written against the workflows as they stand
after #807 and #808 rather than from memory: the two dispatches, publish-first
/ tag-last with the reason it was reordered, the six crates in dependency
order (`wingfoil-wasm` included), the sdist + five abi3 wheels, and where the
`id-token: write` grants have to live. It also records the two operational
prerequisites that until now existed only in a PR body — **trusted publishers
must be registered on PyPI *and* TestPyPI** for `wingfoil-io/wingfoil` +
`pypi-publish.yml` with no `environment:`, and `pypi-publish.yml` wants one
`pypi-target: test` dispatch before a real release — and the known residual: a
*partial* publish is not idempotent, but it leaves no tag and no release, so
the remaining registries get dispatched individually.

**`missing_docs` enabled.** Measured **77** gaps in `wingfoil` (`--all-features`),
plus 5 in `wingfoil-wire-types`. All 82 filled with real documentation —
no placeholder one-liners, no `#[allow(missing_docs)]`, nothing deferred — and
`#[warn(missing_docs)]` turned on in both crate roots with a comment saying
that `-D warnings` makes it a deny in CI.

**Lossy semantics, verified against the current op set.** `merge`'s rustdoc did
already say "the earliest-supplied ticked input wins", and `collapse`'s already
carried a full warning, so only the gap was worth filling: `merge` now spells
out that on a same-cycle tie the losing input's value is *dropped* — not
queued, not emitted next cycle — that `merge_all` / `MergeN` share the rule,
and that `join` is the alternative that sees both values.

**CONTRIBUTING.md refresh**, plus one thing the issue asked for that turned out
to be already fixed:

- the branch table still routed non-`legacy/` work to `next`, which is retired;
- added the local integration-test story: which tests bring up their own
  container via `testcontainers` (etcd, redis, postgres, kafka, fluvio, otlp,
  aeron — Docker daemon is the only prerequisite), which need a service brought
  up by hand and skip rather than fail without it (prometheus, kdb), and which
  need no service at all, just sockets or `/dev/shm` (web, zmq, fix,
  iceoryx2) — and the `-E 'not binary(/_integration$/)'` filter that is the
  only thing keeping them out of the normal job;
- fixed the Aeron CMake floor (3.20 → **3.30**) and the stale "`--all-features`
  adds `async`, `csv` and `augurs`" line;
- **the Discord invite already matches README** (`WfZwpQnZUA` in both), so
  there was no mismatch left to fix;
- the stale "looking for contributors" list is in **`legacy/CONTRIBUTING.md`**,
  not the root one. Five of its items have shipped and are closed (ZMQ
  discovery #103, KDB+ caching #90, SQL #105, Kafka #23, JS/TS browser #110)
  and both "good first issues" (#111, #112) are closed; the list now carries
  only the three that are still open, and points new work at the root tree.

## Why

`docs/IMPROVEMENT_PLAN.md` Phase 5 follow-up. Closes #458.

## How it was verified

Run by hand — the cargo-husky hooks are not installed in this checkout
(`.git/hooks` holds only samples), so none of these ran automatically.

- [x] `cargo fmt --all` — and `cargo fmt --all -- --check` exits 0
- [x] `cargo lint` and `cargo lint-all` — both clean under `-D warnings`, which
      is what proves the newly-enabled `missing_docs` has no remaining gaps
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features`
      (`--no-fail-fast`) — **968 passed, 62 failed**, and *every one of the 62 is
      `failed to initialize a docker client: Socket not found:
      /var/run/docker.sock`* across the nine `*_integration` targets that need a
      container (aeron, etcd, fluvio, kafka, otlp, postgres, redis,
      zmq_cross_lang, zmq_etcd). There is no Docker in this environment; they
      are unrelated to this diff and CI runs them in their own per-adapter
      workflows. No other test failed.
- [x] Doc-tests: **17 passed, 0 failed, 18 ignored** under `--all-features`,
      the new threading example (`src/lib.rs` line 153) among them.
- [ ] New behaviour is covered by a test asserting values and tick times — n/a,
      no behaviour changed. The one new executable artefact is the doc-test.

Three claims were checked against the compiler rather than written from memory:

- the `missing_docs` lint is *active*, not just present — appending an
  undocumented `pub struct` to `tier.rs` produced exactly one
  `missing documentation` warning, then reverted;
- `ChannelSender` / `ExternalSource` / `PooledSender` really are `Send` —
  `assert_send::<T>()` compiled against each;
- the quoted E0277 in the crate docs is rustc's actual output for a
  `thread::spawn` capturing a `GraphBuilder`, pasted after running it. My first
  draft was wrong in two ways (rustc fully-qualifies both types, and blames the
  closure rather than `thread::spawn`), which is the second commit here.

## Notes for the reviewer

**No runtime behaviour changes.** Every `.rs` edit is a doc comment, the two
`#[warn(missing_docs)]` attributes, and the brace-expansion of five
struct-variant declarations onto multiple lines (`FixSessionStatus::SequenceGap`,
`FixStore::Memory`, `ControlMessage::{Subscribe, Unsubscribe, Complete}`) so
their fields could take doc comments — same fields, same names, same types.

Two things I deliberately did not do:

- **I did not soften the `missing_docs` gate.** 77 is large enough that
  placeholder one-liners were a real temptation; the issue is explicit that a
  doc comment restating the item's name is worse than an honest gap, because it
  silences the lint forever. Every one is a sentence that says something the
  signature does not. Where I could not verify a behavioural claim from the
  code (whether the server ignores unknown topics on `Unsubscribe`, whether a
  `FixSessionStatus::Error` is terminal for the attempt, whether `FileCache`
  creates its folder — it does not), I described the item and left the
  behaviour out rather than guess.
- **I left `legacy/`'s Aeron and build sections alone.** That tree is deleted at
  cutover; the only edit there is the contributor list, which was actively
  pointing people at closed issues.

One thing worth a second opinion: `docs/RELEASING.md` is maintainer-facing, and
`docs/README.md` says the top level is for pages *a user* would look for. I put
it at the top level anyway (the issue asked for `docs/RELEASING.md` by name, and
`CONTRIBUTING.md` links it), with a row in the index that labels it
maintainer-facing. Happy to move it if that is the wrong call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019E9ZYUCcabdMAZVz1dF7Yd)_