### PR TITLE
trading_e2e: stamp the deployed build onto the page

### DIFF
--- a/crates/wingfoil/examples/showcase/trading_e2e/README.md
+++ b/crates/wingfoil/examples/showcase/trading_e2e/README.md
@@ -84,6 +84,43 @@ specifiers are now your problem: `@wingfoil/telemetry`'s `chart.js` does
 needs its own importmap entry. The script's final check asserts every mapped
 target exists.
 
+### Which build is deployed?
+
+The script writes `vendor/build.json`, served alongside the page:
+
+```bash
+curl -s https://demo.wingfoil.io/vendor/build.json
+```
+
+```json
+{
+  "commit": "4c0fea56df8b8302364c466e6a3cfe30d1b7b1cf",
+  "dirty": false,
+  "built_at": "2026-08-14T19:01:51Z",
+  "wingfoil": "9.0.0",
+  "wasm": "9.0.0",
+  "client": "9.0.0",
+  "telemetry": "0.1.0",
+  "uplot": "1.6.31"
+}
+```
+
+The page renders the same thing in a footer, with the full detail on hover.
+That footer is written by a **classic** inline script rather than by `app.js`,
+deliberately: it must still render when the module graph fails to load, which
+is precisely when you want to know which build you are looking at.
+
+The three version fields `wingfoil` / `wasm` / `client` are the ones
+`release.yml`'s preflight asserts are equal, so a mismatch between them is
+visible on the deployed page rather than only at release time.
+
+Before this existed, answering "is the demo running the latest code?" meant
+joining the SSM AMI parameter, the running instance's `ImageId` and the
+workflow run history — the AMI is the artifact that actually serves the page,
+so that join is still the authority on *provenance*; this file just makes the
+common case one request. Note the timestamp makes the bundle deliberately
+non-reproducible: compare `commit`, not a hash of `vendor/`.
+
 ## Run it
 
 Two binaries, one browser tab. The order doesn't matter — the iceoryx2

--- a/crates/wingfoil/examples/showcase/trading_e2e/static/index.html
+++ b/crates/wingfoil/examples/showcase/trading_e2e/static/index.html
@@ -87,6 +87,12 @@
     #grafana { width: 100%; height: 280px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); }
     .grafana-note { color: var(--muted); font-size: 11px; margin: 6px 0 0; }
 
+    #build-stamp {
+      color: var(--muted); font-size: 11px; padding: 10px 16px 16px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      border-top: 1px solid var(--border); margin-top: 4px; cursor: help;
+    }
+
     @media (min-width: 980px) {
       main { grid-template-columns: 1fr 1fr; }
       .chart-panel { grid-column: 1 / -1; }
@@ -179,6 +185,44 @@
       </p>
     </section>
   </main>
+
+  <footer id="build-stamp" title="Loading build info…">build …</footer>
+
+  <!--
+    Deliberately a *classic* script, not a module, and not part of app.js:
+    it must still run when the module graph fails to load, which is exactly
+    when you most want to know which build you are looking at. Keep it that
+    way — moving this into app.js would make the stamp disappear in the one
+    failure mode it exists to diagnose.
+
+    build.json is written by scripts/build-demo-vendor.sh. Cache-busted
+    because the path is stable across deploys and a cached copy would report
+    the previous build.
+  -->
+  <script>
+    (function () {
+      var el = document.getElementById('build-stamp');
+      fetch('./vendor/build.json?t=' + Date.now(), { cache: 'no-store' })
+        .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+        .then(function (b) {
+          var sha = (b.commit || 'unknown').slice(0, 12);
+          el.textContent =
+            'wingfoil ' + b.wingfoil + ' · build ' + sha + (b.dirty ? '-dirty' : '') +
+            ' · client ' + b.client + ' · telemetry ' + b.telemetry;
+          el.title =
+            'commit ' + (b.commit || 'unknown') + (b.dirty ? ' (dirty tree)' : '') +
+            '\nbuilt ' + b.built_at +
+            '\nwingfoil ' + b.wingfoil + '  wasm ' + b.wasm +
+            '\n@wingfoil/client ' + b.client +
+            '\n@wingfoil/telemetry ' + b.telemetry +
+            '\nuplot ' + b.uplot;
+        })
+        .catch(function (e) {
+          el.textContent = 'build unknown — /vendor/build.json unreachable';
+          el.title = String(e);
+        });
+    })();
+  </script>
 
   <!--
     Served from this origin, not a CDN. `scripts/build-demo-vendor.sh`

--- a/scripts/build-demo-vendor.sh
+++ b/scripts/build-demo-vendor.sh
@@ -128,6 +128,48 @@ mkdir -p "${VENDOR_DIR}/uplot"
 cp "${WORK_DIR}/uplot/dist/uPlot.esm.js" "${VENDOR_DIR}/uplot/"
 cp "${WORK_DIR}/uplot/dist/uPlot.min.css" "${VENDOR_DIR}/uplot/"
 
+# ── build stamp ──────────────────────────────────────────────────────────
+# Nothing else on the served page identifies which build it is. The esm.sh
+# pin used to double as an accidental version marker; vendoring removed it
+# without replacing it, which left "is the demo running the latest code?"
+# answerable only by joining SSM, EC2 and the workflow history. This file
+# makes it one request.
+#
+# Note this makes the bundle non-reproducible by design (the timestamp
+# changes every run) — do not rely on hashing vendor/ to compare builds;
+# compare `commit` instead.
+#
+# git may be unavailable or the checkout detached, so fall back to the SHA
+# Actions exports. `dirty` reflects *tracked* modifications only — vendor/
+# itself is gitignored and never counts.
+COMMIT="$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo "${GITHUB_SHA:-unknown}")"
+if git -C "${REPO_ROOT}" diff --quiet HEAD -- 2>/dev/null; then
+  DIRTY="false"
+else
+  DIRTY="true"
+fi
+
+# The three Cargo/npm versions release.yml asserts are equal — carrying all
+# of them means a mismatch is visible on the deployed page rather than only
+# in the release preflight.
+crate_version() { grep -m 1 '^version' "$1" | awk -F'"' '{print $2}'; }
+WINGFOIL_VERSION="$(crate_version "${REPO_ROOT}/crates/wingfoil/Cargo.toml")"
+WASM_VERSION="$(crate_version "${REPO_ROOT}/crates/wingfoil-wasm/Cargo.toml")"
+CLIENT_VERSION="$(node -p "require('${REPO_ROOT}/js/package.json').version")"
+
+cat > "${VENDOR_DIR}/build.json" <<EOF
+{
+  "commit": "${COMMIT}",
+  "dirty": ${DIRTY},
+  "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "wingfoil": "${WINGFOIL_VERSION}",
+  "wasm": "${WASM_VERSION}",
+  "client": "${CLIENT_VERSION}",
+  "telemetry": "${TELEMETRY_VERSION}",
+  "uplot": "${UPLOT_VERSION}"
+}
+EOF
+
 # Every bare specifier the page can reach must have an importmap entry, and
 # the set is larger than the imports in app.js: @wingfoil/telemetry's
 # chart.js does `import uPlot from "uplot"`. esm.sh used to rewrite that
@@ -140,7 +182,8 @@ for required in \
   "${VENDOR_DIR}/client/tracing.js" \
   "${VENDOR_DIR}/telemetry/index.js" \
   "${VENDOR_DIR}/uplot/uPlot.esm.js" \
-  "${VENDOR_DIR}/uplot/uPlot.min.css"; do
+  "${VENDOR_DIR}/uplot/uPlot.min.css" \
+  "${VENDOR_DIR}/build.json"; do
   if [ ! -f "${required}" ]; then
     echo "ERROR: expected vendored file is missing: ${required}" >&2
     exit 1
@@ -148,4 +191,6 @@ for required in \
 done
 
 echo "==> Vendored bundle ready:"
-du -sh "${VENDOR_DIR}"/* | sed 's/^/    /'
+du -sh "${VENDOR_DIR}"/*/ | sed 's/^/    /'
+echo "==> Build stamp (served at /vendor/build.json):"
+sed 's/^/    /' "${VENDOR_DIR}/build.json"


### PR DESCRIPTION
## What this changes

`scripts/build-demo-vendor.sh` now writes `vendor/build.json`, served alongside the demo page, and the page renders it in a footer:

```bash
curl -s https://demo.wingfoil.io/vendor/build.json
```
```json
{
  "commit": "4c0fea56df8b8302364c466e6a3cfe30d1b7b1cf",
  "dirty": false,
  "built_at": "2026-08-14T19:01:51Z",
  "wingfoil": "9.0.0",
  "wasm": "9.0.0",
  "client": "9.0.0",
  "telemetry": "0.1.0",
  "uplot": "1.6.31"
}
```

> `wingfoil 9.0.0 · build 4c0fea56df8b · client 9.0.0 · telemetry 0.1.0`

with the full commit, build time, wasm version and uplot pin on hover.

## Why

Answering "is the demo running the latest code?" meant joining three sources: the SSM AMI parameter, the running instance's `ImageId`, and the workflow run history. Nothing the page served identified its own build.

The esm.sh importmap pin used to double as an accidental version marker. Vendoring it (#813) removed that without putting anything in its place — this closes the gap it left.

The three fields `wingfoil` / `wasm` / `client` are the ones `release.yml`'s preflight asserts are equal, so a drift between them is now visible on the deployed page rather than surfacing only when a release is cut.

## How it was verified

Docs, a shell script and static assets — no Rust changed, so the test checkboxes below aren't the relevant evidence here. The pre-commit hook ran fmt and clippy as usual.

- [x] `cargo fmt --all`
- [x] `cargo lint` (via pre-commit hook)
- [ ] `cargo test …` — not applicable, no Rust in this diff
- [ ] Test asserting values and tick times — not applicable

What was actually checked, in headless Chromium against the built bundle:

- The stamp renders with the expected text and hover detail.
- **It renders byte-identically with the vendored client and telemetry entry points aborted mid-load** — the property the design turns on, see below.
- No regression in the page itself: no failed module requests, no off-origin requests except the Grafana iframe, chart and flamegraph canvases still construct.
- `build.json` parses as valid JSON; `dirty` correctly reported `true` against a modified tree and `false` from a clean one.
- `bash -n` on the script; `vendor/` confirmed still gitignored.

## Notes for the reviewer

**The footer is a classic inline script, not part of `app.js`, and not a module.** That is deliberate and load-bearing: if it lived in `app.js` it would disappear whenever the module graph failed to load, which is exactly the failure it is most useful for diagnosing. There is a comment in `index.html` saying so; please keep it that way if this area gets refactored.

**One deliberate cost.** The `built_at` timestamp makes the vendored bundle non-reproducible, so `vendor/` can no longer be compared by hashing. Compare `commit` instead — the script header says this too.

**Provenance is unchanged.** The AMI is still what actually serves the page, through the `/opt/wingfoil/static` bind mount, so the SSM-parameter-to-`ImageId` join remains the ground truth. This only makes the common case a single request.

**Deploying it needs the full chain.** `build.images` → `build.ami` → `deploy`, because the page comes from the AMI overlay rather than the image. Until then the live demo's footer degrades to "build unknown", which is itself an accurate signal that it predates this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Csj4p8XdHpDYt69re6VcBT)_