### PR TITLE
python: rename Stream.not to neg, which is what it actually does

### DIFF
--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -223,7 +223,7 @@ I/O sources are module-level functions taking the graph first — see
 | `.fold(init, f)` | Fold into an accumulator seeded from `init`, emitting it after each fold. |
 | `.reduce(f)` | Like `fold`, but the first value seeds the accumulator. |
 | `.difference()` | Emit `value - previous` (quiet on the first). |
-| `getattr(s, 'not')()` | Arithmetic negation (`5 -> -5`). The method name is the Python keyword `not`, so reach it with `getattr`. |
+| `.neg()` | Arithmetic negation — Python `-value` / `__neg__` (`5 -> -5`). **Not** a logical `not` (`True -> -1`, not `False`) and **not** a bitwise `~` (`5 -> -5`, not `-6`); for those use `.map(lambda v: not v)` or `.map(lambda v: ~v)`. |
 | `.bimap(other, f)` | Combine two streams through `f(this, other)`, whenever either ticks. |
 
 ### Gating and rate control

--- a/crates/wingfoil-python/docs/api.rst
+++ b/crates/wingfoil-python/docs/api.rst
@@ -37,8 +37,20 @@ duration_nanos=None, realtime=False, start_nanos=0)``.
 **Stream combinators (methods on** :class:`~wingfoil.Stream` **)**:
 
 *Transform* — ``map``, ``filter_map``, ``fold``, ``reduce``, ``bimap``,
-``difference``, ``not`` (a Python keyword — reach it with
-``getattr(stream, "not")()``), ``split``.
+``difference``, ``neg`` (arithmetic negation, ``__neg__`` — see below),
+``split``.
+
+.. note::
+
+   ``neg`` is **arithmetic** negation: ``5`` becomes ``-5``. It is not a
+   logical ``not`` (``True`` becomes ``-1``, an ``int``, not ``False``) and
+   not a bitwise ``~`` (that would give ``-6``). Reach those with
+   ``stream.map(lambda v: not v)`` and ``stream.map(lambda v: ~v)``.
+
+   It was called ``not`` before 9.0.0, after the engine op it wires
+   (``std::ops::Not``) rather than the operation it performs. Renamed in
+   9.0.0 with no alias — ``getattr(stream, "not")()`` now raises
+   ``AttributeError``.
 
 *Gate* — ``filter`` (gates on another *stream*'s current value), ``filter_value``
 (gates on a *predicate* — this is legacy's ``filter``), ``filter_none``,

--- a/crates/wingfoil-python/docs/migration.rst
+++ b/crates/wingfoil-python/docs/migration.rst
@@ -144,8 +144,16 @@ Changed or added:
        ``reduce``, ``filter_map``, ``filter_value``, ``filter_none``,
        ``drop_small_change``, ``split``, ``print``
 
-``not`` is still spelled ``not`` (it is a Python keyword, so reach it with
-``getattr(stream, "not")()``), and it is arithmetic negation, as in legacy.
+Legacy's ``not`` is now ``neg``. The **behaviour is unchanged** — it was
+arithmetic negation in legacy (``__neg__``, ``5 -> -5``) and still is; only
+the name moved, because ``not`` described neither what it does nor what a
+Python reader assumes. ``True`` becomes ``-1``, not ``False``. For logical
+negation use ``stream.map(lambda v: not v)``; for bitwise complement,
+``stream.map(lambda v: ~v)``.
+
+The rename is clean: there is no ``not`` alias, so a legacy
+``getattr(stream, "not")()`` raises ``AttributeError`` rather than silently
+doing something other than its name.
 
 Windowed statistics
 -------------------

--- a/crates/wingfoil-python/src/element.rs
+++ b/crates/wingfoil-python/src/element.rs
@@ -121,6 +121,12 @@ impl PartialEq for PyElement {
     }
 }
 
+// Deliberately arithmetic: this impl wears `std::ops::Not`'s name because that
+// is the trait the `Not` op's bound requires, but its body is `__neg__`, so a
+// Python value goes 5 -> -5 rather than Rust's !5 == -6. The Python method it
+// backs is named `neg` for that reason; do not "fix" this to `__invert__`
+// without renaming the method and the op, since the arithmetic behaviour is
+// what the binding has always had and is now pinned by tests.
 impl std::ops::Not for PyElement {
     type Output = PyElement;
 
@@ -129,7 +135,7 @@ impl std::ops::Not for PyElement {
             let res = self
                 .object()
                 .call_method0(py, "__neg__")
-                .expect("invariant: PyElement value must support __neg__ for `not`/`!`");
+                .expect("invariant: PyElement value must support __neg__ for `neg`");
             PyElement::new(res)
         })
     }

--- a/crates/wingfoil-python/src/graph.rs
+++ b/crates/wingfoil-python/src/graph.rs
@@ -445,10 +445,30 @@ impl PyStream {
         self.wrap(self.stream.difference())
     }
 
-    /// Negate each value with [`PyElement`]'s `Not`, which maps to Python
-    /// `__neg__` (arithmetic negation, e.g. `5 -> -5`) — matching the legacy
-    /// `not` node's `T: Not` semantics. Named `not` on the Python side.
-    pub fn not_(&self) -> PyStream {
+    /// Negate each value **arithmetically** — Python `-value` (`__neg__`), so
+    /// `5 -> -5` and `5.0 -> -5.0`. Exposed to Python as `neg`.
+    ///
+    /// # The name is `neg` because that is what it does (issue #456)
+    ///
+    /// This wires the engine's [`Not`](wingfoil::ops::Not) op, whose bound is
+    /// `std::ops::Not` — **bitwise** on integers (`!5i64 == -6`), logical on
+    /// `bool`. `PyElement`'s `Not` impl does not implement that operation: it
+    /// forwards to Python `__neg__`, which is `std::ops::Neg`. The two differ
+    /// on every input a caller is likely to try:
+    ///
+    /// | input | this method | the Rust op's `!` |
+    /// | --- | --- | --- |
+    /// | `5` | `-5` | `-6` |
+    /// | `True` | `-1` (an `int`) | `False` |
+    /// | `5.0` | `-5.0` | *does not compile — `f64: !Not`* |
+    ///
+    /// So it was named `not` after the op it wires rather than the operation
+    /// it performs, which is the thing #456 objects to. Nothing about the
+    /// behaviour changed with the rename — only the name.
+    ///
+    /// Python callers wanting one of the other two reach for
+    /// `map(lambda v: not v)` (logical) or `map(lambda v: ~v)` (bitwise).
+    pub fn neg(&self) -> PyStream {
         self.wrap(self.stream.not())
     }
 
@@ -1379,13 +1399,46 @@ mod tests {
     }
 
     #[test]
-    fn not_negates_value() {
+    fn neg_arithmetically_negates_an_integer() {
         let g = PyGraph::new();
-        // `not` maps to __neg__ (arithmetic negation), matching the legacy node.
-        let negated = g.constant(PyElement::from(5_i64)).not_();
+        // `__neg__`, so 5 -> -5. Note this is NOT the `!` the Rust op's
+        // `std::ops::Not` bound names, which for i64 is bitwise: !5 == -6.
+        let negated = g.constant(PyElement::from(5_i64)).neg();
         run_cycles(&g, 1);
         let v: i64 = (&negated.value()).try_into().unwrap();
         assert_eq!(-5, v);
+    }
+
+    #[test]
+    fn neg_of_a_bool_is_an_int_not_a_logical_negation() {
+        // The reason the method is not called `not` (#456). `bool` subclasses
+        // `int` in Python, so `True.__neg__()` is -1 — it neither flips the
+        // truth value nor stays a `bool`.
+        let g = PyGraph::new();
+        let negated = g.constant(PyElement::from(true)).neg();
+        run_cycles(&g, 1);
+        let out = negated.value();
+        let v: i64 = (&out).try_into().unwrap();
+        assert_eq!(-1, v);
+        Python::attach(|py| {
+            assert!(
+                !out.object()
+                    .bind(py)
+                    .is_instance_of::<pyo3::types::PyBool>()
+            );
+        });
+    }
+
+    #[test]
+    fn neg_of_a_float_negates_where_the_rust_op_would_not_compile() {
+        // `f64: !std::ops::Not`, so the engine's `not()` is unreachable for a
+        // float — `__neg__` is defined, which is further evidence that the
+        // Python-side operation is `Neg`, not `Not`.
+        let g = PyGraph::new();
+        let negated = g.constant(PyElement::from(2.5_f64)).neg();
+        run_cycles(&g, 1);
+        let v: f64 = (&negated.value()).try_into().unwrap();
+        assert_eq!(-2.5, v);
     }
 
     #[test]

--- a/crates/wingfoil-python/src/python.rs
+++ b/crates/wingfoil-python/src/python.rs
@@ -201,11 +201,21 @@ impl Stream {
         Stream(self.0.difference())
     }
 
-    /// Negate each value (arithmetic `__neg__`, e.g. `5 -> -5`). Exposed as
-    /// `not` (a Python keyword, so reach it with `getattr(stream, "not")()`).
-    #[pyo3(name = "not")]
-    fn not_(&self) -> Stream {
-        Stream(self.0.not_())
+    /// Negate each value arithmetically: `-value`, i.e. Python `__neg__`.
+    /// `5` becomes `-5`, `5.0` becomes `-5.0`.
+    ///
+    /// This is **not** a logical `not` and **not** a bitwise `~`. It was
+    /// called `not` before 9.0.0, named after the Rust op it wires rather than
+    /// what it does, which misled on exactly the inputs you would test it
+    /// with: `True` becomes `-1` (an `int`), not `False`, and `5` becomes
+    /// `-5`, not `-6`.
+    ///
+    /// If you wanted one of those instead:
+    ///
+    /// * logical negation — `stream.map(lambda v: not v)`
+    /// * bitwise complement — `stream.map(lambda v: ~v)`
+    fn neg(&self) -> Stream {
+        Stream(self.0.neg())
     }
 
     /// Observe each value with a Python callable, passing it through unchanged;

--- a/crates/wingfoil-python/tests/test_interop.py
+++ b/crates/wingfoil-python/tests/test_interop.py
@@ -483,12 +483,58 @@ def test_merge_lets_the_earliest_supplied_input_win():
     assert [(0, 1), (100, 2), (200, 3)] == out.value()
 
 
-def test_not_negates_value():
-    # `not` is arithmetic negation (__neg__) and is a Python keyword.
+def test_neg_arithmetically_negates_an_integer():
+    # `neg` is arithmetic negation (`__neg__`): 5 -> -5.
+    #
+    # It is emphatically NOT the `!` of the Rust op it wires, whose bound is
+    # `std::ops::Not` — bitwise on integers, so `!5i64` would be -6.
     g = wf.Graph()
-    out = getattr(g.constant(5), "not")()
+    out = g.constant(5).neg()
     g.run(cycles=1)
     assert out.value() == -5
+    assert out.value() != ~5  # -5, not -6
+
+
+def test_neg_of_a_bool_is_an_int_not_a_logical_negation():
+    # The reason this method is not called `not` (#456): `bool` subclasses
+    # `int`, so `True.__neg__()` is -1. It neither flips the truth value nor
+    # stays a `bool`, which is what a Python reader of the name `not` expects.
+    g = wf.Graph()
+    out = g.constant(True).neg()
+    g.run(cycles=1)
+    value = out.value()
+    assert value == -1
+    assert value is not False
+    assert not isinstance(value, bool)
+
+
+def test_neg_of_a_float_negates():
+    # `f64` does not implement `std::ops::Not` at all, so a real `Not` could
+    # not accept this input. `__neg__` can, which is further evidence the
+    # Python-visible operation is `Neg`.
+    g = wf.Graph()
+    out = g.constant(2.5).neg()
+    g.run(cycles=1)
+    assert out.value() == -2.5
+
+
+def test_logical_and_bitwise_negation_are_reached_through_map():
+    # The two operations `neg` is NOT, and how the docstring says to get them.
+    g = wf.Graph()
+    logical = g.constant(True).map(lambda v: not v)
+    bitwise = g.constant(5).map(lambda v: ~v)
+    g.run(cycles=1)
+    assert logical.value() is False
+    assert bitwise.value() == -6
+
+
+def test_not_is_no_longer_a_stream_method():
+    # The 9.0.0 rename is clean: no `not` alias survives, so a stale
+    # `getattr(stream, "not")()` fails loudly instead of quietly working.
+    g = wf.Graph()
+    assert not hasattr(g.constant(5), "not")
+    with pytest.raises(AttributeError):
+        getattr(g.constant(5), "not")()
 
 
 def test_sample_emits_held_value_on_trigger():


### PR DESCRIPTION
## What this changes

The Python `Stream` method spelled `not` is renamed to `neg`, and its docs now describe the operation it actually performs. Behaviour is unchanged.

Closes #456.

## Why — the issue's own description was wrong

#456 asked for a **ruling, not a fix**, and said the method "matches the legacy `not` node's `T: Not` semantics, i.e. `5 -> -5`". Those two clauses contradict each other: `5 -> -5` is `std::ops::Neg`; `std::ops::Not` on an integer is bitwise complement (`!5i64 == -6`). Only the second clause is true of the binding.

Ground truth was measured against the built extension *before* any edit:

```
5     -> -5      -5 -> 5       0 -> 0
True  -> -1      False -> 0
5.0   -> -5.0
```

The Rust op in `ops.rs` is a genuine `std::ops::Not`. But `PyElement`'s `impl std::ops::Not` **does not implement `Not`** — its body calls `__neg__`, and that impl is the only thing the Python method ever reaches. The float case proves it independently: `f64` doesn't implement `std::ops::Not`, so the Rust op is unreachable for floats.

**The `bool` case is the damaging one: `True -> -1`.** Not logical negation, not even a `bool`, because `bool` subclasses `int` in Python. A user calling this on a boolean stream expecting `not` silently gets `-1`.

## The ruling

**Name it for what it does.** `not` → `neg`, with docs stating plainly that a caller wanting logical or bitwise negation wants a *different* operation, and pointing at `.map(lambda v: not v)` and `.map(lambda v: ~v)`.

**No alias, deliberately.** The old name is a Python keyword, so the only way anyone could ever call it was `getattr(stream, "not")()` — there is no muscle memory to preserve, and no published wheel carries it since 9.0.0 is unpublished. An alias would keep a misleading name alive in `dir(Stream)` and tab-completion, which is precisely the defect. A stale call site now raises `AttributeError` immediately rather than silently negating where the author wanted logical `not`; that loud failure is the point, and is pinned by a test.

Renaming a Python method is breaking, which is why it lands in this window.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint-all` — clean, on this branch standing alone off `main`
- [x] `cargo test -p wingfoil-python` — 79 + 23 passed
- [x] `maturin develop` (full feature set) + `pytest` — 358 passed, 28 skipped
- [x] New behaviour covered by tests

Tests pin all three cases in Rust and Python, that the documented workarounds really give `False` and `-6`, and that `not` is no longer a `Stream` attribute.

## Notes for the reviewer

`element.rs` keeps its `impl std::ops::Not` — that is the trait the op's bound requires — but the `expect` message no longer says `` `not`/`!` ``, and a comment now records why that impl wears `Not`'s name while calling `__neg__`, so nobody "fixes" it to `__invert__` without renaming the op too.

**The rest of #456 was re-verified rather than trusted.** The fat-pointer `transmute`, `env_logger::Builder::init()` and the leftover debug `print` are genuinely gone; the adapter silent-data-loss item is closed by existing tests in the web, kafka and csv bindings (no adapter file was modified here — that is a verification result).

**One correction for the tracker:** #456 records `finally` as fixed alongside `not`. It isn't bound in Python at all — the Rust op exists but has no binding — so there is no uncallable method. A different state than the issue describes, and worth noting before closing.

`__neg__` was **not** added as a dunder on `Stream` (so `-stream` still doesn't work). That's a plausible follow-on but a separate decision about whether `Stream` should carry operator dunders at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3wQjYrfk8RpF3TQFjeii7)_