### PR TITLE
fix(js): report dropped publishes and wire mismatches

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -36,7 +36,9 @@ client.subscribe("price", (value, timeNs) => {
 
 // Send a UI event back to the graph. `false` means it was dropped because
 // the client was still booting/reconnecting or encoding/sending failed.
-const sent = client.publish("ui", { kind: "click", note: "hi" });
+if (!client.publish("ui", { kind: "click", note: "hi" })) {
+  // dropped -- see "Publishing is best effort" below
+}
 ```
 
 Start the server to match:
@@ -56,7 +58,10 @@ Svelte, and Vue publisher helpers return the same boolean.
 
 Publishes are not buffered or replayed. A stale UI or order event can be more
 dangerous than a visible drop after reconnect, so callers that require delivery
-should check the return value and apply their own domain-specific retry policy.
+should check the return value and apply a bounded, domain-specific retry policy.
+A drop while booting or reconnecting may be transient; retrying the same value
+that JSON cannot encode will never succeed. Encoding and send failures also log
+a warning, but the boolean alone does not distinguish failure causes.
 Subscriptions are different: they describe desired connection state and are
 therefore replayed automatically after reconnect.
 

--- a/js/README.md
+++ b/js/README.md
@@ -34,8 +34,9 @@ client.subscribe("price", (value, timeNs) => {
   console.log(timeNs, value);
 });
 
-// Send a UI event back to the graph:
-client.publish("ui", { kind: "click", note: "hi" });
+// Send a UI event back to the graph. `false` means it was dropped because
+// the client was still booting/reconnecting or encoding/sending failed.
+const sent = client.publish("ui", { kind: "click", note: "hi" });
 ```
 
 Start the server to match:
@@ -45,6 +46,19 @@ WebServer::bind("127.0.0.1:8080")
     .codec(CodecKind::Json)
     .start()?;
 ```
+
+### Publishing is best effort
+
+`publish()` returns `true` only after it hands the encoded frame to an open
+WebSocket. It returns `false` while wasm is loading, during the initial connect
+or a reconnect, and when encoding or `WebSocket.send()` fails. The Solid,
+Svelte, and Vue publisher helpers return the same boolean.
+
+Publishes are not buffered or replayed. A stale UI or order event can be more
+dangerous than a visible drop after reconnect, so callers that require delivery
+should check the return value and apply their own domain-specific retry policy.
+Subscriptions are different: they describe desired connection state and are
+therefore replayed automatically after reconnect.
 
 ### Data payloads require the JSON codec
 
@@ -283,4 +297,7 @@ The control plane (topic `$ctrl`) carries `Hello` on connect, `Subscribe`
 / `Unsubscribe` from the client, and `Complete { topic }` from the server
 when a publish topic's stream ends (wire protocol version 2). `Complete`
 was appended to the message enum, so a version-1 server that never sends
-it stays compatible — the client simply never fires `onComplete`.
+it stays compatible — the client simply never fires `onComplete`. When the
+server's Hello version differs from the client's `wireVersion()`, the client
+logs one explicit error for that connection but stays connected because wire
+versions can remain backward-compatible.

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -317,7 +317,8 @@ export class WingfoilClient {
    *
    * Returns `true` only when the frame was handed to the open WebSocket.
    * Returns `false` while wasm or the socket is not ready, or when encoding
-   * or sending fails. Dropped publishes are never buffered or replayed.
+   * or sending fails. Dropped publishes are never buffered or replayed, and
+   * callers should bound retries because an unencodable value cannot recover.
    */
   publish(topic: string, value: unknown): boolean {
     if (!this.wasmReady || !this.socket || this.socket.readyState !== WebSocket.OPEN) {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -315,18 +315,21 @@ export class WingfoilClient {
    * silent garbage if it tried. So the only publishes that fail here are
    * values JSON itself cannot carry.
    *
-   * Failures never propagate: an unencodable value, or a socket that is not
-   * open, is warned about and dropped.
+   * Returns `true` only when the frame was handed to the open WebSocket.
+   * Returns `false` while wasm or the socket is not ready, or when encoding
+   * or sending fails. Dropped publishes are never buffered or replayed.
    */
-  publish(topic: string, value: unknown): void {
+  publish(topic: string, value: unknown): boolean {
     if (!this.wasmReady || !this.socket || this.socket.readyState !== WebSocket.OPEN) {
-      return;
+      return false;
     }
     try {
       const bytes = encodePayload(this.codecKind, topic, value);
       this.socket.send(asBufferSource(bytes));
+      return true;
     } catch (err) {
       console.warn("wingfoil: publish failed on", topic, err);
+      return false;
     }
   }
 
@@ -465,6 +468,12 @@ export class WingfoilClient {
       };
       if (ctrl.Hello) {
         this.serverVersion = ctrl.Hello.version;
+        const clientVersion = wireVersion();
+        if (ctrl.Hello.version !== clientVersion) {
+          console.error(
+            `wingfoil: wire protocol version mismatch (client ${clientVersion}, server ${ctrl.Hello.version}); continuing because the versions may still be compatible`,
+          );
+        }
         this.emitConn({
           kind: "open",
           codec: ctrl.Hello.codec as CodecKind,

--- a/js/src/solid.ts
+++ b/js/src/solid.ts
@@ -58,7 +58,8 @@ export function useTopicBurst<T>(
 
 /**
  * A small publish helper. Returns a function that, given a value, sends
- * it to `topic`. Usage in an event handler:
+ * it to `topic` and reports whether the open socket accepted it. Usage in
+ * an event handler:
  *
  * ```tsx
  * const sendClick = usePublisher(client, "ui");
@@ -68,6 +69,6 @@ export function useTopicBurst<T>(
 export function usePublisher<T>(
   client: WingfoilClient,
   topic: string,
-): (value: T) => void {
+): (value: T) => boolean {
   return (value) => client.publish(topic, value);
 }

--- a/js/src/svelte.ts
+++ b/js/src/svelte.ts
@@ -29,7 +29,7 @@ export function topic<T>(
   });
 }
 
-/** Helper to publish from Svelte components. */
-export function publisher<T>(client: WingfoilClient, name: string): (value: T) => void {
+/** Helper to publish from Svelte components and report whether it was sent. */
+export function publisher<T>(client: WingfoilClient, name: string): (value: T) => boolean {
   return (value) => client.publish(name, value);
 }

--- a/js/src/tracing.ts
+++ b/js/src/tracing.ts
@@ -155,7 +155,9 @@ export class LatencyTracker {
   /**
    * Publish a request on the outbound topic. `session`, `client_seq` and
    * `t_client_send` are stamped automatically and override any same-named
-   * keys in `payload`. Returns the `client_seq` that was used.
+   * keys in `payload`. Returns the `client_seq` that was used. The underlying
+   * publish is best effort, so the sequence number does not promise that a
+   * frame was sent or that `onResponse` will observe a round trip.
    *
    * No-op after `close()`; returns the seq that *would* have been used.
    */

--- a/js/src/vue.ts
+++ b/js/src/vue.ts
@@ -24,7 +24,7 @@ export function useTopic<T>(
   return r;
 }
 
-/** Helper to publish from Vue components. */
-export function usePublisher<T>(client: WingfoilClient, name: string): (value: T) => void {
+/** Helper to publish from Vue components and report whether it was sent. */
+export function usePublisher<T>(client: WingfoilClient, name: string): (value: T) => boolean {
   return (value) => client.publish(name, value);
 }

--- a/js/tests/client.test.ts
+++ b/js/tests/client.test.ts
@@ -136,7 +136,7 @@ describe("WingfoilClient Hello version handling", () => {
     vi.unstubAllGlobals();
   });
 
-  it("surfaces a mismatch once and keeps the connection open", async () => {
+  it("surfaces a mismatch and keeps the connection open", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     const { client, socket } = await connectedClient();
     const states: ConnectionState[] = [];

--- a/js/tests/client.test.ts
+++ b/js/tests/client.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const wasm = vi.hoisted(() => ({
+  control: {} as { Hello?: { codec: string; version: number } },
+  encodePayload: vi.fn(() => new Uint8Array([1, 2, 3])),
+  wireVersion: vi.fn(() => 2),
+}));
+
+vi.mock("../src/wasm/wingfoil_wasm.js", () => ({
+  default: () => Promise.resolve(),
+  init_panic_hook: () => {},
+  wireVersion: wasm.wireVersion,
+  controlTopic: () => "$ctrl",
+  decodeEnvelope: () => ({
+    topic: "$ctrl",
+    timeNs: 0n,
+    payload: new Uint8Array([9]),
+  }),
+  encodeEnvelope: () => new Uint8Array(),
+  encodeSubscribe: () => new Uint8Array(),
+  encodeUnsubscribe: () => new Uint8Array(),
+  encodePayload: wasm.encodePayload,
+  decodePayload: () => null,
+  decodeControl: () => wasm.control,
+}));
+
+import { WingfoilClient, type ConnectionState } from "../src/index.js";
+
+type SocketHandler = (event: { data?: ArrayBuffer; code?: number; reason?: string }) => void;
+
+class FakeSocket {
+  static readonly OPEN = 1;
+  static readonly instances: FakeSocket[] = [];
+
+  readyState = 0;
+  binaryType = "";
+  readonly send = vi.fn();
+  private readonly handlers = new Map<string, SocketHandler[]>();
+
+  constructor(_url: string) {
+    FakeSocket.instances.push(this);
+  }
+
+  addEventListener(name: string, handler: SocketHandler): void {
+    const handlers = this.handlers.get(name) ?? [];
+    handlers.push(handler);
+    this.handlers.set(name, handlers);
+  }
+
+  emit(name: string, event: Parameters<SocketHandler>[0] = {}): void {
+    for (const handler of this.handlers.get(name) ?? []) handler(event);
+  }
+
+  close(): void {}
+}
+
+async function connectedClient(): Promise<{
+  client: WingfoilClient;
+  socket: FakeSocket;
+}> {
+  const client = new WingfoilClient({ url: "ws://localhost:8080/ws" });
+  await vi.waitFor(() => expect(FakeSocket.instances).toHaveLength(1));
+  return { client, socket: FakeSocket.instances[0] };
+}
+
+describe("WingfoilClient.publish", () => {
+  beforeEach(() => {
+    FakeSocket.instances.length = 0;
+    wasm.control = {};
+    wasm.encodePayload.mockReset();
+    wasm.encodePayload.mockReturnValue(new Uint8Array([1, 2, 3]));
+    wasm.wireVersion.mockReturnValue(2);
+    vi.stubGlobal("WebSocket", FakeSocket);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("reports a drop while wasm is still booting", () => {
+    const client = new WingfoilClient({ url: "ws://localhost:8080/ws" });
+    expect(client.publish("orders", { id: 1 })).toBe(false);
+    client.close();
+  });
+
+  it("returns true only after handing the encoded frame to an open socket", async () => {
+    const { client, socket } = await connectedClient();
+
+    expect(client.publish("orders", { id: 1 })).toBe(false);
+    expect(socket.send).not.toHaveBeenCalled();
+
+    socket.readyState = FakeSocket.OPEN;
+    expect(client.publish("orders", { id: 2 })).toBe(true);
+    expect(wasm.encodePayload).toHaveBeenCalledWith("json", "orders", { id: 2 });
+    expect(socket.send).toHaveBeenCalledTimes(1);
+    client.close();
+  });
+
+  it("returns false when encoding or sending fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { client, socket } = await connectedClient();
+    socket.readyState = FakeSocket.OPEN;
+    wasm.encodePayload.mockImplementationOnce(() => {
+      throw new Error("unencodable");
+    });
+
+    expect(client.publish("orders", BigInt(1))).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      "wingfoil: publish failed on",
+      "orders",
+      expect.any(Error),
+    );
+
+    socket.send.mockImplementationOnce(() => {
+      throw new Error("socket closed during send");
+    });
+    expect(client.publish("orders", { id: 2 })).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(2);
+    client.close();
+  });
+});
+
+describe("WingfoilClient Hello version handling", () => {
+  beforeEach(() => {
+    FakeSocket.instances.length = 0;
+    wasm.control = {};
+    wasm.encodePayload.mockReset();
+    wasm.encodePayload.mockReturnValue(new Uint8Array());
+    wasm.wireVersion.mockReturnValue(2);
+    vi.stubGlobal("WebSocket", FakeSocket);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("surfaces a mismatch once and keeps the connection open", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client, socket } = await connectedClient();
+    const states: ConnectionState[] = [];
+    client.onConnection((state) => states.push(state));
+    wasm.control = { Hello: { codec: "json", version: 1 } };
+
+    socket.emit("message", { data: new Uint8Array([0]).buffer });
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toContain(
+      "wire protocol version mismatch (client 2, server 1)",
+    );
+    expect(client.version).toBe(1);
+    expect(states).toContainEqual({ kind: "open", codec: "json", version: 1 });
+    client.close();
+  });
+
+  it("does not report matching versions", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { client, socket } = await connectedClient();
+    wasm.control = { Hello: { codec: "json", version: 2 } };
+
+    socket.emit("message", { data: new Uint8Array([0]).buffer });
+
+    expect(error).not.toHaveBeenCalled();
+    client.close();
+  });
+});


### PR DESCRIPTION
## What this changes

- makes `WingfoilClient.publish()` return whether a frame reached an open WebSocket
- propagates that boolean through the Solid, Svelte, and Vue publisher helpers
- reports a Hello wire-version mismatch once per connection without rejecting compatible peers
- documents the best-effort/no-buffering contract and adds focused client regressions

## Why

The client previously dropped publishes silently during wasm startup and reconnect windows, while subscription replay made the API look more durable than it is. It also stored the server's Hello version without comparing it to the local wire version, so incompatibilities surfaced later as opaque decode noise.

Closes #836.

## How it was verified

- `cd js && pnpm run lint`
- `cd js && pnpm test` - 40 passed, including 5 new client tests
- `git diff --check`

The clean checkout does not contain generated `js/src/wasm`, and this Windows host does not have `wasm-pack`. The TypeScript and Vitest runs therefore used a gitignored module-shape stub; the client tests mock the codec functions they exercise. Upstream CI remains the proof for the real WASM build.

## Notes for the reviewer

Publishes are deliberately not queued: replaying stale UI or order events after reconnect is domain-unsafe. A version mismatch is likewise informational rather than fatal because adjacent wire versions can remain compatible.