### PR TITLE
build(deps): move spin off the yanked 0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,9 +5972,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"


### PR DESCRIPTION
## What this changes

Two lines of `Cargo.lock`: `spin` 0.9.8 → 0.9.9.

Addresses the security half of #452 (which turns out to need nothing else — see below).

## Why

`cargo audit`'s yanked-crate check flags `spin` 0.9.8. It is transitive via `lazy_static` 1.5.0 (`spin_no_std`), reached from `aeron-rs`, `iceoryx2-bb-posix`/`-cal`, `dhat` and `sharded-slab` ← `tracing-subscriber`. The whole 0.9.0–0.9.8 line is yanked; 0.9.9 is not.

This is **not an advisory fix** — CI's `cargo audit` exits 0 either way — but publishing a release whose committed lock pins a yanked crate is a reproducibility wart, and 9.0.0 is about to go to three registries.

## How it was verified

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p wingfoil --all-features`

Applied as a deliberate single-crate upgrade (`cargo update -p spin --precise 0.9.9`), leaving 168 other dependencies untouched. `spin` is genuinely in the all-features graph, so the test run covers it:

```
spin v0.9.9
└── lazy_static v1.5.0
    ├── aeron-rs v0.1.8 → wingfoil
    ├── dhat v0.3.3 [dev] → wingfoil
    ├── iceoryx2-bb-posix v0.8.1 → iceoryx2 → wingfoil
    └── sharded-slab v0.1.7 → tracing-subscriber
```

## Notes for the reviewer

**This was the only actionable item in a full sweep of #452, and that issue's body is stale.** Re-derived against a freshly fetched RustSec DB (1216 advisories): **0 vulnerabilities** in the root lock (750 crates), **0** in `crates/wingfoil-wasm/Cargo.lock` (53 crates), and "no known vulnerabilities" from `pnpm audit` across plain/moderate/dev/prod. Everything `cargo audit` still reports is RustSec *informational* (unmaintained/unsound), which does not fail CI and which Dependabot does not raise. The issue's "1 critical, 6 high" is stale by two rounds of remediation.

The issue's other acceptance items are satisfied by attrition: `crates/wingfoil-wasm/Cargo.lock` is committed, and the `quick-xml 0.22` / `sqlx-core 0.5.13` future-incompat pins appear nowhere in the tree (`cargo report future-incompatibilities` returns no reports after a clean workspace build). #452 wants rewriting, not closing — the benches-in-CI item is untouched.

**Caveat worth stating:** the Dependabot alert list could not be read from the session that did this sweep (no `gh` CLI, and `api.github.com` is proxy-blocked), so the reconciliation with GitHub's own count is inference from the tree. Worth a glance at the security tab before relying on it.

**Two follow-ups deliberately not folded in:**
- #461's accepted-informational list needs a refresh: drop `dotenv` (gone from the tree) and `anyhow` RUSTSEC-2026-0190 (lock is at patched 1.0.104); add `lru` RUSTSEC-2026-0253, sibling of the RUSTSEC-2026-0002 already listed and unfixable from the lockfile (`lru >= 0.18.2` is a semver-major move pinned upstream by `rv`/`augurs`).
- `security-audit.yml` justifies its pytest allowance by citing `uv.lock`, which no longer exists. The allowance is still correct; the sentence naming the file is not.

Trivially revertible (`cargo update -p spin --precise 0.9.8`) if you would rather carry zero lockfile churn into the release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wQjYrfk8RpF3TQFjeii7)_