### PR TITLE
interp: skip tombstoned nodes in start_nodes

### DIFF
--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -3038,11 +3038,24 @@ impl Runner {
 
     /// Call every node's `start`, stopping at the first error (with node
     /// context). Shared by [`run`](Runner::run) and
-    /// [`run_dynamic`](Runner::run_dynamic); nothing is tombstoned yet at this
-    /// point, so there is nothing to skip.
+    /// [`run_dynamic`](Runner::run_dynamic).
+    ///
+    /// A tombstoned node takes no part in any lifecycle phase, so the
+    /// [`removed`](Runner::removed) tombstone skips it here exactly as it does
+    /// in [`stop_and_teardown`](Runner::stop_and_teardown). Nothing is
+    /// tombstoned on a *first* run, but a re-run of a graph a previous
+    /// `run_dynamic` mutated starts with the tombstones that run left behind:
+    /// without the skip such a node would be `start`ed with no matching `stop`
+    /// (the removal already ran its `stop`/`teardown`, and the teardown end
+    /// skips it), leaking whatever `start` acquires for the rest of the
+    /// process. `removed` is all-false on a static run, so the skip costs a
+    /// bounds-checked bool read and changes nothing for `run`.
     fn start_nodes(&mut self, kernel: &mut Kernel) -> Option<anyhow::Error> {
         apply_nodes_span!("start");
         for (i, node) in self.nodes.iter_mut().enumerate() {
+            if self.removed[i] {
+                continue;
+            }
             if let Err(e) = (node.start)(kernel) {
                 return Some(e.context(format!("node {i} ({}) start", node.label)));
             }
@@ -3547,6 +3560,13 @@ impl Runner {
     /// statically-built region is restored. A dynamically-appended node carries
     /// a no-op reset by construction (see `rt_append_node`), so it re-runs
     /// carrying its own accumulated state.
+    ///
+    /// The removed half is symmetric and equally permanent: a node deleted
+    /// through [`Extension::remove`] stays deleted. [`reset`](Runner::reset)
+    /// clears neither its tombstone nor its `is_seed` flag, and cannot rebuild
+    /// the edges the removal drained, so it takes no part in the second run —
+    /// its `start` is skipped along with the `stop`/`teardown` it already ran at
+    /// removal.
     #[cfg_attr(feature = "instrument-run", tracing::instrument(skip_all))]
     pub fn run_dynamic<F>(
         &mut self,

--- a/crates/wingfoil/tests/rerun_dynamic.rs
+++ b/crates/wingfoil/tests/rerun_dynamic.rs
@@ -15,11 +15,21 @@
 //!
 //! Both entry points now share one guard, so the contract is `run`'s in either
 //! direction: re-runnable graphs reset, single-run graphs error.
+//!
+//! The last test covers the *removed* half of that contract, which the guard
+//! alone does not settle: `reset` clears neither a node's tombstone nor the
+//! edges its removal drained, so a node deleted through [`Extension::remove`]
+//! must stay out of the second run's lifecycle entirely — `start` included.
 #![cfg(feature = "dynamic-graph")]
 
+use std::cell::Cell;
+use std::rc::Rc;
 use std::time::Duration;
 
+use wingfoil::anyhow::Result;
 use wingfoil::interp::Extension;
+use wingfoil::op;
+use wingfoil::op::{Activation, Ctx, Op, Tick};
 use wingfoil::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
@@ -256,5 +266,123 @@ fn historical_channel_graph_refuses_run_after_run_dynamic() {
     assert!(
         err.to_string().contains("single-run"),
         "unexpected error: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The removed half of the re-run contract.
+// ---------------------------------------------------------------------------
+
+/// Lifecycle call counters, shared between the graph and the test. `Rc<Cell>`
+/// rather than atomics because an interpreted graph runs on the calling thread.
+#[derive(Clone, Default)]
+struct Calls {
+    start: Rc<Cell<u64>>,
+    stop: Rc<Cell<u64>>,
+    teardown: Rc<Cell<u64>>,
+}
+
+/// A pass-through op that exists only to make its own lifecycle observable: it
+/// counts every `start`/`stop`/`teardown` the engine calls on it. Stands in for
+/// any op that *acquires* something on start — the leak the tombstone skip
+/// prevents is one unmatched `start` per re-run.
+struct Tracked;
+
+#[op(build = tracked)]
+impl Op for Tracked {
+    type Cfg = Calls;
+    type State = ();
+    type In<'a> = (&'a u64,);
+    type Out = u64;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut Calls,
+        _state: &mut (),
+        input: (&u64,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<u64>> {
+        Ok(Tick::Value(*input.0))
+    }
+
+    fn start(cfg: &mut Calls, _state: &mut (), _ctx: &mut Ctx<'_>) -> Result<()> {
+        cfg.start.set(cfg.start.get() + 1);
+        Ok(())
+    }
+
+    fn stop(cfg: &mut Calls, _state: &mut (), _ctx: &mut Ctx<'_>) -> Result<()> {
+        cfg.stop.set(cfg.stop.get() + 1);
+        Ok(())
+    }
+
+    fn teardown(cfg: &mut Calls, _state: &mut (), _ctx: &mut Ctx<'_>) -> Result<()> {
+        cfg.teardown.set(cfg.teardown.get() + 1);
+        Ok(())
+    }
+}
+
+/// `run_dynamic` → `remove` → `run_dynamic`: a tombstoned node takes no part in
+/// the second run's lifecycle, so its `start` and `stop` counts stay balanced.
+///
+/// The removal runs the node's `stop`/`teardown` once, at the cycle-2 boundary
+/// of run 1 (`dynamic_graph.rs`'s `remove_runs_teardown_once_at_removal` pins
+/// that end). Run 2 then resets the graph — but `reset` clears neither the
+/// tombstone nor the edges the removal drained, so the node is both unwired and
+/// unstartable. `start_nodes` skips it exactly as `stop_and_teardown` does; it
+/// used to call `start` unconditionally, giving a second `start` against one
+/// `stop` and leaking whatever that start acquired for the rest of the process.
+#[test]
+fn removed_node_is_not_restarted_on_a_re_run() {
+    let calls = Calls::default();
+    let g = GraphBuilder::new();
+    let counted = g.ticker(TEN).count();
+    let cfg = calls.clone();
+    let tracked = counted.wire(move |b, h| b.tracked(h, cfg));
+    let acc = tracked.with_time().accumulate();
+    let victim = tracked.handle();
+    let mut r = g.build();
+
+    // Run 1: the node fires cycles 1 and 2, then is removed at the cycle-2
+    // boundary and never fires again.
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), |ext, cycle| {
+        if cycle == 2 {
+            ext.remove(victim)?;
+        }
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(
+        vec![(NanoTime::new(0), 1u64), (NanoTime::new(10), 2)],
+        r.value(&acc),
+        "removed at the cycle-2 boundary: values and tick times stop there"
+    );
+    assert_eq!(1, calls.start.get(), "started once, by run 1");
+    assert_eq!(1, calls.stop.get(), "stopped once, at removal");
+    assert_eq!(1, calls.teardown.get(), "torn down once, at removal");
+
+    // Run 2: the tombstone survives `reset`, so the node is skipped by every
+    // lifecycle phase — no second `start`, and therefore no imbalance.
+    r.run_dynamic(HISTORICAL, RunFor::Cycles(4), nothing)
+        .unwrap();
+    assert_eq!(
+        1,
+        calls.start.get(),
+        "a tombstoned node must not be re-started by a second run"
+    );
+    assert_eq!(1, calls.stop.get(), "…and is still not re-stopped");
+    assert_eq!(
+        calls.start.get(),
+        calls.stop.get(),
+        "start/stop stay balanced across the re-run"
+    );
+    assert_eq!(1, calls.teardown.get());
+
+    // Its downstream lost its only upstream at removal and `reset` cannot
+    // rebuild that edge, so the whole removed region is silent in run 2 — the
+    // accumulator resets to empty and never ticks again.
+    assert_eq!(
+        Vec::<(NanoTime, u64)>::new(),
+        r.value(&acc),
+        "the removed region is unwired for good; reset restores it to empty"
     );
 }


### PR DESCRIPTION
## What this changes

`Runner::start_nodes` now skips nodes tombstoned by `Extension::remove`, exactly as `stop_and_teardown` already does. A node removed during a `run_dynamic` no longer gets a fresh `start` on a later run of the same graph.

Also:

- `start_nodes`' rustdoc no longer claims nothing can be tombstoned when it runs — it states the actual rule (tombstoned nodes take no part in any lifecycle phase) and why the skip is free for the static `run` path.
- `run_dynamic`'s re-run caveat covered only *appended* nodes; it gains a sentence for the *removed* half — `reset` clears neither the tombstone nor `is_seed`, and cannot rebuild the edges the removal drained, so a removed node stays out of the second run entirely.

## Why

Closes #856.

`start_nodes` iterated every node with no `removed[i]` check while `stop_and_teardown` checks it. That is symmetric on a *first* run, where nothing is tombstoned — but a re-run of a graph a previous `run_dynamic` mutated starts with the tombstones that run left behind. So the removed node got a `start` with no matching `stop`, and any resource it acquires on start leaked for the rest of the process.

Option (1) from the issue: the skip is the fix. `removed` is ungated and all-false on a static run, so it costs a bounds-checked bool read and changes nothing for `run`.

Deliberately **not** fixed here, and now documented rather than papered over: `reset()` cannot restore the edges `remove_node` drains, nor `is_seed`. A removed node stays removed, which is the behaviour the skip makes consistent across both ends of the lifecycle.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test -p wingfoil --all-features`
- [x] `cargo test -p wingfoil-derive`
- [x] New behaviour is covered by a test asserting **values and tick times**

New test: `removed_node_is_not_restarted_on_a_re_run` in `crates/wingfoil/tests/rerun_dynamic.rs`. It wires a small pass-through op whose `start`/`stop`/`teardown` count into a shared `Rc<Cell<u64>>`, runs `run_dynamic` → `remove` at the cycle-2 boundary → `run_dynamic`, and asserts:

- run 1's values *and* tick times stop at the removal — `[(0ns, 1), (10ns, 2)]`;
- `start` = 1, `stop` = 1, `teardown` = 1 after run 1 (the removal ran them);
- after run 2, `start` is still 1 and `start == stop` — the balance the bug broke;
- the removed region is silent in run 2 (its accumulator resets to empty and never ticks), pinning that the drained edges do not come back.

Reverting the `start_nodes` skip makes it fail with two starts against one stop, so it pins the fix rather than the current shape.

The only failures in the `--all-features` run are the `*_integration` suites, which need a Docker socket (`failed to initialize a docker client`) that this sandbox does not have; the rest of the workspace is green, `dynamic_graph.rs` and `rerun_dynamic.rs` included.

## Notes for the reviewer

The test op is declared in the test crate, so its `#[op(build = tracked)]` is an out-of-crate expansion — same path `tests/custom_op.rs` exercises.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRyBUej7RQrqxvrSjvqByM)_