### PR TITLE
Add try_filter_map combinator

### DIFF
--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -882,6 +882,16 @@ pub trait StreamOps<T>: Sized {
         B: Clone + Default + 'static,
         F: Fn(&T) -> (B, bool) + 'static;
 
+    /// Fallible [`map_filter`](StreamOps::map_filter): `f` returns
+    /// `Result<(value, emit?)>`, mapping and filtering in one pass. `Ok((v,
+    /// true))` ticks `v`; `Ok((_, false))` means no value this tick and the
+    /// run continues; `Err(e)` aborts the run with `e` as context — `false`
+    /// and `Err` are not interchangeable.
+    fn try_filter_map<B, F>(&self, f: F) -> Stream<B>
+    where
+        B: Clone + Default + 'static,
+        F: Fn(&T) -> Result<(B, bool)> + 'static;
+
     /// Pair each value with the current engine time: `(time, value)`.
     fn with_time(&self) -> Stream<(NanoTime, T)>
     where
@@ -1284,6 +1294,8 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
     __wf_fluent_try_map!(T);
 
     __wf_fluent_map_filter!(T);
+
+    __wf_fluent_try_filter_map!(T);
 
     fn with_time(&self) -> Stream<(NanoTime, T)>
     where

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -190,6 +190,39 @@ where
     }
 }
 
+/// The fallible [`MapFilter`]: the closure returns `Result<(value, emit?)>`,
+/// mapping and filtering in one pass, with an `Err` aborting the run — the
+/// `try_` counterpart to `map_filter`, composed the same way [`TryMap`]
+/// composes with [`Map`]. `Fn`, like [`Map`].
+///
+/// `false` and `Err` are not interchangeable: `Ok((_, false))` means "no
+/// value this tick" and the run continues; `Err(e)` means the run is broken
+/// and aborts with `e` as context.
+pub struct TryFilterMap<A, B, F>(PhantomData<(A, B, F)>);
+
+#[op(build = try_filter_map, fluent)]
+impl<A, B, F> Op for TryFilterMap<A, B, F>
+where
+    A: 'static,
+    B: Clone + 'static,
+    F: Fn(&A) -> Result<(B, bool)> + 'static,
+{
+    type Cfg = F;
+    type State = ();
+    type In<'a> = (&'a A,);
+    type Out = B;
+    const ACTIVATION: Activation = Activation::NONE;
+
+    fn cycle(cfg: &mut F, _state: &mut (), input: (&A,), _ctx: &mut Ctx<'_>) -> Result<Tick<B>> {
+        let (value, emit) = cfg(input.0)?;
+        Ok(if emit {
+            Tick::Value(value)
+        } else {
+            Tick::Quiet
+        })
+    }
+}
+
 /// Suppresses consecutive duplicate values: emits the first value, then only
 /// when it changes. State is `Option<T>` (not the default-initialised output)
 /// so a genuine first value equal to `T::default()` still ticks.

--- a/crates/wingfoil/src/signal.rs
+++ b/crates/wingfoil/src/signal.rs
@@ -139,6 +139,7 @@ impl<T: 'static> Signal<T> {
     __wf_signal_map!(T);
     __wf_signal_try_map!(T);
     __wf_signal_map_filter!(T);
+    __wf_signal_try_filter_map!(T);
     __wf_signal_fold!(T);
     __wf_signal_scan!(T);
     __wf_signal_for_each!(T);

--- a/crates/wingfoil/tests/catalog.rs
+++ b/crates/wingfoil/tests/catalog.rs
@@ -246,6 +246,31 @@ fn map_filter_maps_and_filters() {
     assert_eq!(vec![1, 9, 25], r.value(&acc));
 }
 
+/// `try_filter_map` is `map_filter`'s fallible twin: squares of odds, same
+/// as the test above, but through a closure that returns `Result<(B, bool)>`
+/// and never actually fails here — the abort path is
+/// `try_filter_map_err_aborts_run` in `fallibility.rs`. Each surviving value
+/// keeps its original tick time, since the op suppresses ticks, not time.
+#[test]
+fn try_filter_map_maps_and_filters_with_tick_times() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count(); // 1..=6
+    let acc = count
+        .try_filter_map(|i| Ok((i * i, i % 2 == 1))) // squares of odds: 1, 9, 25
+        .with_time()
+        .accumulate();
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(
+        vec![
+            (NanoTime::new(0), 1u64),
+            (NanoTime::new(20), 9),
+            (NanoTime::new(40), 25),
+        ],
+        r.value(&acc)
+    );
+}
+
 /// `throttle` suppresses ticks that arrive within `interval` of the last
 /// emit — mirrors legacy `throttle::throttle_suppresses_fast_ticks`
 /// (source every 10ns, interval 25ns → emit at 0, 30, 60, ...).

--- a/crates/wingfoil/tests/fallibility.rs
+++ b/crates/wingfoil/tests/fallibility.rs
@@ -58,6 +58,43 @@ fn cycle_error_aborts_with_context_and_runs_teardown() {
     assert_eq!(Some(2), *torn_down.borrow());
 }
 
+/// `try_filter_map` is `try_map`'s map-and-filter twin: an `Err` aborts the
+/// run with context naming the node, same as `try_map` above — the
+/// `Ok((_, false))` filtering path is not a substitute for propagating a
+/// real error, and this pins that they behave differently.
+#[test]
+fn try_filter_map_err_aborts_run() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count();
+    // Cycles 1 and 2 succeed (odd values kept, even ones filtered); cycle 3
+    // errors instead of filtering.
+    let filtered = count.try_filter_map(|i: &u64| {
+        if *i >= 3 {
+            bail!("boom at count {i}");
+        }
+        Ok((*i * 10, i % 2 == 1))
+    });
+    let acc = filtered.accumulate();
+
+    let mut r = g.build();
+    let result = r.run(HISTORICAL, RunFor::Cycles(10));
+
+    let err = result.expect_err("the run must abort when try_filter_map fails");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("TryFilterMap"),
+        "error should name the node: {msg}"
+    );
+    assert!(
+        msg.contains("boom at count 3"),
+        "error should chain the cause: {msg}"
+    );
+
+    // Only the pre-error, filtered-in value was accumulated (1*10; 2*10 was
+    // filtered out, not erred).
+    assert_eq!(vec![10], r.value(&acc));
+}
+
 /// A clean run runs teardown too — `finally` fires with the last value seen.
 #[test]
 fn teardown_runs_on_clean_completion() {

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -282,13 +282,14 @@ wingfoil::nitro! {
     }
 }
 
-// Fallible active surface: `try_map`, `try_join`.
+// Fallible active surface: `try_map`, `try_filter_map`, `try_join`.
 wingfoil::nitro! {
     fn surface_fallible(g: &GraphBuilder) -> Stream<Vec<u64>> {
         let count = g.ticker(P).count();
         let tried = count.try_map(|i| Ok(i + 1));
+        let filtered = tried.try_filter_map(|i| Ok((*i, i % 2 == 0)));
         let other = count.map(|i| i * 2);
-        let joined = tried.try_join(&other, |x: &u64, y: &u64| Ok(x + y));
+        let joined = filtered.try_join(&other, |x: &u64, y: &u64| Ok(x + y));
         let out = joined.accumulate();
         out
     }

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -287,7 +287,7 @@ wingfoil::nitro! {
     fn surface_fallible(g: &GraphBuilder) -> Stream<Vec<u64>> {
         let count = g.ticker(P).count();
         let tried = count.try_map(|i| Ok(i + 1));
-        let filtered = tried.try_filter_map(|i| Ok((*i, i % 2 == 0)));
+        let filtered = tried.try_filter_map(|i: &u64| Ok((*i, i.is_multiple_of(2))));
         let other = count.map(|i| i * 2);
         let joined = filtered.try_join(&other, |x: &u64, y: &u64| Ok(x + y));
         let out = joined.accumulate();


### PR DESCRIPTION
## Summary

Fixes #801 (part of #459).

`map_filter` (infallible, maps+filters) and `try_map` (fallible, maps) already exist — `try_filter_map` is the missing fallible map+filter corner. `f: Fn(&A) -> Result<(B, bool)>`: `Ok((v, true))` ticks `v`, `Ok((_, false))` means no value this tick and the run continues, `Err(e)` aborts the run with `e` as context. The rustdoc calls out that `false` and `Err` are not interchangeable, per the issue.

Composed from `MapFilter` and `TryMap` in `ops.rs`, following their exact shape.

## Changes

- `crates/wingfoil/src/ops.rs` — `TryFilterMap<A, B, F>` op, `#[op(build = try_filter_map, fluent)]`
- `crates/wingfoil/src/fluent.rs` — fluent method on `StreamOps`
- `crates/wingfoil/src/signal.rs` — `Signal` facade forward
- `crates/wingfoil/tests/op_completeness.rs` — exercised in the `surface_fallible` `nitro!` block (`interpreted() == compiled()`)
- `crates/wingfoil/tests/catalog.rs` — values + tick times parity test
- `crates/wingfoil/tests/fallibility.rs` — `Err` aborts the run with node context, mirroring the existing `try_map` test

No Python binding in this PR — issue #801's acceptance criteria list only the Rust op, fluent method, and the three test obligations, with no Python binding mentioned. Happy to add it as a follow-up if wanted.

## Test plan

- [x] `cargo fmt --all` — no diff
- [x] `cargo test -p wingfoil` — full suite passes
- [x] `cargo test -p wingfoil-derive` — passes
- [x] `cargo clippy -p wingfoil --all-targets -- -D warnings` — clean (two pre-existing warnings unrelated to this change, present on `main` too)
- [ ] `cargo lint-all` / `--all-features` — not run; this environment lacks `protoc`/`libclang` needed for the proto/iceoryx2 adapters, unrelated to this change