### PR TITLE
refactor(ops)!: rename try_filter_map to try_map_filter

### DIFF
--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -887,7 +887,7 @@ pub trait StreamOps<T>: Sized {
     /// true))` ticks `v`; `Ok((_, false))` means no value this tick and the
     /// run continues; `Err(e)` aborts the run with `e` as context — `false`
     /// and `Err` are not interchangeable.
-    fn try_filter_map<B, F>(&self, f: F) -> Stream<B>
+    fn try_map_filter<B, F>(&self, f: F) -> Stream<B>
     where
         B: Clone + Default + 'static,
         F: Fn(&T) -> Result<(B, bool)> + 'static;
@@ -1302,7 +1302,7 @@ impl<T: 'static> StreamOps<T> for Stream<T> {
 
     __wf_fluent_map_filter!(T);
 
-    __wf_fluent_try_filter_map!(T);
+    __wf_fluent_try_map_filter!(T);
 
     fn with_time(&self) -> Stream<(NanoTime, T)>
     where

--- a/crates/wingfoil/src/ops.rs
+++ b/crates/wingfoil/src/ops.rs
@@ -198,10 +198,10 @@ where
 /// `false` and `Err` are not interchangeable: `Ok((_, false))` means "no
 /// value this tick" and the run continues; `Err(e)` means the run is broken
 /// and aborts with `e` as context.
-pub struct TryFilterMap<A, B, F>(PhantomData<(A, B, F)>);
+pub struct TryMapFilter<A, B, F>(PhantomData<(A, B, F)>);
 
-#[op(build = try_filter_map, fluent)]
-impl<A, B, F> Op for TryFilterMap<A, B, F>
+#[op(build = try_map_filter, fluent)]
+impl<A, B, F> Op for TryMapFilter<A, B, F>
 where
     A: 'static,
     B: Clone + 'static,

--- a/crates/wingfoil/src/signal.rs
+++ b/crates/wingfoil/src/signal.rs
@@ -139,7 +139,7 @@ impl<T: 'static> Signal<T> {
     __wf_signal_map!(T);
     __wf_signal_try_map!(T);
     __wf_signal_map_filter!(T);
-    __wf_signal_try_filter_map!(T);
+    __wf_signal_try_map_filter!(T);
     __wf_signal_fold!(T);
     __wf_signal_scan!(T);
     __wf_signal_for_each!(T);
@@ -178,6 +178,11 @@ impl<T: 'static> Signal<T> {
     /// Map and filter with an `Option` (the legacy `filter_map`): tick the
     /// returned `Some`, drop `None`. Delegates to the fluent
     /// [`map_filter`](StreamOps::map_filter).
+    ///
+    /// Not to be confused with
+    /// [`try_map_filter`](StreamOps::try_map_filter), which is the fallible
+    /// twin of `map_filter` and keeps its `(value, emit?)` shape rather than
+    /// this `Option` one.
     pub fn filter_map<B, F>(&self, f: F) -> Signal<B>
     where
         B: Clone + Default + 'static,

--- a/crates/wingfoil/tests/catalog.rs
+++ b/crates/wingfoil/tests/catalog.rs
@@ -279,17 +279,17 @@ fn map_filter_maps_and_filters() {
     assert_eq!(vec![1, 9, 25], r.value(&acc));
 }
 
-/// `try_filter_map` is `map_filter`'s fallible twin: squares of odds, same
+/// `try_map_filter` is `map_filter`'s fallible twin: squares of odds, same
 /// as the test above, but through a closure that returns `Result<(B, bool)>`
 /// and never actually fails here — the abort path is
-/// `try_filter_map_err_aborts_run` in `fallibility.rs`. Each surviving value
+/// `try_map_filter_err_aborts_run` in `fallibility.rs`. Each surviving value
 /// keeps its original tick time, since the op suppresses ticks, not time.
 #[test]
-fn try_filter_map_maps_and_filters_with_tick_times() {
+fn try_map_filter_maps_and_filters_with_tick_times() {
     let g = GraphBuilder::new();
     let count = g.ticker(Duration::from_nanos(10)).count(); // 1..=6
     let acc = count
-        .try_filter_map(|i| Ok((i * i, i % 2 == 1))) // squares of odds: 1, 9, 25
+        .try_map_filter(|i| Ok((i * i, i % 2 == 1))) // squares of odds: 1, 9, 25
         .with_time()
         .accumulate();
     let mut r = g.build();

--- a/crates/wingfoil/tests/fallibility.rs
+++ b/crates/wingfoil/tests/fallibility.rs
@@ -58,17 +58,17 @@ fn cycle_error_aborts_with_context_and_runs_teardown() {
     assert_eq!(Some(2), *torn_down.borrow());
 }
 
-/// `try_filter_map` is `try_map`'s map-and-filter twin: an `Err` aborts the
+/// `try_map_filter` is `try_map`'s map-and-filter twin: an `Err` aborts the
 /// run with context naming the node, same as `try_map` above — the
 /// `Ok((_, false))` filtering path is not a substitute for propagating a
 /// real error, and this pins that they behave differently.
 #[test]
-fn try_filter_map_err_aborts_run() {
+fn try_map_filter_err_aborts_run() {
     let g = GraphBuilder::new();
     let count = g.ticker(Duration::from_nanos(10)).count();
     // Cycles 1 and 2 succeed (odd values kept, even ones filtered); cycle 3
     // errors instead of filtering.
-    let filtered = count.try_filter_map(|i: &u64| {
+    let filtered = count.try_map_filter(|i: &u64| {
         if *i >= 3 {
             bail!("boom at count {i}");
         }
@@ -79,10 +79,10 @@ fn try_filter_map_err_aborts_run() {
     let mut r = g.build();
     let result = r.run(HISTORICAL, RunFor::Cycles(10));
 
-    let err = result.expect_err("the run must abort when try_filter_map fails");
+    let err = result.expect_err("the run must abort when try_map_filter fails");
     let msg = format!("{err:#}");
     assert!(
-        msg.contains("TryFilterMap"),
+        msg.contains("TryMapFilter"),
         "error should name the node: {msg}"
     );
     assert!(

--- a/crates/wingfoil/tests/op_completeness.rs
+++ b/crates/wingfoil/tests/op_completeness.rs
@@ -283,12 +283,12 @@ wingfoil::nitro! {
     }
 }
 
-// Fallible active surface: `try_map`, `try_filter_map`, `try_join`.
+// Fallible active surface: `try_map`, `try_map_filter`, `try_join`.
 wingfoil::nitro! {
     fn surface_fallible(g: &GraphBuilder) -> Stream<Vec<u64>> {
         let count = g.ticker(P).count();
         let tried = count.try_map(|i| Ok(i + 1));
-        let filtered = tried.try_filter_map(|i: &u64| Ok((*i, i.is_multiple_of(2))));
+        let filtered = tried.try_map_filter(|i: &u64| Ok((*i, i.is_multiple_of(2))));
         let other = count.map(|i| i * 2);
         let joined = filtered.try_join(&other, |x: &u64, y: &u64| Ok(x + y));
         let out = joined.accumulate();

--- a/crates/wingfoil/tests/signal.rs
+++ b/crates/wingfoil/tests/signal.rs
@@ -286,6 +286,19 @@ fn legacy_try_map_transforms_values() {
     assert_eq!(vec![2, 4, 6], doubled.peek_value());
 }
 
+/// `try_map_filter` is `map_filter`'s fallible twin on the facade: the `Ok`
+/// path maps and drops in one pass. Distinct from `filter_map` below, which
+/// is `Option`-shaped rather than `(value, emit?)`-shaped.
+#[test]
+fn legacy_try_map_filter_maps_and_filters() {
+    let odds = ticker(Duration::from_nanos(100))
+        .count()
+        .try_map_filter(|i: &u64| Ok((i * i, i % 2 == 1)))
+        .accumulate();
+    odds.run(HISTORICAL, RunFor::Cycles(6)).unwrap();
+    assert_eq!(vec![1, 9, 25], odds.peek_value());
+}
+
 /// `map_filter` maps and drops in one pass, preserving values **and** the tick
 /// times of the values it keeps.
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #880 (which resolved #801), acting on two findings from its review. No release carries the old name, so nothing downstream breaks — this is free now and breaking later.

### The rename

The catalog's fallible-twin convention is `try_` plus the **exact** base name: `map` → `try_map`, `join` → `try_join`, `join_passive` → `try_join_passive`. The base here is `map_filter`, so the twin is `try_map_filter`. The op's own rustdoc already described it as "the `try_` counterpart to `map_filter`" while carrying a name that said otherwise.

The concrete trap this removes is on the `Signal` facade, which already has a `filter_map` taking `Fn(&T) -> Option<B>`. Landing a `try_filter_map` taking `Fn(&T) -> Result<(B, bool)>` next to it put two methods side by side that read as an infallible/fallible pair and are not one — different shapes, different call sites, no relationship between them. `try_map_filter` sits beside `map_filter`, whose `(value, emit?)` shape it does mirror exactly.

**Why rename rather than reshape to `Result<Option<B>>`.** The dummy `B` on the reject path (`Ok((B::default(), false))`) is a real wart, but it is inherited from `map_filter`'s `(B, bool)` shape — it is not introduced here. Giving the fallible twin an `Option` while the infallible one keeps a `bool` would make the pair *less* consistent, not more; matching shapes are what make "fallible twin" checkable at a glance. An `Option`-shaped convenience belongs on `Signal`, layered over this op exactly as `Signal::filter_map` layers over `map_filter` today. Happy to add that separately if wanted.

### Also included, from the same review

- **A `Signal` facade test** (`tests/signal.rs`). The facade forward shipped with no test anywhere — deleting the `__wf_signal_try_map_filter!(T)` line left the build *and* the full suite green. That is exactly the facade drift the op recipe's step 4b records as having already cost 15 methods once. Verified the new test closes the hole: with the macro line removed the test crate now fails to compile (`no method named try_map_filter found for struct Signal<T>`).
- **A disambiguating note on `Signal::filter_map`** pointing at the shape difference, so the two neighbours explain themselves to the next reader.

## Changes

- `crates/wingfoil/src/ops.rs` — `TryFilterMap` → `TryMapFilter`, `build = try_map_filter`
- `crates/wingfoil/src/fluent.rs` — `StreamOps` declaration and macro invocation
- `crates/wingfoil/src/signal.rs` — facade forward, plus the note on `filter_map`
- `crates/wingfoil/tests/{catalog,fallibility,op_completeness}.rs` — call sites and the `msg.contains("TryMapFilter")` assertion
- `crates/wingfoil/tests/signal.rs` — new `legacy_try_map_filter_maps_and_filters`

The generated macro names follow `build =` automatically, so `__wf_fluent_try_filter_map!` / `__wf_signal_try_filter_map!` become `__wf_fluent_try_map_filter!` / `__wf_signal_try_map_filter!` with no separate edit.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p wingfoil` — full suite green (95 unit + all integration targets)
- [x] `cargo test --doc -p wingfoil` — green; the new intra-doc link resolves (`cargo doc --no-deps` surfaces no new warnings)
- [x] `cargo test -p wingfoil-derive` — green
- [x] `cargo lint` (default features) — clean
- [x] Confirmed no `try_filter_map` / `TryFilterMap` occurrences remain in the tree
- [ ] `cargo lint-all` / `--all-features` — not run here; this box has no `protoc`. The rename touches no feature-gated code, and CI's all-features leg covers it.

## Note for #801

Issue #801 specified the name and the `#[op(build = try_filter_map, fluent)]` attribute verbatim, so @zaydmulani09 implemented exactly what was asked — this is a spec correction, not a defect in that PR. Worth editing the issue text if any of it is still being used as a template.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtvqds3f7LPbxT2RT2NzG6)_