### PR TITLE
fix(fix): complete frames across WouldBlock

### DIFF
--- a/crates/wingfoil/src/adapters/fix.rs
+++ b/crates/wingfoil/src/adapters/fix.rs
@@ -162,7 +162,8 @@
 //!
 //! [`FixOperators::fix_send`] opens its own outbound session (connect + logon at
 //! graph `start()`, realtime-only) and writes each [`FixMessage`] from the graph
-//! thread; back-pressure is the kernel TCP send buffer. A historical run aborts
+//! thread. When its non-blocking socket is backpressured, it busy-retries the
+//! current frame until the remaining suffix is written. A historical run aborts
 //! at `start()` with a "real-time" error (matching legacy's `start` check). The
 //! [`FixSender`] handle (from [`FixConnection::sender`]) is the *other* outbound
 //! path — a lock-free bounded queue drained by the `Threaded` session thread,
@@ -1542,6 +1543,25 @@ enum SeqDecision {
     Fatal(String),
 }
 
+/// Write one complete frame, treating `WouldBlock` as transient backpressure.
+///
+/// `AlwaysSpin` sessions use non-blocking sockets, so `Write::write_all` can
+/// return after writing only a prefix. Keep the unwritten suffix here instead
+/// of letting the caller tear down a connection with a partial FIX frame on it.
+/// Blocking sockets retain their normal behavior.
+fn write_frame<W: Write>(writer: &mut W, mut bytes: &[u8]) -> io::Result<()> {
+    while !bytes.is_empty() {
+        match writer.write(bytes) {
+            Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
+            Ok(written) => bytes = &bytes[written..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => std::hint::spin_loop(),
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
 impl FixSession {
     fn new(sender: &str, target: &str) -> Self {
         Self::new_with_logon(sender, target, FixLogon::None)
@@ -1912,7 +1932,7 @@ impl FixSession {
             sending_time,
             extra,
         );
-        sock.write_all(&bytes)?;
+        write_frame(sock, &bytes)?;
         sock.flush()?;
         // Any write resets the outbound heartbeat clock, and the sequence number
         // it consumed must be durable before the counterparty can act on it.
@@ -1948,7 +1968,7 @@ impl FixSession {
             sending_time,
             extra,
         );
-        sock.write_all(&bytes)?;
+        write_frame(sock, &bytes)?;
         sock.flush()?;
         self.last_sent = Instant::now();
         Ok(())
@@ -3190,6 +3210,37 @@ mod tests {
 
     // ── helpers ──────────────────────────────────────────────────────────────
 
+    /// A non-blocking writer that accepts a prefix, reports `WouldBlock` once,
+    /// then becomes writable again. This is the TCP backpressure shape that
+    /// `Write::write_all` does not resume after.
+    #[derive(Default)]
+    struct BackpressuredWriter {
+        bytes: Vec<u8>,
+        writes: usize,
+    }
+
+    impl Write for BackpressuredWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.writes += 1;
+            match self.writes {
+                1 => {
+                    let accepted = buf.len().min(7);
+                    self.bytes.extend_from_slice(&buf[..accepted]);
+                    Ok(accepted)
+                }
+                2 => Err(io::Error::from(io::ErrorKind::WouldBlock)),
+                _ => {
+                    self.bytes.extend_from_slice(buf);
+                    Ok(buf.len())
+                }
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
     /// Frame one complete message, asserting it framed cleanly.
     fn frame(bytes: &[u8]) -> Vec<u8> {
         match find_message(bytes) {
@@ -3307,6 +3358,24 @@ mod tests {
             "expected signed RawData bound to seq 1, got {:?}",
             msg.field(96)
         );
+    }
+
+    /// A temporary full TCP send buffer must not turn a FIX message into a
+    /// torn frame or an adapter error. The writer accepts a prefix, becomes
+    /// unavailable once, and then accepts the exact remaining suffix.
+    #[test]
+    fn outbound_write_survives_nonblocking_backpressure() {
+        let mut session = FixSession::new("ME", "YOU");
+        let mut sock = BackpressuredWriter::default();
+
+        session
+            .send_heartbeat(&mut sock, None)
+            .expect("the pending suffix is retried after WouldBlock");
+
+        let messages = sent(&sock.bytes);
+        assert_eq!(messages.len(), 1, "one complete frame reaches the peer");
+        assert_eq!(messages[0].msg_type, MSG_HEARTBEAT);
+        assert_eq!(sock.writes, 3, "prefix, WouldBlock, then suffix");
     }
 
     /// A [`FixLogon::Password`] session sends Username (tag 553 = SenderCompID)

--- a/crates/wingfoil/src/adapters/fix/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/fix/CLAUDE.md
@@ -75,7 +75,9 @@ the TLS initiator (crypto provider `ring`, same as [`web`](../web/CLAUDE.md));
   initiators do not reconnect at all.
 - **Two outbound paths, don't confuse them.** `fix_send` opens its *own*
   outbound session (connect + logon at `start()`, realtime-only) and writes
-  from the graph thread, back-pressured by the kernel TCP send buffer.
+  from the graph thread. On a non-blocking socket it busy-retries the current
+  frame while the kernel TCP send buffer reports `WouldBlock`, preserving the
+  unwritten suffix but pinning the graph thread until the socket is writable.
   `FixSender` (from `FixConnection::sender()`) injects into an **established**
   session from outside the graph, over a lock-free bounded `kanal` queue
   drained by the `Threaded` session thread — that is what `fix_sub` uses for


### PR DESCRIPTION
## What this changes

FIX writes now retain and busy-retry the unwritten suffix when a non-blocking socket reports `WouldBlock`, so a later send cannot follow a torn frame. The FIX contributor documentation now states the corresponding backpressure behavior.

## Why

`Write::write_all` returns immediately on `WouldBlock`, even after writing a prefix. The resulting error could tear a FIX frame and end the run under temporary TCP backpressure.

Closes #820.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [x] `cargo lint` (upstream pre-commit hook)
- [x] `cargo clippy -p wingfoil --features fix --lib -- -D warnings`
- [x] `cargo test -p wingfoil --features fix --lib` — 137 passed
- [x] `cargo test -p wingfoil --features fix --test fix_adapter` — 2 passed
- [x] `cargo test -p wingfoil --features fix-integration-test --test fix_integration -- --test-threads=1` — 6 passed
- [x] Upstream pre-push hook: `cargo build --workspace --all-targets` and `cargo test --workspace`
- [x] New behavior is covered by a test that accepts a frame prefix, reports `WouldBlock`, then verifies exactly one complete heartbeat frame
- [ ] `cargo lint-all` — local all-feature build stopped in the unrelated Aeron dependency because `cmake` is unavailable
- [ ] `cargo test -p wingfoil --all-features` — not run locally

## Notes for the reviewer

Busy-retrying is deliberate for the latency-first `AlwaysSpin` mode and means its graph thread remains pinned until the socket becomes writable. Threaded sessions keep their existing blocking-socket behavior.
