### PR TITLE
API consistency batch: usize counts, honest NanoTime conversions, dead RunFor::done

### DIFF
--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -101,6 +101,19 @@ shape decides what you *write in the op*, not how much wiring you hand-code:
 | **Phantom type parameter** (a stage, a unit, a marker) | any | `#[op(build = name, explicit = S)]` | `.name::<S>()` — the type crosses as a `PhantomData` argument | `Stamp`, `StampPrecise` |
 | **Variadic** (any number of same-type edges) | `&'a [(&'a T, bool)]` | no attribute — hand `Builder` method *and* hand forwarders | `name(&[Handle<T>])` | `MergeN` |
 
+**Declare a tick flag only on edges whose `cycle` actually reads it.** Every
+`(&'a T, bool)` pair in `In` costs the interpreted builder one
+`ticked_flags()[upstream]` lookup per activation; an edge declared `&'a T` is
+handed a constant `false` the op never looks at. A flag destructured as `_` is
+therefore pure per-activation overhead, and it also misleads the next reader
+about where the op's behaviour comes from. `Filter` had exactly that on its
+condition edge: **resampling on a condition tick comes from the edge being
+*active*** — the engine activates the node, and `cycle` re-emits the held
+source off the condition's current value — never from reading the flag. Active
+vs passive is the `passive = [..]` mask; the flag answers a different question
+("did *this* edge tick, this cycle?") and only `Delay`, `Merge2`, `MergeN` and
+`DelayWithReset` need it.
+
 **`explicit = S` is for a type parameter nothing else mentions.** If an op is
 generic over something that appears only in a `PhantomData` — a latency stage,
 a unit, a marker — inference cannot reach it from `Cfg`/`In`/`Out`, so the call
@@ -275,9 +288,29 @@ Rules the existing ops encode — follow them:
   `Default::default()` per run (re-seeded each run, so a graph re-runs clean).
   A seed that must come from the call site is the `init_arg` shape (`Fold`),
   which `#[op]` also generates — not a reason to hand-write a builder.
-- **Convert config once in `start`**, not per `cycle`, when the conversion is
-  non-trivial (`Ticker` converts its `Duration` period to `NanoTime` in
-  `start`).
+- **Convert config once in `start`**, not per `cycle`. `Ticker` converts its
+  `Duration` period to `NanoTime` in `start` and `TickerState` documents the
+  pattern; `Throttle`, `Delay`, `DelayWithReset` and `Window` follow it. One
+  multiply-and-add per cycle is not what this is about — it is that a
+  `Cfg`-derived value has exactly one place it is computed, so `cycle` reads a
+  field and cannot disagree with `start` about what the config meant.
+- **Overriding `start` obliges every op generic to appear in `Cfg` or
+  `State`.** This is the trap that comes with the bullet above, and it bites
+  at the *call site*, not in your op. When an impl overrides `start`, `#[op]`
+  emits a **real** `__wf_op_<name>_start` forwarder carrying the op's
+  generics — and `nitro!`/`compiled` call it with nothing but the `Cfg` and
+  `State` values to infer from (`start` takes no input). A generic that
+  appears in neither dangles: `error[E0282]: type annotations needed ... on
+  the function __wf_op_<name>_start`, pointing at the user's `.my_op(..)`
+  call. When the op does *not* override `start` the forwarder is a fully-erased
+  no-op and the question never arises — so an op can acquire this failure just
+  by gaining a `start` hook.
+
+  Anchor the generic in the `State` type, with `PhantomData` if the state has
+  no real use for it. `ThrottleState<T>` is the minimal worked example (a
+  throttle stores no values, so `T` is carried purely as the anchor);
+  `DelayState<T>` / `WindowState<T>` anchor theirs through real payload and
+  needed no change.
 - **Validate user config** at wiring when possible; when it needs runtime info,
   `anyhow::bail!` inside `cycle` with a clear message (aborts the run). **Never
   panic** for bad user config. No `.unwrap()` outside `#[cfg(test)]` / doc
@@ -503,6 +536,19 @@ Compiled-specific stateful/lifecycle behaviour has its own suites
 (`tests/compiled_stateful_ops.rs`, `tests/compiled_lifecycle_ops.rs`,
 `tests/nested_islands.rs`) — extend the relevant one if your op is stateful or
 has `start`/`stop`/`teardown` hooks.
+
+**A *delegating forwarder* must delegate `start` too, and cross-engine parity
+cannot tell you when it doesn't.** An op whose `In` shape `#[op]` cannot parse
+is restated by a forwarder witness that carries the attribute and delegates to
+the real op (`DelayWithResetFwd` → `DelayWithReset`). Every tier — interpreted
+included — reaches the op *through* that witness, so a hook the witness forgets
+to forward is missing from all of them **identically**, and an
+`interpreted() == compiled() == nested()` assertion passes on the shared wrong
+answer. Dropping `DelayWithResetFwd::start` turns every `delay_with_reset` in
+the tree into a pass-through and all three tiers agree that it should. Pin such
+an op with an **absolute** expected sequence (values *and* tick times), not
+only against another tier, and sanity-check the test by deleting the delegation
+and watching it fail.
 
 **A lifecycle hook is only covered when its *effect* is observed on all three
 tiers.** `#[op]` emits the `_start` / `_stop` / `_teardown` forwarders for every

--- a/crates/wingfoil-python/src/graph.rs
+++ b/crates/wingfoil-python/src/graph.rs
@@ -423,7 +423,7 @@ impl PyStream {
     }
 
     /// Pass through the first `limit` values, then stay quiet.
-    pub fn limit(&self, limit: u32) -> PyStream {
+    pub fn limit(&self, limit: usize) -> PyStream {
         self.wrap(self.stream.limit(limit))
     }
 

--- a/crates/wingfoil-python/src/python.rs
+++ b/crates/wingfoil-python/src/python.rs
@@ -182,7 +182,7 @@ impl Stream {
     }
 
     /// Pass through the first `limit` values, then stay quiet.
-    fn limit(&self, limit: u32) -> Stream {
+    fn limit(&self, limit: usize) -> Stream {
         Stream(self.0.limit(limit))
     }
 

--- a/crates/wingfoil/examples/core/spawn/main.rs
+++ b/crates/wingfoil/examples/core/spawn/main.rs
@@ -18,7 +18,7 @@ use wingfoil::{NanoTime, RunFor, RunMode};
 
 fn main() {
     let period = Duration::from_millis(10);
-    let n = 5u32;
+    let n = 5usize;
 
     let g = GraphBuilder::new();
 
@@ -47,7 +47,7 @@ fn main() {
     runner
         .run(
             RunMode::HistoricalFrom(NanoTime::ZERO),
-            RunFor::Duration(period * (n + 3)),
+            RunFor::Duration(period * (n as u32 + 3)),
         )
         .expect("run");
     // 0 ms: [10]

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -1068,12 +1068,12 @@ pub trait StreamOps<T>: Sized {
         F: Fn(Stream<T>) -> Stream<B>;
 
     /// Pass through the first `limit` values, then stay quiet.
-    fn limit(&self, limit: u32) -> Stream<T>
+    fn limit(&self, limit: usize) -> Stream<T>
     where
         T: Clone + Default + 'static;
 
     /// Suppress the first `n` values, then pass every later value through.
-    fn skip(&self, n: u32) -> Stream<T>
+    fn skip(&self, n: usize) -> Stream<T>
     where
         T: Clone + Default + 'static;
 

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -412,17 +412,27 @@ where
 
 /// Passes through the first `limit` values, then stays quiet. `Cfg` is the
 /// limit; `State` the count emitted so far.
+///
+/// The count is a `usize`, matching every other count in the catalog
+/// ([`Buffer`]'s capacity, `fan`'s width, the rolling windows) — a tick count
+/// is a count of things, and a long-lived realtime graph really can exceed
+/// `u32`.
 pub struct Limit<T>(PhantomData<T>);
 
 #[op(build = limit, fluent)]
 impl<T: Clone + 'static> Op for Limit<T> {
-    type Cfg = u32;
-    type State = u32;
+    type Cfg = usize;
+    type State = usize;
     type In<'a> = (&'a T,);
     type Out = T;
     const ACTIVATION: Activation = Activation::NONE;
 
-    fn cycle(cfg: &mut u32, state: &mut u32, input: (&T,), _ctx: &mut Ctx<'_>) -> Result<Tick<T>> {
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut usize,
+        input: (&T,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<T>> {
         if *state >= *cfg {
             Ok(Tick::Quiet)
         } else {
@@ -434,18 +444,23 @@ impl<T: Clone + 'static> Op for Limit<T> {
 
 /// Suppresses the first `n` values, then passes every later value through.
 /// The mirror of [`Limit`]: `Cfg` is the number to skip; `State` is the number
-/// suppressed so far.
+/// suppressed so far — and, as [`Limit`], both are `usize`.
 pub struct Skip<T>(PhantomData<T>);
 
 #[op(build = skip, fluent)]
 impl<T: Clone + 'static> Op for Skip<T> {
-    type Cfg = u32;
-    type State = u32;
+    type Cfg = usize;
+    type State = usize;
     type In<'a> = (&'a T,);
     type Out = T;
     const ACTIVATION: Activation = Activation::NONE;
 
-    fn cycle(cfg: &mut u32, state: &mut u32, input: (&T,), _ctx: &mut Ctx<'_>) -> Result<Tick<T>> {
+    fn cycle(
+        cfg: &mut usize,
+        state: &mut usize,
+        input: (&T,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<T>> {
         if *state < *cfg {
             *state += 1;
             Ok(Tick::Quiet)
@@ -458,31 +473,64 @@ impl<T: Clone + 'static> Op for Skip<T> {
 /// Rate-limits: emits the first value, then suppresses until at least
 /// `interval` has passed since the last emit. `Cfg` = the interval as passed
 /// at the call site (`Duration`, per the uniform arg-is-the-config
-/// convention; converted to engine time in `cycle`), `State` = last emit time.
+/// convention; converted to engine time in `start`), `State` = the converted
+/// interval plus the last emit time.
 pub struct Throttle<T>(PhantomData<T>);
+
+/// Pending state for a [`Throttle`] op: the interval in engine nanoseconds
+/// (set by `start`, so `cycle` never converts) and the last emit time.
+///
+/// **`T` is carried only as a `PhantomData` anchor**, and is load-bearing.
+/// An op that overrides `start` gets a *real* `__wf_op_<name>_start`
+/// forwarder emitted with the op's generics, and `nitro!`/`compiled` call it
+/// with nothing but the `Cfg` and `State` values to infer from — so every
+/// generic parameter of such an op must appear in `Cfg` or `State` or it
+/// dangles at the call site (`error[E0282]: type annotations needed`). The
+/// other three time-config ops anchor theirs through real payload
+/// ([`DelayState<T>`], [`WindowState<T>`]); a throttle stores no values, so
+/// it anchors explicitly.
+pub struct ThrottleState<T> {
+    interval: NanoTime,
+    last_emit: Option<NanoTime>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Default for ThrottleState<T> {
+    fn default() -> Self {
+        Self {
+            interval: NanoTime::ZERO,
+            last_emit: None,
+            _marker: PhantomData,
+        }
+    }
+}
 
 #[op(build = throttle, fluent)]
 impl<T: Clone + 'static> Op for Throttle<T> {
     type Cfg = Duration;
-    type State = Option<NanoTime>;
+    type State = ThrottleState<T>;
     type In<'a> = (&'a T,);
     type Out = T;
     const ACTIVATION: Activation = Activation::NONE;
 
+    fn start(cfg: &mut Duration, state: &mut ThrottleState<T>, _ctx: &mut Ctx<'_>) -> Result<()> {
+        state.interval = NanoTime::from(*cfg);
+        Ok(())
+    }
+
     fn cycle(
-        cfg: &mut Duration,
-        state: &mut Option<NanoTime>,
+        _cfg: &mut Duration,
+        state: &mut ThrottleState<T>,
         input: (&T,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<T>> {
-        let interval = NanoTime::from(*cfg);
         let now = ctx.time();
-        let emit = match *state {
+        let emit = match state.last_emit {
             None => true,
-            Some(last) => now - last >= interval,
+            Some(last) => now - last >= state.interval,
         };
         Ok(if emit {
-            *state = Some(now);
+            state.last_emit = Some(now);
             Tick::Value(input.0.clone())
         } else {
             Tick::Quiet
@@ -659,12 +707,15 @@ impl<T: Clone + 'static> Op for Timed<T> {
 /// Buffers values and flushes them as a `Vec` on each fixed time boundary
 /// (`interval`), plus a final flush on the last cycle. `Cfg` = the interval as
 /// passed at the call site (`Duration`, per the uniform arg-is-the-config
-/// convention; converted to engine time in `start`/`cycle`); `State` holds the
-/// next boundary and the pending buffer.
+/// convention; converted to engine time in `start`); `State` holds the
+/// converted interval, the next boundary and the pending buffer.
 pub struct Window<T>(PhantomData<T>);
 
-/// Pending state for a [`Window`] op.
+/// Pending state for a [`Window`] op: the interval in engine nanoseconds (set
+/// by `start`, so `cycle` never converts), the next flush boundary and the
+/// values buffered since the last one.
 pub struct WindowState<T> {
+    interval: NanoTime,
     next_window: NanoTime,
     buffer: Vec<T>,
 }
@@ -672,6 +723,7 @@ pub struct WindowState<T> {
 impl<T> Default for WindowState<T> {
     fn default() -> Self {
         Self {
+            interval: NanoTime::ZERO,
             next_window: NanoTime::ZERO,
             buffer: Vec::new(),
         }
@@ -701,17 +753,18 @@ impl<T: Clone + 'static> Op for Window<T> {
     const ACTIVATION: Activation = Activation::NONE;
 
     fn start(cfg: &mut Duration, state: &mut WindowState<T>, ctx: &mut Ctx<'_>) -> Result<()> {
-        state.next_window = ctx.time() + window_interval(cfg);
+        state.interval = window_interval(cfg);
+        state.next_window = ctx.time() + state.interval;
         Ok(())
     }
 
     fn cycle(
-        cfg: &mut Duration,
+        _cfg: &mut Duration,
         state: &mut WindowState<T>,
         input: (&T,),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<Vec<T>>> {
-        let interval = window_interval(cfg);
+        let interval = state.interval;
         let now = ctx.time();
         let mut out = None;
         if now >= state.next_window {
@@ -2749,23 +2802,30 @@ impl Op for TimeWindowedMedianTimeWeighted {
 /// Emits its source value when the condition stream's current value is true.
 /// Condition ticks resample the held source value after the source has ticked
 /// at least once. Before the first source tick, the filter stays quiet.
+///
+/// **The condition edge declares no tick flag**, and must not: resampling on a
+/// condition tick falls out of the edge being *active* — the engine activates
+/// this node when the condition ticks, and `cycle` then re-emits off the held
+/// source — never out of reading the flag. Every declared flag costs the
+/// interpreted builder a `ticked_flags()[upstream]` lookup per activation, so a
+/// flag the op destructures as `_` is pure overhead on the hot path.
 pub struct Filter<T>(PhantomData<T>);
 
 #[op(build = filter, fluent)]
 impl<T: Clone + 'static> Op for Filter<T> {
     type Cfg = ();
     type State = bool;
-    type In<'a> = ((&'a T, bool), (&'a bool, bool));
+    type In<'a> = ((&'a T, bool), &'a bool);
     type Out = T;
     const ACTIVATION: Activation = Activation::NONE;
 
     fn cycle(
         _cfg: &mut (),
         source_seen: &mut bool,
-        input: ((&T, bool), (&bool, bool)),
+        input: ((&T, bool), &bool),
         _ctx: &mut Ctx<'_>,
     ) -> Result<Tick<T>> {
-        let ((source, source_ticked), (condition, _)) = input;
+        let ((source, source_ticked), condition) = input;
         if source_ticked {
             *source_seen = true;
         }
@@ -3191,9 +3251,12 @@ where
 /// can run it.
 pub struct Delay<T>(PhantomData<T>);
 
-/// Pending values for a [`Delay`] op, plus whether the first upstream value
-/// has been stored into the slot (via [`Tick::Silent`]).
+/// Pending values for a [`Delay`] op: the delay in engine nanoseconds (set by
+/// `start`, so `cycle` never converts), the queue of values still in flight,
+/// and whether the first upstream value has been stored into the slot (via
+/// [`Tick::Silent`]).
 pub struct DelayState<T: PartialEq> {
+    delay: NanoTime,
     queue: TimeQueue<T>,
     seeded: bool,
 }
@@ -3201,6 +3264,7 @@ pub struct DelayState<T: PartialEq> {
 impl<T: PartialEq> Default for DelayState<T> {
     fn default() -> Self {
         Self {
+            delay: NanoTime::ZERO,
             queue: TimeQueue::new(),
             seeded: false,
         }
@@ -3216,14 +3280,19 @@ impl<T: Clone + PartialEq + 'static> Op for Delay<T> {
     type Out = T;
     const ACTIVATION: Activation = Activation::SCHEDULES;
 
+    fn start(cfg: &mut Duration, state: &mut DelayState<T>, _ctx: &mut Ctx<'_>) -> Result<()> {
+        state.delay = NanoTime::from(*cfg);
+        Ok(())
+    }
+
     fn cycle(
-        cfg: &mut Duration,
+        _cfg: &mut Duration,
         state: &mut DelayState<T>,
         input: (&T, bool),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<T>> {
         let (value, src_ticked) = input;
-        let delay = NanoTime::from(*cfg);
+        let delay = state.delay;
         // Legacy parity: a zero delay emits inline in the *same* cycle
         // (scheduling `time + 0` would instead pop next cycle).
         if delay == NanoTime::ZERO {
@@ -3582,10 +3651,12 @@ impl Op for Never {
     }
 }
 
-/// Pending state for a [`DelayWithReset`] op: the queue of not-yet-due values
-/// and whether the first upstream value has been stored into the slot (via
-/// [`Tick::Silent`], as [`Delay`] does).
+/// Pending state for a [`DelayWithReset`] op: the delay in engine nanoseconds
+/// (set by `start`, so `cycle` never converts), the queue of not-yet-due
+/// values, and whether the first upstream value has been stored into the slot
+/// (via [`Tick::Silent`], as [`Delay`] does).
 pub struct DelayWithResetState<T: PartialEq> {
+    delay: NanoTime,
     queue: TimeQueue<T>,
     initialized: bool,
 }
@@ -3593,6 +3664,7 @@ pub struct DelayWithResetState<T: PartialEq> {
 impl<T: PartialEq> Default for DelayWithResetState<T> {
     fn default() -> Self {
         Self {
+            delay: NanoTime::ZERO,
             queue: TimeQueue::new(),
             initialized: false,
         }
@@ -3622,8 +3694,17 @@ impl<T: Clone + PartialEq + 'static> Op for DelayWithReset<T> {
     type Out = T;
     const ACTIVATION: Activation = Activation::SCHEDULES;
 
-    fn cycle(
+    fn start(
         cfg: &mut Duration,
+        state: &mut DelayWithResetState<T>,
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        state.delay = NanoTime::from(*cfg);
+        Ok(())
+    }
+
+    fn cycle(
+        _cfg: &mut Duration,
         state: &mut DelayWithResetState<T>,
         input: (&T, bool, bool),
         ctx: &mut Ctx<'_>,
@@ -3636,7 +3717,7 @@ impl<T: Clone + PartialEq + 'static> Op for DelayWithReset<T> {
             state.initialized = true;
             return Ok(Tick::Value(value.clone()));
         }
-        let delay = NanoTime::from(*cfg);
+        let delay = state.delay;
         // Legacy parity: a zero delay emits inline in the *same* cycle.
         if delay == NanoTime::ZERO {
             return Ok(if upstream_ticked {
@@ -3684,23 +3765,63 @@ impl<T: Clone + PartialEq + 'static> Op for DelayWithReset<T> {
 /// [`delay_with_reset`](crate::fluent::StreamOps::delay_with_reset)`<U>`.
 pub struct DelayWithResetFwd<T, U>(PhantomData<(T, U)>);
 
+/// [`DelayWithResetState`] behind a `PhantomData<U>` anchor for the trigger's
+/// value type.
+///
+/// The forwarder cannot simply reuse `DelayWithResetState<T>`: overriding
+/// `start` (which is where the `Duration` is hoisted to engine time) makes
+/// `#[op]` emit a real `__wf_op_delay_with_reset_start` forwarder carrying
+/// *both* op generics, and `nitro!`/`compiled` call it with only the `Cfg` and
+/// `State` values to infer from — so `U` has to appear in one of them or it
+/// dangles at every call site. See [`ThrottleState`] for the same anchor in
+/// its simplest form.
+pub struct DelayWithResetFwdState<T: PartialEq, U> {
+    inner: DelayWithResetState<T>,
+    _marker: PhantomData<U>,
+}
+
+impl<T: PartialEq, U> Default for DelayWithResetFwdState<T, U> {
+    fn default() -> Self {
+        Self {
+            inner: DelayWithResetState::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
 #[op(build = delay_with_reset)]
 impl<T: Clone + PartialEq + 'static, U: 'static> Op for DelayWithResetFwd<T, U> {
     type Cfg = Duration;
-    type State = DelayWithResetState<T>;
+    type State = DelayWithResetFwdState<T, U>;
     /// Source value, source tick, trigger value (ignored), trigger tick — the
     /// two-edge `(value, tick)`-per-edge form `#[op]` parses.
     type In<'a> = (&'a T, bool, &'a U, bool);
     type Out = T;
     const ACTIVATION: Activation = Activation::SCHEDULES;
 
+    /// Delegated like [`cycle`](Self::cycle): the real op hoists the `Duration`
+    /// to engine nanoseconds here, so the forwarder must run it too or every
+    /// `nitro!`/compiled `delay_with_reset` would cycle with a zero delay.
+    fn start(
+        cfg: &mut Duration,
+        state: &mut DelayWithResetFwdState<T, U>,
+        ctx: &mut Ctx<'_>,
+    ) -> Result<()> {
+        <DelayWithReset<T> as Op>::start(cfg, &mut state.inner, ctx)
+    }
+
     fn cycle(
         cfg: &mut Duration,
-        state: &mut DelayWithResetState<T>,
+        state: &mut DelayWithResetFwdState<T, U>,
         input: (&T, bool, &U, bool),
         ctx: &mut Ctx<'_>,
     ) -> Result<Tick<T>> {
         let (value, upstream_ticked, _trigger_value, trigger_ticked) = input;
-        <DelayWithReset<T> as Op>::cycle(cfg, state, (value, upstream_ticked, trigger_ticked), ctx)
+        <DelayWithReset<T> as Op>::cycle(
+            cfg,
+            &mut state.inner,
+            (value, upstream_ticked, trigger_ticked),
+            ctx,
+        )
     }
 }

--- a/crates/wingfoil/src/runtime/run.rs
+++ b/crates/wingfoil/src/runtime/run.rs
@@ -39,6 +39,16 @@ impl RunMode {
 /// Duration, number of cycles or forever.
 ///
 /// Defaults to [`RunFor::Forever`].
+///
+/// **This type declares the bound; it does not evaluate it.** The single
+/// implementation of "has the run finished?" lives in
+/// [`Kernel::begin_cycle`](crate::runtime::kernel::Kernel::begin_cycle),
+/// which resolves the variant once at construction into an `end_time` /
+/// `end_cycle` pair and compares against those. `RunFor` deliberately carries
+/// no `done`-style predicate of its own: a second copy of the comparison is a
+/// second thing to keep in step, and the one this type used to carry had
+/// already drifted off the kernel's by one cycle (`cycle > cycles` against the
+/// kernel's `cycles >= end`) without a single caller to notice.
 #[derive(Clone, Copy, Debug, Default)]
 pub enum RunFor {
     /// Stop once *engine* time has advanced this far past the start time —
@@ -52,16 +62,4 @@ pub enum RunFor {
     /// a `stop` handle, or an error.
     #[default]
     Forever,
-}
-
-impl RunFor {
-    /// Whether the run has reached its bound, given the cycle just completed
-    /// and the engine time elapsed since the start.
-    pub fn done(&self, cycle: u32, elapsed: NanoTime) -> bool {
-        match self {
-            RunFor::Cycles(cycles) => cycle > *cycles,
-            RunFor::Duration(duration) => elapsed > NanoTime::from(*duration),
-            RunFor::Forever => false,
-        }
-    }
 }

--- a/crates/wingfoil/src/runtime/time.rs
+++ b/crates/wingfoil/src/runtime/time.rs
@@ -101,35 +101,54 @@ impl NanoTime {
             self.0 as i64 - Self::KDB_EPOCH_OFFSET_NANOS
         }
     }
-}
 
-impl From<u128> for NanoTime {
-    fn from(t: u128) -> Self {
-        NanoTime(t as RawTime)
+    /// A nanosecond count held in an `i64`, **clamping a negative input to
+    /// [`ZERO`](Self::ZERO)**.
+    ///
+    /// Narrow a `u128` nanosecond count, **saturating at
+    /// [`MAX`](Self::MAX)** rather than wrapping modulo 2^64.
+    ///
+    /// Private, and deliberately so: its only caller is
+    /// [`From<Duration>`](#impl-From<Duration>-for-NanoTime), where the `u128`
+    /// is forced on us by [`Duration::as_nanos`] — a `Duration` is 64 bits of
+    /// seconds plus 32 of nanos, which is wider than this type's `u64`. That
+    /// makes the narrowing an implementation detail of that one impl rather
+    /// than public vocabulary, so it is not exposed.
+    ///
+    /// There are deliberately **no public lossy constructors**. The `i64`,
+    /// `f64` and `u128` `From` impls this type used to carry were bare `as`
+    /// casts the compiler could insert at any `.into()` — `NanoTime::from(-1i64)`
+    /// silently became [`MAX`](Self::MAX), an instant 584 years in the *future*
+    /// — and named `_lossy` replacements for them were removed unused: every
+    /// one invented a policy (negatives to the epoch, `NaN` to the epoch) for a
+    /// caller that did not exist. A caller holding a signed or floating
+    /// nanosecond count should decide for itself what an out-of-range value
+    /// means and go through [`new`](Self::new) with a checked conversion, which
+    /// is total and says so.
+    fn from_nanos_u128_saturating(nanos: u128) -> Self {
+        Self(RawTime::try_from(nanos).unwrap_or(RawTime::MAX))
     }
 }
 
 impl From<u64> for NanoTime {
     fn from(t: u64) -> Self {
-        NanoTime(t as RawTime)
+        NanoTime(t)
     }
 }
 
-impl From<f64> for NanoTime {
-    fn from(t: f64) -> Self {
-        NanoTime(t as RawTime)
-    }
-}
-
-impl From<i64> for NanoTime {
-    fn from(t: i64) -> Self {
-        NanoTime(t as RawTime)
-    }
-}
-
+/// Exact for every [`Duration`] this type can represent — a nanosecond count
+/// either way, and `NanoTime`'s whole `u64` range is reachable.
+///
+/// It stays a `From` for that reason: unlike the `i64`/`f64`/`u128`
+/// conversions this type used to carry, nothing is reinterpreted or rounded. The single edge is a `Duration` longer than
+/// `u64::MAX` nanoseconds — about 584 years, which `Duration` can hold and
+/// `NanoTime` cannot — and that **saturates at [`NanoTime::MAX`]**. It used to
+/// wrap: the old body was `as_secs() as u64 * 1_000_000_000 + subsec`, which
+/// overflowed for `as_secs() > ~1.8e10` and, in release, silently produced a
+/// small instant from an enormous duration.
 impl From<Duration> for NanoTime {
     fn from(dur: Duration) -> Self {
-        Self(dur.as_secs() as RawTime * 1_000_000_000 + dur.subsec_nanos() as RawTime)
+        NanoTime::from_nanos_u128_saturating(dur.as_nanos())
     }
 }
 
@@ -144,6 +163,14 @@ impl From<NaiveDateTime> for NanoTime {
     }
 }
 
+/// **Lossy above 2^53 nanoseconds** (about 104 days past the epoch, so for
+/// every real wall-clock instant): `f64` has a 53-bit mantissa, and present-day
+/// timestamps are ~2^60 ns, where consecutive representable values are ~256 ns
+/// apart. Kept a `From` because it is an *outbound display* conversion with
+/// well-defined round-to-nearest behaviour — `f64::from(t) * SECONDS_PER_NANO`
+/// for a log line or a plot axis — not an `as`-cast reinterpretation. Do not
+/// round-trip a timestamp through it, and do not use it to compare instants;
+/// [`NanoTime`] is `Ord`.
 impl From<NanoTime> for f64 {
     fn from(t: NanoTime) -> Self {
         t.0 as f64
@@ -172,6 +199,17 @@ impl From<NanoTime> for Duration {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Arithmetic: plain `u64` arithmetic, deliberately unchecked.
+//
+// Every operator below is the raw `u64` operation on the nanosecond count, so
+// it inherits Rust's integer semantics exactly: **panic on overflow/underflow
+// in a debug build, wrap in a release build**. None of them saturate, and
+// none of them should start to — see `Sub`.
+// ---------------------------------------------------------------------------
+
+/// Overflows past [`NanoTime::MAX`] (~year 2554). Panics in debug, wraps in
+/// release, as `u64 + u64` does.
 impl Add<NanoTime> for NanoTime {
     type Output = Self;
     fn add(self, other: Self) -> Self::Output {
@@ -179,6 +217,7 @@ impl Add<NanoTime> for NanoTime {
     }
 }
 
+/// Adds a raw nanosecond count. Overflow behaves as [`Add<NanoTime>`].
 impl Add<RawTime> for NanoTime {
     type Output = Self;
     fn add(self, other: RawTime) -> Self::Output {
@@ -186,13 +225,42 @@ impl Add<RawTime> for NanoTime {
     }
 }
 
+/// Advances by a [`Duration`]. Overflow behaves as [`Add<NanoTime>`]; a
+/// `Duration` past `u64::MAX` nanoseconds saturates first, as
+/// [`From<Duration>`](NanoTime#impl-From<Duration>-for-NanoTime) does.
 impl Add<Duration> for NanoTime {
     type Output = Self;
     fn add(self, other: Duration) -> Self::Output {
-        Self(self.0 + other.as_nanos() as RawTime)
+        Self(self.0 + u64::from(NanoTime::from(other)))
     }
 }
 
+/// The elapsed nanoseconds from `other` to `self` — and **`self` must be the
+/// later instant**.
+///
+/// `NanoTime` is an unsigned count, so there is no negative difference to
+/// return. `a - b` where `b > a` is a `u64` underflow: it **panics in a debug
+/// build and wraps to a near-[`MAX`](NanoTime::MAX) value in a release build**.
+/// Order the operands, or use [`u64::abs_diff`] on the raw counts
+/// (`u64::from(a).abs_diff(u64::from(b))`) when either may be the later one.
+///
+/// **This is deliberately not saturating.** Every subtraction the engine itself
+/// performs is safe by construction — engine time advances strictly
+/// monotonically, so `ctx.time() - earlier` cannot go backwards, and the sites
+/// that difference *externally supplied* stamps guard the comparison before
+/// subtracting. Given that, a `saturating_sub` would buy nothing at those sites
+/// while turning a caller's genuine ordering bug into a silent `0` that reads
+/// as "no time passed at all" — a plausible-looking latency measurement that
+/// nothing downstream can tell from a real one. The loud debug panic is the
+/// better failure, so the sharp edge is documented rather than filed off.
+///
+/// ```
+/// # use wingfoil::NanoTime;
+/// let (a, b) = (NanoTime::new(300), NanoTime::new(100));
+/// assert_eq!(NanoTime::new(200), a - b);
+/// // `b - a` would panic in debug / wrap in release; difference the raw counts:
+/// assert_eq!(200, u64::from(b).abs_diff(u64::from(a)));
+/// ```
 impl Sub<NanoTime> for NanoTime {
     type Output = Self;
     fn sub(self, other: Self) -> Self::Output {
@@ -200,6 +268,9 @@ impl Sub<NanoTime> for NanoTime {
     }
 }
 
+/// Scales the count. Overflow behaves as [`Add<NanoTime>`]; a negative
+/// multiplier on the signed impls reinterprets as a huge unsigned one, so do
+/// not pass one.
 impl Mul<u32> for NanoTime {
     type Output = Self;
     fn mul(self, other: u32) -> Self::Output {
@@ -310,25 +381,68 @@ mod tests {
         assert_eq!(u64::from(NanoTime::from(raw)), raw);
     }
 
+    // `from_nanos_u128_saturating` is private and has exactly one caller
+    // (`From<Duration>`), but its edge is the one that used to be a silent
+    // ordering inversion — the old `impl From<u128>` truncated the high bits,
+    // so one nanosecond past `u64::MAX` became `0`. Pinned here rather than
+    // left to the `From<Duration>` test, because the saturation is the whole
+    // reason the helper exists.
+    //
+    // There is deliberately nothing to test for `i64` or `f64`: those
+    // conversions are gone entirely rather than renamed, so the only way to
+    // build a `NanoTime` from a signed or floating count is a checked
+    // conversion the caller writes and owns.
+
     #[test]
-    fn from_u128_truncates_to_u64() {
+    fn from_nanos_u128_saturating_is_exact_in_range_and_saturates_above_it() {
         let raw: u128 = 1_234_567_890;
-        let t = NanoTime::from(raw);
-        assert_eq!(u64::from(t), raw as u64);
+        assert_eq!(
+            raw as u64,
+            u64::from(NanoTime::from_nanos_u128_saturating(raw))
+        );
+        // Exactly representable, and one past it.
+        let max = u64::MAX as u128;
+        assert_eq!(
+            u64::MAX,
+            u64::from(NanoTime::from_nanos_u128_saturating(max))
+        );
+        assert_eq!(
+            NanoTime::MAX,
+            NanoTime::from_nanos_u128_saturating(max + 1),
+            "saturates rather than wrapping to 0 (what the old `as` cast did)"
+        );
+        assert_eq!(
+            NanoTime::MAX,
+            NanoTime::from_nanos_u128_saturating(u128::MAX)
+        );
     }
 
     #[test]
-    fn from_f64_truncates() {
-        let f: f64 = 1_000_000_000.0;
-        let t = NanoTime::from(f);
-        assert_eq!(u64::from(t), 1_000_000_000u64);
+    fn from_duration_is_exact_in_range_and_saturates_above_it() {
+        // Exact across the whole representable range, sub-second parts included.
+        for d in [
+            Duration::ZERO,
+            Duration::from_nanos(1),
+            Duration::new(1, 999_999_999),
+            Duration::from_nanos(u64::MAX),
+        ] {
+            assert_eq!(d.as_nanos(), u64::from(NanoTime::from(d)) as u128);
+        }
+        // A duration longer than ~584 years saturates. The old body computed
+        // `as_secs() as u64 * 1_000_000_000 + subsec`, which wrapped here.
+        assert_eq!(NanoTime::MAX, NanoTime::from(Duration::from_secs(u64::MAX)));
     }
 
     #[test]
-    fn from_i64_converts() {
-        let i: i64 = 500_000_000;
-        let t = NanoTime::from(i);
-        assert_eq!(u64::from(t), 500_000_000u64);
+    fn sub_is_exact_for_ordered_operands() {
+        // Documented contract: the left operand must be the later instant.
+        // Underflow is a debug panic / release wrap, deliberately not saturating.
+        assert_eq!(
+            NanoTime::ZERO,
+            NanoTime::new(7) - NanoTime::new(7),
+            "an equal pair differences to zero, not to a wrapped value"
+        );
+        assert_eq!(NanoTime::new(200), NanoTime::new(300) - NanoTime::new(100));
     }
 
     #[test]

--- a/crates/wingfoil/tests/catalog.rs
+++ b/crates/wingfoil/tests/catalog.rs
@@ -139,6 +139,44 @@ fn limit_caps_ticks() {
     assert_eq!(vec![1, 2, 3], r.value(&acc));
 }
 
+/// `limit` and `skip` count in `usize`, the catalog's uniform count type
+/// (`buffer`'s capacity, `fan`'s width, every rolling window). Both used to
+/// take `u32`, which made every *computed* bound a cast site — this test is
+/// written to fail to compile if either narrows again: the counts arrive as
+/// plain `usize` bindings, and one of them is past `u32::MAX`.
+#[test]
+fn limit_and_skip_count_in_usize() {
+    let g = GraphBuilder::new();
+    let keep: usize = 3;
+    let drop: usize = 2;
+    // Wider than a `u32` can hold, so it cannot be a narrowed count in
+    // disguise. It bounds nothing away in a 5-cycle run.
+    let unbounded: usize = u32::MAX as usize + 1;
+    let count = g.ticker(Duration::from_nanos(10)).count();
+    let limited = count.limit(keep).with_time().accumulate();
+    let skipped = count.skip(drop).with_time().accumulate();
+    let everything = count.limit(unbounded).accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 1u64),
+            (NanoTime::new(10), 2),
+            (NanoTime::new(20), 3),
+        ],
+        r.value(&limited)
+    );
+    assert_eq!(
+        vec![
+            (NanoTime::new(20), 3u64),
+            (NanoTime::new(30), 4),
+            (NanoTime::new(40), 5),
+        ],
+        r.value(&skipped)
+    );
+    assert_eq!(vec![1u64, 2, 3, 4, 5], r.value(&everything));
+}
+
 /// `skip` suppresses the first N then passes the rest — `limit`'s mirror, and
 /// new surface with no legacy twin, so this pins the contract outright rather
 /// than reproducing a legacy test. Each surviving value keeps its *original*

--- a/crates/wingfoil/tests/compiled_parity.rs
+++ b/crates/wingfoil/tests/compiled_parity.rs
@@ -133,7 +133,7 @@ fn compiled_odds_evens(run_for: RunFor) -> anyhow::Result<Vec<String>> {
             match <Filter<u64>>::cycle(
                 &mut (),
                 &mut odds_source_seen,
-                ((&v_count, t_count), (&v_is_odd, t_is_odd)),
+                ((&v_count, t_count), &v_is_odd),
                 &mut ctx,
             )? {
                 Tick::Value(v) => {
@@ -168,7 +168,7 @@ fn compiled_odds_evens(run_for: RunFor) -> anyhow::Result<Vec<String>> {
             match <Filter<u64>>::cycle(
                 &mut (),
                 &mut evens_source_seen,
-                ((&v_count, t_count), (&v_is_even, t_is_even)),
+                ((&v_count, t_count), &v_is_even),
                 &mut ctx,
             )? {
                 Tick::Value(v) => {

--- a/crates/wingfoil/tests/compiled_stateful_ops.rs
+++ b/crates/wingfoil/tests/compiled_stateful_ops.rs
@@ -249,3 +249,121 @@ fn try_join_error_aborts_both_engines() {
     let compiled_err = try_join_fails::compiled(HISTORICAL, RunFor::Cycles(3));
     assert!(compiled_err.is_err(), "compiled must abort on Err");
 }
+
+// --- delay / delay_with_reset: the `Duration` hoisted into `start` ----------
+//
+// `throttle`, `window`, `delay` and `delay_with_reset` all take their interval
+// as a `Duration` and convert it to engine nanoseconds **once, in `start`** —
+// the shape `TickerState` documents. `throttle` and `window` are covered
+// above; these two blocks cover the other pair, and they matter more than the
+// conversion's cost suggests.
+//
+// `delay_with_reset` in particular is wired through `DelayWithResetFwd`, a
+// forwarder that restates the real op's `In` in the two-edge form `#[op]` can
+// parse and then *delegates*. A delegating forwarder has to delegate `start`
+// too, and if it silently does not, the hoisted delay stays at its `Default`
+// of zero — i.e. every `delay_with_reset` in the tree degrades to a
+// pass-through. That failure is invisible to an interpreted-vs-compiled parity
+// assertion, because both tiers reach the op through the same forwarder and so
+// break together. Only an absolute expectation catches it, which is what these
+// pin.
+
+wingfoil::nitro! {
+    fn delay_values_and_times(g: &GraphBuilder) -> Stream<Vec<(NanoTime, u64)>> {
+        let acc = g
+            .ticker(PERIOD)
+            .count()
+            .delay(INTERVAL)
+            .with_time()
+            .accumulate();
+        acc
+    }
+}
+
+/// The 10ns counter ticks 1,2,3,… at t = 0,10,20,…; `delay(25ns)` re-emits each
+/// value 25ns later, so the delay's own schedule interleaves cycles at
+/// t = 25,35,45,… between the ticker's. Values are unchanged and every one is
+/// shifted by exactly the interval — a delay that had lost its interval (the
+/// hoist landing in the wrong place) would emit at the source's own times.
+#[test]
+fn delay_agrees_across_engines() {
+    assert_three_engines!(
+        delay_values_and_times,
+        RunFor::Cycles(8),
+        vec![
+            (NanoTime::new(25), 1u64),
+            (NanoTime::new(35), 2),
+            (NanoTime::new(45), 3),
+        ]
+    );
+}
+
+wingfoil::nitro! {
+    fn delay_with_reset_values_and_times(g: &GraphBuilder) -> Stream<Vec<(NanoTime, u64)>> {
+        let count = g.ticker(PERIOD).count();
+        // Ticks exactly once, when the count reaches 3 (t = 20ns).
+        let trigger = count.filter_value(|i: &u64| *i == 3);
+        let acc = count
+            .delay_with_reset(INTERVAL, &trigger)
+            .with_time()
+            .accumulate();
+        acc
+    }
+}
+
+/// Same counter and interval as [`delay_agrees_across_engines`], plus a reset
+/// that fires once at t=20 (count 3). The reset snaps the output to the *live*
+/// value and drops everything queued, so the two values already in flight
+/// (1 due at 25, 2 due at 35) never arrive; the delay resumes from the next
+/// upstream tick, putting count 4 (t=30) out at t=55.
+#[test]
+fn delay_with_reset_agrees_across_engines() {
+    assert_three_engines!(
+        delay_with_reset_values_and_times,
+        RunFor::Cycles(11),
+        vec![
+            (NanoTime::new(20), 3u64),
+            (NanoTime::new(55), 4),
+            (NanoTime::new(65), 5),
+        ]
+    );
+}
+
+// --- filter: the condition edge activates, the tick flag does not ----------
+
+wingfoil::nitro! {
+    fn filter_values_and_times(g: &GraphBuilder) -> Stream<Vec<(NanoTime, u64)>> {
+        // Source and condition tick on *different* schedules, so the condition
+        // ticks alone at t = 30 and t = 90.
+        let source = g.ticker(Duration::from_nanos(20)).count();
+        let condition = g
+            .ticker(Duration::from_nanos(30))
+            .count()
+            .map(|i: &u64| i.is_multiple_of(2));
+        let acc = source.filter(&condition).with_time().accumulate();
+        acc
+    }
+}
+
+/// `filter` declares no tick flag on its condition edge, and this is what
+/// proves it does not need one (#834). Resampling on a condition tick comes
+/// from that edge being *active* — the engine activates the node, and `cycle`
+/// re-emits the held source off the condition's current value. The entries at
+/// t=30 and t=90 are cycles in which the **source did not tick at all**: the
+/// condition flipped true on its own schedule and the held source value came
+/// out. If the flag were load-bearing, those two would be missing.
+///
+/// Source ticks 1..5 at t = 0,20,40,60,80; the condition is true from t=30
+/// (its 2nd tick) and from t=90 (its 4th).
+#[test]
+fn filter_resamples_on_condition_ticks_across_engines() {
+    assert_three_engines!(
+        filter_values_and_times,
+        RunFor::Cycles(7),
+        vec![
+            (NanoTime::new(30), 2u64),
+            (NanoTime::new(40), 3),
+            (NanoTime::new(90), 5),
+        ]
+    );
+}

--- a/crates/wingfoil/tests/spawn.rs
+++ b/crates/wingfoil/tests/spawn.rs
@@ -20,10 +20,10 @@ use wingfoil::{NanoTime, RunFor, RunMode};
 #[test]
 fn spawn_source_replays_deterministically_in_historical_mode() {
     let period = Duration::from_millis(10);
-    let n = 6u64;
+    let n = 6usize;
 
     let g = GraphBuilder::new();
-    let counts: Stream<Burst<u64>> = g.spawn(move |wg| wg.ticker(period).count().limit(n as u32));
+    let counts: Stream<Burst<u64>> = g.spawn(move |wg| wg.ticker(period).count().limit(n));
     let scaled = counts
         .map(|b: &Burst<u64>| b.iter().map(|x| x * 10).collect::<Vec<u64>>())
         .with_time();
@@ -58,10 +58,10 @@ fn spawn_source_replays_deterministically_in_historical_mode() {
 #[test]
 fn spawn_source_delivers_all_values_in_realtime() {
     let period = Duration::from_millis(2);
-    let n = 6u64;
+    let n = 6usize;
 
     let g = GraphBuilder::new();
-    let counts: Stream<Burst<u64>> = g.spawn(move |wg| wg.ticker(period).count().limit(n as u32));
+    let counts: Stream<Burst<u64>> = g.spawn(move |wg| wg.ticker(period).count().limit(n));
     let collected = counts.accumulate();
     let mut runner = g.build();
 
@@ -83,10 +83,10 @@ fn spawn_source_delivers_all_values_in_realtime() {
 #[test]
 fn spawn_map_replays_deterministically_in_historical_mode() {
     let period = Duration::from_millis(10);
-    let n = 5u64;
+    let n = 5usize;
 
     let g = GraphBuilder::new();
-    let input = g.ticker(period).count().limit(n as u32); // 1..5 at 0,p,2p,3p,4p
+    let input = g.ticker(period).count().limit(n); // 1..5 at 0,p,2p,3p,4p
     let scaled: Stream<Burst<u64>> =
         input.spawn_map(|s: Stream<Burst<u64>>| s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10));
     let collected = scaled
@@ -118,10 +118,10 @@ fn spawn_map_replays_deterministically_in_historical_mode() {
 #[test]
 fn spawn_map_delivers_all_values_in_realtime() {
     let period = Duration::from_millis(2);
-    let n = 5u64;
+    let n = 5usize;
 
     let g = GraphBuilder::new();
-    let input = g.ticker(period).count().limit(n as u32);
+    let input = g.ticker(period).count().limit(n);
     let scaled: Stream<Burst<u64>> =
         input.spawn_map(|s: Stream<Burst<u64>>| s.map(|b: &Burst<u64>| b.iter().sum::<u64>() * 10));
     let collected = scaled.accumulate();
@@ -147,7 +147,7 @@ fn spawn_map_delivers_all_values_in_realtime() {
     // order, grouped arbitrarily. Each output is `sum(group) * 10` over a
     // contiguous run of the input, so walking the expected counts and
     // consuming one run per output must reproduce the input exactly.
-    let mut expected = 1..=n;
+    let mut expected = 1..=n as u64;
     for value in &flat {
         assert_eq!(
             0,
@@ -175,12 +175,12 @@ fn spawn_map_delivers_all_values_in_realtime() {
 #[test]
 fn bounded_spawn_and_spawn_map_match_the_unbounded_result() {
     let period = Duration::from_millis(10);
-    let n = 5u64;
+    let n = 5usize;
 
     let g = GraphBuilder::new();
     // Bound the producer→graph channel to 2 (worker blocks if it gets >2 ahead).
     let counts: Stream<Burst<u64>> =
-        g.spawn_bounded(Some(2), move |wg| wg.ticker(period).count().limit(n as u32));
+        g.spawn_bounded(Some(2), move |wg| wg.ticker(period).count().limit(n));
     let flat = counts.map(|b: &Burst<u64>| b.iter().sum::<u64>());
     // Bound both worker channels to 2 as well.
     let scaled: Stream<Burst<u64>> = flat.spawn_map_bounded(Some(2), |s: Stream<Burst<u64>>| {

--- a/docs/release-notes/9.0.0.md
+++ b/docs/release-notes/9.0.0.md
@@ -143,8 +143,11 @@ runner.run(RunMode::RealTime, RunFor::Cycles(100))?;
 
 `Rc<dyn Stream<T>>` becomes `Stream<T>`, a cheap `Clone` handle;
 `node.peek_value()` becomes `runner.value(&handle)`. `RunMode`, `RunFor` and
-`NanoTime` are **unchanged** — literally the same types, since both engines
-share one runtime core.
+`NanoTime` keep their shape — both engines share one runtime core, so the
+variants, the arithmetic and the wire representation are all as they were. Two
+narrow removals on those types are listed under
+[what is gone](#what-is-gone): `RunFor::done` and three of `NanoTime`'s
+`From` impls.
 
 **3. Rewrite custom nodes from `#[node]` to `Op`.** State and config become
 associated types, inputs arrive as parameters, and scheduling is declared:
@@ -268,6 +271,19 @@ debug-only helper. Nothing in the engine blocks bringing it back — the builder
 holds the full topology plus debug labels — so if you depend on it, say so and
 it can come back as part of that work.
 
+**`RunFor::done`** — the "has the run finished?" predicate on the run bound. It
+had no callers in the tree and, more to the point, it disagreed with the engine:
+its cycle test was `cycle > cycles` where `Kernel::begin_cycle` uses
+`cycles >= end`, so anything that had started trusting it would have run one
+cycle long. `RunFor` now only *declares* the bound; the single implementation of
+evaluating it lives in the kernel. Nothing needs to replace this — the runner
+already stops at the bound you gave it.
+
+**`limit` and `skip` count in `usize`**, not `u32` — matching `buffer`'s
+capacity, `fan`'s width and every rolling window in the catalog. Literal call
+sites (`.limit(3)`) are unaffected; a call site that had converted on the way in
+(`.limit(n as u32)`) drops the conversion.
+
 **`collapse` iterates its input by reference.** Its bound narrowed from
 `T: Clone + IntoIterator<Item = OUT>` to
 `for<'b> &'b T: IntoIterator<Item = &'b OUT>`, so it clones the one item it
@@ -276,6 +292,35 @@ a clone per item, spent exactly when a burst has grown under producer load,
 which is the case the op exists for. `Burst<T>` and `Vec<T>` both satisfy the
 new bound through their slice iterators, so ordinary call sites are unaffected;
 a container that implements `IntoIterator` only by value no longer compiles.
+
+**Three of `NanoTime`'s `From` impls** — `From<i64>`, `From<f64>` and
+`From<u128>`, with **no replacement**. Each body was a bare `as` cast, which
+meant a conversion the compiler could insert at any `.into()` could silently
+reinterpret its input: `NanoTime::from(-1i64)` was `NanoTime::MAX`, an instant
+584 years in the *future*.
+
+`NanoTime` is a `u64` nanosecond count since the epoch, so there is no total,
+faithful conversion from a signed or floating count — and rather than ship
+`_lossy`-suffixed replacements, we dropped them. A named lossy constructor
+still has to invent a policy (negatives to the epoch, `NaN` to the epoch) on
+behalf of a caller who is better placed to choose one. If you have an `i64` or
+`f64` nanosecond count, decide what an out-of-range value means for your feed
+and go through the total path:
+
+```rust
+NanoTime::new(u64::try_from(n)?)          // i64, rejecting negatives
+NanoTime::new(x.max(0.0) as u64)          // f64, if clamping is what you want
+```
+
+`From<u64>`, `From<Duration>` and `From<NaiveDateTime>` are untouched and stay
+the ergonomic path — every remaining conversion into `NanoTime` is total.
+(`From<Duration>` also stopped wrapping for durations past ~584 years; it
+saturates. `Duration::as_nanos` is a `u128`, so that narrowing still happens,
+but it is now a private detail of that impl rather than public surface.)
+Subtraction is documented but deliberately unchanged — `a - b` with `b > a`
+still panics in debug and wraps in release rather than saturating, because a
+silent `0` reads as a real "no time passed" measurement and a loud failure does
+not.
 
 If you find anything else 8.x did that 9.0 cannot, that is a bug in the port,
 not an intended break. Please


### PR DESCRIPTION
## What this changes

All five items of #834. Counts are `usize` like every other count in the tree, the `NanoTime` conversions that could silently reinterpret their input are gone, and a dead public method that disagreed with the kernel is deleted.

Closes #834.

## Why

**Three of the five are semver-major, and 9.0.0 is unpublished** (last tag `v8.0.0`). This is the last window in which they are free; after `bump.yml` runs each costs a 10.0.0. The two non-breaking items ride along so the issue closes outright.

| Item | Breaking | Change |
|---|---|---|
| `RunFor::done` | yes | deleted — zero callers, and off by one against the kernel |
| `NanoTime`'s lossy `From` impls | yes | deleted, **no replacement** |
| `limit` (and `skip`) | yes | `u32` → `usize` |
| `Filter`'s condition tick flag | no | declared but never read; cost a `__ticked.borrow()` per activation |
| Four per-cycle `Duration` conversions | no | hoisted to `start`, as `TickerState` documents |

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all` — both clean
- [x] `cargo test -p wingfoil --all-features` — 81 suites green
- [x] `cargo test -p wingfoil-derive` — 3 passed
- [x] `cargo test --doc -p wingfoil --all-features` — 19 passed
- [x] Python: `maturin develop` + `pytest` — 355 passed, 28 skipped
- [x] New behaviour covered by tests asserting **values and tick times**

The only failures are the `*_integration.rs` suites needing Docker; an `awk` over the log confirms zero failures outside those files. They run in their own workflows — and this branch's CI has since gone green on the real **etcd integration suite** too.

## Notes for the reviewer

**`NanoTime`'s lossy conversions are deleted outright rather than renamed.** `From<i64>`, `From<f64>` and `From<u128>` were bare `as` casts the compiler could insert at any `.into()` — `NanoTime::from(-1i64)` silently became `MAX`, an instant 584 years in the *future*.

Named `_lossy` constructors were written first and then removed, because nothing in the tree called the `i64` or `f64` ones and each had to **invent a policy** (negatives to the epoch, `NaN` to the epoch) on behalf of a caller better placed to choose. `NanoTime` is a `u64` count since the epoch, so a caller holding a signed or floating count should decide what out-of-range means for their feed and go through `NanoTime::new` with a checked conversion, which is total. Every remaining conversion *into* `NanoTime` is now total.

The `u128` narrowing survives as a **private** `from_nanos_u128_saturating`, because `Duration::as_nanos` forces it — a `Duration` is 64 bits of seconds plus 32 of nanos, wider than this type — making it an implementation detail of `From<Duration>` rather than public vocabulary. It still saturates where the old impl truncated the high bits and turned one nanosecond past `u64::MAX` into `0`, an ordering inversion; that edge stays pinned by a test.

**Two findings the issue did not predict:**

1. **Overriding `start` obliges every op generic to appear in `Cfg` or `State`.** `#[op]` emits a real `start` forwarder only when `start` is overridden, and the compiled tiers call it with nothing but `Cfg`/`State` to infer from — so adding `start` to `Throttle` broke every `nitro!` call site with `E0282`. Fixed by anchoring with `PhantomData`.

2. **`DelayWithResetFwd` needed `start` delegated too, and a parity test cannot catch that.** Without the delegation every `delay_with_reset` silently degrades to a pass-through — and because all three tiers reach the op through the *same* forwarder, they break identically, so an interpreted-vs-compiled assertion stays green. Confirmed by deleting the delegation and watching the new test fail.

**One correction to the issue.** It lists `From<Duration>` as truncating. It isn't — both sides are nanosecond counts and the conversion is exact across `NanoTime`'s entire range. Its only edge was *overflow* past ~584 years, where the old body wrapped; it now saturates. Kept.

**`Sub` is documented, not changed** — deliberately. A saturating `Sub` returns `0`, indistinguishable from a genuine zero-elapsed latency measurement, converting a loud debug panic into a plausible wrong number.

**`skip` was widened alongside `limit`** though #834 doesn't mention it: it sits beside `limit` in `fluent.rs` with identical `u32` `Cfg`/`State`, so fixing one and leaving the other reproduces the inconsistency item 4 exists to remove. Approved as scope.

**`docs/release-notes/9.0.0.md` claimed `RunMode`, `RunFor` and `NanoTime` were unchanged**, which these removals falsify. Corrected, with the migration path for callers who had an `i64`/`f64` nanosecond count.

**The `/new-op` skill gained three rules** per CLAUDE.md's living-document requirement: the tick-flag cost, `start`-obliges-generic-anchoring, and the delegating-forwarder trap with its parity-can't-catch-this caveat.