### PR TITLE
fix(bench): join the worker during shutdown

### DIFF
--- a/crates/wingfoil/src/bencher.rs
+++ b/crates/wingfoil/src/bencher.rs
@@ -47,6 +47,7 @@ use criterion::Criterion;
 use std::cell::RefCell;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
+use std::thread::JoinHandle;
 
 /// Used to add a wingfoil bench to criterion.
 ///
@@ -80,6 +81,7 @@ struct Bencher {
     run_mode: RunMode,
     signal: Arc<AtomicU8>,
     builder: Option<Box<dyn BenchBuilder>>,
+    worker: Option<JoinHandle<()>>,
 }
 
 impl Bencher {
@@ -90,6 +92,7 @@ impl Bencher {
             signal,
             builder,
             run_mode,
+            worker: None,
         }
     }
 
@@ -114,7 +117,7 @@ impl Bencher {
             .expect("invariant: Bencher::start called more than once");
         let signal = self.signal.clone();
         let run_mode = self.run_mode;
-        std::thread::spawn(move || {
+        self.worker = Some(std::thread::spawn(move || {
             let graph = GraphBuilder::new();
             let trigger = bench_trigger(&graph, signal.clone());
             let output = builder(&graph, &trigger);
@@ -128,17 +131,23 @@ impl Bencher {
                 });
             let mut runner = graph.build();
             if let Err(e) = runner.run(run_mode, RunFor::Forever) {
+                if Signal::from(signal.load(Ordering::SeqCst)) == Signal::Kill {
+                    return;
+                }
                 log::error!("bencher worker thread terminated: {e:#}");
                 // Wake the bencher loop so step() doesn't spin forever.
                 signal.store(Signal::End.into(), Ordering::SeqCst);
             }
-        });
+        }));
     }
 
-    pub fn stop(&self) {
-        self.signal
-            .clone()
-            .store(Signal::Kill.into(), Ordering::SeqCst);
+    pub fn stop(&mut self) {
+        self.signal.store(Signal::Kill.into(), Ordering::SeqCst);
+        if let Some(worker) = self.worker.take()
+            && let Err(payload) = worker.join()
+        {
+            std::panic::resume_unwind(payload);
+        }
     }
 }
 
@@ -260,5 +269,24 @@ mod tests {
     fn bench_trigger_cycle_kill_returns_error() {
         let (_signal, result) = run_trigger_once(Signal::Kill);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn stop_joins_worker_and_treats_kill_as_clean_shutdown() {
+        let mut bencher = Bencher::new(
+            |_, trigger: &Stream<()>| trigger.upstream(),
+            RunMode::RealTime,
+        );
+        bencher.start();
+
+        assert!(bencher.worker.is_some());
+        bencher.stop();
+
+        assert!(bencher.worker.is_none());
+        assert_eq!(signal_value(&bencher.signal), Signal::Kill);
+    }
+
+    fn signal_value(signal: &AtomicU8) -> Signal {
+        signal.load(Ordering::SeqCst).into()
     }
 }


### PR DESCRIPTION
## What this changes

Keep the bencher worker's `JoinHandle` and join it during orderly shutdown. A runner exit caused by `Kill` is treated as expected, while a worker panic is resumed on the caller thread.

## Why

The worker was spawned and detached, so benchmark shutdown could return while it was still alive. Joining it makes teardown deterministic and avoids logging the intentional kill signal as an error.

Closes #833.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`
- [ ] `cargo lint-all` (not run: this machine does not have `protoc`)
- [ ] `cargo test -p wingfoil --all-features` (not run: all features require `protoc`)
- [ ] New behaviour is covered by a test asserting **values and tick times** (not applicable to the shutdown lifecycle)
- [x] `cargo test -p wingfoil --lib --features bench` (85 passed)
- [x] `cargo clippy -p wingfoil --lib --features bench -- -D warnings`
- [x] `git diff --check`

## Notes for the reviewer

The focused regression test asserts that `stop` consumes the live worker handle, waits for its exit, and leaves the signal as `Kill` rather than letting the old error path overwrite it with `End`.

Disclosure: OpenAI Codex assisted with implementation and tests. The exact patch was independently reviewed by Grok and validated locally; no AI model is credited as a legal author.
