### PR TITLE
test(ops): pin skip's catalog contract and its Signal forwarder

### DIFF
--- a/crates/wingfoil/tests/catalog.rs
+++ b/crates/wingfoil/tests/catalog.rs
@@ -139,6 +139,42 @@ fn limit_caps_ticks() {
     assert_eq!(vec![1, 2, 3], r.value(&acc));
 }
 
+/// `skip` suppresses the first N then passes the rest — `limit`'s mirror, and
+/// new surface with no legacy twin, so this pins the contract outright rather
+/// than reproducing a legacy test. Each surviving value keeps its *original*
+/// tick time: skipping shifts nothing in time.
+#[test]
+fn skip_suppresses_first_n() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count();
+    let acc = count.skip(3).with_time().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(30), 4u64),
+            (NanoTime::new(40), 5),
+            (NanoTime::new(50), 6),
+        ],
+        r.value(&acc)
+    );
+}
+
+/// The two boundaries of the count: `skip(0)` is a pass-through, and a skip
+/// wider than the run suppresses every tick, leaving the accumulator empty
+/// rather than holding a default-valued entry.
+#[test]
+fn skip_zero_passes_all_and_skip_past_the_run_passes_none() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count();
+    let none_skipped = count.skip(0).accumulate();
+    let all_skipped = count.skip(10).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(vec![1, 2, 3, 4], r.value(&none_skipped));
+    assert!(r.value(&all_skipped).is_empty());
+}
+
 /// A passive `join` input is read but does not trigger — mirrors legacy
 /// `bimap::bimap_passive_does_not_trigger`. The combine fires only when the
 /// active (slow) input ticks, reading the passive (fast) input's current

--- a/crates/wingfoil/tests/signal.rs
+++ b/crates/wingfoil/tests/signal.rs
@@ -102,6 +102,17 @@ fn legacy_limit_passes_first_n() {
     assert_eq!(vec![1, 2, 3], limited.peek_value());
 }
 
+/// `skip` suppresses the first N values, then passes the rest. `limit`'s
+/// mirror on the facade, and the only place the generated
+/// `__wf_signal_skip!` forwarder is exercised.
+#[test]
+fn legacy_skip_suppresses_first_n() {
+    let count = ticker(Duration::from_nanos(100)).count();
+    let skipped = count.skip(2).accumulate();
+    skipped.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(vec![3, 4, 5], skipped.peek_value());
+}
+
 /// `distinct` suppresses consecutive duplicates (emit on change only).
 #[test]
 fn legacy_distinct_drops_repeats() {


### PR DESCRIPTION
## What this changes

Adds the catalog and `Signal` tests for `skip`, matching how its mirror `limit`
is pinned. Tests only — no engine change.

## Why

Follow-up to #846 (merged), which was clean and followed the `/new-op` recipe —
this closes the one coverage gap it left.

`skip` landed with three-engine parity in `compiled_stateful_ops.rs` and a
`nitro!` block in `op_completeness.rs`, but no `tests/catalog*.rs` test, where
`limit` has both `catalog.rs::limit_caps_ticks` and
`signal.rs::legacy_limit_passes_first_n`. That left two things unguarded: the
boundaries of the count, and the `__wf_signal_skip!(T)` line #846 added — the
step-4b obligation the `/new-op` skill calls out as historically drift-prone
(the facade once fell 15 methods behind the catalog).

Three tests:

- `catalog.rs::skip_suppresses_first_n` — values **and** tick times, making the
  contract that surviving values keep their *original* tick time explicit.
- `catalog.rs::skip_zero_passes_all_and_skip_past_the_run_passes_none` — the two
  boundaries: `skip(0)` as a pass-through, and a skip wider than the run leaving
  the accumulator empty rather than holding a default-valued entry.
- `signal.rs::legacy_skip_suppresses_first_n` — the facade twin.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` (via the pre-commit hook — workspace, `--all-targets`)
- [x] `cargo test -p wingfoil --test catalog --test signal` (23 + 42 passed)
- [ ] `cargo test -p wingfoil --all-features` (not run: needs `protoc`; CI covers it)
- [x] New behaviour is covered by a test asserting **values and tick times**

The `Signal` test was checked against the thing it guards: deleting
`__wf_signal_skip!(T);` from `signal.rs` fails the build with E0599, which is
the two-sided guard in `op_completeness.rs` doing its job.

## Notes for the reviewer

`skip` has no legacy twin, so `catalog.rs`'s usual charter — reproduce the
legacy node's own unit tests — doesn't apply. The test doc comment says so
outright and pins the contract directly instead. The module header's "these
mirror the legacy nodes' unit tests" list is deliberately left alone for the
same reason.

Still open from the #846 review, and not folded in here because it is a product
decision rather than a gap: `skip` has no Python binding. #846 stated the
omission (per the skill's rule), but `limit` — the op it mirrors — is bound in
six lines of plain forwarding (`graph.rs:426`, `python.rs:185`). Worth deciding
on the merits rather than inheriting it from legacy parity.


---
_Generated by [Claude Code](https://claude.ai/code/session_016uTUQ2a6B1Hscropr8rvt6)_