### PR TITLE
Add pairwise combinator

### DIFF
--- a/crates/wingfoil-derive/src/lib.rs
+++ b/crates/wingfoil-derive/src/lib.rs
@@ -2677,7 +2677,16 @@ fn expand_fluent(args: &OpArgs, b: &BuilderShape<'_>) -> syn::Result<TokenStream
         let is_generic = matches!(ty, Type::Path(p)
             if p.path.get_ident().is_some_and(|id|
                 Some(id) == self_param.as_ref() || method_generics.contains(&id)));
-        if is_generic {
+
+        // tuples of generics
+        let is_generic_tuple = matches!(ty, Type::Tuple(tuple)
+        if !tuple.elems.is_empty()
+            && tuple.elems.iter().all(|elem| matches!(elem, Type::Path(p)
+                if p.path.get_ident().is_some_and(|id|
+                    Some(id) == self_param.as_ref()
+                        || method_generics.contains(&id)))));
+
+        if is_generic || is_generic_tuple {
             preds.push(sub(quote! { #ty: #bounds }));
         }
     };

--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -1156,6 +1156,13 @@ pub trait StreamOps<T>: Sized {
     where
         T: Clone + Default + Sub<Output = T> + 'static;
 
+    /// Emit pairs of successive values `(previous, current)`.
+    /// Quiet on the first value.
+    fn pairwise(&self) -> Stream<(T, T)>
+    where
+        T: Clone + 'static,
+        (T, T): Default + 'static;
+
     /// Negate each value (`!value`) — sugar over `map`.
     fn not(&self) -> Stream<T>
     where
@@ -1400,6 +1407,8 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
     __wf_fluent_drop_small_change!(T);
 
     __wf_fluent_difference!(T);
+
+    __wf_fluent_pairwise!(T);
 
     __wf_fluent_not!(T);
 

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -298,6 +298,40 @@ where
     }
 }
 
+/// Emits the successive pairs `(previous, value)`. Quiet on the first
+/// value.
+///
+/// See [`difference`](crate::fluent::StreamOps::difference) for the
+/// arithmetic shorthand.
+pub struct Pairwise<T>(PhantomData<T>);
+
+#[op(build = pairwise, fluent)]
+impl<T> Op for Pairwise<T>
+where
+    T: Clone + 'static,
+{
+    type Cfg = ();
+    type State = Option<T>;
+    type In<'a> = (&'a T,);
+    type Out = (T, T);
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(
+        _cfg: &mut (),
+        state: &mut Option<T>,
+        input: (&T,),
+        _ctx: &mut Ctx<'_>,
+    ) -> Result<Tick<(T, T)>> {
+        let value = input.0.clone();
+        let out = match state.take() {
+            Some(prev) => Tick::Value((prev, value.clone())),
+            None => Tick::Quiet,
+        };
+        *state = Some(value);
+        Ok(out)
+    }
+}
+
 /// Negates each value (`!value`).
 ///
 /// Was fluent-only sugar over [`Map`] (`map(|v| !v.clone())`) until it became

--- a/crates/wingfoil/tests/catalog.rs
+++ b/crates/wingfoil/tests/catalog.rs
@@ -127,6 +127,39 @@ fn difference_emits_deltas_after_first() {
     assert_eq!(vec![1, 1, 1], r.value(&acc));
 }
 
+/// Pairwise emits pairs of consecutive values, the first tick is quiet.
+#[test]
+fn pairwise_emits_pairs() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count(); // 1,2,3,4
+    let acc = count.pairwise().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(vec![(1, 2), (2, 3), (3, 4)], r.value(&acc));
+}
+
+/// Pairwise emits pairs of consecutive values, the first tick is quiet, and it
+/// works with non-arithmetic types, here strings.
+#[test]
+fn pairwise_with_non_arithmetic_types() {
+    let g = GraphBuilder::new();
+    let strings = g
+        .ticker(Duration::from_nanos(10))
+        .count()
+        .map(|i| format!("value-{}", i));
+    let acc = strings.pairwise().accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(4)).unwrap();
+    assert_eq!(
+        vec![
+            ("value-1".to_string(), "value-2".to_string()),
+            ("value-2".to_string(), "value-3".to_string()),
+            ("value-3".to_string(), "value-4".to_string()),
+        ],
+        r.value(&acc)
+    );
+}
+
 /// `limit` passes the first N then suppresses — mirrors legacy
 /// `limit::suppresses_after_limit_reached`.
 #[test]

--- a/crates/wingfoil/tests/compiled_stateful_ops.rs
+++ b/crates/wingfoil/tests/compiled_stateful_ops.rs
@@ -85,11 +85,37 @@ fn skip_agrees_across_engines() {
     );
 }
 
+// --- pairwise: emit pairs of consecutive values -------------------------
+
+wingfoil::nitro! {
+    fn pairwise_values_and_times(g: &GraphBuilder) -> Stream<Vec<(NanoTime, (u64,u64)) >> {
+        let acc = g.ticker(PERIOD).count().pairwise().with_time().accumulate();
+        acc
+    }
+}
+
+#[test]
+fn pairwise_agrees_across_engines() {
+    assert_three_engines!(
+        pairwise_values_and_times,
+        RunFor::Cycles(4),
+        vec![
+            (NanoTime::new(10), (1u64, 2u64)),
+            (NanoTime::new(20), (2u64, 3u64)),
+            (NanoTime::new(30), (3u64, 4u64)),
+        ]
+    );
+}
+
 // --- throttle: rate-limit a per-cycle counter ------------------------------
 
 wingfoil::nitro! {
     fn throttle_values(g: &GraphBuilder) -> Stream<Vec<u64>> {
-        let acc = g.ticker(PERIOD).count().throttle(INTERVAL).accumulate();
+        let acc = g
+            .ticker(PERIOD)
+            .count()
+            .throttle(INTERVAL)
+            .accumulate();
         acc
     }
 }

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -201,9 +201,9 @@ const RUN: RunFor = RunFor::Cycles(12);
 const W: Duration = Duration::from_millis(30);
 
 // The stateless / single-input `u64` surface: `count`, `map`, `map_filter`,
-// `distinct`, `drop_small_change`, `difference`, `limit`, `skip`, `inspect`, `filter`
-// (against a derived bool stream), `filter_value` (against a predicate),
-// `scan`, `merge`, and `accumulate`.
+// `distinct`, `drop_small_change`, `difference`, `pairwise`, `limit`, `skip`,
+// `inspect`, `filter` (against a derived bool stream), `filter_value`
+// (against a predicate), `scan`, `merge`, and `accumulate`.
 wingfoil::nitro! {
     fn surface_u64(g: &GraphBuilder) -> Stream<Vec<u64>> {
         let count = g.ticker(P).count();
@@ -214,6 +214,7 @@ wingfoil::nitro! {
         // so this exercises the suppressed path, not just the pass-through.
         let stable = distinct.drop_small_change(|c: &u64, p: &u64| c.abs_diff(*p) < 8);
         let diff = stable.difference();
+        let paired = stable.pairwise().map(|(p, n): &(u64, u64)| *p + *n);
         let limited = diff.limit(100);
         // Skip one value so both the suppressed and pass-through paths are
         // exercised by interpreted and compiled execution.
@@ -226,7 +227,7 @@ wingfoil::nitro! {
         // inside the compiled emission, not just fluently.
         let gated = count.filter_value(|i| !i.is_multiple_of(3));
         let running = gated.scan(0u64, |acc, v| acc + v);
-        let out = seen.merge(&evens).merge(&running).accumulate();
+        let out = seen.merge(&evens).merge(&paired).merge(&running).accumulate();
         out
     }
 }

--- a/crates/wingfoil/tests/op_fluent_shapes.rs
+++ b/crates/wingfoil/tests/op_fluent_shapes.rs
@@ -71,6 +71,28 @@ fn generic_receiver_binds_the_element_type_of_the_invoking_trait() {
     );
 }
 
+trait MyPairwiseOps<T> {
+    fn pairwise(&self) -> Stream<(T, T)>
+    where
+        T: Clone + 'static,
+        (T, T): Default + 'static;
+}
+
+impl<T> MyPairwiseOps<T> for Stream<T> {
+    wingfoil::__wf_fluent_pairwise!(T);
+}
+
+#[test]
+fn generic_receiver_supports_tuple_output() {
+    let g = GraphBuilder::new();
+    let count = SourceOps::ticker(&g, P).count();
+    let pairs = MyPairwiseOps::pairwise(&count).accumulate();
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(3)).unwrap();
+
+    assert_eq!(vec![(1u64, 2u64), (2u64, 3u64)], runner.value(&pairs));
+}
+
 // --- concrete receiver ------------------------------------------------------
 
 /// Edge 0 is `&f64`, so the receiver is fixed at `Stream<f64>` and the macro


### PR DESCRIPTION
## Summary

- add `pairwise()` for emitting `(previous, current)` values after the first tick
- support non-arithmetic types without requiring `Sub`
- add fluent, compiled, and exact-timestamp coverage
- fix generated fluent bounds for generic tuple outputs such as `(T, T)`

## Testing

- `cargo test -p wingfoil pairwise`
- `cargo test -p wingfoil --test op_fluent_shapes`
- `cargo test -p wingfoil --test op_completeness`
- `cargo test -p wingfoil --test compiled_stateful_ops pairwise`
- `git diff --check`

`cargo test -p wingfoil --all-features` was also attempted locally; Kafka integration reached the Redpanda test but the container could not start because the host's Linux AIO capacity was insufficient.

Closes #800
