### PR TITLE
ci: run the derive tests and doctests, close python-test's paths holes

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -5,13 +5,19 @@ on:
   # This leg keeps a `paths` filter where rust-test.yml dropped its own: a
   # maturin wheel build plus pytest is the slowest thing in the matrix, and
   # most commits genuinely cannot affect it. But a filter is only ever as good
-  # as its list, and two entries were missing from this one:
+  # as its list, and three entries were missing from this one:
   #
   # * **this file itself.** A filter that does not name its own workflow makes
   #   an edit to the workflow the one change CI never validates — a broken gate
   #   surfaces only after it has merged. That is the standing ruling recorded
   #   at the top of rust-test.yml, which removed its filter outright rather
   #   than live with the trap.
+  # * **`wingfoil-derive`.** `crates/wingfoil/Cargo.toml` depends on it
+  #   unconditionally — not optional and not feature-gated — so every wheel
+  #   built here contains its output. `nitro!`/`#[op]` generate the wiring the
+  #   bindings expose, and a codegen regression breaks the build of a crate
+  #   this filter *does* name while the change that caused it names none of
+  #   them.
   # * **`wingfoil-wire-types`.** The bindings depend on it, just not by name:
   #   both build steps below pass `all-adapters`, which turns on `web`, which
   #   turns on `wingfoil/web-tls`, which pulls in `dep:wingfoil-wire-types`. A
@@ -27,6 +33,7 @@ on:
       - "crates/wingfoil-python/**"
       - "crates/wingfoil-python-derive/**"
       - "crates/wingfoil/**"
+      - "crates/wingfoil-derive/**"
       - "crates/wingfoil-wire-types/**"
   pull_request:
     branches: [ "main" ]
@@ -35,6 +42,7 @@ on:
       - "crates/wingfoil-python/**"
       - "crates/wingfoil-python-derive/**"
       - "crates/wingfoil/**"
+      - "crates/wingfoil-derive/**"
       - "crates/wingfoil-wire-types/**"
   workflow_dispatch:
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,18 +2,40 @@ name: test.python
 
 on:
   workflow_call:
+  # This leg keeps a `paths` filter where rust-test.yml dropped its own: a
+  # maturin wheel build plus pytest is the slowest thing in the matrix, and
+  # most commits genuinely cannot affect it. But a filter is only ever as good
+  # as its list, and two entries were missing from this one:
+  #
+  # * **this file itself.** A filter that does not name its own workflow makes
+  #   an edit to the workflow the one change CI never validates — a broken gate
+  #   surfaces only after it has merged. That is the standing ruling recorded
+  #   at the top of rust-test.yml, which removed its filter outright rather
+  #   than live with the trap.
+  # * **`wingfoil-wire-types`.** The bindings depend on it, just not by name:
+  #   both build steps below pass `all-adapters`, which turns on `web`, which
+  #   turns on `wingfoil/web-tls`, which pulls in `dep:wingfoil-wire-types`. A
+  #   wire-format change could therefore break the wheel with this leg never
+  #   having run.
+  #
+  # `push` and `pull_request` are independent filters and GitHub will not warn
+  # when they drift, so any addition goes in both lists.
   push:
     branches: [ "main" ]
     paths:
+      - ".github/workflows/python-test.yml"
       - "crates/wingfoil-python/**"
       - "crates/wingfoil-python-derive/**"
       - "crates/wingfoil/**"
+      - "crates/wingfoil-wire-types/**"
   pull_request:
     branches: [ "main" ]
     paths:
+      - ".github/workflows/python-test.yml"
       - "crates/wingfoil-python/**"
       - "crates/wingfoil-python-derive/**"
       - "crates/wingfoil/**"
+      - "crates/wingfoil-wire-types/**"
   workflow_dispatch:
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -108,6 +108,43 @@ jobs:
         env:
           RUST_LOG: INFO
 
+      - name: Run wingfoil-derive tests
+        # `nitro!` reasons about the wiring function it is handed — which
+        # parameters a type mentions, and therefore which streams a node
+        # depends on — and that reasoning has unit tests of its own in
+        # `crates/wingfoil-derive/src/lib.rs`. Every other Rust test invocation
+        # across these workflows names its package — `-p wingfoil` here and in
+        # the integration legs, `-p wingfoil-python` in test.python, and
+        # wingfoil-wasm's own leg in web-integration.yml — and none of them
+        # names this one, so the derive tests had never run in CI at all: a
+        # regression in the macro's own logic could only be caught indirectly,
+        # by whichever generated graph happened to come out wrong.
+        #
+        # The crate is proc-macro-only and declares no features, so a bare `-p`
+        # is its whole surface, and it compiles in seconds — syn/quote are
+        # already built for the step above.
+        run: cargo nextest run -p wingfoil-derive
+
+      - name: Run doctests
+        # **nextest cannot run doctests**, by design: it is a libtest-harness
+        # runner, and `--doc` targets are compiled and driven by rustdoc
+        # instead. So until this step existed, no job in any workflow ran a
+        # single doc fence — and the fences are exactly the snippets users copy
+        # out of the API docs, which a renamed method or a changed signature
+        # rots silently.
+        #
+        # `--all-features` is not optional here. Most of the fences live in
+        # `adapters/`, and every adapter module is gated off by default: a
+        # default-feature run collects 12 of them, all-features collects 35 (17
+        # executed, the rest `ignore`d illustrations). It also means this step
+        # shares its feature set — and so its artifacts — with the step above.
+        #
+        # Cheap despite the count: rustdoc compiles the fences as one merged
+        # binary, ~2s, and running them takes hundredths of a second.
+        run: cargo test --doc -p wingfoil --all-features
+        env:
+          RUST_LOG: INFO
+
   lint:
     name: Lint (fmt & clippy)
     # Skips the release.bump commit — see the note above `jobs:`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,24 @@ cargo fmt --all
 cargo lint        # default features
 cargo lint-all    # all features — CI runs this and feature-gated code is easy to miss
 cargo test -p wingfoil --all-features
+cargo test -p wingfoil-derive   # a separate package: the line above never builds it
 ```
+
+Two notes on what those last two lines do and don't reach:
+
+- **`-p wingfoil` does not build the derive crate's tests.** `nitro!`/`#[op]`
+  reason about the wiring function they are handed, and that reasoning has unit
+  tests of its own in `crates/wingfoil-derive/src/lib.rs`. They only run when
+  you name the package. (CI ran nothing that named it until `rust-test.yml`
+  grew a step for it — issue #835.)
+- **Doc fences are already covered here, and that is a property of `cargo
+  test`, not of the flags.** `cargo test` runs the `--doc` target alongside the
+  unit and integration ones; `--all-features` matters because most of the doc
+  fences live in `adapters/`, which is gated off by default — a default-feature
+  run collects 12 of them, all-features 35. **CI needs a separate step for
+  this** (`cargo test --doc -p wingfoil --all-features` in `rust-test.yml`),
+  because the test leg runs `cargo nextest`, which drives libtest harnesses and
+  cannot run doctests at all. So do not "simplify" the local checklist to
+  `cargo nextest run`: the doc fences would stop being checked before commit.
 
 All must pass without errors before creating a commit.

--- a/crates/wingfoil-python/pyproject.toml
+++ b/crates/wingfoil-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "wingfoil-python"
 dynamic = ["version"]
-description = "Python interop prototype for wingfoil (the Op-pattern engine)"
+description = "Python bindings for wingfoil (the Op-pattern stream processing engine)"
 readme = "README.md"
 # 3.9, not 3.8: 3.8 reached end of life in October 2024, and the floor is now
 # structural as well as a policy — the extension is built against CPython's


### PR DESCRIPTION
## What this changes

CI now runs the two test surfaces it never ran — `wingfoil-derive`'s unit tests and the crate's doc fences — and `python-test.yml` stops skipping changes that can break it.

Closes #835. Also fixes item 4 of #837 (the PyPI description), because that string ships in wheel metadata and 9.0.0 is about to publish.

## Why

**`wingfoil-derive`'s unit tests never ran in CI.** Every Rust test invocation across the workflows names its package — `-p wingfoil` in `rust-test.yml` and the integration legs, `-p wingfoil-python` in `test.python`, and `wingfoil-wasm`'s own leg in `web-integration.yml` — and none named the derive crate. `nitro!`/`#[op]` reason about the wiring function they are handed, and that reasoning has unit tests of its own; a regression in the macro's logic could only be caught indirectly, by whichever generated graph happened to come out wrong. This just became more valuable: #851 added a trybuild fixture to that same crate.

**No doctest ran anywhere.** nextest is a libtest-harness runner and cannot run `--doc` targets at all, and no workflow invoked `cargo test --doc`. The fences are exactly the snippets users copy out of the API docs, and a renamed method rots them silently.

**`python-test.yml`'s `paths:` filter omitted itself and `crates/wingfoil-wire-types/**`.** The wire-types dependency is real and was verified in the tree, not assumed: `all-adapters` → `web` → `wingfoil/web-tls` → `dep:wingfoil-wire-types`. A wire-types change could merge without the Python leg running. `rust-test.yml` already documents the self-omission trap as a standing ruling and removed its own filter for that reason; python-test kept the hole.

## How it was verified

- [x] Both new commands pass locally on this tree, so they go green rather than red on merge

```
cargo test -p wingfoil-derive       -> 3 passed
cargo test --doc -p wingfoil --all-features -> 17 passed, 18 ignored
```

`--all-features` is required and was measured, not guessed: 19 adapter files carry doc fences and every adapter module is gated off by default, so a default-feature run collects **12** doctests against **35** at all features. Both workflow files re-parsed to confirm the steps invoke what they claim and both `paths:` lists match.

## Notes for the reviewer

**#835's body contains an error I did not propagate.** It claims CLAUDE.md's pre-commit checklist misses doctests. Plain `cargo test` runs the `--doc` target by default and `wingfoil` sets no `doctest = false`, so `cargo test -p wingfoil --all-features` already covered the fences locally — only *nextest* skips them. So CI needed a separate step while the local checklist needed only the derive line, and the checklist note now warns against "simplifying" that line to `cargo nextest run`, which would silently drop doc-fence coverage before commit.

The new steps sit in the existing `test` job and share its `--all-features` artifacts, so the added wall-clock is small: the derive crate is proc-macro-only and compiles in seconds, and rustdoc builds the fences as one merged binary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wQjYrfk8RpF3TQFjeii7)_