### PR TITLE
interp: accept a Handle by reference in AsHandle

### DIFF
--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -148,6 +148,18 @@ impl<T> AsHandle<T> for Handle<T> {
     }
 }
 
+// By reference as well as by value, to match `Stream<T>` — which is implemented
+// both ways, and is what the fluent API hands you. Without this the same
+// `Runner::value` call is spelled `value(&total)` against a fluent `Stream` but
+// `value(acc)` against a `nitro!` output `Handle`, and getting it wrong costs an
+// `AsHandle<_> is not implemented` error plus a cascading "type annotations
+// needed" on the binding.
+impl<T> AsHandle<T> for &Handle<T> {
+    fn as_handle(&self) -> Handle<T> {
+        **self
+    }
+}
+
 // Hand-written (not `#[derive]`) on purpose: a `Handle` is only an index +
 // `PhantomData`, so it is `Copy` for *every* `T`. `#[derive(Clone, Copy)]`
 // would emit `impl<T: Clone> …` / `impl<T: Copy> …`, adding a spurious bound

--- a/crates/wingfoil/tests/fluent_primitives.rs
+++ b/crates/wingfoil/tests/fluent_primitives.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use wingfoil::Burst;
 use wingfoil::channel::ChannelSender;
-use wingfoil::interp::StopHandle;
+use wingfoil::interp::{AsHandle, StopHandle};
 use wingfoil::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
@@ -422,4 +422,32 @@ fn stream_build_shares_the_builders_call_once_guard() {
     let s = g.ticker(std::time::Duration::from_nanos(100)).count();
     let _first = s.build();
     let _second = g.build();
+}
+
+/// `Runner::value` accepts a `Handle` by reference as well as by value, the way
+/// it already accepts a `Stream`. `nitro!`'s `interpreted()` hands back
+/// `Handle`s, so without the by-reference impl the same call is spelled
+/// `value(&stream)` on the fluent path and `value(handle)` on the macro path.
+///
+/// The `&handle` forms below are what clippy's `needless_borrows_for_generic_args`
+/// now offers to strip — correctly, since `Handle` is `Copy` and the by-value
+/// impl is the tidier spelling. Exercising both is the point of this test: the
+/// borrow should be a style nit, not a compile error.
+#[test]
+#[allow(clippy::needless_borrows_for_generic_args)]
+fn runner_value_accepts_a_handle_by_reference() {
+    let g = GraphBuilder::new();
+    let counter = g.ticker(std::time::Duration::from_nanos(100)).count();
+    let handle = counter.as_handle();
+    let mut runner = g.build();
+    runner
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(3))
+        .unwrap();
+
+    // By value, by reference, and via the `Stream` — all the same node.
+    assert_eq!(3, runner.value(handle));
+    assert_eq!(3, runner.value(&handle));
+    assert_eq!(3, runner.value(&counter));
+    // The handle is still usable after being passed by reference.
+    assert_eq!(3, runner.value(&handle));
 }


### PR DESCRIPTION
## What this changes

`AsHandle<T>` is now implemented for `&Handle<T>`, so `Runner::value(&handle)` compiles the same way `Runner::value(&stream)` already does.

## Why

`Runner::value` (and `layer_of`, `remove`, the dynamic-graph builder methods) take `impl AsHandle<T>`, implemented for `Stream<T>`, `&Stream<T>` and `Handle<T>` — but not `&Handle<T>`. The fluent API hands out `Stream`s and `nitro!`'s `interpreted()` hands out `Handle`s, so the same call is spelled two different ways depending on which path you arrived from:

```rust
runner.value(&total)   // fluent Stream — fine
runner.value(&acc)     // nitro! Handle — does not compile
```

The failure is an `AsHandle<_> is not implemented for &Handle<T>` error plus a cascading "type annotations needed" on the binding, which reads as a type-inference problem rather than a missing impl. Found while porting a fluent graph into a `nitro!` block.

`Handle` is `Copy`, so the impl is a deref and nothing changes for existing callers.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`
- [x] `cargo test -p wingfoil --features statistics`, plus `cargo test --doc -p wingfoil`
- [x] New behaviour is covered by a test

`runner_value_accepts_a_handle_by_reference` in `tests/fluent_primitives.rs` asserts the by-value, by-reference and `Stream` spellings all read the same node, and that the handle is still usable after being passed by reference.

`cargo lint-all` could not run here: the Aeron adapter needs CMake ≥3.30 and this sandbox has 3.28. Nothing in the diff is feature-gated.

## Notes for the reviewer

Clippy's `needless_borrows_for_generic_args` now offers to strip such a borrow, since `Handle` is `Copy` and the by-value form is tidier. That is the right nudge and the point of the change stands: the borrow should be a style nit, not a compile error. The test carries a scoped `#[allow]` because it deliberately exercises both spellings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Man22KLdENWyAJb6YcWtX8)_