### PR TITLE
interp: make run_dynamic obey the single-run/reset guard

### DIFF
--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -2870,8 +2870,48 @@ impl Runner {
     /// single-run — its producer channels, wakers, and island interiors are
     /// consumed by the first run — and a second `run` returns an error rather
     /// than silently producing wrong values.
+    ///
+    /// `run_dynamic` (feature `dynamic-graph`) enforces the *same* contract
+    /// through the same guard, and the two count against each other: a `run`
+    /// after a `run_dynamic` is a second run, in either order.
     #[cfg_attr(feature = "instrument-run", tracing::instrument(skip_all))]
     pub fn run(&mut self, run_mode: RunMode, run_for: RunFor) -> Result<()> {
+        self.begin_run()?;
+        let mut kernel = self.make_kernel(run_mode, run_for)?;
+        // First error (from start or a cycle) wins; `stop`/`teardown` still
+        // run afterwards regardless, matching the legacy engine.
+        let mut first_err: Option<anyhow::Error> = self.start_nodes(&mut kernel);
+
+        if first_err.is_none() {
+            // Both dispatch strategies produce identical observable results
+            // (see `Dispatch`); the sparse dirty-list is the default, the full
+            // sweep is retained as an executable reference oracle.
+            first_err = match self.dispatch {
+                Dispatch::Sparse => self.run_cycles_sparse(&mut kernel),
+                Dispatch::FullSweep => self.run_cycles_full_sweep(&mut kernel),
+            };
+        }
+
+        self.stop_and_teardown(&mut kernel, &mut first_err);
+
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// The re-run guard, shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic) so both obey one contract: a second
+    /// run of a re-runnable graph first [`reset`](Runner::reset)s it, and a
+    /// second run of a single-run graph errors. Marks the runner as having run
+    /// and zeroes the per-run counters.
+    ///
+    /// Both entry points must go through this. When `run_dynamic` had its own
+    /// (absent) guard, `run` → `run_dynamic` on a single-run channel graph
+    /// silently did nothing (the `finished` flag was still set, so the cycle
+    /// loop exited immediately) and any re-run ordering silently continued
+    /// stale fold/accumulator state.
+    fn begin_run(&mut self) -> Result<()> {
         if self.has_run {
             if self.re_runnable {
                 self.reset();
@@ -2887,6 +2927,13 @@ impl Runner {
         self.has_run = true;
         self.node_visits = 0;
         self.layer_visits = 0;
+        Ok(())
+    }
+
+    /// Validate the run mode against the graph's sources and build the kernel
+    /// for one run — the preamble shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic).
+    fn make_kernel(&mut self, run_mode: RunMode, run_for: RunFor) -> Result<Kernel> {
         let realtime = matches!(run_mode, RunMode::RealTime);
         // `external`/`poll` are wall-clock (realtime-only); `channel` carries
         // timestamps and runs in both modes. These are reachable user errors
@@ -2927,54 +2974,56 @@ impl Runner {
             kernel.set_spin(true);
         }
         kernel.set_timer_policy(self.timer);
-        // First error (from start or a cycle) wins; `stop`/`teardown` still
-        // run afterwards regardless, matching the legacy engine.
-        let mut first_err: Option<anyhow::Error> = None;
+        Ok(kernel)
+    }
 
-        {
-            apply_nodes_span!("start");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.start)(&mut kernel) {
-                    first_err = Some(e.context(format!("node {i} ({}) start", node.label)));
-                    break;
-                }
+    /// Call every node's `start`, stopping at the first error (with node
+    /// context). Shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic); nothing is tombstoned yet at this
+    /// point, so there is nothing to skip.
+    fn start_nodes(&mut self, kernel: &mut Kernel) -> Option<anyhow::Error> {
+        apply_nodes_span!("start");
+        for (i, node) in self.nodes.iter_mut().enumerate() {
+            if let Err(e) = (node.start)(kernel) {
+                return Some(e.context(format!("node {i} ({}) start", node.label)));
             }
         }
+        None
+    }
 
-        if first_err.is_none() {
-            // Both dispatch strategies produce identical observable results
-            // (see `Dispatch`); the sparse dirty-list is the default, the full
-            // sweep is retained as an executable reference oracle.
-            first_err = match self.dispatch {
-                Dispatch::Sparse => self.run_cycles_sparse(&mut kernel),
-                Dispatch::FullSweep => self.run_cycles_full_sweep(&mut kernel),
-            };
-        }
-
-        // Cleanup always runs; a stop/teardown error only surfaces if no
-        // earlier error already won.
+    /// End-of-run cleanup, shared by [`run`](Runner::run) and
+    /// [`run_dynamic`](Runner::run_dynamic): every node's `stop` then every
+    /// node's `teardown`. Always runs — a `stop`/`teardown` error only surfaces
+    /// into `first_err` if no earlier error already won.
+    ///
+    /// A node removed mid-run already ran its `stop`/`teardown` at removal
+    /// (legacy parity), so the [`removed`](Runner::removed) tombstone skips it
+    /// here — no double call. `removed` is all-false on a static run, so the
+    /// skip costs a bounds-checked bool read and changes nothing for `run`.
+    fn stop_and_teardown(&mut self, kernel: &mut Kernel, first_err: &mut Option<anyhow::Error>) {
         {
             apply_nodes_span!("stop");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.stop)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) stop", node.label));
+            for i in 0..self.nodes.len() {
+                if self.removed[i] {
+                    continue;
+                }
+                if let Err(e) = (self.nodes[i].stop)(kernel) {
+                    let e = e.context(format!("node {i} ({}) stop", self.nodes[i].label));
                     first_err.get_or_insert(e);
                 }
             }
         }
         {
             apply_nodes_span!("teardown");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.teardown)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) teardown", node.label));
+            for i in 0..self.nodes.len() {
+                if self.removed[i] {
+                    continue;
+                }
+                if let Err(e) = (self.nodes[i].teardown)(kernel) {
+                    let e = e.context(format!("node {i} ({}) teardown", self.nodes[i].label));
                     first_err.get_or_insert(e);
                 }
             }
-        }
-
-        match first_err {
-            Some(e) => Err(e),
-            None => Ok(()),
         }
     }
 
@@ -3423,6 +3472,22 @@ impl Runner {
     /// and the number of cycles completed so far. Nodes appended (or edges
     /// spliced) through the scope take effect on the *next* cycle — legacy
     /// wingfoil's "requested in cycle N, live in N+1" contract.
+    ///
+    /// **The re-run contract is [`run`](Runner::run)'s, exactly** — the two
+    /// share one guard ([`begin_run`](Runner::begin_run)) and count against each
+    /// other in any order. A second run of a re-runnable graph (tickers /
+    /// constants + combinators + feedback) first restores every node's state and
+    /// value slot via [`reset`](Runner::reset), so it reproduces the first run
+    /// rather than continuing stale accumulator state; a second run of a
+    /// single-run graph (`external`/`poll`/`channel` sources or a `composite`
+    /// island) returns an error.
+    ///
+    /// One caveat on a re-run of a graph this method *mutated*: the graph the
+    /// first run left behind is the one that re-runs — nodes appended through
+    /// `between` are still wired, and fire from its first cycle — but only the
+    /// statically-built region is restored. A dynamically-appended node carries
+    /// a no-op reset by construction (see `rt_append_node`), so it re-runs
+    /// carrying its own accumulated state.
     #[cfg_attr(feature = "instrument-run", tracing::instrument(skip_all))]
     pub fn run_dynamic<F>(
         &mut self,
@@ -3433,50 +3498,12 @@ impl Runner {
     where
         F: FnMut(&mut Extension<'_>, u64) -> Result<()>,
     {
-        // Source/run-mode validation, identical to `run`.
-        self.node_visits = 0;
-        self.layer_visits = 0;
-        let realtime = matches!(run_mode, RunMode::RealTime);
-        if !realtime && self.has_external {
-            bail!(
-                "graphs with external sources require RunMode::RealTime — untimestamped \
-                 external events have no place in a deterministic historical replay (use a \
-                 channel with timestamped sends for historical)"
-            );
-        }
-        if !realtime && self.has_always {
-            bail!(
-                "graphs with poll sources require RunMode::RealTime — there is nothing to \
-                 busy-poll in a deterministic historical replay"
-            );
-        }
-        let needs_waker = self.has_external || (self.has_channel && realtime);
-        let mut kernel = if needs_waker {
-            let Some(ready) = self.ready.take() else {
-                bail!(
-                    "a Runner with realtime sources (external/poll/realtime channel) supports \
-                     only a single run — the waker/ready channel is consumed by the first run"
-                );
-            };
-            Kernel::with_ready(run_mode, run_for, ready)
-        } else {
-            Kernel::new(run_mode, run_for)
-        };
-        if self.has_always {
-            kernel.set_spin(true);
-        }
-        kernel.set_timer_policy(self.timer);
+        // Re-run guard, source/run-mode validation and kernel construction are
+        // `run`'s — shared, not copied, so the two cannot drift apart again.
+        self.begin_run()?;
+        let mut kernel = self.make_kernel(run_mode, run_for)?;
 
-        let mut first_err: Option<anyhow::Error> = None;
-        {
-            apply_nodes_span!("start");
-            for (i, node) in self.nodes.iter_mut().enumerate() {
-                if let Err(e) = (node.start)(&mut kernel) {
-                    first_err = Some(e.context(format!("node {i} ({}) start", node.label)));
-                    break;
-                }
-            }
-        }
+        let mut first_err: Option<anyhow::Error> = self.start_nodes(&mut kernel);
 
         if first_err.is_none() {
             // Scratch is reused across cycles and regrown as nodes are appended.
@@ -3554,34 +3581,7 @@ impl Runner {
             }
         }
 
-        // Cleanup always runs; a stop/teardown error only surfaces if no
-        // earlier error already won. A node removed mid-run already ran its
-        // `stop`/`teardown` at removal (legacy parity), so the tombstone skips
-        // it here — no double call.
-        {
-            apply_nodes_span!("stop");
-            for i in 0..self.nodes.len() {
-                if self.removed[i] {
-                    continue;
-                }
-                if let Err(e) = (self.nodes[i].stop)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) stop", self.nodes[i].label));
-                    first_err.get_or_insert(e);
-                }
-            }
-        }
-        {
-            apply_nodes_span!("teardown");
-            for i in 0..self.nodes.len() {
-                if self.removed[i] {
-                    continue;
-                }
-                if let Err(e) = (self.nodes[i].teardown)(&mut kernel) {
-                    let e = e.context(format!("node {i} ({}) teardown", self.nodes[i].label));
-                    first_err.get_or_insert(e);
-                }
-            }
-        }
+        self.stop_and_teardown(&mut kernel, &mut first_err);
         match first_err {
             Some(e) => Err(e),
             None => Ok(()),

--- a/crates/wingfoil/tests/rerun_dynamic.rs
+++ b/crates/wingfoil/tests/rerun_dynamic.rs
@@ -1,0 +1,260 @@
+//! Re-run contract for [`Runner::run_dynamic`](wingfoil::interp::Runner::run_dynamic).
+//!
+//! `run_dynamic` is a second public entry point into the same runner, and it
+//! used to keep its own copy of `run`'s preamble — minus the re-run guard. So
+//! it neither set nor checked `has_run`, and every ordering silently did the
+//! wrong thing:
+//!
+//! * `run` → `run_dynamic` on a single-run *historical channel* graph returned
+//!   `Ok(())` having done nothing at all: the `finished` flag set by the
+//!   channel's `EndOfStream` is cleared only by `reset`, which never ran, so the
+//!   cycle loop exited on its first test.
+//! * every re-runnable ordering (`run` → `run_dynamic`, `run_dynamic` →
+//!   `run_dynamic`, `run_dynamic` → `run`) continued stale fold/accumulator
+//!   state instead of restoring it.
+//!
+//! Both entry points now share one guard, so the contract is `run`'s in either
+//! direction: re-runnable graphs reset, single-run graphs error.
+#![cfg(feature = "dynamic-graph")]
+
+use std::time::Duration;
+
+use wingfoil::interp::Extension;
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const TEN: Duration = Duration::from_nanos(10);
+
+/// No-op mutation hook — `run_dynamic` with nothing to mutate, i.e. exactly
+/// `run` plus the boundary callback.
+fn nothing(_ext: &mut Extension<'_>, _cycle: u64) -> anyhow::Result<()> {
+    Ok(())
+}
+
+/// A stateful re-runnable graph: a `count` fold and its tick times. The
+/// accumulated `(time, value)` pairs pin both halves of the contract — values
+/// *and* tick times must reproduce.
+fn wire(g: &GraphBuilder) -> (Stream<Vec<(NanoTime, u64)>>, Stream<u64>) {
+    let count = g.ticker(TEN).count();
+    let sum = count.fold(0u64, |acc, x| *acc += *x);
+    (count.with_time().accumulate(), sum)
+}
+
+/// The pinned sequence of a 4-cycle run of [`wire`] — ticker at 10ns, whose
+/// first callback is scheduled at the run's start time and whose first cycle
+/// therefore fires at t=0 (`Kernel::begin_cycle`: "first cycle fires at the
+/// callback's own time").
+fn expected() -> Vec<(NanoTime, u64)> {
+    vec![
+        (NanoTime::new(0), 1),
+        (NanoTime::new(10), 2),
+        (NanoTime::new(20), 3),
+        (NanoTime::new(30), 4),
+    ]
+}
+
+/// `run` then `run_dynamic`: the second run resets, so it reproduces the first
+/// exactly rather than continuing the fold.
+#[test]
+fn run_then_run_dynamic_resets() {
+    let g = GraphBuilder::new();
+    let (acc, sum) = wire(&g);
+    let mut r = g.build();
+
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(expected(), r.value(&acc));
+    assert_eq!(1 + 2 + 3 + 4, r.value(&sum));
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(
+        expected(),
+        r.value(&acc),
+        "run_dynamic after run must reset, not continue"
+    );
+    // Stale state would have left the fold at 10 + 10 = 20.
+    assert_eq!(10, r.value(&sum));
+}
+
+/// `run_dynamic` then `run_dynamic`: same contract between two dynamic runs.
+#[test]
+fn run_dynamic_twice_resets() {
+    let g = GraphBuilder::new();
+    let (acc, sum) = wire(&g);
+    let mut r = g.build();
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(expected(), r.value(&acc));
+    assert_eq!(10, r.value(&sum));
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(expected(), r.value(&acc), "a second run_dynamic must reset");
+    assert_eq!(10, r.value(&sum));
+}
+
+/// `run_dynamic` then `run`: `run_dynamic` must *set* `has_run`, or the plain
+/// `run` that follows skips its reset and continues stale state.
+#[test]
+fn run_dynamic_then_run_resets() {
+    let g = GraphBuilder::new();
+    let (acc, sum) = wire(&g);
+    let mut r = g.build();
+
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(expected(), r.value(&acc));
+    assert_eq!(10, r.value(&sum));
+
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(
+        expected(),
+        r.value(&acc),
+        "run after run_dynamic must reset, not continue"
+    );
+    assert_eq!(10, r.value(&sum));
+}
+
+/// A dynamic run and a plain run of the same re-runnable graph produce
+/// identical values *and* tick times — the boundary hook is the only
+/// difference between the two entry points.
+#[test]
+fn run_dynamic_matches_run() {
+    let g = GraphBuilder::new();
+    let (acc, _sum) = wire(&g);
+    let mut r = g.build();
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    let dynamic = r.value(&acc);
+
+    let g2 = GraphBuilder::new();
+    let (acc2, _sum2) = wire(&g2);
+    let mut r2 = g2.build();
+    r2.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+
+    assert_eq!(r2.value(&acc2), dynamic);
+    assert_eq!(expected(), dynamic);
+}
+
+/// The graph a re-run re-runs is the one the first run *left behind* — a node
+/// appended through the hook is still wired, and fires from cycle 1 of the
+/// second run. Only the *statically built* region is restored, though: a
+/// dynamically-appended node carries a no-op reset by construction
+/// (`Runner::rt_append_node`), so it re-runs carrying its own state. Appended at
+/// the end of cycle 2 of run 1 it fires on cycles 3 and 4 (2 activations), then
+/// on all four cycles of run 2 — 6, not 4. This pins the documented caveat on
+/// `run_dynamic`, so a future change to dynamic-node reset is a deliberate one.
+#[test]
+fn appended_node_survives_run_but_keeps_its_state() {
+    let g = GraphBuilder::new();
+    let src = g.ticker(TEN).count().handle();
+    let mut r = g.build();
+
+    let mut appended = None;
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), |ext, cycle| {
+        if cycle == 2 && appended.is_none() {
+            appended = Some(ext.fold(src, 0u64, |acc, _| *acc += 1));
+        }
+        Ok(())
+    })
+    .unwrap();
+    let appended = appended.expect("node appended at cycle 2");
+    assert_eq!(2, r.value(appended), "fired on cycles 3 and 4 only");
+
+    // Second run: already wired, so it fires all four cycles — but its own
+    // state is not restored, so it continues from 2 rather than restarting.
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(
+        2 + 4,
+        r.value(appended),
+        "an appended node keeps its state across a re-run (no-op reset)"
+    );
+    // The statically-built source *did* reset — 4, not 8.
+    assert_eq!(4, r.value(src));
+}
+
+/// The `finished` case. A historical channel graph is **single-run**: the
+/// channel's `EndOfStream` sets `finished`, which only `reset` clears, and
+/// `reset` cannot restore the consumed producer channel anyway. `run_dynamic`
+/// after `run` must therefore error — it used to return `Ok(())` having run
+/// zero cycles, leaving the first run's values in place and looking like a
+/// success.
+#[test]
+fn historical_channel_graph_refuses_run_dynamic_after_run() {
+    let g = GraphBuilder::new();
+    let (values, sender) = g.channel::<u64>();
+    let acc = values.with_time().accumulate();
+    let mut r = g.build();
+
+    let producer = std::thread::spawn(move || {
+        sender.send_at(10, NanoTime::new(100));
+        sender.send_at(20, NanoTime::new(200));
+        sender.close();
+    });
+    r.run(HISTORICAL, RunFor::Forever).unwrap();
+    producer.join().expect("producer thread");
+
+    let flat: Vec<(NanoTime, Vec<u64>)> = r
+        .value(&acc)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().copied().collect()))
+        .collect();
+    assert_eq!(
+        vec![
+            (NanoTime::new(100), vec![10]),
+            (NanoTime::new(200), vec![20]),
+        ],
+        flat
+    );
+
+    let err = r
+        .run_dynamic(HISTORICAL, RunFor::Forever, nothing)
+        .expect_err("a single-run channel graph must refuse run_dynamic after run");
+    assert!(
+        err.to_string().contains("single-run"),
+        "unexpected error: {err}"
+    );
+}
+
+/// The mirror image: `run_dynamic` first, then `run` — the single-run guard
+/// fires whichever entry point consumed the graph.
+#[test]
+fn historical_channel_graph_refuses_run_after_run_dynamic() {
+    let g = GraphBuilder::new();
+    let (values, sender) = g.channel::<u64>();
+    let acc = values.with_time().accumulate();
+    let mut r = g.build();
+
+    let producer = std::thread::spawn(move || {
+        sender.send_at(7, NanoTime::new(50));
+        sender.close();
+    });
+    r.run_dynamic(HISTORICAL, RunFor::Forever, nothing).unwrap();
+    producer.join().expect("producer thread");
+
+    let flat: Vec<(NanoTime, Vec<u64>)> = r
+        .value(&acc)
+        .into_iter()
+        .map(|(t, b)| (t, b.iter().copied().collect()))
+        .collect();
+    assert_eq!(vec![(NanoTime::new(50), vec![7])], flat);
+
+    let err = r
+        .run(HISTORICAL, RunFor::Forever)
+        .expect_err("a single-run channel graph must refuse a second run");
+    assert!(
+        err.to_string().contains("single-run"),
+        "unexpected error: {err}"
+    );
+
+    let err = r
+        .run_dynamic(HISTORICAL, RunFor::Forever, nothing)
+        .expect_err("...and a second run_dynamic likewise");
+    assert!(
+        err.to_string().contains("single-run"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## What this changes

`run_dynamic` now enforces the same single-run/reset contract as `run`, and the two share every line of preamble and teardown instead of keeping verbatim copies that could drift again.

Closes #819.

## Why

`Runner::run` guards re-runs so that "a second `run` returns an error rather than silently producing wrong values". `run_dynamic` neither set nor checked `has_run` and never called `reset()` — though both are public and nothing documented `run_dynamic` as single-use.

Two verified failure modes:

- **`finished` is set only by a channel `EndOfStream` and cleared only in `reset()`.** On a historical-channel graph, `run()` then `run_dynamic()` hit `self.finished.get()` and returned `Ok(())` having run zero cycles.
- **On re-runnable graphs, every ordering silently continued stale fold and accumulator state** — `run`→`run_dynamic`, `run_dynamic`→`run_dynamic`, and `run_dynamic`→`run`, where `has_run` stays false throughout.

The cause was duplication: the validation and kernel-construction preamble and the stop/teardown loops were verbatim copies differing only in the `removed[]` tombstone skip. So the deduplication is the fix vehicle rather than a separate cleanup.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all` — clean on this branch, rebased on `ea46466`
- [x] `cargo test -p wingfoil --all-features` — 330 lib unit tests, `rerun_dynamic` 7/7, `rerun` 7/7, `dynamic_graph` 10/10, `engine_semantics` 8/8 untouched
- [x] New behaviour is covered by a test asserting **values and tick times**

**The tests were checked for bite, not just for green:** with `begin_run()?` temporarily removed from `run_dynamic`, 6 of the 7 new tests fail.

## Notes for the reviewer

Four private helpers on `Runner` — `begin_run`, `make_kernel`, `start_nodes`, `stop_and_teardown` — now carry the shared logic, leaving only the cycle loop distinct between the two entry points. They live in the **ungated** `impl` block so the `dynamic-graph`-gated `run_dynamic` can call them.

`stop_and_teardown` is the tombstone-aware version for both paths. That is safe because `removed` is an unconditional field set to `vec[false; n]` in `Builder::build` and only ever flipped in the `dynamic-graph` removal path, so the skip is a no-op on a static run — verified against the tree rather than taken from the issue.

**This documents a caveat it did not change.** Re-running a *mutated* graph restores only the statically-built region, because `rt_append_node` gives dynamically-appended nodes a no-op `reset` by construction. That is an existing design decision, previously uncommented in the public contract; it is now in `run_dynamic`'s rustdoc and pinned by a test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wQjYrfk8RpF3TQFjeii7)_