### PR TITLE
fix(cache): touch LRU metadata without rewriting payload

### DIFF
--- a/crates/wingfoil/src/adapters/cache.rs
+++ b/crates/wingfoil/src/adapters/cache.rs
@@ -200,10 +200,17 @@ impl<T> FileCache<T> {
             .ok_or_else(|| anyhow::anyhow!("cache file missing header newline"))?;
         let raw: Vec<(u64, T)> = bincode::deserialize(payload)?;
 
-        // Touch mtime so LRU eviction treats this file as recently used.
-        // We rewrite the unchanged bytes; any IO error is silently ignored
-        // since the data was already read successfully.
-        let _ = tokio::fs::write(&path, &bytes).await;
+        // Touch mtime so LRU eviction treats this file as recently used without
+        // rewriting (and briefly truncating) the cached payload. Keep this
+        // best-effort: the data was already read successfully.
+        let touch_path = path.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            std::fs::OpenOptions::new()
+                .append(true)
+                .open(touch_path)?
+                .set_modified(SystemTime::now())
+        })
+        .await;
 
         info!("cache hit: {}", path.display());
         Ok(Some(

--- a/crates/wingfoil/src/adapters/cache/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/cache/CLAUDE.md
@@ -51,6 +51,10 @@ cache = ["dep:sha2", "dep:bincode", "dep:serde", "async", "tokio/fs"]
   not abort a backtest.
 - **LRU eviction is by file mtime**, applied so total on-disk size stays under
   `max_size_bytes`.
+- A cache hit advances that mtime with a metadata-only touch. **Never rewrite
+  the payload to mark a hit**: entries can be hundreds of megabytes, and an
+  in-place rewrite both doubles hit-path I/O and exposes a transiently
+  truncated file to concurrent readers.
 - **The key does not encode the run window.** It is derived from the query
   string, so the cache stores the *full* slice a query returned. Any window
   clamping belongs in the caller, on emit, on hits **and** misses — see how


### PR DESCRIPTION
## What this changes

Replaces the cache-hit full payload rewrite with a metadata-only mtime touch on Tokio blocking workers. The cache keeps the existing best-effort touch semantics and LRU ordering without doubling hit-path I/O or exposing a transiently truncated file to concurrent readers.

The cache adapter guidance now records the metadata-only touch invariant.

## Why

Closes #825.

A cache entry can be hundreds of megabytes, so rewriting identical bytes on every hit defeats the point of the cache. It also bypasses the atomic tmp-and-rename discipline used by `put()`.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [ ] `cargo lint` and `cargo lint-all` (local Windows host has no MSVC `link.exe`; deferred to CI)
- [ ] `cargo test -p wingfoil --features cache --test cache_adapter` (same local linker prerequisite; deferred to CI)
- [x] `cargo metadata --no-deps --format-version 1`
- [x] Isolated `rustc --emit metadata` API check for `OpenOptions::append(...).set_modified(...)`
- [x] Existing `test_lru_eviction` exercises the metadata touch and verifies the touched entry survives eviction

## Notes for the reviewer

The touch remains intentionally best-effort: a failure to update metadata does not turn an already successful cache read into an error. This PR is draft until the upstream Linux checks provide the unavailable test and clippy evidence.

## AI disclosure

AI-authored under human direction and review. Model: OpenAI Codex.
