### PR TITLE
examples: add slo_monitor, a reliability-monitoring core example

### DIFF
--- a/crates/wingfoil/Cargo.toml
+++ b/crates/wingfoil/Cargo.toml
@@ -689,6 +689,11 @@ name = "statistics"
 path = "examples/core/statistics/main.rs"
 required-features = ["statistics"]
 
+[[example]]
+name = "slo_monitor"
+path = "examples/core/slo_monitor/main.rs"
+required-features = ["statistics"]
+
 # Observability: the `logged` debug tap rendered through `env_logger`. Ports the
 # `log` mode of the classic `tracing` example (the `tracing`-subscriber and
 # engine-span `instruments` modes await wingfoil's instrumentation-feature port).

--- a/crates/wingfoil/examples/core/README.md
+++ b/crates/wingfoil/examples/core/README.md
@@ -24,6 +24,7 @@ between them.
 | [`topological_sort`](topological_sort/) | — | Why topological-order scheduling avoids the O(2^N) blow-up that frameworks propagating one path at a time hit when nodes branch and recombine. (Target name: `breadth_first`.) |
 | [`feedback`](feedback/) | — | Closing a loop with a `feedback` channel — a control loop a plain DAG cannot express. |
 | [`statistics`](statistics/) | `statistics` | The `StatisticsOps` trait: EWMA, cumulative and rolling mean/variance/std/min/max/median. |
+| [`slo_monitor`](slo_monitor/) | `statistics` | Reliability monitoring end to end: rolling burn rate over a channel feed, hysteretic alerting via a `feedback` edge, and a time window that decays because the clock is merged into it. |
 | [`tracing`](tracing/) | — | The `logged` debug tap and the engine's spans — three instrumentation modes. |
 | [`introspect`](introspect/) | — | Seeing the graph you wired: `snapshot()` to text / Mermaid / Graphviz / JSON, with active and passive edges drawn apart. |
 

--- a/crates/wingfoil/examples/core/slo_monitor/README.md
+++ b/crates/wingfoil/examples/core/slo_monitor/README.md
@@ -1,0 +1,74 @@
+## SLO burn-rate monitoring
+
+A service-reliability graph: request events arrive from a producer thread, and
+the graph turns them into an error-budget burn rate, a latency profile and a
+throughput gauge — then pages when the burn rate says the budget will not last,
+and clears when it recovers.
+
+It is the monitoring shape rather than the trading one, but the structure is
+the same as [`ema_crossover`](../ema_crossover/): a live-shaped feed in, rolling
+statistics over it, and a state machine emitting events at the tail. What it
+adds is the two constructs that a straight `map`/`fold` chain cannot express —
+a **feedback edge** for hysteresis, and a **clock merged into a time window** so
+a rate decays when traffic stops.
+
+```rust
+// One SLO covers one endpoint.
+let (incoming, tx) = g.channel::<Request>();
+let requests = incoming.collapse::<Request>().filter_value(|r| r.endpoint == ENDPOINT);
+
+// Burn rate: how many times faster than budget the errors are arriving.
+let violation = requests.map(|r| if r.status >= 500 || r.latency_ms > SLO_LATENCY_MS { 1.0 } else { 0.0 });
+let burn = violation.rolling_mean(WINDOW).map(|r| r / ERROR_BUDGET);
+
+// Hysteresis: page above PAGE, clear below CLEAR, hold in between.
+let (was_alerting, alert_sink) = g.feedback::<bool>();
+let alerting = burn
+    .join_passive(&was_alerting, |b, prev| if *prev { *b > CLEAR } else { *b > PAGE })
+    .feedback(&alert_sink);
+let transitions = alerting.distinct().skip(1);
+```
+
+Traffic runs at 500 rps and degrades between t=2s and t=3s. The page fires as
+the bad window fills, and clears once the good requests have flushed it:
+
+```text
+replaying 3000 requests to /checkout (plus /health noise) ...
+[  0.0s]        rps=   1  p50=  40.0ms  max=  40.0ms
+[  1.0s]        rps= 501  p50=  67.5ms  max=  99.0ms
+[  2.0s]        rps= 501  p50=  71.5ms  max= 380.0ms
+[  2.0s] PAGE  /checkout  burn=15.6x budget
+[  3.0s]        rps= 501  p50= 447.5ms  max= 479.0ms
+[  3.1s] CLEAR /checkout  burn=4.7x budget
+[  4.0s]        rps= 501  p50=  67.5ms  max=  99.0ms
+[  5.0s]        rps= 501  p50=  71.5ms  max=  99.0ms
+[  6.0s]        rps= 500  p50=  71.5ms  max=  99.0ms
+[  7.0s]        rps=   0  p50=  71.5ms  max=  99.0ms
+[  8.0s]        rps=   0  p50=  71.5ms  max=  99.0ms
+```
+
+The run is bounded by `RunFor::Duration(7s)` but a line lands at 8.0s. That is
+deliberate: in `Kernel::begin_cycle` a reached time bound sets `is_last_cycle`
+rather than ending the run there, so the next scheduled cycle still runs and the
+run stops on the one after. A `RunFor::Cycles` bound terminates immediately
+instead — only the time bound grants that final cycle.
+
+### Idiom notes
+
+- **A `time_windowed_*` op evicts only when its input ticks.** Its activation is
+  `NONE`, and the eviction pass runs inside the same update that pushes a new
+  sample — so once traffic stops the op holds its last value indefinitely rather
+  than decaying to zero. Merging the status clock in as a `0.0` sample fixes it
+  for a *sum*: the zero does not change the total but does force the eviction.
+  A mean or median cannot be corrected this way, because the injected sample
+  would enter the statistic.
+- **`distinct()` emits its first value.** As an edge detector that means one
+  spurious transition at the start, which `skip(1)` drops.
+- **Close the sender.** A historical run block-collects its input at `start`, so
+  a channel whose sender is still alive and silent blocks there forever —
+  `RunFor::Cycles`/`Duration` cannot bound a wait that happens before the first
+  cycle. `tx.close()`, or dropping the sender, is what ends the replay.
+- `filter_value` takes a predicate on the value; `filter` takes a separate
+  `Stream<bool>` to gate on. Both are useful — this graph uses the first for the
+  endpoint filter, and the burn-rate state machine is a `join_passive` rather
+  than either.

--- a/crates/wingfoil/examples/core/slo_monitor/main.rs
+++ b/crates/wingfoil/examples/core/slo_monitor/main.rs
@@ -1,0 +1,167 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil --features statistics --example slo_monitor
+//! ```
+
+use std::thread;
+use std::time::Duration;
+
+use wingfoil::adapters::statistics::StatisticsOps;
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+/// One served HTTP request, as a load balancer would report it.
+#[derive(Clone, Debug, Default)]
+struct Request {
+    endpoint: &'static str,
+    latency_ms: f64,
+    status: u16,
+}
+
+/// The endpoint this SLO covers.
+const ENDPOINT: &str = "/checkout";
+/// A request is "good" if it did not error and came back inside this budget.
+const SLO_LATENCY_MS: f64 = 250.0;
+/// The SLO: 99% of requests must be good, so 1% is the error budget.
+const ERROR_BUDGET: f64 = 0.01;
+/// How many recent requests the burn rate is measured over.
+const WINDOW: usize = 64;
+/// Page above this burn rate, and stay paged until it falls back below
+/// `CLEAR` — a single threshold would flap once the rate sits on it.
+const PAGE: f64 = 14.4;
+const CLEAR: f64 = 6.0;
+
+/// How often the status line is printed, and the width of the rate window.
+const TICK: Duration = Duration::from_secs(1);
+
+fn main() -> anyhow::Result<()> {
+    let g = GraphBuilder::new();
+
+    // Requests arrive from a producer thread. `send_at` stamps each one, which
+    // is what makes this replay deterministic — the same feed always produces
+    // the same alerts at the same instants.
+    let (incoming, tx) = g.channel::<Request>();
+    // One SLO covers one endpoint: the health check is served from cache and
+    // would dilute the burn rate to nothing if it were counted.
+    let requests = incoming
+        .collapse::<Request>()
+        .filter_value(|r| r.endpoint == ENDPOINT);
+
+    // Did each request violate the SLO? 1.0 for a violation, 0.0 for a good one.
+    let violation = requests.map(|r| {
+        if r.status >= 500 || r.latency_ms > SLO_LATENCY_MS {
+            1.0
+        } else {
+            0.0
+        }
+    });
+
+    // Burn rate: how many times faster than budget we are spending it. 1.0x is
+    // exactly on budget; 14.4x exhausts a 30-day budget in about two days.
+    let burn = violation.rolling_mean(WINDOW).map(|r| r / ERROR_BUDGET);
+
+    // Latency shape over the same window.
+    let latency = requests.map(|r| r.latency_ms);
+    let p50 = latency.rolling_median(WINDOW);
+    let worst = latency.rolling_max(WINDOW);
+
+    // Requests per second. A `time_windowed_*` op only re-evaluates — and so
+    // only evicts aged samples — when its *input* ticks, so on its own it
+    // freezes at the last value once traffic stops rather than decaying to
+    // zero. Merging the clock in as a 0.0 sample keeps the window honest: it
+    // contributes nothing to the sum but forces the eviction pass.
+    let clock = g.ticker(TICK);
+    let throughput = requests
+        .map(|_| 1.0)
+        .merge(&clock.map(|_| 0.0))
+        .time_windowed_sum(TICK);
+
+    // Hysteresis: page above PAGE, clear below CLEAR, hold in between. Deciding
+    // the next alert state needs the previous one, which is a cycle — and a
+    // feedback edge is the only construct that can express one. `join_passive`
+    // reads the fed-back state without the read itself driving a tick.
+    let (was_alerting, alert_sink) = g.feedback::<bool>();
+    let alerting = burn
+        .join_passive(
+            &was_alerting,
+            |b, prev| {
+                if *prev { *b > CLEAR } else { *b > PAGE }
+            },
+        )
+        .feedback(&alert_sink);
+
+    // Only the edges are worth paging on, not every re-evaluation. `distinct`
+    // emits its first value too, which here is the initial "not alerting" —
+    // `skip(1)` drops that so only genuine transitions reach the sink.
+    let transitions = alerting.distinct().skip(1);
+
+    let _pages = transitions
+        .with_time()
+        .join_passive(&burn, |(t, on), b| {
+            let state = if *on { "PAGE " } else { "CLEAR" };
+            let at = Duration::from(*t).as_secs_f64();
+            format!("[{at:>5.1}s] {state} {ENDPOINT}  burn={b:.1}x budget")
+        })
+        .for_each(|line| {
+            println!("{line}");
+            Ok(())
+        });
+
+    // A once-a-second status line, sampled off the same clock.
+    let _status = p50
+        .join3(&worst, &throughput, |p, w, t| (*p, *w, *t))
+        .sample(&clock)
+        .with_time()
+        .for_each(|(t, (p, w, rps))| {
+            let at = Duration::from(*t).as_secs_f64();
+            println!("[{at:>5.1}s]        rps={rps:>4.0}  p50={p:>6.1}ms  max={w:>6.1}ms");
+            Ok(())
+        });
+
+    let mut runner = g.build();
+
+    let producer = thread::spawn(move || {
+        // 6s of traffic at 500 rps, degrading between t=2s and t=3s.
+        for i in 0..3_000u64 {
+            let at = Duration::from_millis(i * 2);
+            let degraded = (2_000..3_000).contains(&at.as_millis());
+            let latency_ms = if degraded {
+                180.0 + (i % 400) as f64
+            } else {
+                40.0 + (i % 60) as f64
+            };
+            let status = if degraded && i % 9 == 0 { 503 } else { 200 };
+            tx.send_at(
+                Request {
+                    endpoint: ENDPOINT,
+                    latency_ms,
+                    status,
+                },
+                NanoTime::from(at),
+            );
+            // Background health-check traffic on another endpoint, which the
+            // graph filters out.
+            tx.send_at(
+                Request {
+                    endpoint: "/health",
+                    latency_ms: 1.0,
+                    status: 200,
+                },
+                NanoTime::from(at + Duration::from_micros(500)),
+            );
+        }
+        // End-of-stream. Without this the historical run blocks waiting for
+        // input that never comes — `RunFor` cannot bound that wait.
+        tx.close();
+    });
+
+    println!("replaying 3000 requests to {ENDPOINT} (plus /health noise) ...");
+    runner.run(
+        RunMode::HistoricalFrom(NanoTime::ZERO),
+        RunFor::Duration(Duration::from_secs(7)),
+    )?;
+    producer.join().expect("producer thread panicked");
+
+    Ok(())
+}


### PR DESCRIPTION
## What this changes

Adds `examples/core/slo_monitor/` — an SLO error-budget monitor wired end to end, plus its README and the `examples/core/README.md` entry.

## Why

This started as a dogfooding exercise: build something non-trivial as a user would and see where the API bites. The result is worth keeping as an example, and the friction it surfaced is written up in its README so the next person does not rediscover it.

Request events arrive over a `channel` from a producer thread, are filtered to one endpoint, and drive a rolling burn rate, a `rolling_median`/`rolling_max` latency profile and a throughput gauge. Alerting uses a `feedback` edge for hysteresis. It sits alongside `ema_crossover` as a second realistic-shaped graph in a different domain, and it is the only core example combining a channel feed, statistics ops and a feedback loop in one wiring.

Two behaviours it had to work around, both documented in the README:

- **A `time_windowed_*` op evicts only when its input ticks.** The family is `Activation::NONE` and the eviction pass runs inside the same update that pushes a new sample, so once traffic stops it holds its last value indefinitely rather than decaying — a "requests in the last second" gauge reads 500 forever. Merging the status clock in as a `0.0` sample fixes it for a *sum*: the zero does not change the total but does force the eviction. A mean or median cannot be corrected this way, since the injected sample would enter the statistic. Left alone here deliberately — flagged for a separate decision, not fixed in an example PR.
- **`distinct()` emits its first value**, so as an edge detector it produces one spurious transition; `skip(1)` drops it.

The README also records that a historical run collects ahead at `start`, so a live-but-silent sender blocks there and `RunFor` cannot bound it (#865 adds the diagnostic for that), and why a line lands at 8.0s under a `RunFor::Duration(7s)` bound — a reached time bound sets `is_last_cycle` rather than ending the run, so the next scheduled cycle still runs.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint`
- [x] `cargo test -p wingfoil --features statistics`, plus `cargo test -p wingfoil-derive`
- [x] `scripts/check-example-docs.sh` — 46 targets, all documented and indexed

The README's sample output is real: pasted from `cargo run -p wingfoil --features statistics --example slo_monitor`, and re-verified byte-for-byte after rebasing onto `6424c4a`.

`cargo lint-all` could not run here: the Aeron adapter needs CMake ≥3.30 and this sandbox has 3.28. The example is gated on `statistics`, which `cargo lint` plus a targeted `cargo clippy -p wingfoil --all-targets --features statistics` both cover.

## Notes for the reviewer

The example is declared with `required-features = ["statistics"]` and registered under "Execution model" in the group README, next to `statistics`.

The workaround comment on the throughput stage is load-bearing — without it the merged `0.0` clock sample looks like a mistake. If the `time_windowed_*` decay question is settled differently later, that stage and its README note are what need revisiting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Man22KLdENWyAJb6YcWtX8)_