### PR TITLE
docs: post-cutover wording sweep — stale legacy/next/future/prototype references

### DIFF
--- a/.claude/commands/review-adapters.md
+++ b/.claude/commands/review-adapters.md
@@ -248,11 +248,11 @@ findings:
   undocumented deviation from 4) are safe to apply here — edit
   `new-adapter.md`, `deviation-register.md`, or `port-plan.md`, then run
   nothing heavier than a re-read (these are docs). Follow the branch rules in
-  `CLAUDE.md` (this is wingfoil work — the branch is cut from `next`).
+  `CLAUDE.md` (this is wingfoil work — the branch is cut from `main`).
 - **Adapter code fixes** (a real compliance breach) are *not* this skill's job —
   each belongs on its own branch through `/new-adapter`'s pre-commit
   checklist (fmt + `cargo lint` + `cargo lint-all` + tests). Hand them back as a
   prioritised worklist, don't fold them into the review branch.
 
 Commit doc changes with a clear message and push to the designated branch; open
-a PR only if the user asks, with base `next`.
+a PR only if the user asks, with base `main`.

--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -12,7 +12,7 @@ on:
       - 'crates/wingfoil-python/tests/test_aeron.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -11,7 +11,7 @@ on:
       - 'crates/wingfoil-python/tests/test_etcd.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/fix-integration.yml
+++ b/.github/workflows/fix-integration.yml
@@ -11,7 +11,7 @@ on:
       - 'crates/wingfoil-python/tests/test_fix.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/fluvio-integration.yml
+++ b/.github/workflows/fluvio-integration.yml
@@ -11,7 +11,7 @@ on:
       - 'crates/wingfoil-python/tests/test_fluvio.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -15,7 +15,7 @@ on:
       - 'crates/wingfoil-python/tests/test_iceoryx2.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -11,7 +11,7 @@ on:
       - 'crates/wingfoil-python/tests/test_kafka.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -13,7 +13,7 @@ on:
       - "crates/wingfoil-python/tests/test_kdb.py"
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -9,7 +9,7 @@ on:
       - 'crates/wingfoil/tests/otlp_integration.rs'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -12,7 +12,7 @@ on:
       - 'crates/wingfoil-python/tests/test_postgres.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -9,7 +9,7 @@ on:
       - 'crates/wingfoil/tests/prometheus_integration.rs'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -11,7 +11,7 @@ on:
       - 'crates/wingfoil-python/tests/test_redis.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -16,7 +16,7 @@ on:
       - 'js/**'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/.github/workflows/zmq-integration.yml
+++ b/.github/workflows/zmq-integration.yml
@@ -13,7 +13,7 @@ on:
       - 'crates/wingfoil-python/tests/test_zmq.py'
 
 # One in-flight run per ref. Superseded PR pushes are cancelled; pushes to
-# main/next are not, so every merged commit keeps a status of its own. The
+# main are not, so every merged commit keeps a status of its own. The
 # group name is a literal, not ${{ github.workflow }}: when this workflow is
 # reached through `workflow_call` that expression resolves to the *caller's*
 # name, which would make every reusable leg share one group and cancel its

--- a/crates/wingfoil/examples/showcase/trading_e2e/README.md
+++ b/crates/wingfoil/examples/showcase/trading_e2e/README.md
@@ -425,7 +425,8 @@ are worth knowing before you upgrade a running deployment:
   iceoryx2 service names and the `#[type_name(...)]` pins are both part of
   service identity, so a legacy `ws_server` and a wingfoil `fix_gw` will not
   see each other (iceoryx2 reports `IncompatibleTypes`). Run a matched pair.
-  The legacy tree is deleted at cutover, so this is a temporary condition.
+  The legacy tree was deleted at cutover, so this only bites a deployment
+  still running pre-cutover binaries alongside these.
 
 What did **not** move is the deployment infrastructure's own naming: the
 Pulumi project names (`wingfoil-latency-{fargate,ec2-spot,baremetal}`), the

--- a/crates/wingfoil/src/adapters/common.rs
+++ b/crates/wingfoil/src/adapters/common.rs
@@ -24,9 +24,9 @@
 //! etc.) can over-read its bounds, so it should pass each emitted row through a
 //! [`WindowFilter`] first.
 //!
-//! Like the legacy module, the `Sym` and `WindowFilter` surfaces are **always
-//! compiled** (no feature gate) so any adapter can use them without touching
-//! feature flags, and they stay *out* of the [`prelude`](crate::prelude):
+//! The `Sym` and `WindowFilter` surfaces are **always compiled** (no feature
+//! gate) so any adapter can use them without touching feature flags, and they
+//! stay *out* of the [`prelude`](crate::prelude):
 //! reach for them with
 //! `use wingfoil::adapters::common::{Sym, TimeWindow, WindowFilter};`.
 //!
@@ -35,12 +35,19 @@
 //! The module also carries the time-slicing helpers
 //! ([`compute_time_slices`] / [`compute_validated_time_slices`]) that split a
 //! run's `[start, end)` window into contiguous, half-open, midnight-aligned
-//! slices — one query per slice for the time-partitioned historical readers
-//! (`postgres_read`, and `kdb_read` when it ports). They are adapter-agnostic
-//! but, like legacy, feature-gated so the default build does not carry unused
-//! code: gated on `postgres` today, and the kdb port adds its own feature to
-//! the gate later (`docs/planning/port-plan.md`, Phase 4 items 4–5). Only the
-//! `TimeWindow`/`WindowFilter` surface above is always compiled.
+//! slices — one query per slice for the time-partitioned historical readers.
+//! Two adapters share them today: `postgres_read` and `kdb_read` (plus
+//! `kdb_read_cached`).
+//!
+//! They are adapter-agnostic but feature-gated, so the default build does not
+//! carry unused code: the gate is
+//! `#[cfg(any(feature = "postgres", feature = "kdb"))]`. **A third
+//! time-sliced reader belongs here too** — widen that gate with its own
+//! feature and call `compute_validated_time_slices` rather than growing a
+//! second slicer, which is exactly the near-duplication this module exists to
+//! prevent. (`docs/planning/port-plan.md`, Phase 4 items 4–5, records how the
+//! gate came to carry both features.) Only the `TimeWindow`/`WindowFilter`
+//! surface above is always compiled.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -237,20 +244,20 @@ impl SymbolInterner {
 
 // ---- Time slicing --------------------------------------------------------
 //
-// Shared by the time-partitioned historical readers (`postgres_read`, and
-// `kdb_read` once it ports): split the run's `[start, end)` window into
+// Shared by the time-partitioned historical readers (`postgres_read` and
+// `kdb_read`/`kdb_read_cached`): split the run's `[start, end)` window into
 // contiguous, half-open slices, one query per slice. Adapter-agnostic, but
 // feature-gated to the adapters that use it (this module itself is always
-// compiled for `TimeWindow`/`WindowFilter`). Gated on `postgres` or `kdb` — the
-// two time-partitioned readers that share it.
+// compiled for `TimeWindow`/`WindowFilter`). A further time-sliced reader
+// widens the gate with its own feature rather than adding a second slicer.
 
 #[cfg(any(feature = "postgres", feature = "kdb"))]
 /// Validate the run window and period, then compute the time slices.
 ///
-/// Shared front door for time-sliced readers (`postgres_read`, and `kdb_read`
-/// once it ports): enforces the preconditions of [`compute_time_slices`] with
-/// uniform error messages (prefixed with `adapter` so callers see the function
-/// they actually called), then delegates to it.
+/// Shared front door for time-sliced readers (`postgres_read`, `kdb_read` and
+/// `kdb_read_cached`): enforces the preconditions of [`compute_time_slices`]
+/// with uniform error messages (prefixed with `adapter` so callers see the
+/// function they actually called), then delegates to it.
 ///
 /// * `period` must be non-zero (a zero period cannot advance through the window).
 /// * `start_time` must be non-zero — i.e. `RunMode::HistoricalFrom` with an explicit start.

--- a/crates/wingfoil/src/channel.rs
+++ b/crates/wingfoil/src/channel.rs
@@ -25,9 +25,9 @@ use std::sync::Arc;
 use wingfoil::NanoTime;
 
 /// The wire envelope carried between a [`ChannelSender`] and its paired
-/// receiver source. Mirrors the legacy `channel::Message`, minus the
-/// serde/burst machinery that the cross-process adapters (zmq, kafka) will
-/// reintroduce when they land.
+/// receiver source. This is the **in-process** envelope and carries no wire
+/// framing of its own: each cross-process adapter owns its serialization (zmq
+/// encodes its own byte-compatible `WireMessage`; kafka moves raw payloads).
 #[derive(Debug)]
 pub enum Message<T> {
     /// A value with no explicit timestamp: in realtime it ticks on arrival; in
@@ -35,8 +35,10 @@ pub enum Message<T> {
     /// current time"). Use [`ValueAt`](Message::ValueAt) to stamp an explicit
     /// replay time.
     Value(T),
-    /// A value stamped with an explicit time (for a future historical
-    /// replay receiver; the realtime receiver treats it as [`Message::Value`]).
+    /// A value stamped with an explicit time: in a historical run it is
+    /// replayed deterministically at `time` (same-instant values grouped into
+    /// one burst); in realtime the timestamp is ignored and it behaves as
+    /// [`Message::Value`], ticking on arrival.
     ValueAt(T, NanoTime),
     /// A progress marker carrying no value — lets a receiving graph advance
     /// even when this channel ticks less often than its other inputs.

--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -356,7 +356,7 @@ fn pump_historical<R, E: Default>(
         {
             return Err(anyhow::anyhow!(
                 "channel receiver: historical send_at time {t} is out of order (after {mx}) — \
-                 timestamped sends must be non-decreasing (legacy errors on out-of-order)"
+                 timestamped sends must be non-decreasing; sort the feed before sending"
             ));
         }
         state.seen_max = Some(t);


### PR DESCRIPTION
## What this changes

Wording only — no behaviour changes anywhere in the tree. Five items where docs, one runtime error string, and 13 workflow comments still described a pre-cutover world: an engine that was deleted, a receiver that was "future", a feature gate that had already widened, and a `next` branch that is gone.

## Why

Closes #837.

Each of these is stale in a way that misleads a reader who has no memory of the cutover:

1. **`crates/wingfoil/src/interp.rs`** — the out-of-order `send_at` error ended with `(legacy errors on out-of-order)`. That string is runtime-reachable by a downstream user and cited an engine 9.0 deleted. It now states the rule and what to do about it. The porting rationale stays in the code comment directly above it, which is where it belongs. Final text:

   > `channel receiver: historical send_at time {t} is out of order (after {mx}) — timestamped sends must be non-decreasing; sort the feed before sending`

   `tests/parity_bugs.rs` asserts on `"out of order"`, which is unchanged, so the pin still holds.

2. **`crates/wingfoil/src/channel.rs`** — `Message::ValueAt` said it was "for a future historical replay receiver". That receiver exists and is the documented core of the channel layer (module doc at the top of the same file, `send_at`'s doc, and `pump_historical` in `interp.rs`). Reworded to the actual contract: replayed deterministically at `time` in a historical run, same-instant values grouped into one burst; in realtime the timestamp is ignored and it behaves as `Message::Value`.

   The `Message` enum's own doc was the same bug — "the serde/burst machinery that the cross-process adapters (zmq, kafka) **will reintroduce when they land**". Both landed. It now says where wire framing actually lives: zmq encodes its own byte-compatible `WireMessage`, kafka moves raw payloads.

3. **`crates/wingfoil/src/adapters/common.rs`** — the time-slicing docs claimed the helpers were "gated on `postgres` today, and the kdb port adds its own feature to the gate later", for "`postgres_read`, and `kdb_read` when it ports". The gate has been `#[cfg(any(feature = "postgres", feature = "kdb"))]` since the kdb port, and both `kdb_read` and `kdb_read_cached` call `compute_validated_time_slices`.

   Rewritten to describe the gate as it is — **and to keep the paragraph's value.** This is the pointer a third time-sliced adapter follows, so a stale account invites exactly the near-duplication the module exists to prevent; the paragraph now says so explicitly (widen the gate with your feature, call the shared slicer, don't grow a second one). Two matching in-file comments at the gate itself carried the same "once it ports" phrasing and were updated with it.

   The `docs/planning/port-plan.md` Phase 4 items 4–5 pointer is **kept** — port-plan.md is a historical record per CLAUDE.md, and lines 632–633 there already narrate the gate widening correctly. It is reworded so it reads as that record rather than as pending work.

   Also dropped two "like legacy" / "Like the legacy module" phrasings in the same module that read as live comparisons to a deleted tree rather than as history.

4. **`crates/wingfoil-python/pyproject.toml`** — confirmed already fixed on `main` (`description = "Python bindings for wingfoil (the Op-pattern stream processing engine)"`). No change.

5. **13 integration workflows** — `aeron-`, `etcd-`, `fix-`, `fluvio-`, `iceoryx2-`, `kafka-`, `kdb-`, `otlp-`, `postgres-`, `prometheus-`, `redis-`, `web-`, `zmq-integration.yml` each said "pushes to main/next are not [cancelled]" in the concurrency comment. `next` is retired, the branch is gone, and those triggers were stripped on 2026-08-12. The comments now describe what the config does. **Comment-only:** `git diff -- .github/workflows/` is a single changed line per file, verified to contain nothing but that comment.

### Folded in from the sweep — same class, both clear-cut

- **`.claude/commands/review-adapters.md`** told the reader "the branch is cut from `next`" and to open PRs "with base `next`", directly contradicting CLAUDE.md's trunk rule. Both now say `main`. CLAUDE.md treats the skills as living documents, so this is in scope.
- **`crates/wingfoil/examples/showcase/trading_e2e/README.md`** — "The legacy tree is deleted at cutover, so this is a temporary condition." Future tense for something already done; now past tense and scoped to a deployment still running pre-cutover binaries.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all` — both clean
- [x] `cargo test -p wingfoil --all-features` (with `--no-fail-fast`)
- [x] `cargo test --doc -p wingfoil --all-features` — 19 passed
- [x] `cargo test -p wingfoil-derive`
- [x] `scripts/check-example-docs.sh` — 45 example targets, all documented and indexed (an example README changed)
- [ ] New behaviour is covered by a test — n/a, no behaviour changes

The only failing targets are the nine `*_integration` suites (`aeron`, `etcd`, `fluvio`, `kafka`, `otlp`, `postgres`, `redis`, `zmq_cross_lang`, `zmq_etcd`), all with `failed to initialize a docker client: Socket not found: /var/run/docker.sock`. Pre-existing and environmental — there is no Docker in this sandbox. Every other target passes, including `parity_bugs` (which pins the error string above) and `channel`.

## Notes for the reviewer

Found during the sweep and **deliberately left alone** — listed here rather than changed:

- **`crates/wingfoil-python/README.md:82`** — "`wingfoil` is not on PyPI yet — the published `wingfoil` package is still the legacy engine. **Until the cutover**, install from a source checkout". The "until the cutover" framing is stale in the same way, but the substantive claim is about the *current state of PyPI*, which I cannot verify from here, and issue #837 item 4 implies wheels do get published on a `bump.yml` cycle. Someone who knows the publish state should reword the whole section rather than just the tense.
- **`crates/wingfoil/benches/nanotime.rs:3-8`** — "wingfoil re-exports legacy's clock core rather than reimplementing it… **the two bars** measure identical code". Present tense about a deleted tree, and it is unclear whether the bench still has two bars. That is a question about the bench, not a wording fix, so it needs its own change.
- **`crates/wingfoil-python/python/wingfoil/stream.py`** — many `legacy` references describing the `CustomStream` inheritance shape and its deviations. These read as provenance (why the API looks the way it does), which is legitimate history, but there are enough of them that a reader could take it as a live comparison. Worth a deliberate call rather than folding into a sweep.
- **`crates/wingfoil/tests/compiled_parity.rs:1`** — "The load-bearing test of the prototype". Same "prototype" class as item 4, but it is an internal test comment and it is ambiguous whether "the prototype" means the compiled tier or the original design spike.

Explicitly **not** touched, per CLAUDE.md's rule that these are historical accounts: `docs/planning/port-plan.md`, `docs/planning/cutover-plan.md`, `docs/planning/cutover-runbook.md`, `docs/planning/deviation-register.md`, the release notes, `adapters/otlp/CLAUDE.md`'s D5 audit-trail entry, and `zmq.rs`'s `wire_format_matches_legacy_message` test (which pins a byte contract as history).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRyBUej7RQrqxvrSjvqByM)_