### PR TITLE
Add #[inline] to the hot Kernel/Ctx/NanoTime accessors

### DIFF
--- a/crates/wingfoil/src/op.rs
+++ b/crates/wingfoil/src/op.rs
@@ -167,6 +167,7 @@ impl<'a> Ctx<'a> {
     /// wall-clock snap: `wall_time` is left `None` and resolved lazily on
     /// first [`wall_time`](Ctx::wall_time) call, so a cycle in which nothing
     /// stamps reads the clock zero times.
+    #[inline]
     pub fn new(kernel: &'a mut Kernel, node: usize) -> Self {
         Self {
             time: kernel.time(),
@@ -207,6 +208,7 @@ impl<'a> Ctx<'a> {
     /// per-node `now()` was the odd one out, and removing it makes an island's
     /// `start` agree with a flat graph's rather than diverge from it.
     #[doc(hidden)]
+    #[inline]
     pub fn nested(
         time: NanoTime,
         wall_time: NanoTime,
@@ -225,6 +227,7 @@ impl<'a> Ctx<'a> {
     }
 
     /// Current engine time.
+    #[inline]
     pub fn time(&self) -> NanoTime {
         self.time
     }
@@ -236,6 +239,7 @@ impl<'a> Ctx<'a> {
     /// ops that stamp in the same engine cycle share the value. Use
     /// [`wall_time_precise`](Self::wall_time_precise) for intra-cycle
     /// resolution.
+    #[inline]
     pub fn wall_time(&self) -> NanoTime {
         match self.wall_time {
             // An island: the composite resolved the snap once for the whole
@@ -257,17 +261,20 @@ impl<'a> Ctx<'a> {
     /// Wall-clock time snapped fresh right now (a TSC read, ~5-10 ns on x86).
     /// Gives distinct stamps to stages that run in the same engine cycle,
     /// where [`wall_time`](Self::wall_time) would return one shared value.
+    #[inline]
     pub fn wall_time_precise(&self) -> NanoTime {
         NanoTime::now()
     }
 
     /// The run's start time.
+    #[inline]
     pub fn start_time(&self) -> NanoTime {
         self.start_time
     }
 
     /// Whether this is the final cycle of the run. Buffering ops flush their
     /// pending contents when true.
+    #[inline]
     pub fn is_last_cycle(&self) -> bool {
         self.is_last_cycle
     }
@@ -277,12 +284,14 @@ impl<'a> Ctx<'a> {
     /// [`RunMode::HistoricalFrom`] rather than publish backtest values to a
     /// live endpoint. Reported as [`RunMode::RealTime`] inside an island (see
     /// [`nested`](Ctx::nested)).
+    #[inline]
     pub fn run_mode(&self) -> RunMode {
         self.run_mode
     }
 
     /// Schedule this node to be activated at `at`. Only meaningful for ops
     /// declaring [`Activation::SCHEDULES`].
+    #[inline]
     pub fn schedule(&mut self, at: NanoTime) {
         match &mut self.sink {
             Sink::Kernel { kernel, node } => kernel.schedule(*node, at),

--- a/crates/wingfoil/src/runtime/kernel.rs
+++ b/crates/wingfoil/src/runtime/kernel.rs
@@ -237,6 +237,7 @@ impl Kernel {
     /// flag changed. It is the caller's `progressed` signal, and a node marked
     /// twice in one cycle (woken twice, or scheduled at two times that both
     /// come due) is still progress: the cycle must run.
+    #[inline]
     fn mark(&mut self, index: usize, dirty: &mut [bool]) -> bool {
         match dirty.get_mut(index) {
             Some(d) => {
@@ -280,11 +281,13 @@ impl Kernel {
     }
 
     /// The run's start time (wall clock for realtime runs).
+    #[inline]
     pub fn start_time(&self) -> NanoTime {
         self.start_time
     }
 
     /// Current engine time.
+    #[inline]
     pub fn time(&self) -> NanoTime {
         self.time
     }
@@ -302,6 +305,7 @@ impl Kernel {
     ///
     /// A cycle that never calls this never reads the clock at all — see the
     /// field's comment for why that is worth the `Cell`.
+    #[inline]
     pub fn wall_time(&self) -> NanoTime {
         match self.wall_time.get() {
             Some(snap) => snap,
@@ -315,6 +319,7 @@ impl Kernel {
 
     /// The run mode (realtime vs historical) — lets a source op choose
     /// wall-clock (waker-driven) or graph-clock (schedule-driven) behaviour.
+    #[inline]
     pub fn run_mode(&self) -> RunMode {
         self.run_mode
     }
@@ -340,6 +345,7 @@ impl Kernel {
     /// Whether this is the final cycle of the run (the run bound is about to
     /// stop it). Ops that buffer and flush on a boundary (window, buffer) use
     /// this to flush their pending contents before the run ends.
+    #[inline]
     pub fn is_last_cycle(&self) -> bool {
         self.is_last_cycle
     }
@@ -352,6 +358,7 @@ impl Kernel {
     }
 
     /// Schedule node `index` to be marked dirty at `at`.
+    #[inline]
     pub fn schedule(&mut self, index: usize, at: NanoTime) {
         self.scheduled.push(index, at);
     }
@@ -581,6 +588,7 @@ impl Kernel {
     /// its own size on every cycle. `dirty` must therefore be the same slice
     /// `begin_cycle` marked — which it is for every engine in the tree, all of
     /// which keep one long-lived array per run.
+    #[inline]
     pub fn end_cycle(&mut self, dirty: &mut [bool]) {
         for &ix in &self.due {
             if let Some(d) = dirty.get_mut(ix) {

--- a/crates/wingfoil/src/runtime/time.rs
+++ b/crates/wingfoil/src/runtime/time.rs
@@ -77,6 +77,7 @@ impl NanoTime {
     /// instead of calling this per node. **Business logic should not call it:**
     /// use [`Ctx::time`](crate::op::Ctx::time), which is source-driven and
     /// replays deterministically.
+    #[inline]
     pub fn now() -> Self {
         Self(CLOCK.now().as_u64() + *EPOCH_OFFSET_NANOS)
     }
@@ -125,12 +126,14 @@ impl NanoTime {
     /// nanosecond count should decide for itself what an out-of-range value
     /// means and go through [`new`](Self::new) with a checked conversion, which
     /// is total and says so.
+    #[inline]
     fn from_nanos_u128_saturating(nanos: u128) -> Self {
         Self(RawTime::try_from(nanos).unwrap_or(RawTime::MAX))
     }
 }
 
 impl From<u64> for NanoTime {
+    #[inline]
     fn from(t: u64) -> Self {
         NanoTime(t)
     }
@@ -147,6 +150,7 @@ impl From<u64> for NanoTime {
 /// overflowed for `as_secs() > ~1.8e10` and, in release, silently produced a
 /// small instant from an enormous duration.
 impl From<Duration> for NanoTime {
+    #[inline]
     fn from(dur: Duration) -> Self {
         NanoTime::from_nanos_u128_saturating(dur.as_nanos())
     }
@@ -178,6 +182,7 @@ impl From<NanoTime> for f64 {
 }
 
 impl From<NanoTime> for u64 {
+    #[inline]
     fn from(t: NanoTime) -> Self {
         t.0
     }
@@ -194,6 +199,7 @@ impl From<NanoTime> for NaiveDateTime {
 }
 
 impl From<NanoTime> for Duration {
+    #[inline]
     fn from(t: NanoTime) -> Self {
         Duration::from_nanos(u64::from(t))
     }
@@ -212,6 +218,7 @@ impl From<NanoTime> for Duration {
 /// release, as `u64 + u64` does.
 impl Add<NanoTime> for NanoTime {
     type Output = Self;
+    #[inline]
     fn add(self, other: Self) -> Self::Output {
         Self(self.0 + other.0)
     }
@@ -220,6 +227,7 @@ impl Add<NanoTime> for NanoTime {
 /// Adds a raw nanosecond count. Overflow behaves as [`Add<NanoTime>`].
 impl Add<RawTime> for NanoTime {
     type Output = Self;
+    #[inline]
     fn add(self, other: RawTime) -> Self::Output {
         Self(self.0 + other)
     }
@@ -230,6 +238,7 @@ impl Add<RawTime> for NanoTime {
 /// [`From<Duration>`](NanoTime#impl-From<Duration>-for-NanoTime) does.
 impl Add<Duration> for NanoTime {
     type Output = Self;
+    #[inline]
     fn add(self, other: Duration) -> Self::Output {
         Self(self.0 + u64::from(NanoTime::from(other)))
     }
@@ -263,6 +272,7 @@ impl Add<Duration> for NanoTime {
 /// ```
 impl Sub<NanoTime> for NanoTime {
     type Output = Self;
+    #[inline]
     fn sub(self, other: Self) -> Self::Output {
         Self(self.0 - other.0)
     }
@@ -273,6 +283,7 @@ impl Sub<NanoTime> for NanoTime {
 /// not pass one.
 impl Mul<u32> for NanoTime {
     type Output = Self;
+    #[inline]
     fn mul(self, other: u32) -> Self::Output {
         Self(self.0 * other as RawTime)
     }
@@ -280,6 +291,7 @@ impl Mul<u32> for NanoTime {
 
 impl Mul<i32> for NanoTime {
     type Output = Self;
+    #[inline]
     fn mul(self, other: i32) -> Self::Output {
         Self(self.0 * other as RawTime)
     }
@@ -287,6 +299,7 @@ impl Mul<i32> for NanoTime {
 
 impl Mul<u64> for NanoTime {
     type Output = Self;
+    #[inline]
     fn mul(self, other: u64) -> Self::Output {
         Self(self.0 * other as RawTime)
     }
@@ -294,6 +307,7 @@ impl Mul<u64> for NanoTime {
 
 impl Mul<i64> for NanoTime {
     type Output = Self;
+    #[inline]
     fn mul(self, other: i64) -> Self::Output {
         Self(self.0 * other as RawTime)
     }


### PR DESCRIPTION
## What this changes

`#[inline]` on the small, monomorphic per-node-per-cycle accessors in `op.rs`,
`runtime/kernel.rs` and `runtime/time.rs`, so a downstream crate compiling a
`nitro!` `compiled()` graph can inline them across the crate boundary instead
of emitting a real call.

**Attributes only — not one function body is touched.** The diff is 31 added
lines, all of them `#[inline]`.

## Why

Closes #823.

`nitro!`'s `compiled()` tier expands into the *downstream* crate: the derive
emits `::wingfoil::op::Ctx::new`, `__ctx.time()`, `__ctx.wall_time()`,
`__ctx.start_time()`, `__ctx.schedule(..)`, `__k.begin_cycle(..)` and
`__k.end_cycle(..)` at the call site. That includes this repo's own benches,
examples and integration tests, which link the lib as an extern crate. Those
calls land on concrete, non-generic `pub fn`s that carried no `#[inline]`, so
nothing *guaranteed* they were inlinable across the boundary. `latency.rs` and
`ops.rs` already annotate their hot leaves; this applies the same pattern to
the kernel/ctx/time layer.

### The two clocks are untouched

Every invariant CLAUDE.md names under "Two clocks: engine time and the wall
snap" still holds, because no body changed:

- `Ctx::wall_time()` stays on `&self` — the `Cell` is what allows that.
- `Ctx::new` still leaves `wall_time: None` rather than copying the kernel's
  snap, so a cycle in which no op stamps still reads the clock zero times.
- `begin_cycle` still only *invalidates* the snap; it never takes one eagerly.

## What was annotated, and what was not

Annotated (`op.rs`): `Ctx::new`, `nested`, `time`, `wall_time`,
`wall_time_precise`, `start_time`, `is_last_cycle`, `run_mode`, `schedule`.

Annotated (`kernel.rs`): `Kernel::start_time`, `time`, `wall_time`,
`run_mode`, `is_last_cycle`, `schedule`, `end_cycle`, `mark`.

Annotated (`time.rs`): `NanoTime::now`, `from_nanos_u128_saturating`, the four
`Mul` impls, the three `Add` impls, `Sub`, and the trivial `From` conversions
`u64 <-> NanoTime` and `Duration <-> NanoTime`.

**Deviations from the issue's list, in both directions.** The line ranges were
treated as a guide, per the issue's own framing.

*Added beyond the list*, each on the same per-node-per-cycle path:

- `Ctx::nested` — the island tier's constructor, built once per inner node per
  activation. Exactly `Ctx::new`'s role for the other tier, and emitted
  downstream by the same derive.
- `Ctx::start_time` / `Ctx::is_last_cycle` / `Ctx::run_mode` — sibling scalar
  getters to `Ctx::time`. `start_time` is emitted directly by the derive;
  `is_last_cycle` and `run_mode` are read from `cycle` bodies that monomorphize
  downstream (window/buffer flush, the run-mode-gated IO sinks).
- `Ctx::wall_time_precise` — a one-line forwarder to the now-inlined
  `NanoTime::now`, on the latency-stamping path.
- `Kernel::start_time` — called by `Ctx::new` itself, so once per node per
  cycle.
- `NanoTime` `From` conversions for `u64` and `Duration` — each is a single
  field access or a `from_nanos`, and they sit inside the annotated arithmetic
  (`Add<Duration>` goes through both) and the kernel's bound checks. The
  display-oriented conversions (`f64`, `NaiveDateTime`, `pretty`, the kdb
  timestamp pair) are cold and were left alone.

*Excluded although in or near the cited range:*

- **`Kernel::begin_cycle`** — left alone, as the issue asks. Large, and once
  per *cycle* rather than per node.
- **No workspace `[profile]` / LTO change.** Profiles apply only to builds
  rooted at this workspace and never to downstream consumers, so LTO cannot
  address the reported problem.
- `Kernel::run_for`, `cycles`, `new`, `with_ready`, `build`, `set_spin`,
  `set_timer_policy`, `due` — construction, configuration or reporting, not the
  hot path. `due` in particular is only read by the in-crate interpreted
  runner, never emitted downstream.
- `Kernel::drain_ready` — per cycle, does a channel drain, and is reached only
  from `begin_cycle`, which is staying out of line anyway.
- Generic items (`TimeQueue`, `Bucket`) — they monomorphize downstream already
  and need nothing.

One annotated item deserves a note: **`Kernel::mark` is private**, so the
cross-crate argument does not apply to it. It is included because `#[inline]`
still enables cross-*codegen-unit* inlining within the crate (release defaults
to 16 CGUs), and it is small and runs once per due node per cycle. Happy to
drop it if a reviewer would rather keep the diff strictly to the pub surface.

**No `#[inline(always)]` anywhere.** Plain `#[inline]` throughout; nothing here
needed the stronger hint.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test -p wingfoil --all-features` — 81 suites pass. The nine
      `*_integration` suites (aeron, etcd, fluvio, kafka, otlp, postgres,
      redis, zmq_cross_lang, zmq_etcd) fail with
      `failed to initialize a docker client: Socket not found:
      /var/run/docker.sock` — no Docker in this sandbox, pre-existing and
      unrelated.
- [x] `cargo test -p wingfoil-derive`
- [ ] New behaviour is covered by a test asserting values and tick times — n/a,
      this changes no behaviour.

### Measurement

**No timing improvement is claimed, because none could be measured here.** The
honest reading follows.

**Timing: the sandbox is too noisy to say anything.** Building `--bench tiers`
(a bench target *is* a downstream crate running `compiled()` graphs) and
re-running **the identical binary** against its own criterion baseline gave:

| group | same-binary re-run vs itself |
| --- | --- |
| `dense_chain/compiled` | −7.19% ("Performance has improved") |
| `accumulate/compiled` | +10.47% ("Performance has regressed") |
| `dense_chain/nested` | −0.82% |
| `accumulate/nested` | +1.63% |

A ±10% swing with no code change at all is the noise floor of a shared cloud
VM. Any before/after number from this machine would be meaningless, so none is
reported.

**Object code: a deterministic check that is not noise-sensitive.** Comparing
`nm -C` on the `tiers` bench binary built before and after the change
(rustc 1.94.1, `bench` profile, no LTO):

```
before-only symbols, gone after:
  T wingfoil::op::Ctx::schedule
  T wingfoil::op::Ctx::wall_time
```

Those two were emitted as real out-of-line functions in the downstream binary
before this change and are fully inlined away after it.

The rest of the issue's list never appears as an out-of-line symbol in *either*
build: on this toolchain rustc's `cross_crate_inlinable` heuristic already
auto-exports MIR for sufficiently trivial non-generic functions, which covers
the plain field getters and the arithmetic impls. `Ctx::wall_time` and
`Ctx::schedule` are precisely the two with `match` bodies that exceed that
threshold — which is why they were the two still paying a call.

That is worth being clear about in both directions. It narrows the *present*
impact relative to the issue's framing, and it is the main argument for
landing the change anyway: the heuristic is an unstable implementation detail
with no guarantee attached. It varies by toolchain version, and a getter drops
out of it the moment its body grows a branch — silently, with no diagnostic.
`#[inline]` turns "currently inlined by luck" into "inlined by contract", and
pins the two that were already losing that lottery.

`Kernel::begin_cycle` remains an out-of-line symbol in both builds, as
intended.

## Notes for the reviewer

The interesting judgement calls are `Kernel::mark` (private — see above) and
the `NanoTime` `From` impls (in the arithmetic hot path but not named in the
issue). Both are easy to drop if you disagree.

Worth knowing that the object-code comparison above is the reason this PR does
not lead with a percentage: the change is defensible as making an existing
guarantee explicit, not as a measured speedup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRyBUej7RQrqxvrSjvqByM)_