### PR TITLE
docs: add type-map.md, the index into rustdoc by layer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ engine, the one decision everything else follows from, and the rules that bite.
 | | |
 |---|---|
 | [**wingfoil-architecture.md**](wingfoil-architecture.md) | The engine: `Op`, `Tick`, wiring, the two clocks, the three Nitro tiers |
+| [**type-map.md**](type-map.md) | The load-bearing types by layer, and how they contain each other — the index into the rustdoc |
 | [**adding-an-op.md**](adding-an-op.md) | The recipe and touch-point table for a new op — what `#[op]` generates, and why the compiled path is zero-touch |
 | [**migration.md**](migration.md) | Porting Rust code off the 8.x `#[node]` engine onto `Op` |
 | [**python-interop.md**](python-interop.md) | The plugin SDK — authoring ops, graphs and adapters in Rust, then composing them from Python |

--- a/docs/type-map.md
+++ b/docs/type-map.md
@@ -1,0 +1,91 @@
+# The type map
+
+The middle altitude the other docs skip: which types carry the engine, and how
+they contain each other. [`wingfoil-architecture.md`](wingfoil-architecture.md)
+is the level above (the decisions); the rustdoc is the level below (every field
+justified where it is declared — the field docs are the source of truth, and
+this page deliberately does not repeat them). Read this when you know *why* the
+engine is shaped this way and need to know *what to grep for*.
+
+Types are grouped by layer, outermost first. Each name links to the file that
+defines it.
+
+## How they contain each other
+
+```
+GraphBuilder ─┬─ wraps ──▶ Builder ── build() ──▶ Runner ── holds ──▶ Kernel ── holds ──▶ TimeQueue<usize>
+  Stream<T> ──┘  (same Rc)     │                    │
+                               └── mints ──▶ Handle<T> ──▶ SlotRef<T>   (the value slots)
+
+other threads ──▶ ChannelSender / PooledSender / ExternalSource ── KernelWaker ──▶ Kernel
+```
+
+One run, end to end: `GraphBuilder`/`Stream` wire ops into the `Builder`;
+`build()` computes edges and layers and yields a `Runner` holding a `Kernel`.
+Each cycle, `Kernel::begin_cycle` advances engine time and names the due
+frontier; the sparse dispatch drains dirty nodes in `(layer, index)` order,
+each one crossing a single dyn boundary into the same monomorphized
+`Op::cycle` the compiled tier would inline; `Tick` results land in slots and
+propagate. Producers on other threads feed in through the channel layer,
+waking the kernel; `feedback` re-enters at `time + 1` through a `TimeQueue`.
+
+## Vocabulary — [`op.rs`](../crates/wingfoil/src/op.rs)
+
+| Type | What it is |
+|---|---|
+| `Op` | The node contract: `Cfg` (construction-time config, closures included), `State` (engine-owned), `In<'a>` (typed inputs, assembled by the engine), `Out`, `const ACTIVATION`, and `cycle()` plus optional `start`/`stop`/`teardown`. Semantics as an associated *function* — the one decision everything follows from. |
+| `Tick<T>` | The outcome of one cycle: `Value` (update slot and tick downstream), `Silent` (update slot only — what `delay` needs), `Quiet` (nothing). |
+| `Activation` | Scheduling behaviour as a `const`: `NONE` / `SCHEDULES` / `THREADED` / `ALWAYS`. Read at wiring time interpreted, folded into the dispatch condition compiled. |
+| `Ctx<'a>` | The op's entire view of the engine: engine time, the lazy wall snap, run metadata, and *self*-scheduling. Deliberately narrow — that is what lets a composite island drive the same op. |
+
+## Wiring — [`fluent.rs`](../crates/wingfoil/src/fluent.rs)
+
+| Type | What it is |
+|---|---|
+| `GraphBuilder` | A graph under construction: `Rc<RefCell<Builder>>` plus a `built` flag that poisons wiring after `build()`. The `Rc` is why it — and everything wired from it — is `!Send`: a graph lives on one thread, by type. Extension point: `GraphBuilder::source`. |
+| `Stream<T>` | A typed wiring-time reference to one node's output; holds no data. Combinators are extension traits (`SourceOps`, `StreamOps`, `StatisticsOps`, one per adapter), never inherent methods; they all go through `Stream::wire`. |
+| `Upstream` | The type-erased edge descriptor used when declaring a node's inputs. |
+
+## Interpreted engine — [`interp.rs`](../crates/wingfoil/src/interp.rs)
+
+| Type | What it is |
+|---|---|
+| `Builder` | The accumulator behind `GraphBuilder`: per node, the dyn-adapted cycle/lifecycle closures, the op's `Cfg`+`State`, its activation and edges, and a value slot. The engine owns everything the op does not. |
+| `Runner` | Executes the built graph. Sparse dirty-list dispatch: seed from busy-poll nodes plus `Kernel::due`, propagate the tick frontier through the active-downstream lists, drain in `(layer, index)` order — glitch-free, single-fire, cost proportional to nodes that fire. `!Send`, and knows whether it is re-runnable. |
+| `Dispatch` | Which loop `run` uses: `Sparse` (default) or `FullSweep`, the `O(N)` reference oracle kept for tying the two out. |
+| `Handle<T>` / `AsHandle<T>` | A typed node index, stamped with its builder's id so a handle used against the wrong `Runner` asserts instead of reading the wrong slot. `AsHandle` unifies `Handle` and `Stream` (by value and by reference) for `Runner::value`. |
+| `SlotRef<T>` | The frozen access boundary to a value slot — ops only `borrow()`/`borrow_mut()`, never the concrete cell, so the store can become an arena later without touching capture sites. |
+| `ExternalSource<T>` | Producer half of an `external` source: send a value from any thread, wake the kernel. |
+| `FeedbackSink<T>` | Write end of a `feedback` edge: values queue and the paired source node emits them on the *next* cycle, which is what breaks the dependency cycle. |
+| `StopHandle` | Wraps any guard whose `Drop` stops a producer; held for the run, dropped at teardown. |
+| `Extension` / `LiveStream<T>` / `StreamStore<K, V>` / `DemuxEvent` | The `dynamic-graph` surface: runtime splice and remove (removal tombstones the slot so old `Handle`s stay valid), and keyed sub-streams appearing at runtime via `demux`. |
+
+## Kernel — [`runtime/`](../crates/wingfoil/src/runtime)
+
+| Type | What it is |
+|---|---|
+| `Kernel` | The minimal engine core all three tiers drive: engine `time` (source-driven, deterministic under replay), the lazy per-cycle `wall_time` snap, the scheduled-callback `TimeQueue`, run bounds, and the `due` frontier. The interpreted `Runner` holds one; `compiled()` stack-allocates its own; an island borrows the outer one. |
+| `KernelWaker` / `ReadyReceiver` | The wake channel producer threads use to mark a node dirty and un-park a realtime kernel. |
+| `TimerPolicy` | How a realtime kernel waits for the next callback: `Park` (OS sleep) or `SpinAhead` (sleep until a guard before the deadline, then busy-spin — a core traded for scheduler jitter). |
+| `TimeQueue<T>` | The `(value, time)` scheduler behind the kernel, `delay` and `feedback`: earliest instant held out of a `BTreeMap`, FIFO within an instant, **dedup by design**, bounded on `PartialEq` so `f64` flows through. See "The rules that bite". |
+| `NanoTime` | The nanosecond timestamp; `ZERO` is the epoch and the conventional backtest start. |
+| `RunMode` / `RunFor` | `RealTime` vs `HistoricalFrom(t)`; stop after a `Duration` (engine time), a cycle count, or `Forever`. |
+| `Burst<T>` | Same-instant values delivered atomically — a `TinyVec<[T; 1]>`, so the single-value common case allocates nothing. Never coalesced, never dropped. |
+
+## Thread boundary — [`channel.rs`](../crates/wingfoil/src/channel.rs)
+
+| Type | What it is |
+|---|---|
+| `Message<T>` | The in-process envelope: `Value`, `ValueAt` (deterministic replay time), `Checkpoint` (progress without a value, so a quiet channel does not stall a replay), `EndOfStream`, `Error` (aborts the run with node context). |
+| `ChannelSender<T>` | The `Clone + Send` write end of `channel` — an mpsc sender (bounded blocking = the backpressure) plus a `KernelWaker`. The only sanctioned way another thread reaches a running graph. |
+
+## Pool — [`pool.rs`](../crates/wingfoil/src/pool.rs)
+
+The zero-allocation ingress path for large payloads, mirroring iceoryx2's
+loan/write/send protocol.
+
+| Type | What it is |
+|---|---|
+| `PooledSender<T>` | Producer half of `pooled_channel`: a bounded buffer pool plus the sender. `loan()` blocks once `capacity` buffers are in flight — the pool *is* the backpressure. |
+| `PoolLoan<T>` | A writable loan of one recycled buffer: unique owner, so it crosses the thread boundary with no refcount; its `Drop` returns the buffer to the pool. |
+| `Pooled<T>` | The graph-side handle: non-atomic (`Rc`) sharing, so routing ops clone by refcount bump; `PartialEq` is pointer identity (what `delay`/`feedback` dedup wants); `Default` is the empty pre-first-tick handle. |

--- a/docs/wingfoil-architecture.md
+++ b/docs/wingfoil-architecture.md
@@ -102,6 +102,10 @@ Plus `wingfoil-derive` (`nitro!` and `#[op]`), `wingfoil-python`
 (PyO3 bindings), `wingfoil-wire-types` + `wingfoil-wasm` + `js/` (the browser
 side of the web adapter).
 
+That is the *file* map. The *type* map — the ~20 load-bearing types, grouped by
+layer, with the containment chain from `GraphBuilder` down to `TimeQueue` — is
+[`type-map.md`](type-map.md).
+
 ### `Tick<T>` — three outcomes, not two
 
 ```rust
@@ -216,6 +220,7 @@ strategies in one test, comparing them against each other — that is how the
 
 | You want to… | Read |
 |---|---|
+| Find the type that does a thing | [`type-map.md`](type-map.md) |
 | Add an op | `.claude/commands/new-op.md` |
 | Add an I/O adapter | `.claude/commands/new-adapter.md` |
 | Add Python bindings for one | `.claude/commands/bind-adapter.md` |


### PR DESCRIPTION
## What this changes

Adds `docs/type-map.md`, a new middle-altitude reference that indexes the ~20 load-bearing types by layer (wiring, interpreted engine, kernel, thread boundary, pool) and shows how they contain each other. Updates `docs/README.md` and `docs/wingfoil-architecture.md` to link to it.

## Why

The existing docs cover *why* the engine is shaped this way (architecture.md) and *how* to use individual fields (rustdoc). There's a gap in the middle: which types carry the engine, where they live, and what to grep for when you know the architecture and need to find the code.

This is the index that bridges those two levels — a reader who understands the design can now navigate to the concrete types without reading every rustdoc comment.

## How it was verified

- [ ] `cargo fmt --all`
- [ ] `cargo lint` and `cargo lint-all`
- [ ] `cargo test -p wingfoil --all-features`

(Documentation only; no code changes to test.)

## Notes for the reviewer

The type map is deliberately *not* a duplicate of rustdoc — it omits field details (those are the source of truth in the field docs themselves) and focuses on the containment chain and layer grouping. The vocabulary table for `op.rs` is the exception: it summarizes the core contract because understanding `Op`, `Tick`, `Activation`, and `Ctx` is prerequisite to reading anything else.

The diagram at the top shows the wiring-time and runtime paths separately, which is the mental model the architecture doc builds toward.

https://claude.ai/code/session_01MpY4eBTng9F5v1DYZpxRb5