### PR TITLE
interp: warn when a historical channel read is stuck on a live sender

### DIFF
--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -352,6 +352,27 @@ pub trait SourceOps {
     /// **both** modes — realtime (waker-driven) and historical (timestamped
     /// sends replayed deterministically on the graph clock; see
     /// [`Builder::channel`](crate::interp::Builder::channel)).
+    ///
+    /// # A historical run needs the sender closed
+    ///
+    /// A historical source reads ahead from `start` — before the first cycle —
+    /// so it waits there for input. [`close`](ChannelSender::close) at the end
+    /// of the feed is what ends the replay; dropping every sender does the same
+    /// thing (mpsc disconnect). If a sender is still alive and silent the run
+    /// parks in `start` indefinitely, and **`RunFor` cannot bound it**: no cycle
+    /// has been counted and no engine time has advanced. After ten seconds the
+    /// engine logs a `warn!` naming this, but the wait itself does not end.
+    ///
+    /// The shape that catches people is a sender bound but unused, which stays
+    /// alive to the end of the enclosing scope:
+    ///
+    /// ```ignore
+    /// let (incoming, _tx) = g.channel::<f64>();   // `_tx` is still a live sender
+    /// runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(2))?;
+    /// ```
+    ///
+    /// Realtime is unaffected — it is waker-driven and honours its bound whether
+    /// or not anything ever arrives.
     fn channel<T: Clone + Default + 'static>(&self) -> (Stream<Burst<T>>, ChannelSender<T>);
 
     /// [`channel`](Self::channel) with an optional transport bound. `None` is the

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -51,6 +51,7 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use anyhow::{Result, bail};
 
@@ -220,6 +221,52 @@ impl<T: Default> Default for HistRead<T> {
 /// graph-thread-only [`Pooled`](crate::pool::Pooled) handle *here* — this
 /// function only ever runs on the graph thread, which is what makes handing
 /// out a non-`Send` handle sound.
+/// How long a historical read waits before warning that it is probably stuck.
+/// Long enough that a slow-but-live producer never trips it; short enough to
+/// land well before anyone reaches for a debugger.
+const STALL_WARNING_AFTER: Duration = Duration::from_secs(10);
+
+/// [`Receiver::recv`] with one diagnostic bolted on: if nothing arrives within
+/// `warn_after`, warn once and then go on blocking exactly as before. Callers
+/// pass [`STALL_WARNING_AFTER`]; the parameter exists so the unit test can drive
+/// the stall path without a ten-second wait.
+///
+/// A historical channel source reads ahead from `start`, before the first cycle,
+/// so a producer that neither sends nor closes parks the run *there* — and
+/// `RunFor` cannot bound a wait that happens before any cycle is counted. The
+/// symptom is a program that hangs having printed nothing, which gives the user
+/// nothing at all to search for. The usual cause is a sender still in scope:
+///
+/// ```ignore
+/// let (incoming, _tx) = g.channel::<f64>();   // `_tx` lives to end of scope
+/// runner.run(RunMode::HistoricalFrom(..), RunFor::Cycles(2))?;  // never returns
+/// ```
+///
+/// Dropping the sender *does* end the run (mpsc disconnect), so this only fires
+/// when one is genuinely still alive and silent. Realtime is unaffected: it is
+/// waker-driven and honours its bound whether or not anything arrives.
+fn recv_warning_on_stall<R>(
+    rx: &std::sync::mpsc::Receiver<Message<R>>,
+    warn_after: Duration,
+) -> std::result::Result<Message<R>, std::sync::mpsc::RecvError> {
+    use std::sync::mpsc::{RecvError, RecvTimeoutError};
+    match rx.recv_timeout(warn_after) {
+        Ok(m) => Ok(m),
+        Err(RecvTimeoutError::Disconnected) => Err(RecvError),
+        Err(RecvTimeoutError::Timeout) => {
+            log::warn!(
+                target: "wingfoil",
+                "historical channel source has waited {}s for input and its sender is \
+                 still alive. A historical run collects ahead at start, so it will wait \
+                 here indefinitely and RunFor cannot bound it. Call \
+                 ChannelSender::close() when the feed ends (or drop the sender).",
+                warn_after.as_secs(),
+            );
+            rx.recv()
+        }
+    }
+}
+
 fn pump_historical<R, E: Default>(
     rx: &std::sync::mpsc::Receiver<Message<R>>,
     state: &mut HistRead<E>,
@@ -243,7 +290,7 @@ fn pump_historical<R, E: Default>(
             break;
         }
         let msg = if blocking {
-            match rx.recv() {
+            match recv_warning_on_stall(rx, STALL_WARNING_AFTER) {
                 Ok(m) => m,
                 // All senders dropped without an explicit close.
                 Err(_) => {
@@ -4547,6 +4594,40 @@ impl<K: std::hash::Hash + Eq> DemuxMap<K> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The stall diagnostic must not change what `recv` delivers: a value that
+    /// arrives *after* the warning threshold is still returned, intact and in
+    /// order, because the warning is followed by an ordinary blocking `recv`.
+    #[test]
+    fn stall_warning_still_delivers_the_late_value() {
+        let (tx, rx) = std::sync::mpsc::channel::<Message<u32>>();
+        let producer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(120));
+            tx.send(Message::Value(42)).expect("receiver alive");
+            tx.send(Message::EndOfStream).expect("receiver alive");
+        });
+
+        // Threshold well under the producer's delay, so the stall path runs.
+        let first = recv_warning_on_stall(&rx, Duration::from_millis(20))
+            .expect("the late value is delivered after the warning");
+        assert!(matches!(first, Message::Value(42)));
+        // The next read is served from the buffer, no stall involved.
+        let second = recv_warning_on_stall(&rx, Duration::from_millis(20))
+            .expect("end-of-stream is delivered");
+        assert!(matches!(second, Message::EndOfStream));
+
+        producer.join().expect("producer thread panicked");
+    }
+
+    /// All senders dropped is reported as a disconnect, which is what tells
+    /// `pump_historical` to set EOF — the reason dropping a sender ends a
+    /// historical run without an explicit `close()`.
+    #[test]
+    fn stall_warning_reports_disconnect() {
+        let (tx, rx) = std::sync::mpsc::channel::<Message<u32>>();
+        drop(tx);
+        assert!(recv_warning_on_stall(&rx, Duration::from_millis(20)).is_err());
+    }
 
     #[test]
     #[should_panic(


### PR DESCRIPTION
## What this changes

A historical channel source that has waited ten seconds for input now logs a `warn!` naming the cause and the fix, then goes on blocking exactly as before. `SourceOps::channel` documents the requirement.

## Why

A historical channel source reads ahead from `start`, before the first cycle, so it waits there for input. If a sender is still alive and never sends or closes, the run parks in `start` forever — and **`RunFor` cannot bound it**, because no cycle has been counted and no engine time has advanced. The program hangs having printed nothing, which leaves the user with nothing to search for.

The shape that causes it is a sender bound but unused, which stays alive to the end of the enclosing scope — the natural spelling in a test:

```rust
let (incoming, _tx) = g.channel::<f64>();   // `_tx` is a live sender
runner.run(RunMode::HistoricalFrom(..), RunFor::Cycles(2))?;  // never returns
```

I hit this twice writing throwaway probes and had to bisect with `timeout` to work out why, having assumed `RunFor::Cycles(2)` bounded it.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`
- [x] `cargo test -p wingfoil --features statistics`, plus `cargo test --doc -p wingfoil`
- [x] New behaviour is covered by a test

Two unit tests in `interp.rs`: a value arriving *after* the warning is still delivered intact and in order, and all-senders-dropped is still reported as a disconnect — which is what lets a dropped sender end a run without an explicit `close()`. The existing `tests/channel.rs` suite covers that ordinary delivery is unchanged.

`cargo lint-all` could not run here: the Aeron adapter needs CMake ≥3.30 and this sandbox has 3.28. Nothing in the diff is feature-gated.

## Notes for the reviewer

Two judgement calls worth checking:

- **`log::warn!` rather than `eprintln!`.** The house convention (`tier.rs`, the fix and web adapters) is `log`, so that is what this uses — but the symptom being fixed is "hangs with no output", and a user with no logger installed still gets no output. `ops.rs` has precedent for `eprintln!` in the print op if you would rather this were unconditional.
- **The threshold is a parameter on `recv_warning_on_stall`, not read from the const inside.** That exists purely so the unit tests drive the stall path in milliseconds instead of waiting ten seconds. `pump_historical` passes `STALL_WARNING_AFTER`.

The warning fires once and then blocks indefinitely, so a genuinely stuck run logs one line rather than repeating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Man22KLdENWyAJb6YcWtX8)_