### PR TITLE
Refresh the dogfood coverage snapshot: drop two gaps that have since closed

### DIFF
--- a/.claude/commands/dogfood.md
+++ b/.claude/commands/dogfood.md
@@ -68,15 +68,16 @@ concept you cannot find with `grep -rl '<api>' crates/wingfoil/examples/`, is a
 candidate. **Confirm each candidate with that grep before assigning it** — the
 cost of getting this wrong is a wasted agent, and it is easy to get wrong.
 
-Snapshot as of 2026-08-16, useful as a seed but **re-derive rather than
-trusting it**:
+Snapshot as of 2026-08-22, useful as a seed but **re-derive rather than
+trusting it** — the previous snapshot went stale in under a week, losing two
+of its seven rows: the `market` adapter gained an example (#891) and the
+`Signal` facade was deleted outright (#887). A gap list is a perishable
+observation, not a backlog:
 
 | Uncovered | Why it is a gap |
 |---|---|
 | **latency capture** (`latency::Stamp`, `StampEach`, `LatencyReport`) | only reachable inside `showcase/latency` and `trading_e2e`, both multi-process and iceoryx2-gated — there is no small example teaching the stamping API on its own |
 | **`cache` adapter** | no example anywhere in the tree |
-| **`market` adapter** | mentioned once in the `ws` README, never demonstrated |
-| **`Signal` facade** (`signal.rs`) | appears only incidentally in `adapters/iceoryx2` |
 | **`window` / `buffer`** | no example calls either — the bounded look-back `CLAUDE.md` recommends instead of `accumulate()` |
 | **`dhat-heap`, `bench`/`bencher.rs`, `instrument-*`** | profiling and granular instrumentation features with no worked example |
 | **`ws-tls` / `web-tls`** | only exercised through `trading_e2e` |


### PR DESCRIPTION
## What this changes

Removes two rows from the seed table in `.claude/commands/dogfood.md` and dates
the caveat above it. One file, documentation only.

## Why

The table lists uncovered parts of the surface as candidates for the skill's six
example slots. Two of its seven rows closed within a week of being written:

* **`market` adapter** — gained an example in #891.
* **`Signal` facade** — not merely documented since, but **deleted outright** in
  #887, along with `crates/wingfoil/src/signal.rs`.

Left in place, each would have cost a wasted agent. That is exactly the failure
the derivation procedure directly above the table exists to prevent: an agent
whose task turns out to be already done produces no friction data, and one
pointed at a deleted module produces worse than none.

The remaining five rows were re-verified against the tree rather than carried
forward on trust — `cache` still has no example directory, nothing under
`examples/` calls `window` or `buffer`, no example outside `showcase/` touches
the latency stamping API, and `web-tls` is still reachable only through
`trading_e2e_ws_server`.

## How it was verified

- [x] `cargo fmt --all` — no Rust in this diff
- [x] `cargo lint` — unaffected, documentation only
- [ ] `cargo test -p wingfoil --all-features` — not applicable
- [ ] Values-and-tick-times test — not applicable

Each surviving row was checked with a grep against the current tree; each
removed row was checked against the commit that closed it.

## Notes for the reviewer

The caveat above the table now records *how fast* the previous snapshot rotted,
because that is a better argument for re-deriving the list than the instruction
to re-derive it. A gap list is a perishable observation, not a backlog — and
this table proved it in six days.

Worth deciding as a maintainer: the table is useful as a seed but will always
decay. If it decays again by the next run, the honest fix may be to delete it
and keep only the three derivation commands, which cannot go stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaiuuXWEf3FnSmBMASvqvK)_