### PR TITLE
ops: make collapse iterate its input by reference

### DIFF
--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -284,6 +284,35 @@ Rules the existing ops encode — follow them:
   examples (repo-wide rule).
 - **Doc every public item.** `#[op]`-scoped ops get a `Builder::$ARGUMENTS`
   method whose docs are the witness type's docs — write them for a caller.
+- **Prefer a reference bound on an input the op only reads.** An op whose input
+  is a container (`Burst<T>`, `Vec<T>`) and whose `cycle` needs one item out of
+  it should bound `for<'b> &'b T: IntoIterator<Item = &'b OUT>` and iterate the
+  borrow — not `T: Clone + IntoIterator<Item = OUT>`, which clones the whole
+  container and discards all but what it emits. That costs an allocation plus a
+  clone per item, and it lands **exactly under producer load**: bursts are
+  single-item until a producer outruns the cycle, so a quiet test never shows
+  it. `Collapse` is the worked example (#824).
+
+  **A bound on an op's inputs threads itself — the fluent *declaration* does
+  not.** `#[op]` copies the impl's whole `where` clause into one shared
+  predicate list used by every generated surface (the `nitro!` forwarders, the
+  `Builder` method, `__wf_fluent_<name>!`, `__wf_signal_<name>!`); HRTBs and
+  associated-type bindings survive verbatim, and the receiver's ident is
+  rewritten to the macro's `$t` inside them. So there is nothing to change in
+  `wingfoil-derive`. What you **must** update in the same commit is the
+  hand-written trait declaration in `fluent.rs`, because rustc checks the
+  generated body against it — a stale bound there fails with *"the requirement
+  `T: X` appears on the `impl`'s method but not on the corresponding trait's
+  method … originates in the macro `__wf_fluent_<name>`"*. That error is the
+  macro working; do not widen the generator to silence it.
+
+  Cover such a change on **all three tiers** and for every container shape the
+  op claims to accept. `<&Burst<T> as IntoIterator>::Item` is `&T` via tinyvec's
+  slice iterator, same as `Vec<T>` — but confirm rather than assume, and note
+  that `&Burst<T>: IntoIterator` implies `T: Default` (tinyvec's `Array`
+  bound). Where the point of the change is *how much* work an op does, pin it
+  with a payload whose `Clone` increments a counter, and sanity-check the
+  assertion by making the op clone per item and watching it fail.
 
 ## 4. The fluent method — declaration by hand, body usually generated
 

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -1171,9 +1171,15 @@ pub trait StreamOps<T>: Sized {
     /// bursts are single-item until a producer outruns the graph cycle, so the
     /// loss never shows up in a quiet test. See [`ops::Collapse`](crate::ops::Collapse)
     /// for the burst-shaped alternatives to reach for instead.
+    ///
+    /// The receiver is iterated by **reference** (`for<'b> &'b T:
+    /// IntoIterator<Item = &'b OUT>`), so only the emitted item is cloned —
+    /// [`Burst<T>`](crate::Burst) and `Vec<T>` both satisfy that through their
+    /// slice iterators.
     fn collapse<OUT>(&self) -> Stream<OUT>
     where
-        T: Clone + IntoIterator<Item = OUT> + 'static,
+        T: 'static,
+        for<'b> &'b T: IntoIterator<Item = &'b OUT>,
         OUT: Clone + Default + 'static;
 
     /// Run a side-effecting (fallible) closure on each tick — the graph's

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -364,12 +364,31 @@ where
 /// Promoted out of fluent-only sugar over [`MapFilter`] for the same reason as
 /// [`Not`] — the quiet-on-empty rule is a real tick-suppression contract, and
 /// it now lives in one place that every engine executes.
+///
+/// # It iterates the input by **reference**, and that is load-bearing
+///
+/// The bound is `for<'b> &'b T: IntoIterator<Item = &'b OUT>`, not
+/// `T: Clone + IntoIterator<Item = OUT>`, so `cycle` walks a borrow of the
+/// input and clones **one** item — the one it emits. Cloning the whole
+/// container to keep its last element cost an allocation plus one clone per
+/// item the moment a [`Burst`](crate::Burst) spilled its inline slot, which is
+/// exactly the ingest-under-load case this op documents above: bursts are
+/// single-item until a producer outruns the cycle, so the old cost spiked
+/// precisely when the graph was busiest. Do not "simplify" this back to an
+/// owning `into_iter`.
+///
+/// [`Burst<T>`](crate::Burst) (a `TinyVec<[T; 1]>`) and `Vec<T>` both satisfy
+/// the reference bound through their slice iterators, so every in-tree caller
+/// is unaffected. An exotic container that implements `IntoIterator` only by
+/// value no longer compiles — a deliberate, breaking narrowing taken while
+/// 9.0.0 was unpublished.
 pub struct Collapse<T, OUT>(PhantomData<(T, OUT)>);
 
 #[op(build = collapse, fluent)]
 impl<T, OUT> Op for Collapse<T, OUT>
 where
-    T: Clone + IntoIterator<Item = OUT> + 'static,
+    T: 'static,
+    for<'b> &'b T: IntoIterator<Item = &'b OUT>,
     OUT: Clone + 'static,
 {
     type Cfg = ();
@@ -384,8 +403,8 @@ where
         input: (&T,),
         _ctx: &mut Ctx<'_>,
     ) -> Result<Tick<OUT>> {
-        Ok(match input.0.clone().into_iter().last() {
-            Some(last) => Tick::Value(last),
+        Ok(match input.0.into_iter().last() {
+            Some(last) => Tick::Value(last.clone()),
             None => Tick::Quiet,
         })
     }

--- a/crates/wingfoil/tests/catalog_not_collapse.rs
+++ b/crates/wingfoil/tests/catalog_not_collapse.rs
@@ -12,10 +12,11 @@
 //! tick-suppression contract, not just a value mapping, so the tests assert
 //! tick *times* and not merely values.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use wingfoil::prelude::*;
-use wingfoil::{NanoTime, RunFor, RunMode};
+use wingfoil::{Burst, NanoTime, RunFor, RunMode};
 
 const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
 const P: Duration = Duration::from_nanos(100);
@@ -147,4 +148,166 @@ fn collapse_works_on_a_burst() {
     r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
     // Same-instant values ride one burst; collapse takes its last item.
     assert_eq!(vec![2, 3], r.value(&last));
+}
+
+// --- collapse: borrow-iteration (#824) ------------------------------------
+//
+// `Collapse::cycle` iterates a **borrow** of its input
+// (`for<'b> &'b T: IntoIterator<Item = &'b OUT>`) and clones only the item it
+// emits, where it used to clone the whole container and throw all but the last
+// element away. The tests below pin the two halves of that:
+//
+// * behaviour is unchanged for both container shapes — `Burst<T>` (the ingest
+//   shape, a `TinyVec<[T; 1]>`) and `Vec<T>` — at single-item, multi-item and
+//   empty payloads, on **all three engines**. The bound has to be threaded
+//   through the `#[op]`-generated builder/fluent/`nitro!` forwarders as well as
+//   `cycle`, and a forwarder-bound mistake shows up in the compiled tiers, not
+//   the interpreted one;
+// * the clone count itself, which is the point of the change.
+
+/// Assert `interpreted() == compiled() == nested()` for a self-contained
+/// (source) graph module whose single output is an accumulated sequence — the
+/// three-engine pattern from `compiled_stateful_ops.rs`. The nested check
+/// mounts the graph as a source island in an outer interpreted graph.
+macro_rules! assert_three_engines {
+    ($module:ident, $run_for:expr, $expected:expr) => {{
+        let run_for = $run_for;
+
+        let (mut runner, out) = $module::interpreted();
+        runner.run(HISTORICAL, run_for).unwrap();
+        let interpreted = runner.value(out);
+        assert_eq!($expected, interpreted, "interpreted value mismatch");
+
+        let (compiled,) = $module::compiled(HISTORICAL, run_for).unwrap();
+        assert_eq!(interpreted, compiled, "compiled must match interpreted");
+
+        let g = GraphBuilder::new();
+        let island = $module::nested(&g);
+        let mut r = g.build();
+        r.run(HISTORICAL, run_for).unwrap();
+        assert_eq!(
+            interpreted,
+            r.value(&island),
+            "nested island must match interpreted"
+        );
+    }};
+}
+
+wingfoil::nitro! {
+    fn collapse_vec_timed(g: &GraphBuilder) -> Stream<Vec<(NanoTime, u64)>> {
+        let acc = g
+            .ticker(P)
+            .count()
+            // count % 3: 0 -> empty, 1 -> one item, 2 -> three items.
+            .map(|i: &u64| match i % 3 {
+                0 => Vec::new(),
+                1 => vec![*i * 10],
+                _ => vec![*i * 10, *i * 10 + 1, *i * 10 + 2],
+            })
+            .collapse()
+            .with_time()
+            .accumulate();
+        acc
+    }
+}
+
+wingfoil::nitro! {
+    fn collapse_burst_timed(g: &GraphBuilder) -> Stream<Vec<(NanoTime, u64)>> {
+        let acc = g
+            .ticker(P)
+            .count()
+            // The identical payloads as `collapse_vec_timed`, burst-shaped:
+            // empty, inline (one item, no spill), spilled (three items).
+            .map(|i: &u64| -> Burst<u64> {
+                match i % 3 {
+                    0 => wingfoil::burst![],
+                    1 => wingfoil::burst![*i * 10],
+                    _ => wingfoil::burst![*i * 10, *i * 10 + 1, *i * 10 + 2],
+                }
+            })
+            .collapse()
+            .with_time()
+            .accumulate();
+        acc
+    }
+}
+
+/// The counter ticks 1..6 at t = 0,100,…,500. Counts 3 and 6 carry an empty
+/// container and are suppressed; the rest emit their **last** item at the
+/// source's own instant.
+fn collapse_expected() -> Vec<(NanoTime, u64)> {
+    vec![
+        (NanoTime::new(0), 10),   // count 1, one item  -> 10
+        (NanoTime::new(100), 22), // count 2, three     -> 22
+        (NanoTime::new(300), 40), // count 4, one item  -> 40
+        (NanoTime::new(400), 52), // count 5, three     -> 52
+    ]
+}
+
+#[test]
+fn collapse_on_vec_agrees_across_engines() {
+    assert_three_engines!(collapse_vec_timed, RunFor::Cycles(6), collapse_expected());
+}
+
+#[test]
+fn collapse_on_burst_agrees_across_engines() {
+    assert_three_engines!(collapse_burst_timed, RunFor::Cycles(6), collapse_expected());
+}
+
+/// `Burst` and `Vec` are not merely each correct — they are *identical*, item
+/// for item and instant for instant, over the same payloads.
+#[test]
+fn collapse_agrees_between_burst_and_vec() {
+    let (mut vr, vout) = collapse_vec_timed::interpreted();
+    vr.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    let (mut br, bout) = collapse_burst_timed::interpreted();
+    br.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(vr.value(vout), br.value(bout));
+}
+
+/// A payload that counts its own clones, so "one clone per tick, not one per
+/// item" is a pinned fact rather than a claim about speed.
+///
+/// Only this test constructs a `Counted`, so the process-wide counter is not
+/// shared with the parallel tests around it.
+#[derive(Debug, Default, PartialEq)]
+struct Counted(u64);
+
+static CLONES: AtomicUsize = AtomicUsize::new(0);
+
+impl Clone for Counted {
+    fn clone(&self) -> Self {
+        CLONES.fetch_add(1, Ordering::Relaxed);
+        Self(self.0)
+    }
+}
+
+/// `collapse` clones the **one** item it emits, not the whole container: four
+/// items per tick over three ticks is three clones, where cloning the input
+/// first would be twelve.
+#[test]
+fn collapse_clones_only_the_item_it_emits() {
+    let g = GraphBuilder::new();
+    let last = g
+        .ticker(P)
+        .count()
+        // Four freshly *constructed* (not cloned) items per tick.
+        .map(|i: &u64| {
+            vec![
+                Counted(*i),
+                Counted(*i * 10),
+                Counted(*i * 100),
+                Counted(*i * 1000),
+            ]
+        })
+        .collapse()
+        // Read the payload out by reference so the tail adds no clones of its
+        // own — `accumulate` on a `Counted` would.
+        .map(|c: &Counted| c.0)
+        .accumulate();
+    let mut r = g.build();
+    CLONES.store(0, Ordering::Relaxed);
+    r.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+    assert_eq!(vec![1000, 2000, 3000], r.value(&last));
+    assert_eq!(3, CLONES.load(Ordering::Relaxed));
 }

--- a/docs/release-notes/9.0.0.md
+++ b/docs/release-notes/9.0.0.md
@@ -268,6 +268,15 @@ debug-only helper. Nothing in the engine blocks bringing it back — the builder
 holds the full topology plus debug labels — so if you depend on it, say so and
 it can come back as part of that work.
 
+**`collapse` iterates its input by reference.** Its bound narrowed from
+`T: Clone + IntoIterator<Item = OUT>` to
+`for<'b> &'b T: IntoIterator<Item = &'b OUT>`, so it clones the one item it
+emits rather than the whole container it then throws away — an allocation plus
+a clone per item, spent exactly when a burst has grown under producer load,
+which is the case the op exists for. `Burst<T>` and `Vec<T>` both satisfy the
+new bound through their slice iterators, so ordinary call sites are unaffected;
+a container that implements `IntoIterator` only by value no longer compiles.
+
 If you find anything else 8.x did that 9.0 cannot, that is a bug in the port,
 not an intended break. Please
 [open an issue](https://github.com/wingfoil-io/wingfoil/issues).


### PR DESCRIPTION
## What this changes

`collapse` clones the one item it emits instead of the whole container it then throws away.

Closes #824.

## Why

`Collapse::cycle` was `input.0.clone().into_iter().last()` — a deep clone of the whole iterable (an allocation plus one clone per item once a `Burst` spills its inline slot), with everything but the last element dropped.

For the common inline single-item `Burst` that clone is the one the output needs anyway, so **the waste appears exactly when bursts grow past one item** — i.e. under producer load on the adapter ingest bridge, which is the op's documented use. A quiet test never shows it.

The bound narrows from `T: Clone + IntoIterator<Item = OUT>` to `for<'b> &'b T: IntoIterator<Item = &'b OUT>`; `T: Clone` and `T: IntoIterator` are both gone. **This is technically breaking** for a container implementing `IntoIterator` only by value, which is why it lands while 9.0.0 is unpublished rather than costing a 10.0.0.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all` — both clean, on this branch standing alone off `main`
- [x] `cargo test -p wingfoil --all-features` — 999 passed
- [x] `cargo test --doc -p wingfoil --all-features` — 17 passed, no fence broke on the bound
- [x] New behaviour covered by tests asserting **values and tick times**

The 64 failures in the all-features run are all `*_integration.rs`: 60 Docker (`Socket not found: /var/run/docker.sock`), 4 `zmq_cross_lang` needing `maturin develop`. No non-environmental failures.

## Notes for the reviewer

**`Burst` and `Vec` behave identically**, confirmed rather than assumed. tinyvec's `impl<'a, A: Array> IntoIterator for &'a TinyVec<A>` yields `Item = &'a A::Item`, so `Item = &'b OUT` unifies for both. Note its `A: Array` requirement means `&Burst<T>: IntoIterator` implies `T: Default` — already demanded by the fluent surface, so nothing new is asked of callers.

**The derive needed no change, and that is the interesting part.** `#[op]` already copies the impl's whole `where` clause into the single shared predicate list behind the `nitro!` forwarders, the `Builder` method and the fluent/signal macros, and a HRTB survives that verbatim. What *must* move with it is the hand-written trait declaration in `fluent.rs` — rustc checks the generated body against it. Leaving the old bound there fails with:

```
note: the requirement `T: IntoIterator` appears on the `impl`'s method `collapse`
      but not on the corresponding trait's method
 = note: this error originates in the macro `__wf_fluent_collapse`
```

That error is the macro working, not a macro gap. Confirmed by deliberately leaving the old bound in place and reading it.

**The clone reduction is a pinned fact, not a claim.** `collapse_clones_only_the_item_it_emits` uses a payload whose `Clone` bumps an `AtomicUsize`: four items per tick across three ticks asserts **exactly 3 clones** where the old body made 12. The assertion was sanity-checked by restoring the per-item clone and watching it fail. No benchmark — the counter is exact where a timing bar would not be.

Coverage spans all three tiers (`interpreted` / `compiled()` / `nested()`) for both container types across empty, single-item and spilled payloads, plus a test asserting the two containers agree with each other.

**The `/new-op` skill gained the rule** per CLAUDE.md's living-document requirement: prefer a reference bound on a read-only container input, and the note that such bounds thread themselves through the generated surfaces while the hand-written fluent declaration does not.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wQjYrfk8RpF3TQFjeii7)_