### PR TITLE
Collapse the `register_op` arity rungs onto one shared core

### DIFF
--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -540,8 +540,10 @@ Pick the lightest tool that fits:
   which reads as `zscore(stream, window, decay)` instead of taking a tuple.
 
   **Arity 5+ is not a macro gap — it is a missing primitive.** Add
-  `Builder::register_op<n>` (mirror `register_op4`, which mirrors
-  `register_op3` line for line), `PyStream::wire_op<n>`, and the parameter name
+  `Builder::register_op<n>` (mirror `register_op4`: grab the N `SlotRef`s and
+  hand `register_op_cell` a closure that borrows them and calls `step` — a
+  dozen lines, since the registration shape itself lives in that shared core),
+  `PyStream::wire_op<n>`, and the parameter name
   in the macro's `receiver_names`; the emitter itself is arity-generic. Each
   arity needs its own registration function because the inputs are
   heterogeneous static types and Rust has no variadic generics — which is a

--- a/crates/wingfoil-python-derive/src/lib.rs
+++ b/crates/wingfoil-python-derive/src/lib.rs
@@ -59,9 +59,10 @@
 //! tick carries. `#[pyop]` reads them off the `impl` block, `#[pygraph]` off
 //! the wiring fn, `#[pyadapter]` off the free fn or the impl's method.
 //!
-//! Wider ops need a `register_op<n>`/`wire_op<n>` pair for their arity —
-//! `register_op4` mirrors `register_op3` line for line — plus the parameter
-//! name in `receiver_names`. The emitter itself is arity-generic, so nothing
+//! Wider ops need a `register_op<n>`/`wire_op<n>` pair for their arity — a
+//! rung is a dozen lines over the shared `Builder::register_op_cell`: borrow
+//! the N handles, call `step` — plus the parameter name in `receiver_names`.
+//! The emitter itself is arity-generic, so nothing
 //! else changes. (Each arity needs its own registration function because the
 //! inputs are *heterogeneous* static types and Rust has no variadic generics;
 //! a Python-authored node has no such limit — `Graph.custom_node` takes any
@@ -1074,8 +1075,8 @@ fn ref_tuple_elems(ty: &Type) -> syn::Result<Vec<Type>> {
         ty.span(),
         "#[pyop] supports one- to four-input ops (`type In<'a> = (&'a A,)` through \
          `(&'a A, &'a B, &'a C, &'a D)`); a wider op needs a `register_op<n>`/`wire_op<n>` \
-         pair for its arity — add them the way `register_op4` mirrors `register_op3`, then \
-         add the parameter name to `receiver_names`",
+         pair for its arity — add them the way `register_op4` borrows its handles over the \
+         shared `register_op_cell`, then add the parameter name to `receiver_names`",
     ))
 }
 

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -1309,6 +1309,76 @@ impl Builder {
         Rc::new(RefCell::new((cfg, state)))
     }
 
+    /// The shared body of every `register_op<n>` rung — the one place the
+    /// registration *shape* lives.
+    ///
+    /// Arity is the only thing that genuinely differs between the public
+    /// rungs: each borrows its N input slots and calls a step closure over
+    /// `&A`, `&B`, … Everything around that — allocating the output slot,
+    /// packing `cfg`+`state` into a shared cell, pushing the node, translating
+    /// [`Tick`] into the engine's "did it tick?" bool, and installing the
+    /// re-run [`reset`](Self::set_reset) hook — is identical, so it is written
+    /// once here and each rung supplies a `body` closure that has already
+    /// captured its own [`SlotRef`]s.
+    ///
+    /// `body` is handed the op's `cfg`/`state` and a [`Ctx`] and returns the
+    /// tick. It borrows its inputs internally and releases them before
+    /// returning, so the output slot is always written with no input slot
+    /// borrowed.
+    ///
+    /// Returns the output handle *and* the cfg+state cell, so
+    /// [`register_op1_with_stop`](Self::register_op1_with_stop) can give its
+    /// lifecycle hook the same view of them the cycle has.
+    #[allow(clippy::type_complexity)]
+    fn register_op_cell<C, S, Out, SInit, Body>(
+        &mut self,
+        active_ups: Vec<usize>,
+        label: &'static str,
+        activation: Activation,
+        cfg: C,
+        state_init: SInit,
+        mut body: Body,
+    ) -> (Handle<Out>, Rc<RefCell<(C, S)>>)
+    where
+        C: 'static,
+        S: 'static,
+        Out: Default + 'static,
+        SInit: Fn() -> S + 'static,
+        Body: FnMut(&mut C, &mut S, &mut Ctx<'_>) -> Result<Tick<Out>> + 'static,
+    {
+        let idx = self.nodes.len();
+        let out = self.new_slot(Out::default());
+        let cs = Self::cell(cfg, state_init());
+        let (cs_cycle, out_cycle) = (cs.clone(), out.clone());
+        self.push_node(
+            active_ups,
+            activation,
+            short_type_name(label),
+            Box::new(move |k| {
+                let (cfg, state) = &mut *cs_cycle.borrow_mut();
+                let mut ctx = Ctx::new(k, idx);
+                match body(cfg, state, &mut ctx)? {
+                    Tick::Value(v) => {
+                        *out_cycle.borrow_mut() = v;
+                        Ok(true)
+                    }
+                    Tick::Silent(v) => {
+                        *out_cycle.borrow_mut() = v;
+                        Ok(false)
+                    }
+                    Tick::Quiet => Ok(false),
+                }
+            }),
+            Box::new(|_| Ok(())),
+        );
+        let cs_reset = cs.clone();
+        self.set_reset(Box::new(move || {
+            cs_reset.borrow_mut().1 = state_init();
+            *out.borrow_mut() = Out::default();
+        }));
+        (self.make_handle(idx), cs)
+    }
+
     /// Register a **single-active-input** op — the shape shared by `map`,
     /// `fold`, `ewma`, and ~15 others: one upstream read by reference, one
     /// output slot, engine-owned `cfg`+`state`, no lifecycle hooks. Public so
@@ -1367,40 +1437,18 @@ impl Builder {
         SInit: Fn() -> S + 'static,
         Step: FnMut(&mut C, &mut S, &A, &mut Ctx<'_>) -> Result<Tick<Out>> + 'static,
     {
-        let idx = self.nodes.len();
         let src_slot = self.slot(src);
-        let out = self.new_slot(Out::default());
-        let cs = Rc::new(RefCell::new((cfg, state_init())));
-        let (cs_reset, out_reset, cs_out) = (cs.clone(), out.clone(), cs.clone());
-        self.push_node(
+        self.register_op_cell(
             vec![src.idx],
+            label,
             activation,
-            short_type_name(label),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
+            cfg,
+            state_init,
+            move |cfg, state, ctx| {
                 let a = src_slot.borrow();
-                match step(cfg, state, &a, &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop(a);
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = state_init();
-            *out_reset.borrow_mut() = Out::default();
-        }));
-        (self.make_handle(idx), cs_out)
+                step(cfg, state, &a, ctx)
+            },
+        )
     }
 
     /// [`register_op1`](Self::register_op1) plus a **`stop` hook** — the shape a
@@ -1471,44 +1519,19 @@ impl Builder {
         SInit: Fn() -> S + 'static,
         Step: FnMut(&mut C, &mut S, &A, &B, &mut Ctx<'_>) -> Result<Tick<Out>> + 'static,
     {
-        let idx = self.nodes.len();
-        let a_slot = self.slot(a);
-        let b_slot = self.slot(b);
-        let out = self.new_slot(Out::default());
-        let cs = Rc::new(RefCell::new((cfg, state_init())));
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
+        let (a_slot, b_slot) = (self.slot(a), self.slot(b));
+        self.register_op_cell(
             vec![a.idx, b.idx],
+            label,
             activation,
-            short_type_name(label),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let va = a_slot.borrow();
-                let vb = b_slot.borrow();
-                match step(cfg, state, &va, &vb, &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop(va);
-                        drop(vb);
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop(va);
-                        drop(vb);
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = state_init();
-            *out_reset.borrow_mut() = Out::default();
-        }));
-        self.make_handle(idx)
+            cfg,
+            state_init,
+            move |cfg, state, ctx| {
+                let (va, vb) = (a_slot.borrow(), b_slot.borrow());
+                step(cfg, state, &va, &vb, ctx)
+            },
+        )
+        .0
     }
 
     /// Register a **three-active-input** op — the `join3` shape: all three
@@ -1541,44 +1564,19 @@ impl Builder {
         SInit: Fn() -> S + 'static,
         Step: FnMut(&mut Cfg, &mut S, &A, &B, &C, &mut Ctx<'_>) -> Result<Tick<Out>> + 'static,
     {
-        let idx = self.nodes.len();
-        let a_slot = self.slot(a);
-        let b_slot = self.slot(b);
-        let c_slot = self.slot(c);
-        let out = self.new_slot(Out::default());
-        let cs = Rc::new(RefCell::new((cfg, state_init())));
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
+        let (a_slot, b_slot, c_slot) = (self.slot(a), self.slot(b), self.slot(c));
+        self.register_op_cell(
             vec![a.idx, b.idx, c.idx],
+            label,
             activation,
-            short_type_name(label),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let va = a_slot.borrow();
-                let vb = b_slot.borrow();
-                let vc = c_slot.borrow();
-                match step(cfg, state, &va, &vb, &vc, &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop((va, vb, vc));
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop((va, vb, vc));
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = state_init();
-            *out_reset.borrow_mut() = Out::default();
-        }));
-        self.make_handle(idx)
+            cfg,
+            state_init,
+            move |cfg, state, ctx| {
+                let (va, vb, vc) = (a_slot.borrow(), b_slot.borrow(), c_slot.borrow());
+                step(cfg, state, &va, &vb, &vc, ctx)
+            },
+        )
+        .0
     }
 
     /// Register a **four-active-input** op: all four upstreams read by
@@ -1589,7 +1587,10 @@ impl Builder {
     /// Each arity is its own function because the inputs are *heterogeneous* —
     /// `&A, &B, &C, &D` are distinct static types the step closure is
     /// monomorphized over, and Rust has no variadic generics to fold them into
-    /// one signature. A wider op adds the next rung the same way.
+    /// one signature. What each rung still owns is exactly that: borrow its
+    /// handles and call `step`. Everything else is
+    /// [`register_op_cell`](Self::register_op_cell), so a wider op adds the
+    /// next rung in a dozen lines.
     // As the smaller arities: over clippy's limit because it is a registration
     // primitive whose arguments mirror them plus one handle.
     #[allow(clippy::too_many_arguments)]
@@ -1616,46 +1617,25 @@ impl Builder {
         SInit: Fn() -> S + 'static,
         Step: FnMut(&mut Cfg, &mut S, &A, &B, &C, &D, &mut Ctx<'_>) -> Result<Tick<Out>> + 'static,
     {
-        let idx = self.nodes.len();
-        let a_slot = self.slot(a);
-        let b_slot = self.slot(b);
-        let c_slot = self.slot(c);
-        let d_slot = self.slot(d);
-        let out = self.new_slot(Out::default());
-        let cs = Rc::new(RefCell::new((cfg, state_init())));
-        let (cs_reset, out_reset) = (cs.clone(), out.clone());
-        self.push_node(
+        let (a_slot, b_slot, c_slot, d_slot) =
+            (self.slot(a), self.slot(b), self.slot(c), self.slot(d));
+        self.register_op_cell(
             vec![a.idx, b.idx, c.idx, d.idx],
+            label,
             activation,
-            short_type_name(label),
-            Box::new(move |k| {
-                let (cfg, state) = &mut *cs.borrow_mut();
-                let mut ctx = Ctx::new(k, idx);
-                let va = a_slot.borrow();
-                let vb = b_slot.borrow();
-                let vc = c_slot.borrow();
-                let vd = d_slot.borrow();
-                match step(cfg, state, &va, &vb, &vc, &vd, &mut ctx)? {
-                    Tick::Value(v) => {
-                        drop((va, vb, vc, vd));
-                        *out.borrow_mut() = v;
-                        Ok(true)
-                    }
-                    Tick::Silent(v) => {
-                        drop((va, vb, vc, vd));
-                        *out.borrow_mut() = v;
-                        Ok(false)
-                    }
-                    Tick::Quiet => Ok(false),
-                }
-            }),
-            Box::new(|_| Ok(())),
-        );
-        self.set_reset(Box::new(move || {
-            cs_reset.borrow_mut().1 = state_init();
-            *out_reset.borrow_mut() = Out::default();
-        }));
-        self.make_handle(idx)
+            cfg,
+            state_init,
+            move |cfg, state, ctx| {
+                let (va, vb, vc, vd) = (
+                    a_slot.borrow(),
+                    b_slot.borrow(),
+                    c_slot.borrow(),
+                    d_slot.borrow(),
+                );
+                step(cfg, state, &va, &vb, &vc, &vd, ctx)
+            },
+        )
+        .0
     }
 
     /// A source that never ticks (the legacy `never`). No upstreams and no

--- a/docs/decisions/macro-extensibility-decision.md
+++ b/docs/decisions/macro-extensibility-decision.md
@@ -255,7 +255,14 @@ Two consequences fell out, both deliberate:
   crates that must be able to name every step. That is the same status
   `SlotRef` and `Stream::__slot` already carried for `nitro!`'s `nested()`
   expansion. `register_op1`…`register_op4` are **unchanged** and remain the
-  curated, documented primitives for wiring a shape by hand.
+  curated, documented primitives for wiring a shape by hand. Their *bodies*
+  were since folded into one private core, `Builder::register_op_cell`
+  ([#731](https://github.com/wingfoil-io/wingfoil/issues/731)) — output slot,
+  cfg+state cell, `push_node`, the `Tick` → bool translation and the re-run
+  `reset` hook are written once, and each public rung is left holding only what
+  is genuinely arity-specific: borrow its N slots, call `step`. Every signature
+  is byte-identical, so no call site moved and the seam is unchanged for
+  anyone outside the crate.
 - **Trait scoping replaced inherent scoping.** The generated method is callable
   only where its trait is in scope — automatic in the op's own module,
   a `use` from anywhere else. In-crate that is why `fluent.rs`, `signal.rs` and


### PR DESCRIPTION
## What this changes

`Builder::register_op1`…`register_op4` no longer each carry their own copy of the registration shape. That shape now lives once, in a private `Builder::register_op_cell`, and each public rung is left holding only the part that is genuinely arity-specific: borrow its N input slots and call `step`.

**No public signature changed** — every `register_op*` is byte-identical in its public form, so no call site moved anywhere: not in the engine, the adapters, the Python bindings, the benches, or out-of-crate.

## Why

Closes #731.

### Item 1 — collapse the arity rungs (the real work)

First, what `main` actually has, since the issue predates #815 by a week:

- There is **no `register_op0`**. The issue's title names one, but the family on `main` is `register_op1`, the private `register_op1_cell`, `register_op1_with_stop`, `register_op2`, `register_op3`, `register_op4`. The body's own wording — "the arity-specialised registration functions share enough shape to be collapsed" — is the accurate description, and that is what this PR does.
- #815 left the family untouched, as it said it would. Confirmed against the code, not assumed.

Each rung repeated: allocate the output slot, pack `cfg`+`state` into a shared `Rc<RefCell<(C, S)>>`, `push_node` with a cycle closure, translate `Tick` into the engine's "did it tick?" bool across three arms, and install the re-run `reset` hook. Roughly 30 lines, four times over. The only real difference between them is how many slots get borrowed and what `step`'s argument list looks like — and that difference is irreducible, because `&A, &B, &C, &D` are heterogeneous static types the step closure is monomorphized over and Rust has no variadic generics.

So `register_op_cell` takes the active-upstream indices plus a `body` closure that has **already captured its own `SlotRef`s**, which is what lets the shared core stay free of the arity. A rung is now:

```rust
let (a_slot, b_slot) = (self.slot(a), self.slot(b));
self.register_op_cell(vec[a.idx, b.idx], label, activation, cfg, state_init,
    move |cfg, state, ctx| {
        let (va, vb) = (a_slot.borrow(), b_slot.borrow());
        step(cfg, state, &va, &vb, ctx)
    },
).0
```

`register_op1_cell` stays as a thin wrapper over the same core, because `register_op1_with_stop` needs the cfg+state cell handed back.

**On the seam being public.** This family is the documented public wiring seam that 9.0.0 is about to publish, so a signature change here would be a breaking change to something users are about to depend on. The collapse was chosen for that constraint: it is purely internal, and there is nothing for a caller to notice. No call site in this diff changed.

One behavioural nicety falls out, in the safe direction: the per-arity copies dropped their input borrows explicitly (`drop(va); drop(vb);`) before writing the output slot. That is now structural — `body` releases its borrows when it returns, so the output is always written with no input slot borrowed, without anyone having to remember the `drop`.

### Item 2 — "document `#[op]` as crate-internal": **done by #815, in the opposite direction**

Not implemented, deliberately — the item is stale and inverts. #815 (issue #782) made `#[op]` expand **out-of-crate**: the expansion is `::wingfoil::`-qualified, the generated `Builder` method is a per-op `#[doc(hidden)]` extension trait (`__WfBuild<CamelName>`), and `#[op]` is re-exported as `wingfoil::op`. Documenting it as crate-internal would now be documenting a falsehood.

I checked whether any such claim survives on `main` and **none does**. The docs #815 touched are accurate and complete as they stand:

- `docs/adding-an-op.md` has a whole section, "Out-of-crate ops take the identical path", opening `#[op]` is **not** in-crate tooling.
- `.claude/commands/new-op.md` says the same, and correctly reframes the hand-written route (`register_op1`…`register_op4` / `bimap` / `fold`) as the *escape hatch* rather than the out-of-crate path.
- `docs/decisions/macro-extensibility-decision.md` records the ruling, and its one mention of the old inherent-impl behaviour is a historical table row that already says #782 replaced it.

So item 2 is ticked as **done-by-#815**, with nothing invented to fill it.

## Docs moved with the shape

Three places described a new arity rung as a line-for-line copy of `register_op4`, which is no longer how you'd add one:

- `crates/wingfoil-python-derive/src/lib.rs` — the module-level arity-ceiling note **and** the `#[pyop]` error message a user actually hits at arity 5.
- `.claude/commands/new-op.md` — the "arity 5+ is not a macro gap" step.

Each now says what is true: a rung is a dozen lines over the shared core. The decision record, which tracks this family, gets the collapse on record with the signatures-unchanged point stated explicitly.

## How it was verified

The cargo-husky hooks are **not installed in this checkout** (`.git/hooks` holds only samples), so all four gates were run by hand.

- [x] `cargo fmt --all` — exit 0
- [x] `cargo lint` — exit 0 · `cargo lint-all` — exit 0
- [x] `cargo test --manifest-path crates/wingfoil/Cargo.toml --all-features` — **exit 101**, see below
- [ ] New behaviour is covered by a test asserting values and tick times — n/a: this is a pure refactor with no new behaviour. Its coverage is the existing suite, which exercises every rung: `tests/fluent_primitives.rs` pins `register_op3`/`register_op4` (values, tick times, and state re-seeding across a second run), and `register_op1`/`register_op2` are underneath most of the op catalog, the adapters and the Python bindings.

**The test gate's literal exit code is 101, and I am not calling that a pass.** With `--no-fail-fast` the failures resolve to exactly the nine `*_integration` binaries that need a container runtime — aeron, etcd, fluvio, kafka, otlp, postgres, redis, zmq_cross_lang, zmq_etcd — every one of them `failed to initialize a docker client: Socket not found: /var/run/docker.sock`. That is the sandbox, not this diff. Everything else is green, including the 323 lib unit tests and every non-containerised integration binary.

Two sandbox artifacts worth naming so nobody re-debugs them:

- A first run died with `could not parse/generate dep info` on four crates — the `scripts/disk.sh auto` post-command hook deleted extracted registry sources mid-build. Cleaned and re-ran; it did not recur.
- `--test trybuild` failed once on `No space left on device`, mid-`aws-lc-sys`. Since **`tests/trybuild/pass/out_of_crate_op.rs` is the regression guard for this change** — the only place in the repo where `crate::` provably cannot reach the engine — I would not sign this off on an ENOSPC. Deep-cleaned and ran it alone with `--all-features`: **exit 0**, `tests/trybuild/pass/out_of_crate_op.rs [should pass] ... ok`. `#[op]`'s generated code still wires itself correctly through this seam both in-crate and out.

## Notes for the reviewer

- The reduction reads as only ~20 net lines in `interp.rs` because the shared core carries ~30 lines of new doc comment. The code deduplication is the four copies of the push/tick/reset boilerplate going to one.
- No boxing or indirection was added: `body` is a concrete generic closure monomorphized into the same `Box<dyn FnMut>` cycle closure that was already there, so the call is static.
- I did not touch #815's changes, and did not comment on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019E9ZYUCcabdMAZVz1dF7Yd)_