### PR TITLE
deps: bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

`cargo audit` has been failing on `main` since 2026-08-18. RUSTSEC-2026-0258 ("h2 unbounded empty DATA frames", published 2026-08-17) flags `h2 0.4.14`, with the fix in `>=0.4.16`.

`h2` is transitive via `hyper`, `reqwest` and `tonic`, so it is feature-gated in the build — but `cargo audit` reads `Cargo.lock` wholesale and fires regardless of which features are enabled. Every PR inherits the red check; #880 is currently blocked behind it through no fault of its own.

The other ten findings in that job are `warning:` lines (unmaintained `bincode`/`instant`/`mach`/`memmap`/`paste`/`rustls-pemfile`, unsound `lru`) and are already allowlisted — only the one `error:` fails the job.

## Changes

- `Cargo.lock` — `h2` 0.4.14 → 0.4.16 (version + checksum, two lines)

I edited the `h2` stanza directly rather than running `cargo update -p h2 --precise 0.4.16`. That command works, but it re-resolves the whole lock and, under MSRV-aware resolution against `rust-version = "1.88"`, downgrades unrelated pins as collateral — `windows-sys` 0.61.2 → 0.52.0 in four places, `socket2` 0.6.3 → 0.5.10, `windows-sys` 0.61.2 → 0.48.0 in another. `h2`'s own dependency list is identical between 0.4.14 and 0.4.16, so the two-line edit is exactly the intended change and nothing else.

## Test plan

- [x] `cargo fetch --locked` — lock is self-consistent (cargo did not need to modify it) and the 0.4.16 checksum verifies on download
- [x] `cargo check -p wingfoil --features prometheus-integration-test` — the feature that actually pulls `h2` in; `cargo tree -i h2` confirms `h2 v0.4.16` under `hyper v1.10.0` and `reqwest v0.12.28`
- [ ] `cargo audit` — not run locally (not installed here); this PR's own `security-audit` job is the check that matters

No source files change, and `h2` is not in the default-feature dependency tree.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtvqds3f7LPbxT2RT2NzG6)_