### PR TITLE
etcd: replace etcd_pub's positional args with an options struct

### DIFF
--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -201,6 +201,33 @@ in several shapes (bare `&str` endpoint, prebuilt config struct, tuple) — one
 signature, several natural call sites (see `AugursForecastConfig`'s
 `From<(usize, usize)>`).
 
+**More than one optional knob → an options struct, never positional
+`Option`/`bool` arguments.** `etcd_pub(conn, None, true)` tells a reader
+nothing about what `true` means, and adding a third knob is a breaking change
+to every call site. Two shapes exist in the tree and both are fine — pick by
+whether the connection target belongs in the struct:
+
+| Shape | Use when | Precedent |
+|---|---|---|
+| Options-only struct + `Default` + a `*_with_options` twin | the target is already a separate `impl Into<Conn>` parameter and every knob has a default | `FixOptions`, `EtcdPubOptions` |
+| Config struct with chainable setters, target included | the config carries the target and has required fields worth a `new(..)` | `WsConfig`, `KafkaSourceConfig` |
+
+For the first shape, make the plain method a **provided** trait method
+delegating to the required `*_with_options` one, so implementors write the
+options version once and the common case stays a one-liner. Callers override
+selectively with struct update: `EtcdPubOptions { force: false, ..Default::default() }`.
+
+**A `Default` is a compatibility surface.** Pin it with a unit test and say in
+the docs what it is — changing one later silently changes behaviour at every
+default call site, which is worse than a signature break because it does not
+fail to compile.
+
+**Python bindings keep the knobs flat** as keyword arguments and assemble the
+struct inside the binding; no binding exposes a Rust options struct as a
+class (`ws.rs` does this for `WsConfig`, `adapters/etcd.rs` for
+`EtcdPubOptions`). A Rust-side signature change of this kind should leave the
+Python surface untouched.
+
 ## 1. Branch
 
 **Never edit files directly on `main`** (see `CLAUDE.md`). `main` is the trunk

--- a/crates/wingfoil-python/src/adapters/etcd.rs
+++ b/crates/wingfoil-python/src/adapters/etcd.rs
@@ -8,6 +8,12 @@
 //! | `etcd_sub(graph, …)`    | [`etcd_sub`]     | prefix snapshot then live watch |
 //! | `etcd_pub(stream, …)`   | [`EtcdSinkOps`]  | `PUT` sink, optionally leased |
 //!
+//! `etcd_pub`'s lease and `force` settings are a Rust
+//! [`EtcdPubOptions`] struct, but the binding keeps them **flat keyword
+//! arguments** (`lease_ttl_secs=None, force=True`) and assembles the struct
+//! here — the same shape the `ws` binding uses for `WsConfig`, and what
+//! Python callers expect. The defaults match `EtcdPubOptions::default()`.
+//!
 //! # The dynamic edge
 //!
 //! [`EtcdEvent`] is concrete on the Rust side, so only the *shape* is dynamic:
@@ -46,7 +52,8 @@ use anyhow::{Result, anyhow};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyString, PyTuple};
 use wingfoil::adapters::etcd::{
-    EtcdConnection, EtcdEntry, EtcdEvent, EtcdEventKind, EtcdSinkOps, etcd_sub as etcd_watch,
+    EtcdConnection, EtcdEntry, EtcdEvent, EtcdEventKind, EtcdPubOptions, EtcdSinkOps,
+    etcd_sub as etcd_watch,
 };
 use wingfoil::prelude::{Burst, GraphBuilder, Stream, StreamOps};
 
@@ -224,7 +231,13 @@ fn publish(
             .map(element_to_entry)
             .collect::<Result<Burst<EtcdEntry>>>()
     });
-    entries.etcd_pub(conn, lease, force)
+    entries.etcd_pub_with_options(
+        conn,
+        EtcdPubOptions {
+            lease_ttl: lease,
+            force,
+        },
+    )
 }
 
 #[cfg(test)]

--- a/crates/wingfoil-python/tests/test_etcd.py
+++ b/crates/wingfoil-python/tests/test_etcd.py
@@ -84,6 +84,19 @@ def test_pub_optional_args_have_defaults():
     assert isinstance(wf.etcd_pub(source, UNREACHABLE), wf.Stream)
 
 
+def test_pub_accepts_non_default_lease_and_force():
+    """The flat kwargs assemble the Rust ``EtcdPubOptions``.
+
+    Nothing connects at wiring, so this only proves the non-default values are
+    accepted and plumbed through; the behaviour they select is asserted by the
+    Rust integration suite (lease revoke, conditional write).
+    """
+    g = wf.Graph()
+    source = g.counter(period_nanos=SECOND_NANOS)
+    stream = wf.etcd_pub(source, UNREACHABLE, lease_ttl_secs=30.0, force=False)
+    assert isinstance(stream, wf.Stream)
+
+
 def test_pub_rejects_a_nonsense_lease_ttl():
     g = wf.Graph()
     source = g.counter(period_nanos=SECOND_NANOS)

--- a/crates/wingfoil/examples/adapters/etcd/README.md
+++ b/crates/wingfoil/examples/adapters/etcd/README.md
@@ -45,7 +45,7 @@ let _seed = g
         EtcdEntry { key: format!("{SOURCE_PREFIX}greeting"), value: b"hello".to_vec() },
         EtcdEntry { key: format!("{SOURCE_PREFIX}subject"),  value: b"world".to_vec() },
     ])
-    .etcd_pub(conn.clone(), None, true)?;
+    .etcd_pub(conn.clone())?;
 
 // Root 2 — watch, transform, write back.
 let _round_trip = etcd_sub(&g, params.run_mode, conn.clone(), SOURCE_PREFIX)?
@@ -57,7 +57,7 @@ let _round_trip = etcd_sub(&g, params.run_mode, conn.clone(), SOURCE_PREFIX)?
             })
             .collect::<Burst<EtcdEntry>>()
     })
-    .etcd_pub(conn, None, false)?;
+    .etcd_pub(conn)?;
 ```
 
 This is the one example in the tree that passes its own runtime handle — every

--- a/crates/wingfoil/examples/adapters/etcd/main.rs
+++ b/crates/wingfoil/examples/adapters/etcd/main.rs
@@ -58,7 +58,7 @@ fn main() -> anyhow::Result<()> {
                 value: b"world".to_vec(),
             },
         ])
-        .etcd_pub(conn.clone(), None, true)?;
+        .etcd_pub(conn.clone())?;
 
     // Watch the source prefix, uppercase each value, write to the dest prefix.
     let params = RunParams {
@@ -90,7 +90,7 @@ fn main() -> anyhow::Result<()> {
                 })
                 .collect::<Burst<EtcdEntry>>()
         })
-        .etcd_pub(conn, None, true)?;
+        .etcd_pub(conn)?;
 
     g.build().run(RunMode::RealTime, RunFor::Cycles(3))?;
     Ok(())

--- a/crates/wingfoil/src/adapters/etcd.rs
+++ b/crates/wingfoil/src/adapters/etcd.rs
@@ -20,7 +20,7 @@
 //!
 //! Every legacy *capability* (snapshot→watch, deletes, leases with keepalive
 //! and revoke-on-shutdown, the `force` conditional write) is preserved. The
-//! surface differs in three deliberate ways:
+//! surface differs in four deliberate ways:
 //!
 //! 1. **The graph owns the tokio runtime.** Legacy `etcd_sub`/`etcd_pub` hide a
 //!    never-dropped global runtime inside `produce_async`/`consume_async`. Wingfoil's
@@ -44,6 +44,14 @@
 //!    entry point into the [`EtcdSinkOps`] trait (renamed for the sink-as-trait
 //!    convention shared with [`lines`](crate::adapters::lines) /
 //!    [`csv`](crate::adapters::csv)).
+//! 4. **The sink's options are a struct, not positional arguments.** Legacy took
+//!    `(conn, lease_ttl: Option<Duration>, force: bool)`, so the common call read
+//!    `etcd_pub(conn, None, true)` — a bare `Option` and a bare `bool` that say
+//!    nothing at the call site. Wingfoil splits that into
+//!    [`EtcdSinkOps::etcd_pub`] (the defaults) and
+//!    [`EtcdSinkOps::etcd_pub_with_options`] taking [`EtcdPubOptions`], the same
+//!    shape `FixOptions` uses for the FIX session factories. The *behaviour* is
+//!    unchanged: `EtcdPubOptions::default()` is legacy's `(None, true)`.
 //!
 //! ## Runtime requirement (a `block_on` footgun)
 //!
@@ -95,14 +103,20 @@
 //! consumer, in order, so any failure aborts the run with context — matching the
 //! legacy consumer's ordering and error-surfacing guarantees.
 //!
-//! - `lease_ttl: None` writes plain keys that persist until deleted.
+//! `etcd_pub(conn)` is the plain sink: unleased keys, existing keys overwritten.
+//! Anything else is named at the call site through [`EtcdPubOptions`], passed to
+//! [`EtcdSinkOps::etcd_pub_with_options`]:
+//!
+//! - [`lease_ttl: None`](EtcdPubOptions::lease_ttl) (the default) writes plain
+//!   keys that persist until deleted.
 //! - `lease_ttl: Some(ttl)` attaches an etcd lease with a background keepalive
 //!   task that renews it every `ttl/3`; the lease is **revoked** when the sink
 //!   is dropped at graph teardown, so leased keys vanish immediately rather than
 //!   waiting out the TTL (presence/heartbeat pattern).
-//! - `force: true` silently overwrites an existing key; `force: false` issues a
-//!   conditional transaction (`create_revision == 0`) and aborts the run,
-//!   naming the key, if it already exists.
+//! - [`force: true`](EtcdPubOptions::force) (the default) silently overwrites an
+//!   existing key; `force: false` issues a conditional transaction
+//!   (`create_revision == 0`) and aborts the run, naming the key, if it already
+//!   exists.
 //!
 //! # Setup
 //!
@@ -377,6 +391,55 @@ pub fn etcd_sub(
     )
 }
 
+/// Optional settings for [`EtcdSinkOps::etcd_pub_with_options`].
+///
+/// Every field defaults to what the plain [`EtcdSinkOps::etcd_pub`] uses, so
+/// `EtcdPubOptions::default()` is exactly that sink's behaviour and you name only
+/// what you want to change:
+///
+/// ```
+/// use std::time::Duration;
+/// use wingfoil::adapters::etcd::EtcdPubOptions;
+///
+/// // A presence key: leased, so it vanishes at teardown.
+/// let heartbeat = EtcdPubOptions {
+///     lease_ttl: Some(Duration::from_secs(30)),
+///     ..EtcdPubOptions::default()
+/// };
+/// assert!(heartbeat.force);
+///
+/// // A claim: must not clobber an existing key.
+/// let claim = EtcdPubOptions {
+///     force: false,
+///     ..EtcdPubOptions::default()
+/// };
+/// assert!(claim.lease_ttl.is_none());
+/// ```
+#[derive(Debug, Clone)]
+pub struct EtcdPubOptions {
+    /// The lease to write every key under. `None` (the default) writes plain
+    /// keys that persist until deleted; `Some(ttl)` grants an etcd lease with a
+    /// background keepalive task renewing it every `ttl/3`, **revoked** at graph
+    /// teardown so leased keys vanish immediately rather than waiting out the
+    /// TTL (the presence/heartbeat pattern). etcd's minimum TTL is one second,
+    /// so a sub-second `ttl` rounds up.
+    pub lease_ttl: Option<Duration>,
+    /// Whether an existing key may be overwritten. `true` (the default, as in
+    /// legacy) issues a plain PUT that silently overwrites; `false` issues a
+    /// conditional transaction (`create_revision == 0`) and aborts the run,
+    /// naming the key, if it already exists.
+    pub force: bool,
+}
+
+impl Default for EtcdPubOptions {
+    fn default() -> Self {
+        Self {
+            lease_ttl: None,
+            force: true,
+        }
+    }
+}
+
 /// Holds a granted lease alive and revokes it on drop.
 ///
 /// Lazily-established sink state, shared between the `consume_async` consumer
@@ -396,13 +459,26 @@ struct EtcdSinkState {
 /// `Stream<EtcdEntry>` (single-item, auto-wrapped into one-element bursts), so
 /// burst wrapping is never required in user code.
 pub trait EtcdSinkOps {
-    /// Write this stream to etcd via PUT. Returns the sink `Stream<()>`.
+    /// Write this stream to etcd via PUT with the default settings — unleased
+    /// keys, existing keys overwritten. Returns the sink `Stream<()>`.
     ///
-    /// - `lease_ttl`: `None` for plain writes; `Some(duration)` to attach a lease
-    ///   with automatic keepalive renewal (keys vanish on sink teardown via
-    ///   revoke).
-    /// - `force`: `true` silently overwrites existing keys; `false` aborts the
-    ///   run, naming the key, if it already exists (a conditional transaction).
+    /// This is [`etcd_pub_with_options`](EtcdSinkOps::etcd_pub_with_options) with
+    /// [`EtcdPubOptions::default()`]; reach for that when you want a lease or the
+    /// conditional (`force: false`) write.
+    ///
+    /// The graph owns the tokio runtime (see the module docs).
+    ///
+    /// # Errors
+    ///
+    /// The connection is established lazily on the first write, so an etcd
+    /// connection failure aborts the *run* (not wiring) with context, as does a
+    /// per-write failure.
+    fn etcd_pub(&self, conn: impl Into<EtcdConnection>) -> Result<Stream<()>> {
+        self.etcd_pub_with_options(conn, EtcdPubOptions::default())
+    }
+
+    /// Write this stream to etcd via PUT under `options`. Returns the sink
+    /// `Stream<()>`. See [`EtcdPubOptions`] for the lease and `force` settings.
     ///
     /// The graph owns the tokio runtime (see the module docs).
     ///
@@ -410,23 +486,23 @@ pub trait EtcdSinkOps {
     ///
     /// The connection (and any lease) is established lazily on the first write,
     /// so an etcd connection or `lease_grant` failure aborts the *run* (not
-    /// wiring) with context. A per-write failure (including a `force: false`
-    /// conflict) likewise aborts the run with context.
-    fn etcd_pub(
+    /// wiring) with context. A per-write failure (including a
+    /// [`force: false`](EtcdPubOptions::force) conflict) likewise aborts the run
+    /// with context.
+    fn etcd_pub_with_options(
         &self,
         conn: impl Into<EtcdConnection>,
-        lease_ttl: Option<Duration>,
-        force: bool,
+        options: EtcdPubOptions,
     ) -> Result<Stream<()>>;
 }
 
 impl EtcdSinkOps for Stream<Burst<EtcdEntry>> {
-    fn etcd_pub(
+    fn etcd_pub_with_options(
         &self,
         conn: impl Into<EtcdConnection>,
-        lease_ttl: Option<Duration>,
-        force: bool,
+        options: EtcdPubOptions,
     ) -> Result<Stream<()>> {
+        let EtcdPubOptions { lease_ttl, force } = options;
         let conn = conn.into();
         // The graph owns the runtime; the sink connects/keepalives/revokes on it.
         let handle = self.graph().async_runtime_handle()?;
@@ -586,20 +662,21 @@ impl EtcdSinkOps for Stream<Burst<EtcdEntry>> {
 }
 
 impl EtcdSinkOps for Stream<EtcdEntry> {
-    fn etcd_pub(
+    fn etcd_pub_with_options(
         &self,
         conn: impl Into<EtcdConnection>,
-        lease_ttl: Option<Duration>,
-        force: bool,
+        options: EtcdPubOptions,
     ) -> Result<Stream<()>> {
         self.map(|entry: &EtcdEntry| burst![entry.clone()])
-            .etcd_pub(conn, lease_ttl, force)
+            .etcd_pub_with_options(conn, options)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{EtcdConnection, EtcdEntry};
+    use std::time::Duration;
+
+    use super::{EtcdConnection, EtcdEntry, EtcdPubOptions};
 
     #[test]
     fn value_str_reads_utf8() {
@@ -620,5 +697,35 @@ mod tests {
             many.endpoints,
             vec!["http://a:2379".to_string(), "http://b:2379".to_string()]
         );
+    }
+
+    /// `EtcdPubOptions::default()` must stay legacy's `(lease_ttl: None,
+    /// force: true)` — the plain `etcd_pub(conn)` behaviour, and the default the
+    /// Python binding's `lease_ttl_secs=None, force=True` signature mirrors.
+    /// Flipping either would silently change what an existing call site does.
+    #[test]
+    fn pub_options_default_is_unleased_and_overwriting() {
+        let options = EtcdPubOptions::default();
+        assert_eq!(options.lease_ttl, None);
+        assert!(options.force);
+    }
+
+    /// The struct-update form names one field and inherits the rest, which is the
+    /// whole point of the options struct over the old positional `(None, true)`.
+    #[test]
+    fn pub_options_struct_update_keeps_the_other_default() {
+        let leased = EtcdPubOptions {
+            lease_ttl: Some(Duration::from_secs(30)),
+            ..EtcdPubOptions::default()
+        };
+        assert_eq!(leased.lease_ttl, Some(Duration::from_secs(30)));
+        assert!(leased.force, "force keeps its default");
+
+        let conditional = EtcdPubOptions {
+            force: false,
+            ..EtcdPubOptions::default()
+        };
+        assert!(!conditional.force);
+        assert_eq!(conditional.lease_ttl, None, "lease_ttl keeps its default");
     }
 }

--- a/crates/wingfoil/src/adapters/etcd/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/etcd/CLAUDE.md
@@ -30,10 +30,19 @@ features on, `EtcdRegistry` becomes a `ZmqRegistry` discovery backend.
 | Item | Kind | Notes |
 |---|---|---|
 | `etcd_sub(g, run_mode, conn, prefix)` | source | `Result<Stream<Burst<EtcdEvent>>>` — snapshot then watch |
-| `EtcdSinkOps::etcd_pub(conn, lease_ttl, force)` | sink trait | on `Stream<Burst<EtcdEntry>>` **and** `Stream<EtcdEntry>` |
+| `EtcdSinkOps::etcd_pub(conn)` | sink trait | the defaults — unleased, overwriting; on `Stream<Burst<EtcdEntry>>` **and** `Stream<EtcdEntry>` |
+| `EtcdSinkOps::etcd_pub_with_options(conn, EtcdPubOptions)` | sink trait | the required method; `etcd_pub` is a provided method forwarding `EtcdPubOptions::default()` |
 
 Config types: `EtcdConnection` (`new` / `with_endpoints`, plus `From<&str>` /
-`From<String>` / `From<&String>`), `EtcdEntry`, `EtcdEvent`, `EtcdEventKind`.
+`From<String>` / `From<&String>`), `EtcdPubOptions`, `EtcdEntry`, `EtcdEvent`,
+`EtcdEventKind`.
+
+`EtcdPubOptions` is plain public fields + a hand-written `Default`
+(`lease_ttl: None`, `force: true`), the `FixOptions` shape — callers write
+`EtcdPubOptions { force: false, ..EtcdPubOptions::default() }`. **`Default` is
+legacy's `(None, true)` and the Python binding's `lease_ttl_secs=None,
+force=True`; a unit test in `etcd.rs` pins it.** Flipping either default would
+silently change every call site that names neither.
 
 ## What to know before changing it
 
@@ -85,7 +94,10 @@ Canonical list: the `# Deviations from legacy` block in `etcd.rs` —
 (1) the graph owns the tokio runtime and `etcd_sub` takes a `RunMode`
 (register A5); (2) the sink connects lazily on the first write (A1/A4);
 (3) the sink is a **trait only** — legacy had both a free `etcd_pub` and an
-`EtcdPubOperators` trait (register D1). Every legacy capability
+`EtcdPubOperators` trait (register D1); (4) the sink's options are an
+`EtcdPubOptions` struct rather than legacy's positional
+`(lease_ttl: Option<Duration>, force: bool)` — a readability change only, the
+defaults are legacy's (issue #459). Every legacy capability
 (snapshot→watch, deletes, leases with keepalive and revoke-on-shutdown, the
 `force` conditional write) is preserved.
 
@@ -126,7 +138,9 @@ but it needs `protoc` at build time to compile the etcd protos, which
 `pypi-publish.yml` installs.
 
 - Entry points: `etcd_sub(graph, …)`, `etcd_pub(stream, …)` — `#[pyadapter]`,
-  in `src/adapters/etcd.rs`.
+  in `src/adapters/etcd.rs`. `EtcdPubOptions` stays **flat keyword arguments**
+  on the Python side (`lease_ttl_secs=None, force=True`), assembled into the
+  struct in the binding — the `ws`/`WsConfig` shape.
 - Tests: `tests/test_etcd.py` — service-free group by default,
   `@pytest.mark.requires_etcd` group in the workflow above.
 

--- a/crates/wingfoil/tests/etcd_adapter.rs
+++ b/crates/wingfoil/tests/etcd_adapter.rs
@@ -7,7 +7,9 @@
 //! ```
 #![cfg(feature = "etcd")]
 
-use wingfoil::adapters::etcd::{EtcdConnection, EtcdEntry, EtcdSinkOps, etcd_sub};
+use std::time::Duration;
+
+use wingfoil::adapters::etcd::{EtcdConnection, EtcdEntry, EtcdPubOptions, EtcdSinkOps, etcd_sub};
 use wingfoil::async_source::RunParams;
 use wingfoil::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
@@ -75,8 +77,68 @@ fn pub_connection_refused_surfaces_an_error() {
     let conn = EtcdConnection::new("http://127.0.0.1:59999");
 
     let _sink = source
-        .etcd_pub(conn, None, true)
+        .etcd_pub(conn)
         .expect("wiring must succeed (connect is deferred to the run)");
+    let outcome = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
+    assert!(
+        outcome.is_err(),
+        "an unreachable etcd endpoint must abort the run"
+    );
+}
+
+/// The options struct must actually reach the sink. Without a service the
+/// observable part is the *wiring* contract: non-default options wire without
+/// error (nothing connects, nothing is leased, at graph construction) and the
+/// run then aborts on the unreachable endpoint — i.e. the lease grant is
+/// deferred to the first write exactly like the default path's connect.
+#[test]
+fn pub_with_options_defers_lease_and_conditional_write_to_the_run() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let source = g.constant(burst![EtcdEntry {
+        key: "/x/k".to_string(),
+        value: b"v".to_vec(),
+    }]);
+    let conn = EtcdConnection::new("http://127.0.0.1:59999");
+
+    let _sink = source
+        .etcd_pub_with_options(
+            conn,
+            EtcdPubOptions {
+                lease_ttl: Some(Duration::from_secs(30)),
+                force: false,
+            },
+        )
+        .expect("wiring must succeed (connect + lease_grant are deferred to the run)");
+    let outcome = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
+    assert!(
+        outcome.is_err(),
+        "an unreachable etcd endpoint must abort the run"
+    );
+}
+
+/// The single-entry convenience impl forwards its options to the burst impl, so
+/// a `Stream<EtcdEntry>` caller never has to wrap a value in a burst to name a
+/// lease.
+#[test]
+fn pub_single_entry_impl_accepts_options() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
+    let source: Stream<EtcdEntry> = g.constant(EtcdEntry {
+        key: "/x/k".to_string(),
+        value: b"v".to_vec(),
+    });
+    let conn = EtcdConnection::new("http://127.0.0.1:59999");
+
+    let _sink = source
+        .etcd_pub_with_options(
+            conn,
+            EtcdPubOptions {
+                lease_ttl: Some(Duration::from_secs(30)),
+                ..EtcdPubOptions::default()
+            },
+        )
+        .expect("wiring must succeed");
     let outcome = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
     assert!(
         outcome.is_err(),

--- a/crates/wingfoil/tests/etcd_integration.rs
+++ b/crates/wingfoil/tests/etcd_integration.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use etcd_client::Client;
 use testcontainers::{GenericImage, ImageExt, core::WaitFor, runners::SyncRunner};
 use wingfoil::adapters::etcd::{
-    EtcdConnection, EtcdEntry, EtcdEvent, EtcdEventKind, EtcdSinkOps, etcd_sub,
+    EtcdConnection, EtcdEntry, EtcdEvent, EtcdEventKind, EtcdPubOptions, EtcdSinkOps, etcd_sub,
 };
 use wingfoil::async_source::RunParams;
 use wingfoil::prelude::*;
@@ -293,11 +293,9 @@ fn test_pub_round_trip() -> anyhow::Result<()> {
 
     {
         let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
-        let _sink = g.constant(burst![entry("/rt/key1", b"value1")]).etcd_pub(
-            EtcdConnection::new(&endpoint),
-            None,
-            true,
-        )?;
+        let _sink = g
+            .constant(burst![entry("/rt/key1", b"value1")])
+            .etcd_pub(EtcdConnection::new(&endpoint))?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -318,7 +316,7 @@ fn test_pub_no_lease_keys_persist() -> anyhow::Result<()> {
         let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![entry("/nolease/k1", b"persist")])
-            .etcd_pub(EtcdConnection::new(&endpoint), None, true)?;
+            .etcd_pub(EtcdConnection::new(&endpoint))?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -339,11 +337,15 @@ fn test_pub_lease_keys_expire_after_revoke() -> anyhow::Result<()> {
     {
         let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         // A 30s TTL — the key must still vanish on revoke, not wait 30s.
-        let _sink = g.constant(burst![entry("/lease/k1", b"hello")]).etcd_pub(
-            EtcdConnection::new(&endpoint),
-            Some(Duration::from_secs(30)),
-            true,
-        )?;
+        let _sink = g
+            .constant(burst![entry("/lease/k1", b"hello")])
+            .etcd_pub_with_options(
+                EtcdConnection::new(&endpoint),
+                EtcdPubOptions {
+                    lease_ttl: Some(Duration::from_secs(30)),
+                    ..EtcdPubOptions::default()
+                },
+            )?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
     // Sink dropped → lease revoked → key must be gone.
@@ -396,10 +398,12 @@ fn test_pub_lease_keepalive_extends_ttl() -> anyhow::Result<()> {
         let _sink = g
             .ticker(Duration::from_millis(500))
             .map(|_: &()| burst![entry("/lease/heartbeat", b"alive")])
-            .etcd_pub(
+            .etcd_pub_with_options(
                 EtcdConnection::new(&endpoint),
-                Some(Duration::from_secs(3)),
-                true,
+                EtcdPubOptions {
+                    lease_ttl: Some(Duration::from_secs(3)),
+                    ..EtcdPubOptions::default()
+                },
             )?;
         g.build()
             .run(RunMode::RealTime, RunFor::Duration(Duration::from_secs(10)))?;
@@ -418,11 +422,9 @@ fn test_pub_force_true_overwrites() -> anyhow::Result<()> {
 
     {
         let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
-        let _sink = g.constant(burst![entry("/force/k", b"updated")]).etcd_pub(
-            EtcdConnection::new(&endpoint),
-            None,
-            true,
-        )?;
+        let _sink = g
+            .constant(burst![entry("/force/k", b"updated")])
+            .etcd_pub(EtcdConnection::new(&endpoint))?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 
@@ -443,7 +445,13 @@ fn test_pub_force_false_fails_if_exists() -> anyhow::Result<()> {
     let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
     let _sink = g
         .constant(burst![entry("/noforce/k", b"should-not-overwrite")])
-        .etcd_pub(EtcdConnection::new(&endpoint), None, false)?;
+        .etcd_pub_with_options(
+            EtcdConnection::new(&endpoint),
+            EtcdPubOptions {
+                force: false,
+                ..EtcdPubOptions::default()
+            },
+        )?;
     let result = g.build().run(RunMode::RealTime, RunFor::Cycles(1));
 
     assert!(result.is_err(), "expected error when key already exists");
@@ -471,7 +479,13 @@ fn test_pub_force_false_succeeds_if_absent() -> anyhow::Result<()> {
         let g = GraphBuilder::new().with_async_runtime(rt.handle().clone());
         let _sink = g
             .constant(burst![entry("/noforce/new", b"value")])
-            .etcd_pub(EtcdConnection::new(&endpoint), None, false)?;
+            .etcd_pub_with_options(
+                EtcdConnection::new(&endpoint),
+                EtcdPubOptions {
+                    force: false,
+                    ..EtcdPubOptions::default()
+                },
+            )?;
         g.build().run(RunMode::RealTime, RunFor::Cycles(1))?;
     }
 


### PR DESCRIPTION
## What this changes

`etcd_pub(conn, Option<Duration>, bool)` becomes `etcd_pub(conn)` plus `etcd_pub_with_options(conn, EtcdPubOptions { .. })`.

Closes the `etcd_pub` item of #459.

## Why

A call site read `etcd_pub(conn, None, true)`, which tells the reader nothing about what `true` means — and a third knob would have broken every caller. Every other option-bearing adapter surface in the tree already takes a struct; #459 records this one as the outlier.

**This is a semver-major signature change, and 9.0.0 is unpublished** (last tag `v8.0.0`), so it is free now and costs a 10.0.0 after `bump.yml` runs. That is the reason for the timing.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint-all` — clean (the `etcd` feature is off by default, so `cargo lint` alone would not see this code)
- [x] `cargo test -p wingfoil --features etcd --lib --tests` — 439 passed, 0 failed
- [x] `cargo test --doc -p wingfoil --all-features` — 22 passed, including the new `EtcdPubOptions` fence
- [x] New behaviour is covered by tests

Also: `cargo test -p wingfoil --features etcd-integration-test --test etcd_integration --no-run` compiles; the example builds; `cargo clippy -D warnings` clean on the integration targets and on `wingfoil-python --features etcd`.

The etcd **integration** suite compiles but was not executed — no Docker daemon in the dev sandbox. It runs in `etcd-integration.yml`.

## Notes for the reviewer

**`FixOptions` is the reference, chosen after reading the alternatives.** The tree has two established shapes: options-only structs with plain fields and a `Default` (`FixOptions`), and config structs with chainable setters that carry the connection target (`WsConfig`, `KafkaSourceConfig`). The latter does not fit — etcd's connection is already a separate `impl Into<EtcdConnection>` parameter, so there is no required field for a `new(..)` to take, and both remaining fields are optional.

`etcd_pub` is a **provided** trait method delegating to the required `etcd_pub_with_options`, so both impls — `Stream<Burst<EtcdEntry>>` and the single-entry convenience — implement it once.

**The `Default` is deliberately `lease_ttl: None, force: true`**, matching legacy's documented default and what the Python binding already exposes. Flipping `force` would have silently turned every existing default call into a conditional write — a semantic change #459 did not ask for, and one that *would not fail to compile*. That makes it worse than a signature break, so it is pinned by a unit test.

**The Python surface is unchanged** — `etcd_pub(stream, endpoints, lease_ttl_secs=None, force=True)` — with the binding assembling the struct. That is the established pattern (`ws.rs` does the same for `WsConfig`); no binding exposes a Rust options struct as a class.

**Incidental fix:** the example README's second snippet had drifted from `main.rs` — it passed `false` where the code overwrites. Both now read `.etcd_pub(conn)`.

**The `/new-adapter` skill is updated in the same PR**, per CLAUDE.md's living-documents rule: when to reach for an options struct, which of the two shapes to pick, that a `Default` is a compatibility surface needing a pinning test, and that Python bindings keep the knobs flat. The skill's Naming section had no rule about option-bearing signatures, which is how this drifted in the first place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wQjYrfk8RpF3TQFjeii7)_