### PR TITLE
docs(interp): correct the builder_id guard docs after the assert promotion

### DIFF
--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -55,8 +55,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use anyhow::{Result, bail};
 
 /// Process-unique id stamped on every [`Builder`] (and its [`Handle`]s) so a
-/// handle used with a *different* builder's [`Runner`] is caught by a
-/// `debug_assert` rather than silently returning the wrong node's value.
+/// handle used with a *different* builder's [`Runner`] is caught by an
+/// `assert` rather than silently returning the wrong node's value. The check
+/// is unconditional — not a `debug_assert` — because none of the three sites
+/// that make it (`Builder::slot`, `Runner::value`, `Runner::rt_slot`) is on
+/// the cycle path, so release-mode silence would buy nothing and cost a
+/// wrong-graph read.
 static NEXT_BUILDER_ID: AtomicU64 = AtomicU64::new(0);
 
 use crate::Burst;
@@ -594,7 +598,7 @@ pub struct Builder {
     re_runnable: bool,
     /// Process-unique id (see [`NEXT_BUILDER_ID`]), stamped on every [`Handle`]
     /// this builder mints and carried into its [`Runner`], so a handle used
-    /// with a *different* runner is caught by a `debug_assert`.
+    /// with a *different* runner is caught by an `assert`.
     id: u64,
     /// Mutations staged by in-graph dynamic nodes (e.g. a
     /// [`dynamic_group`](Builder::dynamic_group)) during a cycle, applied at the
@@ -4532,6 +4536,14 @@ impl<K: std::hash::Hash + Eq> DemuxMap<K> {
     }
 }
 
+/// Cross-builder / cross-runner handle misuse, at each of the three sites that
+/// guard against it.
+///
+/// **These pass under `debug_assertions` either way**, so they document the
+/// guard rather than gate it: reverting the `assert_eq!`s to `debug_assert_eq!`
+/// would still leave them green in CI's debug test run. What the unconditional
+/// assert buys is caught only by running them with `--release` (or any profile
+/// with `debug-assertions = false`).
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What this changes

Three comments in `interp.rs`. Nothing else — no behaviour change, no code touched.

- `NEXT_BUILDER_ID` (`interp.rs:57`) and the `Builder::id` field (`interp.rs:595`) no longer describe the handle-vs-runner guard as a `debug_assert`, and the former now records *why* the check is unconditional: none of the three sites that make it is on the cycle path.
- The `mod tests` added by #841 gets a doc comment recording what those tests do and do not cover.

## Why

#841 promoted the three `builder_id` checks from `debug_assert_eq!` to `assert_eq!` but left the surrounding prose describing the weaker guarantee. One of the two stale comments is the `Builder::id` field doc that #822 quoted as the justification for making the change in the first place, so the drift is exactly the kind the issue was about.

The test note is the second half. The three panic tests pass under `debug_assertions` either way, so they document the guard rather than gate it — a revert to `debug_assert_eq!` would stay green in CI's debug test run (`.github/workflows/rust-test.yml` has no `--release` job). Worth stating at the tests rather than leaving a future reader to assume they're a regression gate.

Follow-up to #841, which is already merged. No issue.

## How it was verified

- [x] `cargo fmt --all` — clean
- [x] `cargo lint` — clean. `cargo lint-all` not run (the all-features build needs the aeron system deps: clang, libuuid, CMake ≥ 3.30)
- [ ] `cargo test -p wingfoil --all-features` — not run, same reason. `cargo test -p wingfoil --lib` and the suite with `dynamic-graph,statistics,market` were run against this content while reviewing #841: all green
- [ ] New behaviour is covered by a test — n/a, comments only

Separately, and the reason the test note above is worth having: the guard tests were run under `--release`, where a `debug_assert_eq!` would have compiled out. `cross_builder_handle_panics_in_slot` and `cross_runner_handle_panics_in_value` both panic as intended, which is the behaviour #822 asked for.

## Notes for the reviewer

The claim that the assert is off the cycle path — now written into the `NEXT_BUILDER_ID` doc — was checked rather than taken from the issue: every `Builder::slot` caller is wiring-time (`interp.rs:1440`–`4387`, `fluent.rs:765`/`781`, and the derive's `self.slot(#edge_names)` at `wingfoil-derive/src/lib.rs:2450`), and all four `rt_slot` callers sit inside the deferred `run_dynamic` boundary closure, i.e. per dynamic append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGEjcn38qQog5VaH8tfdZ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGEjcn38qQog5VaH8tfdZ2)_