### PR TITLE
fluent: count() on any stream, not just Stream&lt;()&gt;

### DIFF
--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -876,6 +876,13 @@ pub trait StreamOps<T>: Sized {
     where
         T: 'static;
 
+    /// Running count of ticks: 1, 2, 3, … — regardless of what this stream
+    /// carries. The values are counted, not inspected, so this is the tick
+    /// count of any stream, not just a `Stream<()>` clock.
+    fn count(&self) -> Stream<u64>
+    where
+        T: 'static;
+
     /// Fold values into an accumulator, emitting it after each fold. The
     /// closure mutates the accumulator in place; [`scan`](StreamOps::scan) is
     /// the same op with the closure returning the new accumulator instead.
@@ -1264,6 +1271,16 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
         self.wire(|b, h| b.with_time(h))
     }
 
+    // Hand-written rather than `__wf_fluent_count!`: `Count` is declared
+    // `#[op(build = count)]` without `fluent`, and its `In` is `(&'a T,)` for
+    // any `T` — the op counts ticks and never reads the value.
+    fn count(&self) -> Stream<u64>
+    where
+        T: 'static,
+    {
+        self.wire(|b, h| b.count(h))
+    }
+
     __wf_fluent_ticked_at!(T);
 
     __wf_fluent_ticked_at_elapsed!(T);
@@ -1475,13 +1492,6 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
             built: self.built.clone(),
             handle: out_handle,
         }
-    }
-}
-
-impl Stream<()> {
-    /// Running count of ticks: 1, 2, 3, ...
-    pub fn count(&self) -> Stream<u64> {
-        self.wire(|b, h| b.count(h))
     }
 }
 

--- a/crates/wingfoil/tests/fluent_primitives.rs
+++ b/crates/wingfoil/tests/fluent_primitives.rs
@@ -451,3 +451,39 @@ fn runner_value_accepts_a_handle_by_reference() {
     // The handle is still usable after being passed by reference.
     assert_eq!(3, runner.value(&handle));
 }
+
+/// `count()` counts ticks on a stream of any payload, not just a `Stream<()>`
+/// clock. It used to be an inherent method on `Stream<()>` alone, which made
+/// `some_f64_stream.count()` fail with rustc falling back to `Iterator::count`
+/// — "`Stream<f64>` is not an iterator" — rather than naming the real problem.
+#[test]
+fn count_works_on_any_payload_type() {
+    let g = GraphBuilder::new();
+    let clock = g.ticker(std::time::Duration::from_nanos(100));
+
+    // Stream<()> — the original inherent form.
+    let clock_ticks = clock.count();
+    // Stream<u64>, Stream<f64>, Stream<String>: all count their own ticks.
+    let numbers = clock.count();
+    let number_ticks = numbers.count();
+    let floats = numbers.map(|n: &u64| *n as f64 * 1.5);
+    let float_ticks = floats.count();
+    let text = floats.map(|f: &f64| format!("{f:.1}"));
+    let text_ticks = text.count();
+
+    // Counting a *filtered* stream counts only the ticks that got through,
+    // which is the case the `Stream<()>` restriction made awkward.
+    let evens = numbers.filter_value(|n: &u64| n.is_multiple_of(2));
+    let even_ticks = evens.count();
+
+    let mut runner = g.build();
+    runner
+        .run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(6))
+        .unwrap();
+
+    assert_eq!(6, runner.value(&clock_ticks));
+    assert_eq!(6, runner.value(&number_ticks));
+    assert_eq!(6, runner.value(&float_ticks));
+    assert_eq!(6, runner.value(&text_ticks));
+    assert_eq!(3, runner.value(&even_ticks), "only 2, 4, 6 pass the filter");
+}


### PR DESCRIPTION
## What this changes

`count()` moves from an inherent method on `Stream<()>` to `StreamOps<T>`, so any stream can count its own ticks without an intermediate `.map(|_| ())`.

## Why

Counting the ticks of a stream that carries anything — a filtered stream, a stream of parsed records — required mapping the payload away first.

The restriction was only ever on the fluent method. The op behind it is `Count<T>`, already generic, with `In<'a> = (&'a T,)` and a `cycle` that increments a counter without reading the value at all; the `#[op(build = count)]` forwarder that `nitro!` dispatches through was likewise already generic. So this is the fluent surface catching up with the op, not a new capability.

What makes it worth fixing is how it failed. `Stream<T>` had no inherent `count` for `T != ()`, so rustc fell back to `Iterator::count` and reported:

```
error[E0599]: `Stream<f64>` is not an iterator
  = note: `Stream<f64>: Iterator`
          which is required by `&mut Stream<f64>: Iterator`
```

which sends you looking for an iterator bug instead of a missing method.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`
- [x] `cargo test -p wingfoil --features statistics`, plus `cargo test --doc -p wingfoil`
- [x] New behaviour is covered by a test

`count_works_on_any_payload_type` in `tests/fluent_primitives.rs` counts ticks on `Stream<()>`, `Stream<u64>`, `Stream<f64>` and `Stream<String>`, and asserts that counting a *filtered* stream counts only the ticks that got through (3 of 6) — the case the old restriction made awkward.

`cargo lint-all` could not run here: the Aeron adapter needs CMake ≥3.30 and this sandbox has 3.28. Nothing in the diff is feature-gated.

## Notes for the reviewer

`StreamOps` is in the prelude, so every caller in this tree is unaffected — the full suite passes untouched. It is technically breaking for a downstream caller who reached `Stream<()>::count` inherently without importing `StreamOps`, which seems unlikely to exist but is worth a moment's thought given 9.0.0 is unpublished.

The impl is hand-written next to `with_time`'s rather than generated via `__wf_fluent_count!`, because `Count` is declared `#[op(build = count)]` without `fluent`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Man22KLdENWyAJb6YcWtX8)_