### PR TITLE
test(bench): assert the worker join, not just the taken handle

### DIFF
--- a/crates/wingfoil/src/bencher.rs
+++ b/crates/wingfoil/src/bencher.rs
@@ -284,6 +284,12 @@ mod tests {
 
         assert!(bencher.worker.is_none());
         assert_eq!(signal_value(&bencher.signal), Signal::Kill);
+        // Taking the handle proves nothing on its own — `worker.take()` alone
+        // satisfies the two asserts above whether or not the join happened.
+        // The worker's own clones of `signal` (the trigger's and the sink's)
+        // drop with its stack, so the caller holding the last reference is
+        // only true once the thread has actually finished.
+        assert_eq!(Arc::strong_count(&bencher.signal), 1);
     }
 
     fn signal_value(signal: &AtomicU8) -> Signal {


### PR DESCRIPTION
## What this changes

Adds one assertion to `stop_joins_worker_and_treats_kill_as_clean_shutdown` so
it actually guards the join that gives it its name.

## Why

Follow-up to #845 (merged), which was correct — this is a gap in its test, not
in its fix.

The test asserted `bencher.worker.is_none()` and that the signal stayed `Kill`.
Both hold as soon as the handle is *taken*, whether or not it is joined, so the
`Kill` half of #845 was guarded and the join half was not. Verified by mutation
on the merged commit:

| Mutation | Test result |
|---|---|
| Remove the `Kill` early-return in the worker | FAILS (guarded) |
| Replace the join with `let _ = self.worker.take();` | **PASSES** (unguarded) |

`Arc::strong_count(&bencher.signal) == 1` closes it. The worker holds its own
clones of `signal` — the trigger's and the sink's — which drop with its stack,
so the caller owning the last reference is observable only once the thread has
genuinely finished.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` (via the pre-commit hook — workspace, `--all-targets`)
- [x] `cargo test -p wingfoil --lib --features bench` (87 passed)
- [ ] `cargo test -p wingfoil --all-features` (not run: needs `protoc`; CI covers it)
- [x] New behaviour is covered by a test — this PR *is* the test

Mutation-checked both ways, which is the point of the change: the new assertion
passes 5/5 runs with the join in place and fails 8/8 with the join removed.

## Notes for the reviewer

One deliberate non-goal: `Bencher` still has no `Drop`, so if criterion panics
between `start()` and `stop()` the `ALWAYS`-activated worker keeps spinning a
core for the life of the process. That is pre-existing rather than introduced by
#845, and it is a behaviour change rather than a test fix, so it is left out of
this PR. Happy to open it separately if wanted.


---
_Generated by [Claude Code](https://claude.ai/code/session_016uTUQ2a6B1Hscropr8rvt6)_