### PR TITLE
Clear the 9.0.0 release blockers: browser payload corruption, run_dynamic's missing guard, CI holes

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,18 +2,40 @@ name: test.python
 
 on:
   workflow_call:
+  # This leg keeps a `paths` filter where rust-test.yml dropped its own: a
+  # maturin wheel build plus pytest is the slowest thing in the matrix, and
+  # most commits genuinely cannot affect it. But a filter is only ever as good
+  # as its list, and two entries were missing from this one:
+  #
+  # * **this file itself.** A filter that does not name its own workflow makes
+  #   an edit to the workflow the one change CI never validates — a broken gate
+  #   surfaces only after it has merged. That is the standing ruling recorded
+  #   at the top of rust-test.yml, which removed its filter outright rather
+  #   than live with the trap.
+  # * **`wingfoil-wire-types`.** The bindings depend on it, just not by name:
+  #   both build steps below pass `all-adapters`, which turns on `web`, which
+  #   turns on `wingfoil/web-tls`, which pulls in `dep:wingfoil-wire-types`. A
+  #   wire-format change could therefore break the wheel with this leg never
+  #   having run.
+  #
+  # `push` and `pull_request` are independent filters and GitHub will not warn
+  # when they drift, so any addition goes in both lists.
   push:
     branches: [ "main" ]
     paths:
+      - ".github/workflows/python-test.yml"
       - "crates/wingfoil-python/**"
       - "crates/wingfoil-python-derive/**"
       - "crates/wingfoil/**"
+      - "crates/wingfoil-wire-types/**"
   pull_request:
     branches: [ "main" ]
     paths:
+      - ".github/workflows/python-test.yml"
       - "crates/wingfoil-python/**"
       - "crates/wingfoil-python-derive/**"
       - "crates/wingfoil/**"
+      - "crates/wingfoil-wire-types/**"
   workflow_dispatch:
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -108,6 +108,43 @@ jobs:
         env:
           RUST_LOG: INFO
 
+      - name: Run wingfoil-derive tests
+        # `nitro!` reasons about the wiring function it is handed — which
+        # parameters a type mentions, and therefore which streams a node
+        # depends on — and that reasoning has unit tests of its own in
+        # `crates/wingfoil-derive/src/lib.rs`. Every other Rust test invocation
+        # across these workflows names its package — `-p wingfoil` here and in
+        # the integration legs, `-p wingfoil-python` in test.python, and
+        # wingfoil-wasm's own leg in web-integration.yml — and none of them
+        # names this one, so the derive tests had never run in CI at all: a
+        # regression in the macro's own logic could only be caught indirectly,
+        # by whichever generated graph happened to come out wrong.
+        #
+        # The crate is proc-macro-only and declares no features, so a bare `-p`
+        # is its whole surface, and it compiles in seconds — syn/quote are
+        # already built for the step above.
+        run: cargo nextest run -p wingfoil-derive
+
+      - name: Run doctests
+        # **nextest cannot run doctests**, by design: it is a libtest-harness
+        # runner, and `--doc` targets are compiled and driven by rustdoc
+        # instead. So until this step existed, no job in any workflow ran a
+        # single doc fence — and the fences are exactly the snippets users copy
+        # out of the API docs, which a renamed method or a changed signature
+        # rots silently.
+        #
+        # `--all-features` is not optional here. Most of the fences live in
+        # `adapters/`, and every adapter module is gated off by default: a
+        # default-feature run collects 12 of them, all-features collects 35 (17
+        # executed, the rest `ignore`d illustrations). It also means this step
+        # shares its feature set — and so its artifacts — with the step above.
+        #
+        # Cheap despite the count: rustdoc compiles the fences as one merged
+        # binary, ~2s, and running them takes hundredths of a second.
+        run: cargo test --doc -p wingfoil --all-features
+        env:
+          RUST_LOG: INFO
+
   lint:
     name: Lint (fmt & clippy)
     # Skips the release.bump commit — see the note above `jobs:`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,24 @@ cargo fmt --all
 cargo lint        # default features
 cargo lint-all    # all features — CI runs this and feature-gated code is easy to miss
 cargo test -p wingfoil --all-features
+cargo test -p wingfoil-derive   # a separate package: the line above never builds it
 ```
+
+Two notes on what those last two lines do and don't reach:
+
+- **`-p wingfoil` does not build the derive crate's tests.** `nitro!`/`#[op]`
+  reason about the wiring function they are handed, and that reasoning has unit
+  tests of its own in `crates/wingfoil-derive/src/lib.rs`. They only run when
+  you name the package. (CI ran nothing that named it until `rust-test.yml`
+  grew a step for it — issue #835.)
+- **Doc fences are already covered here, and that is a property of `cargo
+  test`, not of the flags.** `cargo test` runs the `--doc` target alongside the
+  unit and integration ones; `--all-features` matters because most of the doc
+  fences live in `adapters/`, which is gated off by default — a default-feature
+  run collects 12 of them, all-features 35. **CI needs a separate step for
+  this** (`cargo test --doc -p wingfoil --all-features` in `rust-test.yml`),
+  because the test leg runs `cargo nextest`, which drives libtest harnesses and
+  cannot run doctests at all. So do not "simplify" the local checklist to
+  `cargo nextest run`: the doc fences would stop being checked before commit.
 
 All must pass without errors before creating a commit.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,9 +5972,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -786,10 +786,22 @@ g.run(realtime=True, duration_nanos=10_000_000_000)
 ### web (WebSocket)
 
 A stateful `WebServer` handle. Publishing is a **server** method, not a stream
-method, because the handle owns the topic registry. Values marshal through the
-selected codec (`"bincode"` or `"json"`); `bytes` become an array of ints —
-wire-compatible with a Rust `Vec<u8>` peer, and therefore decoded back as a
-`list`, not `bytes`.
+method, because the handle owns the topic registry. Values marshal through
+`serde_json::Value`, serialized with the selected codec (`"bincode"` or
+`"json"`).
+
+**Use `codec="json"` unless you know otherwise.** `sub` rejects `"bincode"`
+outright: it decodes into `serde_json::Value`, whose `Deserialize` calls
+`deserialize_any`, which bincode refuses for every value of every shape — so a
+Python subscription could never read a frame from any peer, Rust or otherwise.
+`pub` still accepts bincode, because it is peer-dependent rather than
+impossible: a scalar or a same-width sequence reaches a typed Rust peer
+correctly, while a `dict` sent to a Rust `struct` decodes as silent garbage.
+
+`bytes` become an array of ints, which is wire-compatible with a Rust
+`Vec<u8>` peer **under JSON only** — `Value` writes each element as a `u64`,
+so the bincode encoding does not match. A subscription decodes such a frame
+back as a `list`, not `bytes`, since nothing on the wire distinguishes them.
 
 ```python
 g = wf.Graph()

--- a/crates/wingfoil-python/docs/api.rst
+++ b/crates/wingfoil-python/docs/api.rst
@@ -372,10 +372,16 @@ authored in a third-party crate looks identical to a built-in one.
        ``.sub(graph, topic)``, ``.pub(stream, topic)``,
        ``.pub_bursts(stream, topic)``, ``.stop()``
      - A stateful handle; publishing is a **server** method, not a stream
-       method. Values marshal through JSON; ``bytes`` become an array of ints
-       (wire-compatible with a Rust ``Vec<u8>`` peer, and therefore decoded back
-       as a ``list``, not ``bytes``). ``pub_bursts`` puts a whole same-instant
-       group on the wire as one atomic frame.
+       method. Values marshal through a schema-less JSON value, so
+       ``codec="json"`` is the interoperable setting: bincode cannot decode an
+       untyped value at all, which makes ``.sub()`` **raise** under
+       ``codec="bincode"`` (the default) and leaves a bincode publish readable
+       only by a Rust ``web_sub::<T>`` whose ``T`` is a scalar or same-width
+       sequence — never by a browser or a second Python process. ``bytes``
+       become an array of ints (wire-compatible with a Rust ``Vec<u8>`` peer
+       **under JSON**, and decoded back as a ``list``, not ``bytes``).
+       ``pub_bursts`` puts a whole same-instant group on the wire as one atomic
+       frame.
    * - **Aeron**
      - ``aeron_sub``, ``aeron_sub_with_status``, ``aeron_pub``,
        ``aeron_pub_with_status``

--- a/crates/wingfoil-python/pyproject.toml
+++ b/crates/wingfoil-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "wingfoil-python"
 dynamic = ["version"]
-description = "Python interop prototype for wingfoil (the Op-pattern engine)"
+description = "Python bindings for wingfoil (the Op-pattern stream processing engine)"
 readme = "README.md"
 # 3.9, not 3.8: 3.8 reached end of life in October 2024, and the floor is now
 # structural as well as a policy — the extension is built against CPython's

--- a/crates/wingfoil-python/src/adapters/web.rs
+++ b/crates/wingfoil-python/src/adapters/web.rs
@@ -23,17 +23,41 @@
 //!
 //! # The payload edge
 //!
-//! Python values marshal through **`serde_json::Value`**, which the adapter
-//! serialises with whichever codec the server was built with (bincode or JSON),
-//! and which the browser client decodes the same way — so a Python publisher is
-//! wire-compatible with a Rust one. `None` / `bool` / `int` / `float` / `str` /
-//! `list` / `dict` map to the obvious JSON shapes.
+//! Python values marshal through **`serde_json::Value`**: `None` / `bool` /
+//! `int` / `float` / `str` / `list` / `dict` map to the obvious JSON shapes,
+//! and `bytes` become an **array of ints**, as legacy did.
 //!
-//! `bytes` become a JSON **array of ints**, as legacy did, so they stay
-//! wire-compatible with a Rust peer publishing a `Vec<u8>`. That is
-//! deliberately asymmetric: a subscription decodes such a frame back to a
-//! `list` of ints, not to `bytes`, because nothing on the wire distinguishes
-//! the two.
+//! `Value` is a *schema-less* shape, and that — not the adapter — is what
+//! decides which codec and which peers actually work.
+//!
+//! # The codec is not a free choice: `codec="json"` is the interoperable one
+//!
+//! bincode is schema-driven and non-self-describing, so it needs the Rust type
+//! at both ends. It therefore **cannot deserialize into a `serde_json::Value`
+//! at all**: `Value`'s `Deserialize` asks for `deserialize_any`, which bincode
+//! refuses for every input, of every shape. That single fact settles the
+//! matrix (`sub` ← anything is what issue #821's Rust/wasm half hit from the
+//! other side):
+//!
+//! | From Python | to | `codec="json"` | `codec="bincode"` |
+//! |---|---|---|---|
+//! | `pub` / `pub_bursts` | a typed Rust `web_sub::<T>` | yes | **only when `T`'s bincode layout happens to coincide with `Value`'s** — a scalar or a homogeneous sequence does; a `dict` reaches a `struct` as **silent garbage** (#821), and `bytes` reach a `Vec<u8>` as garbage, since `Value` writes each element as a `u64` |
+//! | `pub` / `pub_bursts` | another Python `sub` | yes | **no** — nothing can decode it |
+//! | `pub` / `pub_bursts` | the browser (`@wingfoil/client`) | yes | **no** — the client rejects bincode data payloads outright |
+//! | `sub` | any peer at all | yes | **rejected at wiring**, with a message naming the fix |
+//!
+//! So: **`codec="json"` is the only setting every peer can talk to**, and the
+//! only one a browser or a second Python process can talk to at all.
+//! `codec="bincode"` — the default, matching the Rust adapter's — is
+//! publish-only from Python, and only to a Rust peer whose `T` is a scalar or
+//! a sequence of one width. The envelope and `$ctrl` control frames are
+//! unaffected either way: they have fixed shapes both sides know.
+//!
+//! The `bytes` → array-of-ints mapping is wire-compatible with a Rust peer's
+//! `Vec<u8>` **under JSON** — JSON has one number type, so `[1, 42]` reads
+//! straight back as a `Vec<u8>`. It is deliberately asymmetric: a subscription
+//! decodes such a frame back to a `list` of ints, not to `bytes`, because
+//! nothing on the wire distinguishes the two.
 //!
 //! `sub` is burst-shaped, so each tick yields a **`list`** of the frames that
 //! arrived between graph cycles. `pub` puts one value per frame on the wire;
@@ -52,6 +76,11 @@
 //! 3. **New capabilities**: `pub_bursts` (legacy had no burst overload —
 //!    callers converted by hand), TLS (`cert_path` / `key_path`), `stop()`, and
 //!    the `is_historical_noop` / `is_tls` introspection.
+//! 4. **`sub` refuses `codec="bincode"` at wiring.** Legacy accepted the call
+//!    and then aborted the run on the *first frame* with bincode's
+//!    `deserialize_any` complaint — a failure with no bearing on the frame that
+//!    triggered it. It cannot decode any frame, so the diagnosis belongs at the
+//!    call that chose the codec.
 
 use anyhow::{Result, anyhow, bail};
 use pyo3::prelude::*;
@@ -100,7 +129,9 @@ fn to_json(obj: &Bound<'_, PyAny>) -> Result<Value> {
         return Ok(Value::String(obj.extract::<String>()?));
     }
     if let Ok(bytes) = obj.cast::<PyBytes>() {
-        // An array of ints — wire-compatible with a Rust peer's `Vec<u8>`.
+        // An array of ints — wire-compatible with a Rust peer's `Vec<u8>`
+        // under JSON. Under bincode it is not: each element goes out as a
+        // `u64`, which a `Vec<u8>` peer misreads (see the module docs).
         return Ok(Value::Array(
             bytes
                 .as_bytes()
@@ -229,9 +260,16 @@ impl PyWebServer {
     /// Bind `addr` and start the server.
     ///
     /// `addr` is e.g. `"0.0.0.0:8080"`, or `"127.0.0.1:0"` for an OS-assigned
-    /// port. `codec` is `"bincode"` (the default) or `"json"` — whichever the
-    /// browser client is configured for. `static_dir` serves files under
-    /// `GET /` alongside the WebSocket endpoint.
+    /// port. `static_dir` serves files under `GET /` alongside the WebSocket
+    /// endpoint.
+    ///
+    /// `codec` is `"bincode"` (the default, matching the Rust adapter) or
+    /// `"json"`, and **it is not a free choice from Python**. Python payloads
+    /// marshal through a schema-less `serde_json::Value`, which bincode cannot
+    /// deserialize at all, so `"bincode"` is publish-only here — `sub` rejects
+    /// it, a browser rejects it, and a second Python process cannot read it. Use
+    /// `"json"` for anything but publishing scalars to a typed Rust peer; see
+    /// the *"The codec is not a free choice"* table in [the module docs](self).
     ///
     /// `historical=True` builds a **no-op** server: no port is bound, and both
     /// `pub` and `sub` become no-ops, so a backtest can run the same graph
@@ -298,9 +336,17 @@ impl PyWebServer {
     /// between graph cycles, losslessly grouped. A decode failure aborts the
     /// run. The stream never ticks under a historical run (see the constructor).
     ///
+    /// **Requires `codec="json"`, and raises otherwise** — including on a
+    /// `historical=True` no-op server, whose whole point is that the same graph
+    /// also runs live. This is not a policy choice: frames decode into a
+    /// schema-less `serde_json::Value`, and bincode refuses that for every
+    /// input, so a bincode subscription has no decodable frame from any peer.
+    ///
     /// Takes the `Graph` because this creates a source node on it; the other
     /// two methods wire onto the stream they are given.
     fn sub(&self, graph: PyRef<'_, Graph>, topic: String) -> PyResult<crate::Stream> {
+        Self::require_decodable_codec(self.server.codec())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
         let object = graph.object();
         let frames: Stream<Burst<Value>> = web_sub(object.builder(), &self.server, topic)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#}")))?;
@@ -315,6 +361,15 @@ impl PyWebServer {
     /// non-`str` keys, a non-finite float — aborts the run rather than being
     /// published as `null`. Returns a terminal stream whose value is `None`; it
     /// must stay wired into the graph for anything to be sent.
+    ///
+    /// Under `codec="bincode"` the only peer that can read these frames is a
+    /// Rust `web_sub::<T>` whose `T` has the same bincode layout the value's
+    /// `serde_json::Value` produces — true of a scalar or a sequence of one
+    /// width, **false of a `dict` against a `struct`**, which arrives as silent
+    /// garbage (#821). No check can catch that here: the adapter never sees the
+    /// peer's type, and a `dict` against a `HashMap` peer is genuinely fine. Use
+    /// `codec="json"` unless the peer is that Rust scalar case; see [the module
+    /// docs](self).
     #[pyo3(name = "pub")]
     fn publish(&self, stream: PyRef<'_, crate::Stream>, topic: String) -> PyResult<crate::Stream> {
         let object = stream.object();
@@ -331,6 +386,9 @@ impl PyWebServer {
     /// other value is a one-element one. The whole same-instant group crosses
     /// the wire atomically, so a lossy client drop can never split a timestamp
     /// — the browser client surfaces it whole via `subscribeBurst`.
+    ///
+    /// The codec caveat on [`publish`](Self::publish) applies unchanged; the
+    /// browser leg of it needs `codec="json"` outright.
     ///
     /// Legacy had no burst overload; callers converted by hand.
     #[pyo3(name = "pub_bursts")]
@@ -356,6 +414,31 @@ impl PyWebServer {
 }
 
 impl PyWebServer {
+    /// Reject `codec="bincode"` on the subscribe path.
+    ///
+    /// `sub` is `web_sub::<serde_json::Value>`, and `Value`'s `Deserialize`
+    /// asks for `deserialize_any` — which bincode, not being self-describing,
+    /// refuses for every input of every shape. So there is no frame, from any
+    /// peer, that a bincode subscription could decode: the alternative to this
+    /// check is one abort per frame, mid-run, quoting a serde internal.
+    ///
+    /// Deliberately *not* mirrored on the publish path — a bincode publish has
+    /// real working peers (a Rust `web_sub::<f64>`, `<String>`, `<Vec<f64>>`),
+    /// and which ones work depends on the peer's type, which is not observable
+    /// from here.
+    fn require_decodable_codec(codec: CodecKind) -> Result<()> {
+        if matches!(codec, CodecKind::Bincode) {
+            bail!(
+                "web: sub requires codec=\"json\" (this server is \"bincode\"). \
+                 Frames decode into an untyped JSON value, and bincode is not \
+                 self-describing, so no frame from any peer could be decoded and \
+                 every one would abort the run. Build the server with \
+                 WebServer(addr, codec=\"json\")."
+            );
+        }
+        Ok(())
+    }
+
     /// The fallible half of the constructor, kept in `anyhow` so the argument
     /// validation reads the same as every other binding's.
     fn build(
@@ -388,6 +471,7 @@ impl PyWebServer {
 mod tests {
     use super::*;
     use pyo3::IntoPyObjectExt;
+    use wingfoil::adapters::web::Envelope;
 
     fn json(py: Python<'_>, source: &str) -> Result<Value> {
         let obj = py.eval(&std::ffi::CString::new(source).unwrap(), None, None)?;
@@ -524,6 +608,173 @@ mod tests {
             let value = json(py, "2 ** 70").unwrap();
             assert!(value.as_f64().unwrap() > 1e21);
         });
+    }
+
+    // -----------------------------------------------------------------
+    // The codec matrix. These pin *why* `sub` rejects bincode while `pub`
+    // does not, at the exact call (`CodecKind::encode` / `decode`) the
+    // adapter's read.rs and write.rs make. No socket: the whole question is
+    // in the codec.
+    // -----------------------------------------------------------------
+
+    /// A stand-in for "a typed Rust peer": a plain struct, so decoding it runs
+    /// `deserialize_struct` — bare fields in declaration order — exactly as a
+    /// user's `web_sub::<SomeStruct>()` does.
+    fn peer_struct() -> Envelope {
+        Envelope {
+            topic: "ui".into(),
+            time_ns: 7,
+            payload: vec![1, 2],
+        }
+    }
+
+    /// **The fact the whole rejection rests on.** `sub` decodes into
+    /// `serde_json::Value`, whose `Deserialize` asks for `deserialize_any`;
+    /// bincode refuses that for *every* input, so a bincode subscription can
+    /// never decode a frame — not from a Rust peer, not from another Python
+    /// process, not from itself.
+    #[test]
+    fn bincode_cannot_decode_the_value_that_sub_needs_for_any_shape() {
+        for shape in [
+            Value::Null,
+            Value::Bool(true),
+            Value::from(42),
+            Value::from(1.5),
+            Value::from("hi"),
+            serde_json::json!([1, 2]),
+            serde_json::json!({"a": 1}),
+        ] {
+            let bytes = CodecKind::Bincode
+                .encode(&shape)
+                .expect("bincode encodes a Value fine — it is decoding that cannot work");
+            let err = CodecKind::Bincode
+                .decode::<Value>(&bytes)
+                .expect_err("a bincode Value decode must fail");
+            assert!(
+                format!("{err:#}").contains("deserialize_any"),
+                "unexpected bincode error for {shape}: {err:#}"
+            );
+        }
+    }
+
+    /// Python -> Python under bincode therefore does not round-trip either;
+    /// the publisher's own binding cannot read what it wrote.
+    #[test]
+    fn a_python_peer_cannot_read_a_bincode_python_publish() {
+        let published = element_to_json(&PyElement::from(serde_json::json!({"px": 1.5})))
+            .expect("a dict marshals");
+        let bytes = CodecKind::Bincode.encode(&published).expect("encode");
+        assert!(CodecKind::Bincode.decode::<Value>(&bytes).is_err());
+    }
+
+    /// So `sub` refuses at wiring rather than once per frame at run time.
+    #[test]
+    fn sub_refuses_bincode_and_names_the_fix() {
+        let err = PyWebServer::require_decodable_codec(CodecKind::Bincode).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("codec=\"json\""), "{message}");
+        assert!(message.contains("self-describing"), "{message}");
+        assert!(PyWebServer::require_decodable_codec(CodecKind::Json).is_ok());
+    }
+
+    /// **Why `pub` is not rejected too.** A scalar or same-width sequence
+    /// `Value` encodes byte-for-byte as the matching Rust `T`, so these Rust
+    /// peers really do read a bincode Python publish. A blanket rejection
+    /// would break them.
+    #[test]
+    fn a_scalar_python_publish_reaches_a_typed_rust_peer_under_bincode() {
+        let float = CodecKind::Bincode
+            .encode(&Value::from(1.5))
+            .expect("encode");
+        assert_eq!(
+            1.5,
+            CodecKind::Bincode.decode::<f64>(&float).expect("decode")
+        );
+
+        let text = CodecKind::Bincode
+            .encode(&Value::from("AAPL"))
+            .expect("encode");
+        assert_eq!(
+            "AAPL",
+            CodecKind::Bincode.decode::<String>(&text).expect("decode")
+        );
+
+        let seq = CodecKind::Bincode
+            .encode(&serde_json::json!([1.0, 2.0]))
+            .expect("encode");
+        assert_eq!(
+            vec![1.0, 2.0],
+            CodecKind::Bincode.decode::<Vec<f64>>(&seq).expect("decode")
+        );
+    }
+
+    /// ...but a `dict` against a typed peer is issue #821: a `Value::Object`
+    /// encodes as a length-prefixed map with keys inline, while
+    /// `deserialize_struct` reads bare fields in declaration order. The
+    /// mismatch is not reported — it is silent garbage, which is precisely
+    /// what no runtime check here can catch.
+    #[test]
+    fn a_dict_reaches_a_typed_rust_peer_as_garbage_under_bincode() {
+        let peer = peer_struct();
+        let as_value = serde_json::to_value(&peer).expect("the struct is JSON-representable");
+        let payload = CodecKind::Bincode.encode(&as_value).expect("encode");
+
+        match CodecKind::Bincode.decode::<Envelope>(&payload) {
+            Ok(garbage) => assert_ne!(
+                garbage, peer,
+                "a schema-less payload decoded correctly under bincode: if this \
+                 ever holds, revisit the codec table in this module's docs"
+            ),
+            Err(_) => { /* also fine — either way the value never arrives */ }
+        }
+    }
+
+    /// The `bytes` mapping is `Vec<u8>`-compatible under **JSON only**: JSON
+    /// has one number type, while `Value` writes each element as a bincode
+    /// `u64` and a `Vec<u8>` peer reads one byte each.
+    #[test]
+    fn bytes_reach_a_vec_u8_peer_under_json_but_not_under_bincode() {
+        let published = Python::attach(|py| json(py, "bytes([1, 42])").expect("bytes marshal"));
+
+        let json_bytes = CodecKind::Json.encode(&published).expect("encode");
+        assert_eq!(
+            vec![1_u8, 42],
+            CodecKind::Json
+                .decode::<Vec<u8>>(&json_bytes)
+                .expect("decode")
+        );
+
+        let bincode_bytes = CodecKind::Bincode.encode(&published).expect("encode");
+        let under_bincode = CodecKind::Bincode.decode::<Vec<u8>>(&bincode_bytes).ok();
+        assert_ne!(
+            Some(vec![1_u8, 42]),
+            under_bincode,
+            "if bytes ever survive bincode, revisit the codec table in this module's docs"
+        );
+    }
+
+    /// The JSON path is what a typed Rust peer and the browser both need, and
+    /// it works in both directions for every shape — including the `dict` the
+    /// bincode path corrupts.
+    #[test]
+    fn json_round_trips_both_directions_for_a_typed_peer() {
+        let peer = peer_struct();
+        // Rust peer -> Python: the struct decodes into the `Value` `sub` uses.
+        let from_rust = CodecKind::Json.encode(&peer).expect("encode");
+        let seen = CodecKind::Json
+            .decode::<Value>(&from_rust)
+            .expect("a JSON payload is self-describing");
+        assert_eq!(serde_json::json!(7), seen["time_ns"]);
+
+        // Python -> Rust peer: the marshaled dict decodes into the struct.
+        let published = element_to_json(&PyElement::from(seen)).expect("a dict marshals");
+        let from_python = CodecKind::Json.encode(&published).expect("encode");
+        assert_eq!(
+            peer,
+            CodecKind::Json
+                .decode::<Envelope>(&from_python)
+                .expect("decode")
+        );
     }
 
     #[test]

--- a/crates/wingfoil-python/tests/test_web.py
+++ b/crates/wingfoil-python/tests/test_web.py
@@ -113,9 +113,14 @@ def test_static_files_are_served(tmp_path):
         server.stop()
 
 
-def _noop_server():
-    """A no-op server: no port, no sockets — but the value edge still runs."""
-    return wf.WebServer("127.0.0.1:0", historical=True)
+def _noop_server(codec="json"):
+    """A no-op server: no port, no sockets — but the value edge still runs.
+
+    Defaults to the JSON codec because `sub` requires it (see
+    `test_sub_rejects_the_bincode_codec`); `pub` is codec-agnostic here, since
+    marshaling happens on the graph side of the sink.
+    """
+    return wf.WebServer("127.0.0.1:0", codec=codec, historical=True)
 
 
 def test_the_three_wiring_calls_return_streams():
@@ -157,6 +162,56 @@ def test_a_historical_sub_never_ticks():
     g.run(duration_nanos=SECOND_NANOS)
     # Never ticked, so the accumulator never ticked either — `None`, not `[]`.
     assert seen.value() is None
+
+
+# ---- The codec matrix (the Python sibling of #821) ----
+#
+# Payloads marshal through a schema-less `serde_json::Value`. bincode is not
+# self-describing, so it cannot *decode* one at all — which makes `sub`
+# impossible under bincode for every peer, and makes `pub` peer-dependent
+# rather than broken. The Rust unit tests in `src/adapters/web.rs` pin the
+# codec bytes behind these; these pin the Python-visible behaviour.
+
+
+def test_sub_rejects_the_bincode_codec():
+    """Every frame would abort the run, so the call that chose it raises."""
+    server = wf.WebServer("127.0.0.1:0")  # bincode is the default
+    try:
+        assert server.codec_name() == "bincode"
+        with pytest.raises(RuntimeError) as excinfo:
+            server.sub(wf.Graph(), "clicks")
+    finally:
+        server.stop()
+    message = str(excinfo.value)
+    assert 'codec="json"' in message
+    assert "self-describing" in message
+
+
+def test_sub_rejects_bincode_on_a_historical_server_too():
+    """A backtest that cannot also run live is a misconfiguration, not a pass."""
+    server = _noop_server(codec="bincode")
+    with pytest.raises(RuntimeError) as excinfo:
+        server.sub(wf.Graph(), "clicks")
+    assert 'codec="json"' in str(excinfo.value)
+
+
+def test_sub_accepts_the_json_codec():
+    server = wf.WebServer("127.0.0.1:0", codec="json")
+    try:
+        assert isinstance(server.sub(wf.Graph(), "clicks"), wf.Stream)
+    finally:
+        server.stop()
+
+
+def test_pub_still_accepts_the_bincode_codec():
+    """Not rejected: a Rust `web_sub::<f64>` / `<String>` / `<Vec<f64>>` peer
+    really does read a bincode publish, and the adapter cannot see the peer's
+    type. Only the docs can carry that caveat."""
+    g = wf.Graph()
+    server = _noop_server(codec="bincode")
+    assert isinstance(server.pub(g.constant(1.5), "px"), wf.Stream)
+    assert isinstance(server.pub_bursts(g.constant([1.0, 2.0]), "book"), wf.Stream)
+    g.run(cycles=1)
 
 
 # ---- WebSocket round trips (need the `websockets` package) ----

--- a/crates/wingfoil-wasm/src/lib.rs
+++ b/crates/wingfoil-wasm/src/lib.rs
@@ -83,6 +83,25 @@ pub fn encode_unsubscribe(codec: &str, topics: Vec<String>) -> Result<Vec<u8>, J
 /// frame (ready to send on the WebSocket). Used for client → server
 /// publishes.
 ///
+/// # The JSON codec is required for data payloads
+///
+/// **This function errors under [`CodecKind::Bincode`]** — see
+/// [`BINCODE_PAYLOAD_UNSUPPORTED`]. bincode is schema-driven and
+/// non-self-describing: a JS object can only be encoded as a
+/// length-prefixed map (keys and all), while the server decodes with
+/// `deserialize_struct`, which expects bare fields in declaration
+/// order. The two do not line up, and the mismatch does not surface as
+/// an error — the server decodes *silent garbage*. A browser has no
+/// Rust schema, so it cannot produce a correct bincode encoding of a
+/// server struct at all. Start the server with `.codec(CodecKind::Json)`
+/// and construct the client with `codec: "json"`.
+///
+/// Envelope and control frames are unaffected: their shapes are fixed
+/// by [`wingfoil_wire_types`] and known to both sides, so
+/// [`encode_envelope`] / [`encode_subscribe`] work under either codec.
+/// It is only the *user* payload — whose type only the server knows —
+/// that bincode cannot carry from the browser.
+///
 /// For the JSON codec we sidestep `serde_wasm_bindgen` and use the JS
 /// engine's own `JSON.stringify` to produce the payload bytes. The
 /// detour through `serde_json::Value` forces JS Numbers outside the
@@ -91,31 +110,33 @@ pub fn encode_unsubscribe(codec: &str, topics: Vec<String>) -> Result<Vec<u8>, J
 /// server's `u64` fields reject floating-point input. JS's native
 /// `JSON.stringify` writes integer-valued Numbers without a decimal
 /// regardless of magnitude, so the server decodes cleanly.
-///
-/// For bincode we still need the serde round-trip because there is no
-/// JS-native bincode encoder.
 #[wasm_bindgen(js_name = encodePayload)]
 pub fn encode_payload(codec: &str, topic: &str, value: JsValue) -> Result<Vec<u8>, JsError> {
     let codec = parse_codec(codec)?;
     let payload: Vec<u8> = match codec {
         CodecKind::Json => js_sys::JSON::stringify(&value)
             .map(|s| String::from(s).into_bytes())
-            .map_err(|e| JsError::new(&format!("encode_payload: JSON.stringify: {e:?}")))?,
+            .map_err(|e| JsError::new(&format!("encodePayload: JSON.stringify: {e:?}")))?,
         CodecKind::Bincode => {
-            let json: serde_json::Value = serde_wasm_bindgen::from_value(value)
-                .map_err(|e| JsError::new(&format!("encode_payload: from JS: {e}")))?;
-            codec.encode(&json).map_err(to_js_error)?
+            return Err(JsError::new(&bincode_payload_error("encodePayload")));
         }
     };
-    let env = Envelope {
-        topic: topic.to_string(),
-        time_ns: 0,
-        payload,
-    };
-    codec.encode(&env).map_err(to_js_error)
+    frame(codec, topic, payload).map_err(to_js_error)
 }
 
 /// Decode the payload bytes of an envelope into a JS value.
+///
+/// # The JSON codec is required for data payloads
+///
+/// **This function errors under [`CodecKind::Bincode`]** — see
+/// [`BINCODE_PAYLOAD_UNSUPPORTED`] and the note on [`encode_payload`].
+/// Decoding a bincode payload needs the Rust schema of the value the
+/// server published, which the browser does not have; the schema-less
+/// attempt (`decode::<serde_json::Value>`) always fails with
+/// `DeserializeAnyNotSupported`, because bincode carries no type tags to
+/// deserialize *any* from. Start the server with
+/// `.codec(CodecKind::Json)` and construct the client with
+/// `codec: "json"`.
 ///
 /// JSON: parse with `JSON.parse` rather than the serde_json →
 /// `serde_wasm_bindgen` round-trip. The latter rejects u64 values past
@@ -128,15 +149,11 @@ pub fn decode_payload(codec: &str, bytes: &[u8]) -> Result<JsValue, JsError> {
     match codec {
         CodecKind::Json => {
             let s = std::str::from_utf8(bytes)
-                .map_err(|e| JsError::new(&format!("decode_payload: utf8: {e}")))?;
+                .map_err(|e| JsError::new(&format!("decodePayload: utf8: {e}")))?;
             js_sys::JSON::parse(s)
-                .map_err(|e| JsError::new(&format!("decode_payload: JSON.parse: {e:?}")))
+                .map_err(|e| JsError::new(&format!("decodePayload: JSON.parse: {e:?}")))
         }
-        CodecKind::Bincode => {
-            let json: serde_json::Value = codec.decode(bytes).map_err(to_js_error)?;
-            serde_wasm_bindgen::to_value(&json)
-                .map_err(|e| JsError::new(&format!("decode_payload: to JS: {e}")))
-        }
+        CodecKind::Bincode => Err(JsError::new(&bincode_payload_error("decodePayload"))),
     }
 }
 
@@ -147,7 +164,46 @@ pub fn decode_control(codec: &str, bytes: &[u8]) -> Result<JsValue, JsError> {
     serde_wasm_bindgen::to_value(&ctrl).map_err(|e| JsError::new(&format!("decode_control: {e}")))
 }
 
+/// Why the browser cannot carry a **data payload** under
+/// [`CodecKind::Bincode`], and what to do instead.
+///
+/// Appended to an `encodePayload:` / `decodePayload:` prefix and surfaced
+/// to JS as a `JsError`. This is a hard limitation of the format, not a
+/// missing feature: bincode is schema-driven, and the browser has no Rust
+/// schema.
+pub const BINCODE_PAYLOAD_UNSUPPORTED: &str = "\
+the bincode codec cannot carry browser data payloads. bincode is \
+schema-driven and non-self-describing, so a JS value encodes as a \
+length-prefixed map while the server's `deserialize_struct` expects bare \
+fields in declaration order — the server would decode silent garbage rather \
+than report an error — and a server-encoded struct cannot be decoded in the \
+browser at all without its Rust schema. Use the JSON codec for browser \
+payloads: start the server with `.codec(CodecKind::Json)` and construct the \
+client with `codec: \"json\"`. Envelope and control frames are unaffected; \
+this applies only to user data payloads.";
+
 // ---- internal helpers ----
+
+/// The `JsError` text for a browser payload attempted under bincode.
+/// `func` is the JS-facing function name (`encodePayload` /
+/// `decodePayload`) so the message points at the call that failed.
+fn bincode_payload_error(func: &str) -> String {
+    format!("{func}: {BINCODE_PAYLOAD_UNSUPPORTED}")
+}
+
+/// Wrap already-serialized `payload` bytes in an [`Envelope`] on `topic`
+/// and encode the whole frame — the exact bytes that go on the wire.
+///
+/// `time_ns` is always zero: clients cannot set graph time, and the
+/// server ignores the field on inbound frames.
+fn frame(codec: CodecKind, topic: &str, payload: Vec<u8>) -> anyhow::Result<Vec<u8>> {
+    let env = Envelope {
+        topic: topic.to_string(),
+        time_ns: 0,
+        payload,
+    };
+    codec.encode(&env)
+}
 
 fn parse_codec(s: &str) -> Result<CodecKind, JsError> {
     match s {
@@ -161,13 +217,10 @@ fn parse_codec(s: &str) -> Result<CodecKind, JsError> {
 
 fn encode_control_frame(codec: &str, ctrl: &ControlMessage) -> Result<Vec<u8>, JsError> {
     let codec = parse_codec(codec)?;
+    // Control messages *are* schema-known on both sides, so unlike user
+    // data payloads they encode correctly under either codec.
     let payload = codec.encode(ctrl).map_err(to_js_error)?;
-    let env = Envelope {
-        topic: CONTROL_TOPIC.to_string(),
-        time_ns: 0,
-        payload,
-    };
-    codec.encode(&env).map_err(to_js_error)
+    frame(codec, CONTROL_TOPIC, payload).map_err(to_js_error)
 }
 
 fn to_js_error(e: anyhow::Error) -> JsError {
@@ -238,5 +291,121 @@ mod tests {
         let bytes = CodecKind::Json.encode(&ctrl).unwrap();
         let back: ControlMessage = CodecKind::Json.decode(&bytes).unwrap();
         assert_eq!(back, ctrl);
+    }
+
+    // ---- browser payload codec: the four directions ----
+    //
+    // The server-side struct a browser publishes to / receives from. Kept
+    // byte-identical in shape to `UiClick` in
+    // `crates/wingfoil/tests/web_integration.rs`, which pins the same four
+    // facts from the server's side of the socket.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct UiClick {
+        button: String,
+        count: u32,
+    }
+
+    fn a_click() -> UiClick {
+        UiClick {
+            button: "ok".to_string(),
+            count: 1,
+        }
+    }
+
+    /// **Client → server, JSON: works.**
+    ///
+    /// Reproduces `encode_payload`'s JSON leg — the payload bytes are the
+    /// JS engine's `JSON.stringify` output, which for this value is
+    /// byte-identical to `serde_json::to_vec` — then wraps it with the
+    /// same [`frame`] helper the exported function uses, and decodes it
+    /// the way the server's `web_sub` does (`Envelope`, then
+    /// `codec.decode::<T>(&env.payload)`).
+    #[test]
+    fn json_payload_client_to_server_round_trip() {
+        let click = a_click();
+        let payload = serde_json::to_vec(&click).unwrap();
+        let bytes = frame(CodecKind::Json, "ui_events", payload).unwrap();
+
+        // --- server side ---
+        let env: Envelope = CodecKind::Json.decode(&bytes).unwrap();
+        assert_eq!(env.topic, "ui_events");
+        assert_eq!(env.time_ns, 0);
+        let decoded: UiClick = CodecKind::Json.decode(&env.payload).unwrap();
+        assert_eq!(decoded, click);
+    }
+
+    /// **Server → client, JSON: works.**
+    ///
+    /// The server encodes the struct with its codec; `decode_payload`'s
+    /// JSON leg is `str::from_utf8` + `JSON.parse`. `JSON.parse` cannot run
+    /// off-wasm, so the parse is stood in for by `serde_json` — what is
+    /// being pinned here is that the server's payload bytes *are* valid
+    /// UTF-8 JSON with the expected fields, which is exactly what that leg
+    /// requires.
+    #[test]
+    fn json_payload_server_to_client_round_trip() {
+        let click = a_click();
+        let payload = CodecKind::Json.encode(&click).unwrap();
+
+        let s = std::str::from_utf8(&payload).expect("JSON payload is UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(s).unwrap();
+        assert_eq!(parsed["button"], serde_json::json!("ok"));
+        assert_eq!(parsed["count"], serde_json::json!(1));
+    }
+
+    /// **Client → server, bincode: silently corrupt — hence rejected.**
+    ///
+    /// This is the bug behind the rejection. The browser can only offer a
+    /// schema-less `serde_json::Value`; bincode writes it as a
+    /// length-prefixed map, and the server's `deserialize_struct` reads
+    /// bare fields in declaration order. The result is *not* an error, it
+    /// is garbage — which is why `encode_payload` refuses rather than
+    /// letting the value onto the wire.
+    #[test]
+    fn bincode_payload_client_to_server_would_corrupt() {
+        let click = a_click();
+        let as_json: serde_json::Value = serde_json::to_value(&click).unwrap();
+        let payload = CodecKind::Bincode.encode(&as_json).unwrap();
+
+        match CodecKind::Bincode.decode::<UiClick>(&payload) {
+            Ok(garbage) => assert_ne!(
+                garbage, click,
+                "bincode decoded a browser payload *correctly*: if this ever \
+                 holds, revisit the encodePayload rejection"
+            ),
+            Err(_) => { /* also fine — either way the value never arrives */ }
+        }
+    }
+
+    /// **Server → client, bincode: impossible — hence rejected.**
+    ///
+    /// The browser has no schema for the published type, so the only
+    /// schema-less decode available (`serde_json::Value`) hits bincode's
+    /// `DeserializeAnyNotSupported`. `decode_payload` now says so up front
+    /// instead of surfacing that error per frame.
+    #[test]
+    fn bincode_payload_server_to_client_cannot_decode() {
+        let payload = CodecKind::Bincode.encode(&a_click()).unwrap();
+        let err = CodecKind::Bincode
+            .decode::<serde_json::Value>(&payload)
+            .expect_err("schema-less bincode decode must fail");
+        assert!(
+            format!("{err:#}").contains("deserialize_any"),
+            "unexpected bincode error: {err:#}"
+        );
+    }
+
+    /// The rejection message names the failing call and points at the fix.
+    /// `JsError::new` panics off-wasm, so the exported functions cannot be
+    /// called here — the message builder they both use is asserted instead.
+    #[test]
+    fn bincode_payload_error_is_actionable() {
+        for func in ["encodePayload", "decodePayload"] {
+            let msg = bincode_payload_error(func);
+            assert!(msg.starts_with(&format!("{func}: ")), "{msg}");
+            assert!(msg.contains("bincode codec cannot carry browser data payloads"));
+            assert!(msg.contains("CodecKind::Json"));
+            assert!(msg.contains("codec: \"json\""));
+        }
     }
 }

--- a/crates/wingfoil/src/adapters/web/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/web/CLAUDE.md
@@ -194,11 +194,25 @@ the wheel.**
   `Graph` explicitly (`web_sub` needs a builder); contrast prometheus's
   exporter, which takes no `Graph` at all.
 - Payload edge: Python values marshal through `serde_json::Value`, serialized
-  with whichever codec the server was built with — so a Python publisher is
-  wire-compatible with a Rust one. `bytes` become a JSON **array of ints** (as
-  legacy did, for wire compatibility with a Rust `Vec<u8>` peer), and a
-  subscription decodes such a frame back to a `list` of ints, not `bytes` —
-  deliberately asymmetric, because nothing on the wire distinguishes them.
+  with whichever codec the server was built with. **That is not the same as
+  being wire-compatible with a Rust peer, and the docs used to claim it was.**
+  `Value` carries no schema, so the codec decides what is possible:
+  - `sub` **rejects `bincode`** at wiring. It decodes into `Value`, whose
+    `Deserialize` calls `deserialize_any`, and bincode refuses that for every
+    value of every shape — a Python subscription could not read a frame from
+    any peer. The rejection covers the `historical=True` no-op server too, so a
+    backtest cannot pass where the identical live graph would abort.
+  - `pub` **keeps `bincode`**: it is peer-dependent, not impossible. Scalars
+    and same-width sequences reach a typed Rust peer byte-for-byte; a `dict`
+    against a `struct` is the #821 silent-garbage case, while a `dict` against
+    a `HashMap` is fine. The peer's type is not observable from the adapter, so
+    rejecting outright would break correct configurations — hence docs, and no
+    constructor-time warning that could not tell the two apart.
+- `bytes` become a JSON **array of ints** (as legacy did), wire-compatible with
+  a Rust `Vec<u8>` peer **under JSON only** — `Value` writes each element as a
+  `u64`, so the bincode encoding does not match. A subscription decodes such a
+  frame back to a `list` of ints, not `bytes` — deliberately asymmetric,
+  because nothing on the wire distinguishes them.
 - `sub` is burst-shaped: each tick yields a Python `list` of the frames that
   arrived between cycles.
 - Tests: `tests/test_web.py` — service-free group by default,

--- a/crates/wingfoil/src/adapters/web/mod.rs
+++ b/crates/wingfoil/src/adapters/web/mod.rs
@@ -41,6 +41,20 @@
 //! client on upgrade), `Subscribe`/`Unsubscribe { topics }` (client → server),
 //! and `Complete { topic }` (server → client at end-of-stream).
 //!
+//! ## A browser peer needs [`CodecKind::Json`]
+//!
+//! bincode is schema-driven and non-self-describing: encoding *and* decoding
+//! a payload require the Rust type. A browser does not have it, so under the
+//! default [`CodecKind::Bincode`] a JS value can only be offered as a
+//! schema-less map — which `deserialize_struct` reads as **silent garbage**,
+//! not as an error — and a server-encoded payload cannot be decoded in the
+//! browser at all. `@wingfoil/client` therefore rejects data payloads under
+//! bincode outright (`encodePayload` / `decodePayload` throw), so
+//! **`.codec(CodecKind::Json)` whenever a browser publishes to or subscribes
+//! to this server**. Envelope and `$ctrl` frames have fixed shapes both sides
+//! know and are unaffected; a Rust or Python peer, which does have the
+//! schema, can use bincode freely.
+//!
 //! # Publishing
 //!
 //! ```ignore

--- a/crates/wingfoil/src/adapters/web/mod.rs
+++ b/crates/wingfoil/src/adapters/web/mod.rs
@@ -52,8 +52,13 @@
 //! bincode outright (`encodePayload` / `decodePayload` throw), so
 //! **`.codec(CodecKind::Json)` whenever a browser publishes to or subscribes
 //! to this server**. Envelope and `$ctrl` frames have fixed shapes both sides
-//! know and are unaffected; a Rust or Python peer, which does have the
-//! schema, can use bincode freely.
+//! know and are unaffected; a Rust peer, which does have the schema, can use
+//! bincode freely. A **Python** peer cannot be lumped in with it: the binding
+//! marshals through `serde_json::Value`, so it has no more schema than the
+//! browser does. `WebServer.sub` rejects bincode for that reason, and a
+//! Python `pub` is only bincode-safe against a peer whose type matches the
+//! value's own shape — see `wingfoil-python`'s `adapters::web` module docs for
+//! the peer/codec table.
 //!
 //! # Publishing
 //!

--- a/crates/wingfoil/src/adapters/web/read.rs
+++ b/crates/wingfoil/src/adapters/web/read.rs
@@ -24,6 +24,12 @@ use crate::fluent::{GraphBuilder, Stream};
 /// codec (bincode or JSON). Frames arriving between graph cycles group into one
 /// [`Burst`]; decoding errors abort the run with context.
 ///
+/// **Browser publishers require [`CodecKind::Json`](super::CodecKind::Json)** —
+/// bincode needs the Rust schema of `T`, which a browser does not have, and the
+/// mismatch decodes as silent garbage rather than an error. See the *"A browser
+/// peer needs `CodecKind::Json`"* note in [the module docs](super). Rust and
+/// Python publishers are unaffected.
+///
 /// The stream never ticks in historical mode — whether the server is a
 /// [`start_historical`](super::WebServerBuilder::start_historical) no-op *or* a
 /// live server driving a graph in

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -2870,8 +2870,48 @@ impl Runner {
     /// single-run — its producer channels, wakers, and island interiors are
     /// consumed by the first run — and a second `run` returns an error rather
     /// than silently producing wrong values.
+    ///
+    /// `run_dynamic` (feature `dynamic-graph`) enforces the *same* contract
+    /// through the same guard, and the two count against each other: a `run`
+    /// after a `run_dynamic` is a second run, in either order.
     #[cfg_attr(feature = "instrument-run", tracing::instrument(skip_all))]
     pub fn run(&mut self, run_mode: RunMode, run_for: RunFor) -> Result<()> {
+        self.begin_run()?;
+        let mut kernel = self.make_kernel(run_mode, run_for)?;
+        // First error (from start or a cycle) wins; `stop`/`teardown` still
+        // run afterwards regardless, matching the legacy engine.
+        let mut first_err: Option<anyhow::Error> = self.start_nodes(&mut kernel);
+
+        if first_err.is_none() {
+            // Both dispatch strategies produce identical observable results
+            // (see `Dispatch`); the sparse dirty-list is the default, the full
+            // sweep is retained as an executable reference oracle.
+            first_err = match self.dispatch {
+                Dispatch::Sparse => self.run_cycles_sparse(&mut kernel),
+                Dispatch::FullSweep => self.run_cycles_full_sweep(&mut kernel),
+            };
+        }
+
+        self.stop_and_teardown(&mut kernel, &mut first_err);
+
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// The re-run guard, shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic) so both obey one contract: a second
+    /// run of a re-runnable graph first [`reset`](Runner::reset)s it, and a
+    /// second run of a single-run graph errors. Marks the runner as having run
+    /// and zeroes the per-run counters.
+    ///
+    /// Both entry points must go through this. When `run_dynamic` had its own
+    /// (absent) guard, `run` → `run_dynamic` on a single-run channel graph
+    /// silently did nothing (the `finished` flag was still set, so the cycle
+    /// loop exited immediately) and any re-run ordering silently continued
+    /// stale fold/accumulator state.
+    fn begin_run(&mut self) -> Result<()> {
         if self.has_run {
             if self.re_runnable {
                 self.reset();
@@ -2887,6 +2927,13 @@ impl Runner {
         self.has_run = true;
         self.node_visits = 0;
         self.layer_visits = 0;
+        Ok(())
+    }
+
+    /// Validate the run mode against the graph's sources and build the kernel
+    /// for one run — the preamble shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic).
+    fn make_kernel(&mut self, run_mode: RunMode, run_for: RunFor) -> Result<Kernel> {
         let realtime = matches!(run_mode, RunMode::RealTime);
         // `external`/`poll` are wall-clock (realtime-only); `channel` carries
         // timestamps and runs in both modes. These are reachable user errors
@@ -2927,54 +2974,56 @@ impl Runner {
             kernel.set_spin(true);
         }
         kernel.set_timer_policy(self.timer);
-        // First error (from start or a cycle) wins; `stop`/`teardown` still
-        // run afterwards regardless, matching the legacy engine.
-        let mut first_err: Option<anyhow::Error> = None;
+        Ok(kernel)
+    }
 
-        {
-            apply_nodes_span!("start");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.start)(&mut kernel) {
-                    first_err = Some(e.context(format!("node {i} ({}) start", node.label)));
-                    break;
-                }
+    /// Call every node's `start`, stopping at the first error (with node
+    /// context). Shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic); nothing is tombstoned yet at this
+    /// point, so there is nothing to skip.
+    fn start_nodes(&mut self, kernel: &mut Kernel) -> Option<anyhow::Error> {
+        apply_nodes_span!("start");
+        for (i, node) in self.nodes.iter_mut().enumerate() {
+            if let Err(e) = (node.start)(kernel) {
+                return Some(e.context(format!("node {i} ({}) start", node.label)));
             }
         }
+        None
+    }
 
-        if first_err.is_none() {
-            // Both dispatch strategies produce identical observable results
-            // (see `Dispatch`); the sparse dirty-list is the default, the full
-            // sweep is retained as an executable reference oracle.
-            first_err = match self.dispatch {
-                Dispatch::Sparse => self.run_cycles_sparse(&mut kernel),
-                Dispatch::FullSweep => self.run_cycles_full_sweep(&mut kernel),
-            };
-        }
-
-        // Cleanup always runs; a stop/teardown error only surfaces if no
-        // earlier error already won.
+    /// End-of-run cleanup, shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic): every node's `stop` then every
+    /// node's `teardown`. Always runs — a `stop`/`teardown` error only surfaces
+    /// into `first_err` if no earlier error already won.
+    ///
+    /// A node removed mid-run already ran its `stop`/`teardown` at removal
+    /// (legacy parity), so the [`removed`](Runner::removed) tombstone skips it
+    /// here — no double call. `removed` is all-false on a static run, so the
+    /// skip costs a bounds-checked bool read and changes nothing for `run`.
+    fn stop_and_teardown(&mut self, kernel: &mut Kernel, first_err: &mut Option<anyhow::Error>) {
         {
             apply_nodes_span!("stop");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.stop)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) stop", node.label));
+            for i in 0..self.nodes.len() {
+                if self.removed[i] {
+                    continue;
+                }
+                if let Err(e) = (self.nodes[i].stop)(kernel) {
+                    let e = e.context(format!("node {i} ({}) stop", self.nodes[i].label));
                     first_err.get_or_insert(e);
                 }
             }
         }
         {
             apply_nodes_span!("teardown");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.teardown)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) teardown", node.label));
+            for i in 0..self.nodes.len() {
+                if self.removed[i] {
+                    continue;
+                }
+                if let Err(e) = (self.nodes[i].teardown)(kernel) {
+                    let e = e.context(format!("node {i} ({}) teardown", self.nodes[i].label));
                     first_err.get_or_insert(e);
                 }
             }
-        }
-
-        match first_err {
-            Some(e) => Err(e),
-            None => Ok(()),
         }
     }
 
@@ -3423,6 +3472,22 @@ impl Runner {
     /// and the number of cycles completed so far. Nodes appended (or edges
     /// spliced) through the scope take effect on the *next* cycle — legacy
     /// wingfoil's "requested in cycle N, live in N+1" contract.
+    ///
+    /// **The re-run contract is [`run`](Runner::run)'s, exactly** — the two
+    /// share one guard ([`begin_run`](Runner::begin_run)) and count against each
+    /// other in any order. A second run of a re-runnable graph (tickers /
+    /// constants + combinators + feedback) first restores every node's state and
+    /// value slot via [`reset`](Runner::reset), so it reproduces the first run
+    /// rather than continuing stale accumulator state; a second run of a
+    /// single-run graph (`external`/`poll`/`channel` sources or a `composite`
+    /// island) returns an error.
+    ///
+    /// One caveat on a re-run of a graph this method *mutated*: the graph the
+    /// first run left behind is the one that re-runs — nodes appended through
+    /// `between` are still wired, and fire from its first cycle — but only the
+    /// statically-built region is restored. A dynamically-appended node carries
+    /// a no-op reset by construction (see `rt_append_node`), so it re-runs
+    /// carrying its own accumulated state.
     #[cfg_attr(feature = "instrument-run", tracing::instrument(skip_all))]
     pub fn run_dynamic<F>(
         &mut self,
@@ -3433,50 +3498,12 @@ impl Runner {
     where
         F: FnMut(&mut Extension<'_>, u64) -> Result<()>,
     {
-        // Source/run-mode validation, identical to `run`.
-        self.node_visits = 0;
-        self.layer_visits = 0;
-        let realtime = matches!(run_mode, RunMode::RealTime);
-        if !realtime && self.has_external {
-            bail!(
-                "graphs with external sources require RunMode::RealTime — untimestamped \
-                 external events have no place in a deterministic historical replay (use a \
-                 channel with timestamped sends for historical)"
-            );
-        }
-        if !realtime && self.has_always {
-            bail!(
-                "graphs with poll sources require RunMode::RealTime — there is nothing to \
-                 busy-poll in a deterministic historical replay"
-            );
-        }
-        let needs_waker = self.has_external || (self.has_channel && realtime);
-        let mut kernel = if needs_waker {
-            let Some(ready) = self.ready.take() else {
-                bail!(
-                    "a Runner with realtime sources (external/poll/realtime channel) supports \
-                     only a single run — the waker/ready channel is consumed by the first run"
-                );
-            };
-            Kernel::with_ready(run_mode, run_for, ready)
-        } else {
-            Kernel::new(run_mode, run_for)
-        };
-        if self.has_always {
-            kernel.set_spin(true);
-        }
-        kernel.set_timer_policy(self.timer);
+        // Re-run guard, source/run-mode validation and kernel construction are
+        // `run`'s — shared, not copied, so the two cannot drift apart again.
+        self.begin_run()?;
+        let mut kernel = self.make_kernel(run_mode, run_for)?;
 
-        let mut first_err: Option<anyhow::Error> = None;
-        {
-            apply_nodes_span!("start");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.start)(&mut kernel) {
-                    first_err = Some(e.context(format!("node {i} ({}) start", node.label)));
-                    break;
-                }
-            }
-        }
+        let mut first_err: Option<anyhow::Error> = self.start_nodes(&mut kernel);
 
         if first_err.is_none() {
             // Scratch is reused across cycles and regrown as nodes are appended.
@@ -3554,34 +3581,7 @@ impl Runner {
             }
         }
 
-        // Cleanup always runs; a stop/teardown error only surfaces if no
-        // earlier error already won. A node removed mid-run already ran its
-        // `stop`/`teardown` at removal (legacy parity), so the tombstone skips
-        // it here — no double call.
-        {
-            apply_nodes_span!("stop");
-            for i in 0..self.nodes.len() {
-                if self.removed[i] {
-                    continue;
-                }
-                if let Err(e) = (self.nodes[i].stop)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) stop", self.nodes[i].label));
-                    first_err.get_or_insert(e);
-                }
-            }
-        }
-        {
-            apply_nodes_span!("teardown");
-            for i in 0..self.nodes.len() {
-                if self.removed[i] {
-                    continue;
-                }
-                if let Err(e) = (self.nodes[i].teardown)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) teardown", self.nodes[i].label));
-                    first_err.get_or_insert(e);
-                }
-            }
-        }
+        self.stop_and_teardown(&mut kernel, &mut first_err);
         match first_err {
             Some(e) => Err(e),
             None => Ok(()),

--- a/crates/wingfoil/tests/rerun_dynamic.rs
+++ b/crates/wingfoil/tests/rerun_dynamic.rs
@@ -1,0 +1,260 @@
+//! Re-run contract for [`Runner::run_dynamic`](wingfoil::interp::Runner::run_dynamic).
+//!
+//! `run_dynamic` is a second public entry point into the same runner, and it
+//! used to keep its own copy of `run`'s preamble — minus the re-run guard. So
+//! it neither set nor checked `has_run`, and every ordering silently did the
+//! wrong thing:
+//!
+//! * `run` → `run_dynamic` on a single-run *historical channel* graph returned
+//!   `Ok(())` having done nothing at all: the `finished` flag set by the
+//!   channel's `EndOfStream` is cleared only by `reset`, which never ran, so the
+//!   cycle loop exited on its first test.
+//! * every re-runnable ordering (`run` → `run_dynamic`, `run_dynamic` →
+//!   `run_dynamic`, `run_dynamic` → `run`) continued stale fold/accumulator
+//!   state instead of restoring it.
+//!
+//! Both entry points now share one guard, so the contract is `run`'s in either
+//! direction: re-runnable graphs reset, single-run graphs error.
+#![cfg(feature = "dynamic-graph")]
+
+use std::time::Duration;
+
+use wingfoil::interp::Extension;
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const TEN: Duration = Duration::from_nanos(10);
+
+/// No-op mutation hook — `run_dynamic` with nothing to mutate, i.e. exactly
+/// `run` plus the boundary callback.
+fn nothing(_ext: &mut Extension<'_>, _cycle: u64) -> anyhow::Result<()> {
+    Ok(())
+}
+
+/// A stateful re-runnable graph: a `count` fold and its tick times. The
+/// accumulated `(time, value)` pairs pin both halves of the contract — values
+/// *and* tick times must reproduce.
+fn wire(g: &GraphBuilder) -> (Stream<Vec<(NanoTime, u64)>>, Stream<u64>) {
+    let count = g.ticker(TEN).count();
+    let sum = count.fold(0u64, |acc, x| *acc += *x);
+    (count.with_time().accumulate(), sum)
+}
+
+/// The pinned sequence of a 4-cycle run of [`wire`] — ticker at 10ns, whose
+/// first callback is scheduled at the run's start time and whose first cycle
+/// therefore fires at t=0 (`Kernel::begin_cycle`: "first cycle fires at the
+/// callback's own time").
+fn expected() -> Vec<(NanoTime, u64)> {
+    vec![
+        (NanoTime::new(0), 1),
+        (NanoTime::new(10), 2),
+        (NanoTime::new(20), 3),
+        (NanoTime::new(30), 4),
+    ]
+}
+
+/// `run` then `run_dynamic`: the second run resets, so it reproduces the first
+/// exactly rather than continuing the fold.
+#[test]
+fn run_then_run_dynamic_resets() {
+    let g = GraphBuilder::new();
+    let (acc, sum) = wire(&g);
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(expected(), r.value(&acc));
+    assert_eq!(1 + 2 + 3 + 4, r.value(&sum));
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(
+        expected(),
+        r.value(&acc),
+        "run_dynamic after run must reset, not continue"
+    );
+    // Stale state would have left the fold at 10 + 10 = 20.
+    assert_eq!(10, r.value(&sum));
+}
+
+/// `run_dynamic` then `run_dynamic`: same contract between two dynamic runs.
+#[test]
+fn run_dynamic_twice_resets() {
+    let g = GraphBuilder::new();
+    let (acc, sum) = wire(&g);
+    let mut r = g.build();
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(expected(), r.value(&acc));
+    assert_eq!(10, r.value(&sum));
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(expected(), r.value(&acc), "a second run_dynamic must reset");
+    assert_eq!(10, r.value(&sum));
+}
+
+/// `run_dynamic` then `run`: `run_dynamic` must *set* `has_run`, or the plain
+/// `run` that follows skips its reset and continues stale state.
+#[test]
+fn run_dynamic_then_run_resets() {
+    let g = GraphBuilder::new();
+    let (acc, sum) = wire(&g);
+    let mut r = g.build();
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(expected(), r.value(&acc));
+    assert_eq!(10, r.value(&sum));
+
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(
+        expected(),
+        r.value(&acc),
+        "run after run_dynamic must reset, not continue"
+    );
+    assert_eq!(10, r.value(&sum));
+}
+
+/// A dynamic run and a plain run of the same re-runnable graph produce
+/// identical values *and* tick times — the boundary hook is the only
+/// difference between the two entry points.
+#[test]
+fn run_dynamic_matches_run() {
+    let g = GraphBuilder::new();
+    let (acc, _sum) = wire(&g);
+    let mut r = g.build();
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    let dynamic = r.value(&acc);
+
+    let g2 = GraphBuilder::new();
+    let (acc2, _sum2) = wire(&g2);
+    let mut r2 = g2.build();
+    r2.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+
+    assert_eq!(r2.value(&acc2), dynamic);
+    assert_eq!(expected(), dynamic);
+}
+
+/// The graph a re-run re-runs is the one the first run *left behind* — a node
+/// appended through the hook is still wired, and fires from cycle 1 of the
+/// second run. Only the *statically built* region is restored, though: a
+/// dynamically-appended node carries a no-op reset by construction
+/// (`Runner::rt_append_node`), so it re-runs carrying its own state. Appended at
+/// the end of cycle 2 of run 1 it fires on cycles 3 and 4 (2 activations), then
+/// on all four cycles of run 2 — 6, not 4. This pins the documented caveat on
+/// `run_dynamic`, so a future change to dynamic-node reset is a deliberate one.
+#[test]
+fn appended_node_survives_run_but_keeps_its_state() {
+    let g = GraphBuilder::new();
+    let src = g.ticker(TEN).count().handle();
+    let mut r = g.build();
+
+    let mut appended = None;
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), |ext, cycle| {
+        if cycle == 2 && appended.is_none() {
+            appended = Some(ext.fold(src, 0u64, |acc, _| *acc += 1));
+        }
+        Ok(())
+    })
+    .unwrap();
+    let appended = appended.expect("node appended at cycle 2");
+    assert_eq!(2, r.value(appended), "fired on cycles 3 and 4 only");
+
+    // Second run: already wired, so it fires all four cycles — but its own
+    // state is not restored, so it continues from 2 rather than restarting.
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(
+        2 + 4,
+        r.value(appended),
+        "an appended node keeps its state across a re-run (no-op reset)"
+    );
+    // The statically-built source *did* reset — 4, not 8.
+    assert_eq!(4, r.value(src));
+}
+
+/// The `finished` case. A historical channel graph is **single-run**: the
+/// channel's `EndOfStream` sets `finished`, which only `reset` clears, and
+/// `reset` cannot restore the consumed producer channel anyway. `run_dynamic`
+/// after `run` must therefore error — it used to return `Ok(())` having run
+/// zero cycles, leaving the first run's values in place and looking like a
+/// success.
+#[test]
+fn historical_channel_graph_refuses_run_dynamic_after_run() {
+    let g = GraphBuilder::new();
+    let (values, sender) = g.channel::<u64>();
+    let acc = values.with_time().accumulate();
+    let mut r = g.build();
+
+    let producer = std::thread::spawn(move || {
+        sender.send_at(10, NanoTime::new(100));
+        sender.send_at(20, NanoTime::new(200));
+        sender.close();
+    });
+    r.run(HISTORICAL, RunFor::Forever).unwrap();
+    producer.join().expect("producer thread");
+
+    let flat: Vec<(NanoTime, Vec<u64>)> = r
+        .value(&acc)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().copied().collect()))
+        .collect();
+    assert_eq!(
+        vec![
+            (NanoTime::new(100), vec![10]),
+            (NanoTime::new(200), vec![20]),
+        ],
+        flat
+    );
+
+    let err = r
+        .run_dynamic(HISTORICAL, RunFor::Forever, nothing)
+        .expect_err("a single-run channel graph must refuse run_dynamic after run");
+    assert!(
+        err.to_string().contains("single-run"),
+        "unexpected error: {err}"
+    );
+}
+
+/// The mirror image: `run_dynamic` first, then `run` — the single-run guard
+/// fires whichever entry point consumed the graph.
+#[test]
+fn historical_channel_graph_refuses_run_after_run_dynamic() {
+    let g = GraphBuilder::new();
+    let (values, sender) = g.channel::<u64>();
+    let acc = values.with_time().accumulate();
+    let mut r = g.build();
+
+    let producer = std::thread::spawn(move || {
+        sender.send_at(7, NanoTime::new(50));
+        sender.close();
+    });
+    r.run_dynamic(HISTORICAL, RunFor::Forever, nothing).unwrap();
+    producer.join().expect("producer thread");
+
+    let flat: Vec<(NanoTime, Vec<u64>)> = r
+        .value(&acc)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().copied().collect()))
+        .collect();
+    assert_eq!(vec![(NanoTime::new(50), vec![7])], flat);
+
+    let err = r
+        .run(HISTORICAL, RunFor::Forever)
+        .expect_err("a single-run channel graph must refuse a second run");
+    assert!(
+        err.to_string().contains("single-run"),
+        "unexpected error: {err}"
+    );
+
+    let err = r
+        .run_dynamic(HISTORICAL, RunFor::Forever, nothing)
+        .expect_err("...and a second run_dynamic likewise");
+    assert!(
+        err.to_string().contains("single-run"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/wingfoil/tests/web_integration.rs
+++ b/crates/wingfoil/tests/web_integration.rs
@@ -88,6 +88,22 @@ async fn send_payload<T: Serialize>(
     value: &T,
 ) -> anyhow::Result<()> {
     let payload = codec.encode(value)?;
+    send_raw_payload(socket, codec, topic, payload).await
+}
+
+/// Send *already-serialized* payload bytes, wrapped in an envelope.
+///
+/// The browser never hands the codec a typed Rust value — `encodePayload`
+/// produces the payload bytes itself (from `JSON.stringify`) and then frames
+/// them. This is that shape, and it is what the browser-payload tests below
+/// use so they exercise the real client → server byte path rather than a
+/// Rust-to-Rust one.
+async fn send_raw_payload(
+    socket: &mut TungsteniteStream,
+    codec: CodecKind,
+    topic: &str,
+    payload: Vec<u8>,
+) -> anyhow::Result<()> {
     let env = Envelope {
         topic: topic.to_string(),
         time_ns: 0,
@@ -279,6 +295,119 @@ fn sub_round_trip_bincode() -> anyhow::Result<()> {
         assert_eq!(click.count, i as u32);
     }
     Ok(())
+}
+
+/// **Browser → server under the JSON codec: the supported path.**
+///
+/// `sub_round_trip_bincode` above sends a *Rust* client's bytes — it encodes
+/// a typed `UiClick` with bincode, which a browser can never do. This is the
+/// browser's shape: the payload is raw JSON text, exactly what
+/// `wingfoil-wasm`'s `encodePayload` produces from `JSON.stringify`, framed in
+/// a JSON envelope. It is the only payload shape a browser can produce that
+/// the server decodes correctly, which is why `@wingfoil/client` requires
+/// `codec: "json"` for `publish`.
+#[test]
+fn sub_round_trip_json_browser_payload() -> anyhow::Result<()> {
+    let server = WebServer::bind("127.0.0.1:0")
+        .codec(CodecKind::Json)
+        .start()?;
+    let port = server.port();
+    let codec = server.codec();
+
+    let g = GraphBuilder::new();
+    let collected = web_sub::<UiClick>(&g, &server, "ui_events")?.collapse_accumulate();
+
+    let client_handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new()?;
+        rt.block_on(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let mut socket = connect(port).await?;
+            for i in 0..3u32 {
+                // What the browser sends: `JSON.stringify({button, count})`.
+                let payload = format!(r#"{{"button":"ok","count":{i}}}"#).into_bytes();
+                send_raw_payload(&mut socket, codec, "ui_events", payload).await?;
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            anyhow::Ok(())
+        })
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(2)))?;
+    client_handle.join().expect("client thread panic")?;
+
+    let all = runner.value(&collected);
+    assert!(
+        all.len() >= 3,
+        "expected at least 3 clicks, got {}",
+        all.len()
+    );
+    for (i, click) in all.iter().take(3).enumerate() {
+        assert_eq!(click.button, "ok");
+        assert_eq!(click.count, i as u32);
+    }
+    Ok(())
+}
+
+/// **Browser → server under bincode: silently corrupt, which is why the
+/// browser client refuses to send it at all.**
+///
+/// The server half of `wingfoil-wasm`'s `bincode_payload_client_to_server_
+/// would_corrupt`. A browser has no Rust schema, so the best payload it could
+/// offer bincode is a schema-less `serde_json::Value` — encoded as a
+/// length-prefixed map, while `web_sub`'s `codec.decode::<T>` runs
+/// `deserialize_struct`, which reads bare fields in declaration order. The
+/// mismatch is not reported: the server gets garbage. `encodePayload` now
+/// errors instead of putting these bytes on the wire, so this pins *why*.
+///
+/// No socket: the corruption is in the codec, and `web_sub` decodes payload
+/// bytes with exactly this call.
+#[test]
+fn browser_bincode_payload_does_not_decode_as_the_struct() {
+    let click = UiClick {
+        button: "ok".to_string(),
+        count: 1,
+    };
+    let as_json = serde_json::to_value(&click).expect("UiClick is JSON-representable");
+    let payload = CodecKind::Bincode
+        .encode(&as_json)
+        .expect("bincode encodes a Value as a map");
+
+    match CodecKind::Bincode.decode::<UiClick>(&payload) {
+        Ok(garbage) => assert_ne!(
+            garbage, click,
+            "a schema-less browser payload decoded correctly under bincode: if \
+             this ever holds, revisit the encodePayload rejection in \
+             crates/wingfoil-wasm/src/lib.rs"
+        ),
+        Err(_) => { /* also fine — either way the intended value never arrives */ }
+    }
+}
+
+/// **Server → browser under bincode: undecodable, hence `decodePayload`
+/// rejects it.**
+///
+/// `web_pub` writes the value with the server's codec. A browser decoding
+/// that has no schema to decode *into*, and bincode carries no type tags, so
+/// the only schema-less attempt available fails outright — which is what
+/// `decodePayload` used to surface once per frame and now reports up front.
+#[test]
+fn server_bincode_payload_cannot_be_decoded_without_a_schema() {
+    let payload = CodecKind::Bincode
+        .encode(&UiClick {
+            button: "ok".to_string(),
+            count: 1,
+        })
+        .expect("bincode encodes the struct");
+
+    let err = CodecKind::Bincode
+        .decode::<serde_json::Value>(&payload)
+        .expect_err("schema-less bincode decode must fail");
+    assert!(
+        format!("{err:#}").contains("deserialize_any"),
+        "unexpected bincode error: {err:#}"
+    );
 }
 
 #[test]

--- a/js/README.md
+++ b/js/README.md
@@ -26,7 +26,8 @@ package (see `vite.config.ts` for the alias pattern).
 import { WingfoilClient } from "@wingfoil/client";
 
 const client = new WingfoilClient({
-  url: "ws://localhost:8080/ws",   // bincode is the default
+  url: "ws://localhost:8080/ws",
+  codec: "json",                   // required for data payloads — see below
 });
 
 client.subscribe("price", (value, timeNs) => {
@@ -36,6 +37,39 @@ client.subscribe("price", (value, timeNs) => {
 // Send a UI event back to the graph:
 client.publish("ui", { kind: "click", note: "hi" });
 ```
+
+Start the server to match:
+
+```rust
+WebServer::bind("127.0.0.1:8080")
+    .codec(CodecKind::Json)
+    .start()?;
+```
+
+### Data payloads require the JSON codec
+
+**`subscribe` / `subscribeBurst` / `publish` only work when the server is
+started with `.codec(CodecKind::Json)` and the client is constructed with
+`codec: "json"`.** Under the server's default `CodecKind::Bincode`,
+`publish` and payload decoding throw — deliberately, and with a message
+that says this.
+
+The reason is structural, not a missing feature. bincode is schema-driven
+and non-self-describing: the bytes carry no field names and no type tags,
+so both encoding and decoding need the Rust type. The browser does not
+have it. A JS object can only be encoded as a length-prefixed *map*, while
+the server's `deserialize_struct` expects bare fields in declaration order
+— the two do not line up, and the mismatch is **not** an error on the
+server: it decodes silent garbage. In the other direction, a schema-less
+decode of bincode bytes fails outright. So the client refuses both rather
+than corrupting your data.
+
+Connection-level frames are unaffected — the envelope and the `$ctrl`
+control messages have fixed shapes known to both sides, so a bincode
+connection still connects, subscribes and receives frames. It is only the
+user *payload*, whose type only the server knows, that bincode cannot
+carry to or from a browser. A Rust or Python client, which does have the
+schema, can use bincode freely.
 
 ### Bursts
 
@@ -121,9 +155,11 @@ both outbound publishes and inbound parsing). The end-to-end latency
 demo at `crates/wingfoil/examples/showcase/trading_e2e/static/app.js` is the canonical
 example.
 
-Requires the server to use `CodecKind::Json`: the tracker sends
-`session` as a JS `number[]`, which the JSON codec round-trips as
-`[u8; 16]` but the bincode codec encodes as a length-prefixed `Vec<u8>`.
+Requires the server to use `CodecKind::Json` — as every data payload does
+([above](#data-payloads-require-the-json-codec)). The tracker adds a
+second reason of its own: it sends `session` as a JS `number[]`, which the
+JSON codec round-trips as a Rust `[u8; 16]` but bincode would encode as a
+length-prefixed `Vec<u8>`.
 
 The main package also re-exports the small browser helpers the tracker
 relies on, in case you need them directly: `newSessionId`,
@@ -214,15 +250,21 @@ Then open <http://localhost:5173> — the Solid dashboard connects to
 ## Wire format
 
 Every WebSocket frame is binary — either a `bincode`-serialized
-[`Envelope`](../crates/wingfoil-wire-types/src/lib.rs) (default) or a JSON one
-(if the server was started with `.codec(CodecKind::Json)`). The
-`wingfoil-wasm` decoder handles both without any user configuration
-other than the codec hint passed to `WingfoilClient`.
+[`Envelope`](../crates/wingfoil-wire-types/src/lib.rs) (the server's default) or
+a JSON one (if the server was started with `.codec(CodecKind::Json)`). The
+`wingfoil-wasm` decoder handles both envelope framings without any user
+configuration other than the codec hint passed to `WingfoilClient`.
 
 The payload is the stream's value serialized by the codec. A scalar is a
 single value; a value that decodes to an array is surfaced as a
 same-`timeNs` **burst** (the client collapses it for `subscribe` and passes
 it whole to `subscribeBurst`). Client → server frames carry a single value.
+
+**Payloads are the exception to "handles both".** A browser has no Rust
+schema, and bincode needs one in both directions, so a browser client
+requires the JSON codec for any payload it sends or receives —
+[see above](#data-payloads-require-the-json-codec). The envelope and
+`$ctrl` frames, whose shapes both sides know, work under either.
 
 The control plane (topic `$ctrl`) carries `Hello` on connect, `Subscribe`
 / `Unsubscribe` from the client, and `Complete { topic }` from the server

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -75,6 +75,15 @@ export interface ClientOptions {
    * Wire codec the server is using. Defaults to `bincode` (the
    * server's default); swap to `json` if the server was started with
    * `.codec(CodecKind::Json)`.
+   *
+   * **Data payloads require `"json"`.** A browser has no Rust schema, and
+   * bincode is schema-driven in both directions: a JS object encodes as a
+   * length-prefixed map that the server's `deserialize_struct` reads as
+   * silent garbage, and bincode bytes cannot be decoded here at all. So
+   * {@link WingfoilClient.publish} and payload decoding throw under
+   * `"bincode"`. Envelope and `$ctrl` control frames — fixed shapes both
+   * sides know — work under either codec. Start the server with
+   * `.codec(CodecKind::Json)` whenever a browser is a peer.
    */
   codec?: CodecKind;
   /**
@@ -235,7 +244,18 @@ export class WingfoilClient {
     );
   }
 
-  /** Publish a value on `topic` to the server. */
+  /**
+   * Publish a value on `topic` to the server.
+   *
+   * **Requires the JSON codec** ({@link ClientOptions.codec} `= "json"`,
+   * server started with `.codec(CodecKind::Json)`). Under `"bincode"` the
+   * encode throws and the value is dropped with a `console.warn`, because
+   * the browser cannot produce a bincode encoding of a Rust struct and the
+   * server would decode silent garbage if it tried.
+   *
+   * Failures never propagate: an unencodable value, or a socket that is not
+   * open, is warned about and dropped.
+   */
   publish(topic: string, value: unknown): void {
     if (!this.wasmReady || !this.socket || this.socket.readyState !== WebSocket.OPEN) {
       return;

--- a/js/src/tracing.ts
+++ b/js/src/tracing.ts
@@ -14,8 +14,13 @@
 // clock-sync required, because every subtraction lives in one domain.
 //
 // Codec assumption: requires the server's web adapter to use
-// `CodecKind::Json`. The bincode codec serialises a JS `number[]` as a
-// length-prefixed `Vec<u8>`, which doesn't match a Rust `[u8; 16]` field.
+// `CodecKind::Json` — as every browser data payload does, because bincode
+// is schema-driven and the browser has no Rust schema (see the `codec`
+// note on `ClientOptions`, and "Data payloads require the JSON codec" in
+// the README). `publish` throws under bincode rather than corrupting the
+// value. The tracker adds a second reason of its own: it sends `session`
+// as a JS `number[]`, which JSON round-trips as a Rust `[u8; 16]` but
+// bincode would serialise as a length-prefixed `Vec<u8>`.
 //
 // Field-name overrides (`LatencyTrackerOptions.fields`) apply
 // symmetrically to outbound publishes *and* inbound parsing.


### PR DESCRIPTION
## What this changes

Clears the issues that should not ship in 9.0.0: a silently-corrupting browser payload path, a public run entry point that skipped the re-run guard, two CI holes that let changes merge without the thing they broke ever running, and a lockfile pin on a yanked crate.

Closes #821, #819, #835. Addresses #837 (item 4 only) and the security half of #452.

## Why

These came out of a triage of all 47 open issues against the tree. 9.0.0 is not published yet — the last tag is `v8.0.0` — so these are the last things standing between the tree and a first publish to three registries.

**#821 — browser data payloads corrupt silently under the default codec.** `encode_payload` serialized the JS value as a `serde_json::Value`, but the server decodes with `codec.decode::<T>()`. bincode is schema-driven and non-self-describing, so a JS object encodes as a length-prefixed map with keys inline while `deserialize_struct` expects bare fields in declaration order. The server did not error — it decoded garbage: `{"button":"ok","count":1}` arrived as `UiClick { button: "\u{6}\0", count: 0 }`. The other direction always failed with `DeserializeAnyNotSupported`. `js/README.md`'s quick start demonstrated exactly this, under the default codec.

A JS client cannot produce a bincode encoding of a Rust struct — there is no schema in the browser — so the path is impossible rather than merely buggy. Both legs now fail loudly with a message naming the call, `CodecKind::Json` and `codec: "json"`, and the docs stop promising otherwise.

**#819 — `run_dynamic` bypassed the single-run/reset guard.** `run` guards re-runs so that "a second `run` returns an error rather than silently producing wrong values"; `run_dynamic` neither set nor checked `has_run` and never called `reset()`, though both are public. On a historical-channel graph, `run()` then `run_dynamic()` returned `Ok(())` having run zero cycles; on re-runnable graphs every ordering silently continued stale fold state. The cause was duplication — the preamble and teardown were verbatim copies — so the dedup is the fix vehicle.

**#835 — CI never ran the derive tests or any doctest**, and `python-test.yml`'s paths filter omitted both itself and `crates/wingfoil-wire-types/**`, so a wire-types change could merge without the Python leg running at all.

## How it was verified

Full gate run over the combined branch, not per-commit:

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all` — both clean
- [x] `cargo test -p wingfoil --all-features` — **985 passed**
- [x] New behaviour is covered by a test asserting **values and tick times**

64 failures, all confined to the nine container-dependent suites (`aeron`, `etcd`, `fluvio`, `kafka`, `otlp`, `postgres`, `redis`, `zmq_cross_lang`, `zmq_etcd`) failing on `Socket not found: /var/run/docker.sock` — no daemon in the dev sandbox. These run in their own workflows here. Every other binary is green, including `web_integration` 11/11, `rerun_dynamic` 7/7, `engine_semantics` 8/8 (untouched), and 17 doctests.

Also verified: the two new CI steps pass locally on this tree, so they go green rather than red on merge (`cargo test -p wingfoil-derive` → 3 passed; `cargo test --doc -p wingfoil --all-features` → 17 passed, 18 ignored). `wasm32-unknown-unknown` builds; 8/8 wasm unit tests; `pnpm lint` and 27/27 JS tests.

The #819 tests were checked for bite, not just for green: with the new `begin_run()?` temporarily removed from `run_dynamic`, 6 of the 7 new tests fail.

## Notes for the reviewer

**Routing browser payloads as JSON regardless of frame codec was considered and rejected.** `read.rs`/`write.rs` both encode payloads with the frame codec, and real bincode payload peers exist (the `sub_round_trip_bincode` test and the Python binding), so it would need a per-frame signal the envelope has no field for — a wire-version bump. Failing loudly is the release-safe fix; the richer protocol change can come later.

**#819 documents a caveat it did not change.** Re-running a *mutated* graph restores only the statically-built region, because `rt_append_node` gives dynamically-appended nodes a no-op `reset` by construction. That is an existing design decision, previously uncommented in the public contract; it is now in the rustdoc and pinned by a test.

**`spin` 0.9.8 → 0.9.9 is a yank fix, not an advisory fix.** CI's `cargo audit` exits 0 either way, but shipping a release whose committed lock pins a yanked crate is a reproducibility wart. Trivially revertible if you would rather the release PR carry zero lockfile churn.

**#452 is not a release blocker and its body is wrong.** Re-derived against a freshly fetched RustSec DB: 0 vulnerabilities in the root lock (750 crates), 0 in `crates/wingfoil-wasm/Cargo.lock`, and "no known vulnerabilities" from `pnpm audit`. Everything remaining is RustSec *informational*, which does not fail CI. The issue's "1 critical, 6 high" is stale by two rounds of remediation. Caveat: the Dependabot alert list itself could not be read from this session (no `gh`, and `api.github.com` is proxy-blocked), so that is inference from the tree — worth a glance at the security tab before relying on it.

**#835's body contains an error worth not propagating.** It claims CLAUDE.md's local checklist misses doctests. Plain `cargo test` runs the `--doc` target by default and `wingfoil` sets no `doctest = false`, so the existing `cargo test -p wingfoil --all-features` already covers the fences locally. Only *nextest* skips them, which is why CI needed a separate step but the local checklist only needed the derive line.

### Follow-ups deliberately not folded in

- **#461's accepted-advisory list needs a refresh**: drop `dotenv` (gone from the tree) and `anyhow` RUSTSEC-2026-0190 (lock is at patched 1.0.104); add `lru` RUSTSEC-2026-0253, sibling of the RUSTSEC-2026-0002 already listed and unfixable from the lockfile (`lru >= 0.18.2` is a semver-major move pinned upstream by `rv`/`augurs`).
- `security-audit.yml` justifies its pytest allowance by citing `uv.lock`, which no longer exists. The allowance is still correct; the sentence naming the file is not.
- The remaining four items of #837 (the wording sweep) are untouched; only the PyPI description is fixed here, because that string ships in wheel metadata.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wQjYrfk8RpF3TQFjeii7)_