### PR TITLE
Add /dogfood: harvest contribution friction with a team of small-model agents

### DIFF
--- a/.claude/commands/dogfood.md
+++ b/.claude/commands/dogfood.md
@@ -1,192 +1,179 @@
 Dogfood this repository with a team of small-model agents and harvest the
-friction they hit. Scope: `$ARGUMENTS` names what the team should build (e.g.
-`3 ops and 2 examples`, or a specific list). Leave it blank and you choose the
-tasks yourself from the gaps described in step 1.
+friction they hit. `$ARGUMENTS`, if given, narrows or overrides the fixed team
+in step 1; blank runs the standard eight.
 
 This is a **measurement** skill. The code the agents write is the vehicle, not
-the product — the product is a deduplicated, actionable list of everything that
-made contributing to this repo harder than it needed to be, put to the user as
-a menu of fixes to choose from.
+the product. The product is a deduplicated, actionable list of everything that
+made contributing here harder than it needed to be, put to the user as a menu
+of fixes to choose from.
 
-## Why a deliberately weak model
+## The model is Haiku. Do not ask, do not offer alternatives.
 
-Run the team on **Haiku** by default. This is counter-intuitive and it is the
-whole point: a strong model silently infers past ambiguity in the docs and
-skills, so it finds nothing. A weak model hits every under-specified step
-head-on and reports it. Haiku failures are a map of where the documentation is
-thin.
+Counter-intuitive and load-bearing: a strong model silently infers past
+ambiguity in the docs and so finds nothing — its silence is not evidence. A
+weak model hits every under-specified step head-on. Haiku failures are a map of
+where the documentation is thin, which is the entire output.
 
-The corollary is that **broken code is an expected, acceptable outcome**. Tell
-the agents so explicitly, or they will over-claim success. A friction log that
-says "did not compile, 3 errors remaining, here is where I got stuck" is worth
-more than a clean-looking diff.
+**Broken code is therefore an expected, acceptable outcome.** Say so in every
+agent prompt or they will over-claim success. "Did not compile, 3 errors
+remaining, here is where I got stuck" is worth more than a clean-looking diff.
 
-Offer the user the choice up front if they have not already made it —
-Haiku for friction signal, Sonnet/Opus if they actually want landable code —
-and say plainly which output each buys.
+## 1. The team — eight agents, fixed composition
 
-## 1. Choose the tasks
+Spread deliberately so the friction is not all from one recipe:
 
-Aim for **6–8 agents**, one task each, spread deliberately across surfaces so
-the friction is not all from one recipe. A good spread:
+- **6 examples.** Each must touch a *different* corner of the feature and
+  adapter surface — do not send six agents at plain `core/`. Aim for one with
+  no features at all, then spread the rest across `statistics`, `csv`,
+  `async`, `dynamic-graph`, `web`/`ws`, `fix`, `iceoryx2`, and both the
+  `adapters/` and `showcase/` groups. Examples exercise a rule set nothing else
+  touches: directory + README + explicit Cargo target + two index links,
+  enforced by `scripts/check-example-docs.sh`, with the README's sample output
+  required to be real.
+- **1 op with Python bindings**, via `/new-op`. The `#[pyop]` / `pyop_fn!` step
+  is the thinnest part of that skill, so say in the prompt that binding
+  friction is what you most want reported.
+- **1 new adapter with Python bindings**, via `/new-adapter` *then*
+  `/bind-adapter`. This is the heaviest task in the set and the one most likely
+  to come back unfinished — that is fine and it is the point: it is the only
+  task that crosses two skills, and the seam between them is exactly where the
+  instructions have never been walked end to end.
 
-- **3–4 ops** via `/new-op` — one simple stateful op, one predicate/closure op,
-  one time-scheduling op (`Activation::SCHEDULES`), one statistics-family op.
-- **1 op with Python bindings** — the `#[pyop]` / `pyop_fn!` step is where
-  `/new-op` is thinnest; give it its own agent and say so in the prompt.
-- **2–3 `core/` examples** — these exercise a completely different rule set
-  (the directory + README + explicit Cargo target + two README index links,
-  checked by `scripts/check-example-docs.sh`).
-- **1 adapter binding** via `/bind-adapter` — pick an adapter that is ported in
-  Rust but genuinely unbound in Python. Compare
-  `crates/wingfoil/src/adapters/` against
-  `crates/wingfoil-python/src/adapters/` to find one; do not invent a gap that
-  is already filled.
-
-Pick tasks that are real gaps, not busywork. Before spawning, grep to confirm
-the op/example/binding does not already exist — an agent that discovers its
-task is already done produces no friction data.
+Every task must be a **real gap**. Before spawning, confirm it: grep `ops.rs`
+for the op, `examples/` for the example, and compare
+`crates/wingfoil/src/adapters/` against `crates/wingfoil-python/src/adapters/`
+for genuinely unbound adapters. An agent that discovers its task is already
+done produces no friction data and wastes a slot.
 
 ## 2. Spawn the team
 
-All agents in **one message** so they run concurrently, each with
-`isolation: "worktree"` so they cannot conflict, and `model: "haiku"`.
+All eight in **one message** so they run concurrently, each with
+`isolation: "worktree"` and `model: "haiku"`.
 
-### Protect the disk — this is the failure mode that kills the run
+### Protect the disk — the failure mode that kills the run
 
-Eight worktrees each building independently will exhaust the sandbox's
-writable allowance (see "Disk space" in `CLAUDE.md`). Two mitigations, both
-mandatory:
+Eight worktrees building independently will exhaust a sandbox's writable
+allowance (see "Disk space" in `CLAUDE.md`). Both mitigations are mandatory:
 
-1. **Pre-warm the shared dependency cache** before spawning:
-   `CARGO_INCREMENTAL=0 cargo check -p wingfoil --features statistics`, run in
-   the background while you write the prompts.
-2. **Every agent prompt must set** `export
+1. **Pre-warm the shared dependency cache** before spawning, in the background
+   while you write the prompts:
+   `CARGO_INCREMENTAL=0 cargo check -p wingfoil --features statistics`.
+2. **Every agent prompt sets** `export
    CARGO_TARGET_DIR=/home/user/wingfoil/target`. Registry dependencies are
-   keyed by package id and features, not by workspace path, so all agents reuse
-   the one ~700-crate dep cache and only recompile the workspace crate itself.
-   Cargo locks the directory, so checks serialise — tell the agents that
-   `Blocking waiting for file lock` is expected and to wait it out.
+   keyed by package id and features, not workspace path, so all agents share
+   the one ~700-crate cache and recompile only the workspace crate. Cargo locks
+   the directory, so checks serialise — tell agents `Blocking waiting for file
+   lock` is expected and to wait.
+
+Check `df` between waves. Prompt-level bans are not self-enforcing (see the
+lessons below), so size headroom to survive a few violations.
 
 ### Rules every agent prompt must carry
 
-- **Allowed**: `cargo check -p <crate> [--features ...]`,
-  `cargo test -p wingfoil --lib <filter>`, `cargo run -p wingfoil --example
-  <name>`, `cargo fmt`, `scripts/check-example-docs.sh`.
+- **Allowed**: `cargo check -p <crate> [--features …]`, `cargo test -p wingfoil
+  --lib <filter>`, `cargo run -p wingfoil --example <name>`, `cargo fmt`,
+  `scripts/check-example-docs.sh`, `scripts/check-python-bindings.sh`.
 - **Forbidden**: `--all-targets`, `--all-features`, `cargo build --release`,
   `cargo bench`, `maturin`, `pytest`. The first four exhaust the disk; the last
   two are unavailable. Where a skill step calls for maturin or pytest, the agent
-  should **skip the run but still write the tests**, and record the unverified
-  step in its friction log.
+  **skips the run but still writes the tests** and records the unverified step.
 - **Do not `git commit`** — `.cargo-husky`'s pre-commit hook runs a full
-  `clippy --workspace --all-targets`, which is exactly the build the disk rules
-  forbid. Agents leave changes uncommitted in their worktree and report the
-  path.
+  `clippy --workspace --all-targets`, precisely the build the disk rules avoid.
+  Agents leave work uncommitted and report the worktree path.
 - **Read `CLAUDE.md` first**, then invoke the matching skill via the Skill tool
-  (`Skill(skill="new-op")` etc.) rather than reimplementing its steps.
+  (`Skill(skill="new-op")`) rather than reimplementing its steps.
 
 ### The friction log
 
-Have each agent **write its log to a file** under the scratchpad
-(`<scratchpad>/friction/<name>.md`) as well as returning a short summary. The
-file is the durable artifact you review; the return text is only a pointer.
-Mandate this structure:
+Each agent **writes its log to a file** under the scratchpad
+(`<scratchpad>/friction/<name>.md`) and returns only a short summary. The file
+is the durable artifact; the return text is a pointer. Mandate this shape:
 
 ```
 # <task name>
 ## Status
-Did it compile? Did tests pass? What was verified vs assumed? What could not
-be verified and why? Be honest — a failed build is useful data.
+Compiled? Tests passed? What was verified vs assumed? What could not be
+verified, and why? A failed build is useful data — be honest.
 ## Worktree path
 ## What I changed
 Files touched, one line each.
 ## Friction log
-Numbered. Each entry: **Expected** / **What happened** / **Where** (file:line
-or skill step) / **Suggested fix** (concrete).
+Numbered. Each: **Expected** / **What happened** / **Where** (file:line or
+skill step) / **Suggested fix** (concrete).
 ## What went well
 Which parts of the docs/skills genuinely worked.
 ```
 
-Prompt for the categories you want covered, or you will only get compiler
-errors back: missing or wrong docs, contradictory instructions, under-specified
-skill steps, steps the agent had to guess at, unclear errors, slow or awkward
-tooling, and **boilerplate mechanical enough to automate**. Add one
-task-specific probe per agent — e.g. ask the examples agents to count how many
-separate places a new example must be registered and whether anything catches a
-missed one; ask the bindings agents whether an external user has everything
-exported and documented.
+Name the categories you want or you will get only compiler errors back: wrong
+or missing docs, contradictory instructions, under-specified steps, guesses,
+unclear errors, awkward tooling, and **boilerplate mechanical enough to
+automate**. Add one task-specific probe per agent — ask the examples agents how
+many places an example must be registered and whether anything catches a miss;
+ask the bindings agents whether an external user has everything exported and
+documented.
 
-## 3. Review
+## 3. Review — verify, do not read
 
-Read every friction log file. Then, independently, **read the actual diffs** —
-`git -C <worktree> diff` — because agent self-reports are unreliable in both
-directions: they claim success they did not verify, and they omit friction they
-worked around without noticing. Cross-check status claims against the code.
+Read every log, then **independently check every claim**: run the build, run
+the tests, read `git -C <worktree> diff`. Self-reports are unreliable in both
+directions — they claim success they never verified and omit friction they
+worked around without noticing. This is the bulk of the work; budget for it.
 
 ## 4. Synthesise
 
-Deduplicate across agents. **Friction reported independently by several agents
-is the signal**; a single agent's confusion is often just that model being
-weak, so weight by how many agents hit it and whether the diff corroborates it.
+Deduplicate. **Friction hit independently by several agents is the signal**; a
+lone agent's confusion is often just the model being weak. Weight by agents
+affected and whether the diff corroborates it.
 
-Turn each surviving item into an actionable entry with: the problem in one
-line, how many agents hit it, the concrete fix, which files it touches, and a
-rough size. Sort by (agents affected × cheapness of fix). Separate genuine repo
-defects from artifacts of the harness (disk limits, forbidden commands,
-Haiku's own comprehension failures) — the latter are not fixes to offer.
+Each surviving item gets: the problem in one line, how many agents hit it, the
+concrete fix, files touched, rough size. Sort by (agents affected × cheapness).
+Separate genuine repo defects from harness artifacts — disk limits, forbidden
+commands, Haiku's own comprehension failures are not fixes to offer, but say
+out loud that you discarded them so the discard is visible.
 
 ## 5. Put it to the user
 
-Present the summary, then use `AskUserQuestion` (multi-select) to ask which
-items to implement. Do not start implementing before they choose. Note which
-fixes belong in a skill file versus in code or CI, since per `CLAUDE.md` the
-three skills are living documents and folding lessons back into them is part of
-"done".
+Present the summary, then `AskUserQuestion` (multi-select) for which items to
+implement. Do not implement before they choose. Flag which fixes belong in a
+skill file versus code or CI — per `CLAUDE.md` the skills are living documents,
+and folding lessons back is part of "done".
 
 ## 6. Clean up
 
-The worktrees hold uncommitted work. Once the user has chosen, carry the
-selected changes onto the working branch and remove the rest
-(`git worktree remove`). Run `scripts/disk.sh light` afterwards — eight
-worktrees leave a lot behind.
+Worktrees hold uncommitted work. Once the user has chosen, carry the selected
+changes onto the working branch, `git worktree remove` the rest, and run
+`scripts/disk.sh light`.
 
 ## What the first run (2026-08-16) taught
 
-All five are about **not trusting the reports**, and they cost most of the
-review time on that run:
+All five are about **not trusting the reports**, and they cost most of that
+run's review time:
 
-1. **Self-reports are wrong in both directions, so verify every one.** One
-   agent reported a hard blocker ("`#[op(fluent)]` doesn't generate the macro")
-   that was simply false — the code compiled; its op logic was broken instead,
-   which it never found. Another reported clean success while introducing the
-   first `panic!` into a crate that had zero. A third reported "all tests pass"
-   for an op that silently deviated from its spec and encoded the deviation as
-   a passing test. Run the build yourself, run the tests yourself, and read the
-   diff. Budget for this — it is the bulk of the work.
-2. **Confident root-cause attributions from a weak model are the most
-   expensive output.** "The proc macro is broken" would have sent a maintainer
-   into `wingfoil-derive` for nothing. Treat any *diagnosis* in a friction log
-   as a symptom report; re-derive the cause before it reaches the summary.
+1. **Self-reports are wrong in both directions.** One agent reported a hard
+   blocker ("`#[op(fluent)]` doesn't generate the macro") that was false — the
+   code compiled, and its op logic was broken instead, which it never found.
+   Another reported clean success while introducing the first `panic!` into a
+   crate that had zero. A third reported "all tests pass" for an op that had
+   silently deviated from its spec and encoded the deviation as a passing test.
+2. **A weak model's confident root-cause attribution is its most expensive
+   output.** "The proc macro is broken" would have sent a maintainer into
+   `wingfoil-derive` for nothing. Treat every *diagnosis* as a symptom report
+   and re-derive the cause before it reaches the summary.
 3. **Check reported gaps against the docs before believing them.** Several
-   "X is missing / undocumented" items were wrong: `Burst`, `Activation`, `Ctx`
-   and `Tick` are all in the prelude, and `_common` is documented twice in
-   `/bind-adapter`. The underlying friction was real but the agent's
-   explanation of it was not — and the *correct* diagnosis usually implies a
-   different fix.
-4. **A shared `CARGO_TARGET_DIR` manufactures its own friction.** Three of four
-   op agents reported needing `cargo clean` for "proc macro regeneration". That
-   is fingerprint thrash from the shared directory, not a repo defect. Keep the
-   sharing — it is what makes eight concurrent agents fit on the disk — but
-   discount that entire class of report, and say so in the summary rather than
-   letting it look like a finding.
+   "X is undocumented" items were wrong: `Burst`, `Activation`, `Ctx` and
+   `Tick` are all in the prelude, and `_common` is documented twice in
+   `/bind-adapter`. The friction was real; the explanation was not — and the
+   correct diagnosis usually implies a different fix.
+4. **The shared `CARGO_TARGET_DIR` manufactures its own friction.** Three of
+   four op agents reported needing `cargo clean` for "proc macro regeneration" —
+   fingerprint thrash, not a repo defect. Keep the sharing, discount the
+   reports, and say so in the summary rather than letting it look like a
+   finding.
 5. **Prompt-level build prohibitions are not self-enforcing.** An agent ran
-   `cargo lint` (a full `--all-targets` clippy) despite an explicit ban. Size
-   the disk headroom to survive a few such violations rather than assuming
-   compliance, and check `df` between waves.
+   `cargo lint` despite an explicit ban.
 
 ## Feed lessons back into this skill
 
-If a run surfaces something this recipe does not capture — a task shape that
-produced no useful signal, a disk mitigation that failed, a prompt phrasing
-that got agents to over-claim — fold it back into this file in the same
-session.
+If a run surfaces something this recipe misses — a task shape that produced no
+signal, a disk mitigation that failed, a phrasing that got agents to over-claim
+— fold it back into this file in the same session.

--- a/.claude/commands/dogfood.md
+++ b/.claude/commands/dogfood.md
@@ -22,11 +22,8 @@ remaining, here is where I got stuck" is worth more than a clean-looking diff.
 
 Spread deliberately so the friction is not all from one recipe:
 
-- **6 examples.** Each must touch a *different* corner of the feature and
-  adapter surface — do not send six agents at plain `core/`. Aim for one with
-  no features at all, then spread the rest across `statistics`, `csv`,
-  `async`, `dynamic-graph`, `web`/`ws`, `fix`, `iceoryx2`, and both the
-  `adapters/` and `showcase/` groups. Examples exercise a rule set nothing else
+- **6 examples**, each on a *different* uncovered part of the surface —
+  see "Choosing the six" below. Examples exercise a rule set nothing else
   touches: directory + README + explicit Cargo target + two index links,
   enforced by `scripts/check-example-docs.sh`, with the README's sample output
   required to be real.
@@ -44,6 +41,55 @@ for the op, `examples/` for the example, and compare
 `crates/wingfoil/src/adapters/` against `crates/wingfoil-python/src/adapters/`
 for genuinely unbound adapters. An agent that discovers its task is already
 done produces no friction data and wastes a slot.
+
+### Choosing the six — derive it, don't guess
+
+The examples *are* the coverage map, so read it out of the tree rather than
+picking from memory. Three commands:
+
+```bash
+# 1. What is already covered — declared targets and their features.
+#    (Skip the leading [[bench]] blocks; examples start at hello_graph.)
+awk '/^\[\[example\]\]/{if(n)print n" ["rf"]";n="";rf="-";next}
+     /^\[/{if(n)print n" ["rf"]";n="";rf="-"}
+     /^name[[:space:]]*=/{split($0,a,"\"");n=a[2]}
+     /^required-features/{rf=$0;sub(/^[^=]*= */,"",rf);gsub(/[]["]/,"",rf)}
+     END{if(n)print n" ["rf"]"}' crates/wingfoil/Cargo.toml
+
+# 2. The whole feature surface, to diff against it.
+sed -n '/^\[features\]/,/^\[dependencies\]/p' crates/wingfoil/Cargo.toml
+
+# 3. Adapters that exist in the engine.
+ls crates/wingfoil/src/adapters/
+```
+
+Then diff: any feature or adapter with no example target, and any engine
+concept you cannot find with `grep -rl '<api>' crates/wingfoil/examples/`, is a
+candidate. **Confirm each candidate with that grep before assigning it** — the
+cost of getting this wrong is a wasted agent, and it is easy to get wrong.
+
+Snapshot as of 2026-08-16, useful as a seed but **re-derive rather than
+trusting it**:
+
+| Uncovered | Why it is a gap |
+|---|---|
+| **latency capture** (`latency::Stamp`, `StampEach`, `LatencyReport`) | only reachable inside `showcase/latency` and `trading_e2e`, both multi-process and iceoryx2-gated — there is no small example teaching the stamping API on its own |
+| **`cache` adapter** | no example anywhere in the tree |
+| **`market` adapter** | mentioned once in the `ws` README, never demonstrated |
+| **`Signal` facade** (`signal.rs`) | appears only incidentally in `adapters/iceoryx2` |
+| **`window` / `buffer`** | no example calls either — the bounded look-back `CLAUDE.md` recommends instead of `accumulate()` |
+| **`dhat-heap`, `bench`/`bencher.rs`, `instrument-*`** | profiling and granular instrumentation features with no worked example |
+| **`ws-tls` / `web-tls`** | only exercised through `trading_e2e` |
+
+Already covered — do **not** spend a slot on these: `demux` and `demux_map`
+have examples of their own, and `fan` plus the `nested()` island tier are both
+demonstrated in `dual_mode`.
+
+Spread the six across *kinds* as well as features: at least one needing no
+feature flag, one adapter-group example, and one that is purely an engine
+concept. An example that needs a live external service is a poor choice — the
+agent cannot run it, and an unrunnable example cannot have real sample output,
+which is the rule most worth testing.
 
 ## 2. Spawn the team
 

--- a/.claude/commands/dogfood.md
+++ b/.claude/commands/dogfood.md
@@ -1,0 +1,192 @@
+Dogfood this repository with a team of small-model agents and harvest the
+friction they hit. Scope: `$ARGUMENTS` names what the team should build (e.g.
+`3 ops and 2 examples`, or a specific list). Leave it blank and you choose the
+tasks yourself from the gaps described in step 1.
+
+This is a **measurement** skill. The code the agents write is the vehicle, not
+the product — the product is a deduplicated, actionable list of everything that
+made contributing to this repo harder than it needed to be, put to the user as
+a menu of fixes to choose from.
+
+## Why a deliberately weak model
+
+Run the team on **Haiku** by default. This is counter-intuitive and it is the
+whole point: a strong model silently infers past ambiguity in the docs and
+skills, so it finds nothing. A weak model hits every under-specified step
+head-on and reports it. Haiku failures are a map of where the documentation is
+thin.
+
+The corollary is that **broken code is an expected, acceptable outcome**. Tell
+the agents so explicitly, or they will over-claim success. A friction log that
+says "did not compile, 3 errors remaining, here is where I got stuck" is worth
+more than a clean-looking diff.
+
+Offer the user the choice up front if they have not already made it —
+Haiku for friction signal, Sonnet/Opus if they actually want landable code —
+and say plainly which output each buys.
+
+## 1. Choose the tasks
+
+Aim for **6–8 agents**, one task each, spread deliberately across surfaces so
+the friction is not all from one recipe. A good spread:
+
+- **3–4 ops** via `/new-op` — one simple stateful op, one predicate/closure op,
+  one time-scheduling op (`Activation::SCHEDULES`), one statistics-family op.
+- **1 op with Python bindings** — the `#[pyop]` / `pyop_fn!` step is where
+  `/new-op` is thinnest; give it its own agent and say so in the prompt.
+- **2–3 `core/` examples** — these exercise a completely different rule set
+  (the directory + README + explicit Cargo target + two README index links,
+  checked by `scripts/check-example-docs.sh`).
+- **1 adapter binding** via `/bind-adapter` — pick an adapter that is ported in
+  Rust but genuinely unbound in Python. Compare
+  `crates/wingfoil/src/adapters/` against
+  `crates/wingfoil-python/src/adapters/` to find one; do not invent a gap that
+  is already filled.
+
+Pick tasks that are real gaps, not busywork. Before spawning, grep to confirm
+the op/example/binding does not already exist — an agent that discovers its
+task is already done produces no friction data.
+
+## 2. Spawn the team
+
+All agents in **one message** so they run concurrently, each with
+`isolation: "worktree"` so they cannot conflict, and `model: "haiku"`.
+
+### Protect the disk — this is the failure mode that kills the run
+
+Eight worktrees each building independently will exhaust the sandbox's
+writable allowance (see "Disk space" in `CLAUDE.md`). Two mitigations, both
+mandatory:
+
+1. **Pre-warm the shared dependency cache** before spawning:
+   `CARGO_INCREMENTAL=0 cargo check -p wingfoil --features statistics`, run in
+   the background while you write the prompts.
+2. **Every agent prompt must set** `export
+   CARGO_TARGET_DIR=/home/user/wingfoil/target`. Registry dependencies are
+   keyed by package id and features, not by workspace path, so all agents reuse
+   the one ~700-crate dep cache and only recompile the workspace crate itself.
+   Cargo locks the directory, so checks serialise — tell the agents that
+   `Blocking waiting for file lock` is expected and to wait it out.
+
+### Rules every agent prompt must carry
+
+- **Allowed**: `cargo check -p <crate> [--features ...]`,
+  `cargo test -p wingfoil --lib <filter>`, `cargo run -p wingfoil --example
+  <name>`, `cargo fmt`, `scripts/check-example-docs.sh`.
+- **Forbidden**: `--all-targets`, `--all-features`, `cargo build --release`,
+  `cargo bench`, `maturin`, `pytest`. The first four exhaust the disk; the last
+  two are unavailable. Where a skill step calls for maturin or pytest, the agent
+  should **skip the run but still write the tests**, and record the unverified
+  step in its friction log.
+- **Do not `git commit`** — `.cargo-husky`'s pre-commit hook runs a full
+  `clippy --workspace --all-targets`, which is exactly the build the disk rules
+  forbid. Agents leave changes uncommitted in their worktree and report the
+  path.
+- **Read `CLAUDE.md` first**, then invoke the matching skill via the Skill tool
+  (`Skill(skill="new-op")` etc.) rather than reimplementing its steps.
+
+### The friction log
+
+Have each agent **write its log to a file** under the scratchpad
+(`<scratchpad>/friction/<name>.md`) as well as returning a short summary. The
+file is the durable artifact you review; the return text is only a pointer.
+Mandate this structure:
+
+```
+# <task name>
+## Status
+Did it compile? Did tests pass? What was verified vs assumed? What could not
+be verified and why? Be honest — a failed build is useful data.
+## Worktree path
+## What I changed
+Files touched, one line each.
+## Friction log
+Numbered. Each entry: **Expected** / **What happened** / **Where** (file:line
+or skill step) / **Suggested fix** (concrete).
+## What went well
+Which parts of the docs/skills genuinely worked.
+```
+
+Prompt for the categories you want covered, or you will only get compiler
+errors back: missing or wrong docs, contradictory instructions, under-specified
+skill steps, steps the agent had to guess at, unclear errors, slow or awkward
+tooling, and **boilerplate mechanical enough to automate**. Add one
+task-specific probe per agent — e.g. ask the examples agents to count how many
+separate places a new example must be registered and whether anything catches a
+missed one; ask the bindings agents whether an external user has everything
+exported and documented.
+
+## 3. Review
+
+Read every friction log file. Then, independently, **read the actual diffs** —
+`git -C <worktree> diff` — because agent self-reports are unreliable in both
+directions: they claim success they did not verify, and they omit friction they
+worked around without noticing. Cross-check status claims against the code.
+
+## 4. Synthesise
+
+Deduplicate across agents. **Friction reported independently by several agents
+is the signal**; a single agent's confusion is often just that model being
+weak, so weight by how many agents hit it and whether the diff corroborates it.
+
+Turn each surviving item into an actionable entry with: the problem in one
+line, how many agents hit it, the concrete fix, which files it touches, and a
+rough size. Sort by (agents affected × cheapness of fix). Separate genuine repo
+defects from artifacts of the harness (disk limits, forbidden commands,
+Haiku's own comprehension failures) — the latter are not fixes to offer.
+
+## 5. Put it to the user
+
+Present the summary, then use `AskUserQuestion` (multi-select) to ask which
+items to implement. Do not start implementing before they choose. Note which
+fixes belong in a skill file versus in code or CI, since per `CLAUDE.md` the
+three skills are living documents and folding lessons back into them is part of
+"done".
+
+## 6. Clean up
+
+The worktrees hold uncommitted work. Once the user has chosen, carry the
+selected changes onto the working branch and remove the rest
+(`git worktree remove`). Run `scripts/disk.sh light` afterwards — eight
+worktrees leave a lot behind.
+
+## What the first run (2026-08-16) taught
+
+All five are about **not trusting the reports**, and they cost most of the
+review time on that run:
+
+1. **Self-reports are wrong in both directions, so verify every one.** One
+   agent reported a hard blocker ("`#[op(fluent)]` doesn't generate the macro")
+   that was simply false — the code compiled; its op logic was broken instead,
+   which it never found. Another reported clean success while introducing the
+   first `panic!` into a crate that had zero. A third reported "all tests pass"
+   for an op that silently deviated from its spec and encoded the deviation as
+   a passing test. Run the build yourself, run the tests yourself, and read the
+   diff. Budget for this — it is the bulk of the work.
+2. **Confident root-cause attributions from a weak model are the most
+   expensive output.** "The proc macro is broken" would have sent a maintainer
+   into `wingfoil-derive` for nothing. Treat any *diagnosis* in a friction log
+   as a symptom report; re-derive the cause before it reaches the summary.
+3. **Check reported gaps against the docs before believing them.** Several
+   "X is missing / undocumented" items were wrong: `Burst`, `Activation`, `Ctx`
+   and `Tick` are all in the prelude, and `_common` is documented twice in
+   `/bind-adapter`. The underlying friction was real but the agent's
+   explanation of it was not — and the *correct* diagnosis usually implies a
+   different fix.
+4. **A shared `CARGO_TARGET_DIR` manufactures its own friction.** Three of four
+   op agents reported needing `cargo clean` for "proc macro regeneration". That
+   is fingerprint thrash from the shared directory, not a repo defect. Keep the
+   sharing — it is what makes eight concurrent agents fit on the disk — but
+   discount that entire class of report, and say so in the summary rather than
+   letting it look like a finding.
+5. **Prompt-level build prohibitions are not self-enforcing.** An agent ran
+   `cargo lint` (a full `--all-targets` clippy) despite an explicit ban. Size
+   the disk headroom to survive a few such violations rather than assuming
+   compliance, and check `df` between waves.
+
+## Feed lessons back into this skill
+
+If a run surfaces something this recipe does not capture — a task shape that
+produced no useful signal, a disk mitigation that failed, a prompt phrasing
+that got agents to over-claim — fold it back into this file in the same
+session.


### PR DESCRIPTION
## What this changes

Adds one file: `.claude/commands/dogfood.md`, a skill that runs a team of
agents through the repo's own skills — `/new-op`, `/bind-adapter`, the examples
rules — each implementing a real gap in an isolated worktree, then collects and
deduplicates the friction they hit into a menu of fixes.

Nothing else in the tree is touched. No code, no CI.

## Why

We have three living skills and a `CLAUDE.md` that encode how to contribute
here, and no systematic way to find where they have drifted from what a
contributor actually experiences. Reading them does not reveal the gaps —
following them does.

The design choice worth arguing about is **using a deliberately weak model**.
It is counter-intuitive and it is the point: a strong model silently infers
past ambiguity and reports nothing, so its silence is not evidence that the
docs are good. A weak model hits every under-specified step head-on. The
corollary, stated explicitly in the skill so agents do not over-claim, is that
broken code is an expected outcome rather than a failed run.

The skill also encodes the operational details that are easy to get wrong and
expensive to rediscover: pre-warming a shared `CARGO_TARGET_DIR` so eight
concurrent worktrees fit in a sandbox's disk allowance, which build commands to
forbid, why agents must not commit (the pre-commit hook runs precisely the
`--all-targets` build the disk rules exist to avoid), and the friction-log
template that makes the reports comparable.

## How it was verified

- [x] `cargo fmt --all` — no Rust in this diff
- [x] `cargo lint` — unaffected, documentation only
- [ ] `cargo test -p wingfoil --all-features` — not applicable
- [ ] Values-and-tick-times test — not applicable

The real verification is that the skill has been run end to end once, on eight
agents across ops, examples and Python bindings. That run produced the findings
in #874 and, per the skill's own "feed lessons back" mandate, its lessons are
already folded into the "What the first run taught" section here.

## Notes for the reviewer

**The most useful section is the one about not trusting the reports**, and it
is written from being burned. On the first run: one agent reported a hard
blocker in `#[op(fluent)]` that was simply false — the code compiled and its
own op logic was broken instead, which it never noticed, and acting on that
report would have sent someone into `wingfoil-derive` for nothing. Another
reported clean success while introducing the first `panic!` into a crate that
had zero. A third reported "all tests pass" for an op that had silently
deviated from its spec and encoded the deviation as a passing test. Several
"X is undocumented" findings were wrong on checking. Budget review time
accordingly — verification was the bulk of the work, not the agent runs.

**One known cost, deliberately kept.** Sharing a `CARGO_TARGET_DIR` across
agents is what makes eight of them fit on a sandbox disk, and it manufactures
its own false signal: three of four op agents reported needing `cargo clean`
for "proc macro regeneration", which was fingerprint thrash rather than a repo
defect. The skill says to keep the sharing and discount that class of report.

**This was split out of #874** so the tooling can be judged on its own terms
rather than bundled with the fixes it produced. #874 is the findings; this is
the instrument.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaiuuXWEf3FnSmBMASvqvK)_