### PR TITLE
feat(fluent): add `Stream::filter_map`, the `Option`-shaped `map_filter`

### DIFF
--- a/.claude/commands/new-op.md
+++ b/.claude/commands/new-op.md
@@ -78,6 +78,61 @@ git checkout main && git pull origin main && git checkout -b $ARGUMENTS-op
 
 When you open the PR, its **base branch is `main`**.
 
+## 1b. Is it an op at all? — sugar over an existing op vs. a catalog entry
+
+Do this before step 2, because if the answer is "sugar" then most of the rest
+of this skill does not apply and following it anyway adds a catalog entry that
+buys nothing.
+
+**The test is node count, not ergonomics.** If the behaviour is an existing op
+*re-spelled* — the same single node, the same `cycle`, differing only in how the
+call site phrases it — it is a fluent one-liner over that op, and the fluent
+layer is where it goes. `filter_none`, `collapse_accumulate` and `split` are
+that shape, and so is `filter_map` (#831): `Option`-shaped where `map_filter` is
+`(B, bool)`-shaped, but the same `MapFilter` node underneath. If instead the
+convenient spelling would wire *two* nodes (`.map(f).filter_none()`), that is a
+candidate op — promoting it takes a node out of every graph that uses it, which
+is exactly the argument that promoted `not`, `collapse`, `count`, `accumulate`
+and `merge_all` out of the fluent-only allowlist.
+
+**Do not let a trait bound talk you into a new op.** The instinct is that a
+purpose-built op could drop a bound the sugar carries. It usually cannot: the
+`#[op]` forwarders add `Out: Default` to *every* op for value-slot seeding, so a
+dedicated `FilterMap` would still have required `B: Default` — the sugar's only
+visible cost, and not actually the sugar's. Check the forwarder bounds in the
+macro crate before arguing from ergonomics.
+
+**Sugar is cheap in the fluent layer and *not* free in the macro crate.** This
+is the part that is easy to miss, and shipping without it means shipping a
+method that silently works interpreted and fails incomprehensibly compiled. A
+fluent method with no op behind it has no `__wf_op_<name>_*` forwarders, but it
+*does* resolve on `Stream`, so inside a `nitro!` block the expansion dies on
+leaked `__WF_OP_<NAME>_…` internals with no `no method named` error to explain
+them. Three touch-points, all required:
+
+1. `non_op_method_advice` in `crates/wingfoil-derive/src/lib.rs` — an arm naming
+   the primitive to spell instead. (Also update the two doc comments there that
+   enumerate the set.)
+2. `crates/wingfoil/tests/trybuild/fluent_only_sugar.rs` + its `.stderr` — a
+   `nitro!` block calling it, pinning that message. Adding a block **shifts the
+   line/column numbers of the existing cases**, so re-run and re-check the whole
+   `.stderr`, not just your new stanza (`TRYBUILD=overwrite cargo test -p
+   wingfoil --test trybuild` regenerates it).
+3. `crates/wingfoil/tests/op_completeness.rs` — category 2 of the documented
+   allowlist, with the one-line reason.
+
+A method on a *specialised* receiver (`Stream<Option<T>>`, `Stream<Burst<T>>`)
+is easy to forget here because it is out of reach of most `nitro!` blocks; a
+`StreamOps` method like `filter_map` is in reach of all of them, so for that one
+it is not optional.
+
+**What a sugar method still owes:** the same tests as an op (values *and* tick
+times under `RunMode::HistoricalFrom(NanoTime::ZERO)`, including a case pinning
+that a filtered-out cycle does **not** tick downstream), a doc fence, a
+`#[must_use]` on the returned stream. Steps **4c**, **6** and **9** below apply
+unchanged — including the `must_use_combinators.rs` pin, which a sugar method
+owes exactly as an op does. Steps **2**, **3** and **5** do not.
+
 ## 2. Classify the op shape — the load-bearing decision
 
 The shape decides how much you write and which engines you reach for free.

--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -197,9 +197,9 @@
 //! no macro-crate change; a new method on `impl<T> Stream<T>` does.
 //!
 //! **A method that cannot be an op** — `split` (two outputs, where an `Op` has
-//! one `Out`), `feedback` (a cycle), or `collapse_accumulate` / `filter_none`
-//! (sugar over `fold` / `map_filter`) — is rejected with one message naming
-//! what to write instead:
+//! one `Out`), `feedback` (a cycle), or `collapse_accumulate` / `filter_none` /
+//! `filter_map` (sugar over `fold` / `map_filter`) — is rejected with one
+//! message naming what to write instead:
 //!
 //! ```text
 //! error: `.split(..)` has no `nitro!` forwarder, so it cannot appear in a
@@ -952,9 +952,9 @@ impl ChainWalker {
 /// `count`, `accumulate` and `merge_all` made before them. **Promoting is the
 /// preferred fix; this list is for what is left**: `split` yields two outputs
 /// where an `Op` has one `Out`, `feedback` is a cycle straight-line compiled
-/// emission cannot express, and `collapse_accumulate` / `filter_none` are
-/// one-liners over `fold` / `map_filter`, both already ops — so the primitive
-/// is what a compiled graph should spell.
+/// emission cannot express, and `collapse_accumulate` / `filter_none` /
+/// `filter_map` are one-liners over `fold` / `map_filter`, both already ops —
+/// so the primitive is what a compiled graph should spell.
 ///
 /// It exists purely for diagnostics and collision hygiene. An inherent method
 /// name could otherwise mean one thing in the ordinary `wire()` function and
@@ -1019,7 +1019,7 @@ fn non_op_method_advice(method: &str) -> Option<String> {
         // (`ops::Not` / `ops::Collapse`) and started working in `nitro!`
         // outright. What is left is what *cannot* be promoted: `split` has two
         // outputs where an `Op` has one, `feedback` is a cycle, and the last
-        // two are one-liners over a primitive that is already an op.
+        // three are one-liners over a primitive that is already an op.
         "split" => {
             "it is sugar over two `map`s — bind them separately: \
              `let a = pairs.map(|t| t.0.clone()); let b = pairs.map(|t| t.1.clone());`"
@@ -1033,6 +1033,12 @@ fn non_op_method_advice(method: &str) -> Option<String> {
         "filter_none" => {
             "it is sugar over `map_filter` — spell the primitive: \
              `.map_filter(|opt| match opt.clone() { Some(v) => (v, true), None => \
+             (Default::default(), false) })`"
+        }
+        "filter_map" => {
+            "it is sugar over `map_filter` — spell the primitive, carrying the \
+             emit decision beside the value: \
+             `.map_filter(|v| match f(v) { Some(out) => (out, true), None => \
              (Default::default(), false) })`"
         }
         "feedback" => {

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -925,6 +925,51 @@ pub trait StreamOps<T>: Sized {
         B: Clone + Default + 'static,
         F: Fn(&T) -> Result<(B, bool)> + 'static;
 
+    /// Map and filter in one pass with an `Option`, spelled the way
+    /// [`Iterator::filter_map`](std::iter::Iterator::filter_map) is: tick the
+    /// returned `Some`, and stay **quiet** on `None` — the downstream does not
+    /// tick at all on a dropped value.
+    ///
+    /// Sugar over [`map_filter`](StreamOps::map_filter), which is the same op
+    /// with the emit decision carried beside the value as `(B, bool)`. Reach
+    /// for `map_filter` when there is a meaningful value to carry on the
+    /// don't-emit branch; reach for this one — and for
+    /// [`Stream::filter_none`] when the stream is already `Stream<Option<B>>`
+    /// — the rest of the time. `B: Default` is not a hidden cost of the sugar:
+    /// every op's output slot is seeded with `Out::default()`, so `map_filter`
+    /// requires it too.
+    ///
+    /// **This spelling has no fallible twin, deliberately.**
+    /// [`try_map_filter`](StreamOps::try_map_filter) is the `try_` counterpart
+    /// of `map_filter` — `try_` plus the exact base name — and mirrors that
+    /// method's `Result<(value, emit?)>` shape, not this one's `Option`. The
+    /// two are neighbours here, not an infallible/fallible pair; for a fallible
+    /// `Option` decision, return `Ok((v, true))` / `Ok((_, false))` from
+    /// `try_map_filter`.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use wingfoil::prelude::*;
+    /// use wingfoil::{NanoTime, RunFor, RunMode};
+    ///
+    /// let g = GraphBuilder::new();
+    /// // counts 1..=4; keep the squares of the odd counts → 1, 9
+    /// let odd_squares = g
+    ///     .ticker(Duration::from_nanos(10))
+    ///     .count()
+    ///     .filter_map(|n: &u64| if n % 2 == 1 { Some(n * n) } else { None })
+    ///     .accumulate();
+    /// let mut r = g.build();
+    /// r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(4))
+    ///     .unwrap();
+    /// assert_eq!(vec![1u64, 9], r.value(&odd_squares));
+    /// ```
+    #[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
+    fn filter_map<B, F>(&self, f: F) -> Stream<B>
+    where
+        B: Clone + Default + 'static,
+        F: Fn(&T) -> Option<B> + 'static;
+
     /// Pair each value with the current engine time: `(time, value)`.
     #[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
     fn with_time(&self) -> Stream<(NanoTime, T)>
@@ -1385,6 +1430,20 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
 
     __wf_fluent_try_map_filter!(T);
 
+    // Sugar, not an op: `MapFilter` already carries the semantics, so this is
+    // the same node with the emit decision spelled as an `Option`. See
+    // `filter_none`, which is the same one-liner on a `Stream<Option<T>>`.
+    fn filter_map<B, F>(&self, f: F) -> Stream<B>
+    where
+        B: Clone + Default + 'static,
+        F: Fn(&T) -> Option<B> + 'static,
+    {
+        self.map_filter(move |v| match f(v) {
+            Some(out) => (out, true),
+            None => (B::default(), false),
+        })
+    }
+
     fn with_time(&self) -> Stream<(NanoTime, T)>
     where
         T: Clone + 'static,
@@ -1656,6 +1715,9 @@ impl<T: Clone + Default + 'static> Stream<Option<T>> {
     /// (the legacy `filter_none`) — sugar over
     /// [`map_filter`](StreamOps::map_filter). A node that has nothing to say
     /// this cycle emits `None` and the downstream simply does not tick.
+    ///
+    /// The already-`Option` case of [`filter_map`](StreamOps::filter_map),
+    /// which produces the `Option` from a closure instead.
     #[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
     pub fn filter_none(&self) -> Stream<T> {
         self.map_filter(|opt: &Option<T>| match opt.clone() {

--- a/crates/wingfoil/tests/catalog_flow.rs
+++ b/crates/wingfoil/tests/catalog_flow.rs
@@ -396,6 +396,75 @@ fn filter_none_drops_none() {
     assert_eq!(vec![20u64, 40], r.value(&acc));
 }
 
+/// `filter_map` emits the `Some` payloads and stays quiet on `None`, asserting
+/// tick *times* as well as values so the suppressed cycles are pinned: a 10ns
+/// ticker counts 1..=4 at t = 0/10/20/30, only the odd counts survive, and the
+/// two even instants being **absent** from the accumulation is the filtering
+/// half of the contract.
+#[test]
+fn filter_map_emits_some_and_stays_quiet_on_none() {
+    let g = GraphBuilder::new();
+    let counts = g.ticker(Duration::from_nanos(10)).count();
+    let acc = counts
+        .filter_map(|i: &u64| if i % 2 == 1 { Some(i * i) } else { None })
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(
+        vec![(NanoTime::new(0), 1u64), (NanoTime::new(20), 9)],
+        r.value(&acc)
+    );
+}
+
+/// A `filter_map` that never emits leaves the downstream completely untouched:
+/// the sink is wired and the source ticks four times, but no tick reaches past
+/// the node.
+#[test]
+fn filter_map_all_none_never_ticks_downstream() {
+    let seen = Rc::new(RefCell::new(0u32));
+    let sink_hits = seen.clone();
+    let g = GraphBuilder::new();
+    let _sink = g
+        .ticker(Duration::from_nanos(10))
+        .count()
+        .filter_map(|_: &u64| None::<u64>)
+        .for_each(move |_| {
+            *sink_hits.borrow_mut() += 1;
+            Ok(())
+        });
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(0, *seen.borrow());
+}
+
+/// `filter_map` is exactly `map_filter` with the emit decision spelled as an
+/// `Option` — same values, same tick times, wired side by side in one graph.
+#[test]
+fn filter_map_matches_map_filter() {
+    let g = GraphBuilder::new();
+    let counts = g.ticker(Duration::from_nanos(10)).count();
+    let sugar = counts
+        .filter_map(|i: &u64| if *i > 2 { Some(i * 10) } else { None })
+        .with_time()
+        .accumulate();
+    let primitive = counts
+        .map_filter(|i: &u64| if *i > 2 { (i * 10, true) } else { (0, false) })
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(20), 30u64),
+            (NanoTime::new(30), 40),
+            (NanoTime::new(40), 50),
+        ],
+        r.value(&sugar)
+    );
+    assert_eq!(r.value(&primitive), r.value(&sugar));
+}
+
 /// `collapse` emits the last item of a non-empty iterator value and stays
 /// quiet on an empty one — mirrors legacy `mod::collapse_skips_empty_iterator`.
 #[test]

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -106,6 +106,15 @@
 //!     *test instrument* (it grows for the whole run), which is its own reason
 //!     not to want it in a compiled kernel. Both are rejected by name in
 //!     `nitro!`, pinned by `tests/trybuild/fluent_only_sugar.rs`.
+//!   * `filter_map` → `map_filter`, and this one **is** on `StreamOps` (#831).
+//!     It is `MapFilter` with the emit decision spelled as an `Option` rather
+//!     than carried beside the value as `(B, bool)`, so it is one node either
+//!     way and the primitive is what a compiled graph spells. Promotion buys
+//!     nothing here even in principle: a dedicated `FilterMap` op could not
+//!     shed the `B: Default` bound that is the sugar's only visible cost,
+//!     because the `#[op]` forwarders add `Out: Default` to *every* op for
+//!     value-slot seeding. It is rejected by name in `nitro!` alongside the
+//!     other two, in the same trybuild case.
 //!
 //!     **`not` and `collapse` were here and have since been promoted** to real
 //!     ops (`ops::Not` / `ops::Collapse`), so both are dual-mode now and are

--- a/crates/wingfoil/tests/trybuild/fluent_only_sugar.rs
+++ b/crates/wingfoil/tests/trybuild/fluent_only_sugar.rs
@@ -1,9 +1,13 @@
-// `collapse_accumulate` and `filter_none` are inherent one-liners over `fold`
-// and `map_filter` — both already ops — so neither has forwarders of its own.
-// Like `split`, they resolve fine fluently, which is what makes the untreated
-// failure so poor: the expansion dies on `__WF_OP_*` internals with no `no
-// method named` error to explain them. Each must name the primitive to spell
-// instead. See `fluent_only_split.rs` for the same shape on `split`.
+// `collapse_accumulate`, `filter_none` and `filter_map` are one-liners over
+// `fold` and `map_filter` — both already ops — so none has forwarders of its
+// own. Like `split`, they resolve fine fluently, which is what makes the
+// untreated failure so poor: the expansion dies on `__WF_OP_*` internals with
+// no `no method named` error to explain them. Each must name the primitive to
+// spell instead. See `fluent_only_split.rs` for the same shape on `split`.
+//
+// `filter_map` is the one of the three that is *not* on a specialised
+// `Stream<..>` — it is a `StreamOps` method, so it is in reach of every
+// `nitro!` block, which is exactly why it needs its own arm here.
 #![allow(unused)]
 use std::time::Duration;
 use wingfoil::prelude::*;
@@ -18,6 +22,13 @@ wingfoil::nitro! {
 wingfoil::nitro! {
     fn dropping_none(g: &GraphBuilder, opts: &Stream<Option<u64>>) -> Stream<u64> {
         let out = opts.filter_none();
+        out
+    }
+}
+
+wingfoil::nitro! {
+    fn mapping_and_filtering(g: &GraphBuilder, counts: &Stream<u64>) -> Stream<u64> {
+        let out = counts.filter_map(|n: &u64| (n % 2 == 1).then(|| n * n));
         out
     }
 }

--- a/crates/wingfoil/tests/trybuild/fluent_only_sugar.stderr
+++ b/crates/wingfoil/tests/trybuild/fluent_only_sugar.stderr
@@ -1,11 +1,17 @@
 error: `.collapse_accumulate(..)` has no `nitro!` forwarder, so it cannot appear in a compiled graph: it is sugar over `fold` — spell the primitive: `.fold(Vec::new(), |acc, burst| acc.extend(burst.iter().cloned()))`. Like `accumulate`, it grows for the whole run, so it is a test instrument rather than an output edge
-  --> tests/trybuild/fluent_only_sugar.rs:13:26
+  --> tests/trybuild/fluent_only_sugar.rs:17:26
    |
-13 |         let out = bursts.collapse_accumulate();
+17 |         let out = bursts.collapse_accumulate();
    |                          ^^^^^^^^^^^^^^^^^^^
 
 error: `.filter_none(..)` has no `nitro!` forwarder, so it cannot appear in a compiled graph: it is sugar over `map_filter` — spell the primitive: `.map_filter(|opt| match opt.clone() { Some(v) => (v, true), None => (Default::default(), false) })`
-  --> tests/trybuild/fluent_only_sugar.rs:20:24
+  --> tests/trybuild/fluent_only_sugar.rs:24:24
    |
-20 |         let out = opts.filter_none();
+24 |         let out = opts.filter_none();
    |                        ^^^^^^^^^^^
+
+error: `.filter_map(..)` has no `nitro!` forwarder, so it cannot appear in a compiled graph: it is sugar over `map_filter` — spell the primitive, carrying the emit decision beside the value: `.map_filter(|v| match f(v) { Some(out) => (out, true), None => (Default::default(), false) })`
+  --> tests/trybuild/fluent_only_sugar.rs:31:26
+   |
+31 |         let out = counts.filter_map(|n: &u64| (n % 2 == 1).then(|| n * n));
+   |                          ^^^^^^^^^^

--- a/crates/wingfoil/tests/trybuild/must_use_combinators.rs
+++ b/crates/wingfoil/tests/trybuild/must_use_combinators.rs
@@ -32,6 +32,7 @@ fn transforms(g: &GraphBuilder) {
     count.delay(Duration::from_nanos(10));
     count.pairwise();
     count.try_map_filter(|i: &u64| Ok((i * 2, *i > 2)));
+    count.filter_map(|i: &u64| (*i > 2).then(|| i * 2));
 }
 
 fn sources(g: &GraphBuilder) {

--- a/crates/wingfoil/tests/trybuild/must_use_combinators.stderr
+++ b/crates/wingfoil/tests/trybuild/must_use_combinators.stderr
@@ -99,50 +99,62 @@ help: use `let _ = ...` to ignore the resulting value
 34 |     let _ = count.try_map_filter(|i: &u64| Ok((i * 2, *i > 2)));
    |     +++++++
 
-error: unused return value of `ticker` that must be used
-  --> tests/trybuild/must_use_combinators.rs:39:5
+error: unused return value of `wingfoil::fluent::StreamOps::filter_map` that must be used
+  --> tests/trybuild/must_use_combinators.rs:35:5
    |
-39 |     g.ticker(Duration::from_nanos(10));
+35 |     count.filter_map(|i: &u64| (*i > 2).then(|| i * 2));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: a dropped stream stays wired and cycles every tick, producing an unread value
+help: use `let _ = ...` to ignore the resulting value
+   |
+35 |     let _ = count.filter_map(|i: &u64| (*i > 2).then(|| i * 2));
+   |     +++++++
+
+error: unused return value of `ticker` that must be used
+  --> tests/trybuild/must_use_combinators.rs:40:5
+   |
+40 |     g.ticker(Duration::from_nanos(10));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: a dropped stream stays wired and cycles every tick, producing an unread value
 help: use `let _ = ...` to ignore the resulting value
    |
-39 |     let _ = g.ticker(Duration::from_nanos(10));
+40 |     let _ = g.ticker(Duration::from_nanos(10));
    |     +++++++
 
 error: unused return value of `constant` that must be used
-  --> tests/trybuild/must_use_combinators.rs:40:5
+  --> tests/trybuild/must_use_combinators.rs:41:5
    |
-40 |     g.constant(1u64);
+41 |     g.constant(1u64);
    |     ^^^^^^^^^^^^^^^^
    |
    = note: a dropped stream stays wired and cycles every tick, producing an unread value
 help: use `let _ = ...` to ignore the resulting value
    |
-40 |     let _ = g.constant(1u64);
+41 |     let _ = g.constant(1u64);
    |     +++++++
 
 error: unused return value of `never` that must be used
-  --> tests/trybuild/must_use_combinators.rs:41:5
+  --> tests/trybuild/must_use_combinators.rs:42:5
    |
-41 |     g.never();
+42 |     g.never();
    |     ^^^^^^^^^
    |
    = note: a dropped stream stays wired and cycles every tick, producing an unread value
 help: use `let _ = ...` to ignore the resulting value
    |
-41 |     let _ = g.never();
+42 |     let _ = g.never();
    |     +++++++
 
 error: unused return value of `wingfoil::fluent::SourceOps::channel` that must be used
-  --> tests/trybuild/must_use_combinators.rs:42:5
+  --> tests/trybuild/must_use_combinators.rs:43:5
    |
-42 |     g.channel::<u64>();
+43 |     g.channel::<u64>();
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: a dropped stream stays wired and cycles every tick, producing an unread value
 help: use `let _ = ...` to ignore the resulting value
    |
-42 |     let _ = g.channel::<u64>();
+43 |     let _ = g.channel::<u64>();
    |     +++++++

--- a/docs/adding-an-op.md
+++ b/docs/adding-an-op.md
@@ -12,6 +12,31 @@ it defers to for *why* the boilerplate is shaped the way it is.
 > gets its own page. The design argument behind the no-table mechanism is
 > [`decisions/macro-extensibility-decision.md`](decisions/macro-extensibility-decision.md).
 
+## First: is it an op at all?
+
+Some new vocabulary is not a new node. If the behaviour you want is an existing
+op *re-spelled* — the same single node, the same `cycle`, differing only in how
+the call site phrases it — it belongs in the fluent layer as a one-liner over
+that op, not in the catalog. `filter_none` and `collapse_accumulate` are that
+shape, and so is `filter_map` (#831): `Option`-shaped rather than `(B, bool)`,
+but the same `MapFilter` node underneath.
+
+The test is **node count**, not ergonomics: sugar wires exactly the node the
+primitive would. A "sugar" method that wires *two* nodes (`.map(f).filter_none()`)
+is a candidate op, because promoting it removes a node from every graph that
+uses it. And a bound that looks like the sugar's cost usually isn't one — a
+dedicated `FilterMap` op could not have dropped `B: Default`, since the `#[op]`
+forwarders add `Out: Default` to every op for value-slot seeding.
+
+The cost of choosing sugar is a real one and is paid in the macro crate: a
+fluent-only method resolves fine when called but has no `__wf_op_<name>_*`
+forwarders, so inside `nitro!` it fails on leaked internal symbols. It must be
+named in `non_op_method_advice` (`wingfoil-derive`) with the primitive to spell
+instead, pinned by a case in `tests/trybuild/fluent_only_sugar.rs`, and recorded
+in the `tests/op_completeness.rs` allowlist. If that is not what you want, write
+the op — see the promotion precedents (`not`, `collapse`, `count`,
+`accumulate`, `merge_all`) in that allowlist.
+
 ## The recipe
 
 Per node, in this order, no exceptions:


### PR DESCRIPTION
## What this changes

`StreamOps` gains `filter_map(f)` taking `Fn(&T) -> Option<B>`: tick the returned `Some`, stay **quiet** on `None`.

```rust
#[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
fn filter_map<B, F>(&self, f: F) -> Stream<B>
where
    B: Clone + Default + 'static,
    F: Fn(&T) -> Option<B> + 'static;
```

It is fluent **sugar** over the existing `MapFilter` op — the same single node, differing only in how the call site spells the emit decision — not a new catalog entry. `map_filter` is untouched: neither replaced nor deprecated.

## Why — and the premise has changed since the issue was filed

**Read this part before the rest.** #831 argued a *parity gap*: `Signal::filter_map` existed, `Stream` had no twin. #887 then deleted the `Signal` facade outright (deviation D29), so **that premise is gone** — nothing in the tree has an `Option`-shaped filter-map any more, and this PR no longer closes a gap between two surfaces. The `Signal::filter_map` delegation that was part of the original branch has been dropped in the rebase; it had nowhere to land.

The change is now a **fresh API addition**, and it stands on a narrower but still real argument:

`map_filter`'s `(value, emit?)` convention **inverts `Iterator::filter_map`**, which is the shape every Rust programmer already reaches for. Under the current API a Stream user has three options and all three are worse than the one they expect:

- discover `map_filter` and **fabricate a discarded `B`** on the don't-emit branch (`(Default::default(), false)`) — a value the engine never reads, written only to satisfy the tuple;
- chain **two nodes** via `.map(f).filter_none()`, paying a node per cycle for a spelling;
- or reach for `filter_map` by name, find it resolves on `Stream`… nowhere, because it didn't exist.

The third is the tell: `filter_none` already exists for the *already-`Option`* case, which means the `Option` convention is one this API teaches — it just had no entry point when the `Option` comes out of a closure.

**Why sugar and not an op.** The behaviour is the *same single `MapFilter` node*, so promoting it would add a catalog entry that removes no node from any graph. The bound that looks like the sugar's cost isn't one: a dedicated `FilterMap` op could not have shed `B: Default`, because the `#[op]` forwarders add `Out: Default` to every op for value-slot seeding (`wingfoil-derive/src/lib.rs`). A new op would have bought nothing and cost a catalog entry.

**If you don't buy that argument, this is the PR to close rather than the one to trim.** With the parity premise gone the whole change is an ergonomics call, and the reviewer's call — not something to land on momentum. The counter-case is legitimate: it is a second spelling of an existing node, and the catalog is smaller for not having it.

## Naming, under the #884 ruling

#884 ruled the fallible-twin convention: `try_` + the **exact** base name, so `map_filter` → `try_map_filter`. It renamed `try_filter_map` specifically to avoid a false infallible/fallible pair with an `Option`-shaped `filter_map`. That ruling anticipated exactly this method, and the shapes land correctly beside each other:

| method | closure | pairs with |
|---|---|---|
| `map_filter` | `Fn(&T) -> (B, bool)` | `try_map_filter` |
| `try_map_filter` | `Fn(&T) -> Result<(B, bool)>` | `map_filter` |
| `filter_map` (this PR) | `Fn(&T) -> Option<B>` | — deliberately no `try_` twin |

`filter_map` and `try_map_filter` are neighbours, **not** a pair — different base names, so the trap #884 removed does not come back. The rustdoc on the new method now says so explicitly, replacing the disambiguating note #884 put on `Signal::filter_map` (which died with the facade). `enumerate` (#892) and `pairwise` (#879) were checked for overlap: neither touches this shape.

## What the rebase onto `main` changed

Rebased from `932107e` onto `f794b07`. Two conflicts, both deliberate resolutions rather than mechanical ones:

- **`signal.rs` (modify/delete)** — took main's deletion. The `Signal::filter_map` delegation is gone with it. A `tests/signal.rs` cross-reference in one of the new test doc comments was dropped for the same reason (that file no longer exists).
- **`fluent.rs`** — kept both sides: `try_map_filter` (#884) and `filter_map` sit adjacent in the trait and the impl, and `filter_none` keeps main's `#[must_use]` alongside this branch's added doc line.

Picked up from what landed underneath:

- **`#[must_use]` (#871)** with that PR's message verbatim — it was already on this branch — and now **pinned in `tests/trybuild/must_use_combinators.rs` + `.stderr`**, which is what `/new-op` step 4c asks for. The fixture confirms the attribute fires at the call site, i.e. it is on the hand-written trait declaration and not lost in an impl.
- `/new-op` step 1b lost its reference to the deleted step 4b and to `Signal` delegation; it now points at step 4c.

## How it was verified

Toolchain: **1.98.0**, which is what `dtolnay/rust-toolchain@stable` resolves to today — so the `.stderr` fixtures were generated and checked against the same rustc CI will use. `fluent_only_sugar.stderr` needed **no** regeneration after the rebase; `must_use_combinators.stderr` was regenerated (`TRYBUILD=overwrite`) for the added case and the line shifts it causes below it.

- [x] `cargo fmt --all -- --check`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test -p wingfoil --all-features --no-fail-fast`
- [x] `cargo test --doc -p wingfoil --all-features`
- [x] `cargo test -p wingfoil-derive`
- [x] `scripts/check-example-docs.sh`

Green except the nine `*_integration` suites (aeron, etcd, fluvio, kafka, otlp, postgres, redis, zmq_cross_lang, zmq_etcd) that fail with `failed to initialize a docker client: Socket not found: /var/run/docker.sock` — no Docker in that environment, pre-existing and unrelated.

Three tests in `tests/catalog_flow.rs`, all `RunMode::HistoricalFrom(NanoTime::ZERO)`:

- `filter_map_emits_some_and_stays_quiet_on_none` — `with_time().accumulate()` pins values *and* stamps: a 10ns ticker counts 1..=4 at t = 0/10/20/30, only the odd counts survive, and the two even instants being **absent** is the filtering half of the contract.
- `filter_map_all_none_never_ticks_downstream` — an all-`None` closure with a counting `for_each` behind it: source ticks four times, sink fires zero. The "a filtered-out tick does not tick downstream" case stated directly rather than inferred from a gap in a `Vec`.
- `filter_map_matches_map_filter` — sugar and primitive wired side by side in one graph, asserted equal on values and stamps, so the two cannot drift.

Plus a doc fence on the method and the two trybuild cases.

## Notes for the reviewer

**`nitro!` diagnostics are the non-obvious cost of sugar, and they are here.** Sugar composes out of what already exists and needs no *forwarder* — but that is true of the emission, not of the diagnostics. A fluent method with no op behind it has no `__wf_op_*` forwarders yet still resolves on `Stream`, so inside a `nitro!` block the expansion dies on leaked `__WF_OP_FILTER_MAP_…` internals carrying nonsense "a constant with a similar name exists" suggestions, with **no** `no method named` error pointing at the real problem. `filter_none`, `collapse_accumulate` and `split` each have an arm in `non_op_method_advice` (`wingfoil-derive`) that turns that into one message naming the primitive to spell instead; `filter_map` now has one too, pinned by a case in `tests/trybuild/fluent_only_sugar.rs` and recorded in the fluent-only allowlist in `tests/op_completeness.rs` (category 2).

Worth flagging: `filter_map` is the **first** of that set on `StreamOps` rather than on a specialised receiver (`Stream<Option<T>>`, `Stream<Burst<T>>`). The other two are out of reach of most `nitro!` blocks by their receiver type; this one is in reach of all of them, so the arm is not optional for it.

**Python is unaffected.** `PyStream` already exposes `filter_map` (`wingfoil-python/src/graph.rs`, `python.rs`), so this closes a Rust-side gap Python never had. No binding changes.

**Living-document update.** Per CLAUDE.md, the decision this turned on — *sugar over an existing op vs. a new catalog op* — was not written down anywhere, which is why the issue had to argue it from first principles. It is now step **1b** of `/new-op` and a matching section in `docs/adding-an-op.md`: the node-count test that answers it (sugar wires exactly the node the primitive would; a two-node "sugar" method is a promotion candidate — the argument that promoted `not`, `collapse`, `count`, `accumulate` and `merge_all`), the warning not to let a trait bound argue for a new op when the forwarders impose it anyway, and the three macro-crate touch-points sugar owes — including that adding a `trybuild` block shifts the line numbers of the existing cases in the shared `.stderr`.

**Unrelated gap noticed while rebasing, not fixed here.** `take_while` (#886) and `enumerate` (#892) landed on `StreamOps` **without** `#[must_use]`, against `fluent.rs`'s own module doc ("Every transform and source declaration here therefore carries `#[must_use]`") and `/new-op` step 4c. `must_use_combinators.rs` does not catch it because it is a representative sample, not an exhaustive one. Deliberately left alone so it does not ride along in this PR — worth its own issue.

## Closes

Closes #831 — **but see "Why" above**: the issue's parity framing no longer describes the tree, and the issue text should be read as superseded by this PR's argument rather than as the case for merging.
