### PR TITLE
fix(derive): validate passive masks for no-builder ops

### DIFF
--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -1698,6 +1698,18 @@ fn expand_op(args: &OpArgs, imp: &ItemImpl) -> syn::Result<TokenStream2> {
     let state_ty = state_ty.ok_or_else(|| missing("State"))?;
     let out_ty = out_ty.ok_or_else(|| missing("Out"))?;
     let shape = parse_in_shape(&in_ty)?;
+    let edge_count = shape.edge_ref_tys.len();
+    if args
+        .passive
+        .checked_shr(edge_count as u32)
+        .unwrap_or_default()
+        != 0
+    {
+        return Err(syn::Error::new(
+            self_ty.span(),
+            format!("#[op]: `passive` names an edge position beyond this op's {edge_count} inputs"),
+        ));
+    }
     let activation_expr = activation_expr
         .ok_or_else(|| syn::Error::new(imp.span(), "#[op]: impl has no `const ACTIVATION`"))?;
 
@@ -2225,12 +2237,6 @@ fn expand_builder(args: &OpArgs, b: &BuilderShape<'_>) -> syn::Result<TokenStrea
         return Err(syn::Error::new(
             self_ty.span(),
             "#[op]: a generated Builder method supports at most 26 input edges",
-        ));
-    }
-    if n < 32 && args.passive >> n != 0 {
-        return Err(syn::Error::new(
-            self_ty.span(),
-            format!("#[op]: `passive` names an edge position beyond this op's {n} inputs"),
         ));
     }
 

--- a/crates/wingfoil/tests/trybuild/passive_no_builder_out_of_range.rs
+++ b/crates/wingfoil/tests/trybuild/passive_no_builder_out_of_range.rs
@@ -1,0 +1,25 @@
+use wingfoil::anyhow::Result;
+use wingfoil::op;
+use wingfoil::op::{Activation, Ctx, Op, Tick};
+
+struct InvalidPassive;
+
+#[op(build = invalid_passive, no_builder, passive = [1])]
+impl Op for InvalidPassive {
+    type Cfg = ();
+    type State = ();
+    type In<'a> = (&'a u64,);
+    type Out = u64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        _state: &mut (),
+        input: (&u64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<u64>> {
+        Ok(Tick::Value(*input.0))
+    }
+}
+
+fn main() {}

--- a/crates/wingfoil/tests/trybuild/passive_no_builder_out_of_range.stderr
+++ b/crates/wingfoil/tests/trybuild/passive_no_builder_out_of_range.stderr
@@ -1,0 +1,5 @@
+error: #[op]: `passive` names an edge position beyond this op's 1 inputs
+ --> tests/trybuild/passive_no_builder_out_of_range.rs:8:13
+  |
+8 | impl Op for InvalidPassive {
+  |             ^^^^^^^^^^^^^^


### PR DESCRIPTION
## What this changes

Validate `#[op]` passive edge positions immediately after parsing the op's input shape, before the expansion can skip the generated Builder path. Add a compile-fail regression covering an out-of-range passive mask on a `no_builder` op.

## Why

`no_builder` ops bypass `expand_builder`, which was the only place that rejected passive bits beyond the declared input edges. Nitro forwarders still emit and consume the passive-mask constant, so an invalid mask compiled successfully and could silently diverge from the intended dispatch semantics.

Closes #832.

## How it was verified

- [x] `cargo fmt --all` and `cargo fmt --all -- --check`
- [x] `cargo lint` and `cargo lint-all` in the upstream `Lint (fmt & clippy)` workflow
- [x] `cargo test -p wingfoil --all-features` in the upstream `Test (wingfoil)` workflow, including the new trybuild fixture
- [ ] New behaviour is covered by a test asserting **values and tick times** — not applicable; this is a proc-macro compile-fail boundary
- [x] Added `tests/trybuild/passive_no_builder_out_of_range.rs` with the exact expected diagnostic
- [x] `cargo metadata --no-deps --format-version 1`
- [x] `git diff --check`
- [x] Python interop, Cargo/pnpm audits, and dependency review workflows

## Notes for the reviewer

The local Windows host has no MSVC `link.exe`, so local Rust compilation stopped before crate code; the complete upstream Linux lint and test workflows passed. `checked_shr` treats bits above a 32-or-more-edge input shape as absent, avoiding a shift overflow for `no_builder` ops while preserving the existing 26-edge limit on generated Builder methods.

AI assistance was used for call-path tracing and patch drafting; the final diff, issue match, and repository instructions were reviewed directly.
