### PR TITLE
docs(examples): demonstrate pooled channel backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ that move that line. All four are open: see [Get Involved](#get-involved).
 
 ## Examples
 
-44 runnable examples, each in its own directory with a README covering what it
+45 runnable examples, each in its own directory with a README covering what it
 teaches, the wiring, and its expected output. Full index:
 [`examples/README.md`](crates/wingfoil/examples/README.md).
 
@@ -262,6 +262,7 @@ No services, no feature flags — these run with a plain `cargo run`.
 | [`async`](crates/wingfoil/examples/core/async/) | Tokio async/await at the graph's edges, with the core graph staying synchronous. |
 | [`async_source`](crates/wingfoil/examples/core/async_source/) | An async quote feed driving the graph through an `external` source. |
 | [`threading`](crates/wingfoil/examples/core/threading/) | Distribute graph execution across worker threads, with no locks on the execution path. |
+| [`pooled_channel`](crates/wingfoil/examples/core/pooled_channel/) | Recycle pre-sized payload buffers through a loan-based channel with a bounded backpressure budget. |
 | [`spawn`](crates/wingfoil/examples/core/spawn/) | Offload slow work off the graph thread with `spawn` / `spawn_map`. |
 | [`tracing`](crates/wingfoil/examples/core/tracing/) | Observability: the `logged` debug tap and the engine's own spans. |
 | [`introspect`](crates/wingfoil/examples/core/introspect/) | Read back the graph you wired — text, Mermaid, DOT, JSON or GML. |

--- a/crates/wingfoil/Cargo.toml
+++ b/crates/wingfoil/Cargo.toml
@@ -703,6 +703,12 @@ path = "examples/core/tracing/main.rs"
 name = "threading"
 path = "examples/core/threading/main.rs"
 
+# Loan-based ingress with recycled, pre-sized payload buffers and a bounded
+# pool as backpressure. Uses only default features.
+[[example]]
+name = "pooled_channel"
+path = "examples/core/pooled_channel/main.rs"
+
 # The same thread offload as `threading`, but through the `spawn` / `spawn_map`
 # combinators that wrap the channel plumbing into one call each.
 [[example]]

--- a/crates/wingfoil/examples/README.md
+++ b/crates/wingfoil/examples/README.md
@@ -40,7 +40,7 @@ Then pick a direction:
 
 **Tiers (`nitro!`)**: [`dual_mode`](core/dual_mode/)
 
-**Concurrency**: [`threading`](core/threading/) · [`spawn`](core/spawn/) · [`async`](core/async/) · [`async_source`](core/async_source/)
+**Concurrency**: [`threading`](core/threading/) · [`pooled_channel`](core/pooled_channel/) · [`spawn`](core/spawn/) · [`async`](core/async/) · [`async_source`](core/async_source/)
 
 **Dynamism** ([full index](core/dynamism/)): [`dynamic_group`](core/dynamism/dynamic_group/) · [`dynamic_manual`](core/dynamism/dynamic_manual/) · [`demux_it`](core/dynamism/demux_it/) · [`demux_map`](core/dynamism/demux_map/)
 

--- a/crates/wingfoil/examples/core/README.md
+++ b/crates/wingfoil/examples/core/README.md
@@ -45,6 +45,7 @@ The measured cost of each tier is in [`../../benches/`](../../benches/) —
 | Example | Features | What it teaches |
 |---|---|---|
 | [`threading`](threading/) | — | A producer sub-graph on a worker thread, feeding the main graph over the channel layer — written out by hand. |
+| [`pooled_channel`](pooled_channel/) | — | Loan, write in place and send pre-sized payloads; cheap graph-side handles and the bounded loan budget provide recycling and backpressure. |
 | [`spawn`](spawn/) | — | The same offload via the `spawn` / `spawn_map` combinators, which wrap that plumbing into one call. |
 | [`async`](async/) | `async` | The classic `async` example ported: `produce_async` — an async producer of **timestamped** values driving the graph, in both modes off one definition. |
 | [`async_source`](async_source/) | `async` | `external` sources — a tokio task pushing into a realtime graph, burst-delivered. |

--- a/crates/wingfoil/examples/core/pooled_channel/README.md
+++ b/crates/wingfoil/examples/core/pooled_channel/README.md
@@ -1,0 +1,61 @@
+## Pooled channel — recycled buffers under backpressure
+
+Loan a pre-sized, heap-owning payload on a producer thread, write into it in
+place, and send its unique owner into a Wingfoil graph. The graph sees a
+`Pooled<Book>` handle: cloning it through routing and enrichment only bumps a
+single-threaded `Rc`, rather than deep-cloning the book's `Vec`s.
+
+The capacity-two pool is also the backpressure budget. Once the graph holds
+book #1 and the producer loans the other buffer, `try_loan()` returns `None`.
+When the graph advances to book #2, every handle to book #1 drops, returning
+that buffer — with its interior vector capacity intact — for book #3.
+
+```rust
+let (books, mut sender) =
+    g.pooled_channel_with(2, Book::with_depth);
+
+let _printed = books
+    .map(|burst: &Burst<Pooled<Book>>| burst.last().unwrap().clone())
+    .map(|book: &Pooled<Book>| EnrichedBook {
+        spread: book.spread(),
+        book: book.clone(), // handle clone, not Book clone
+    })
+    .for_each(|event: &EnrichedBook| {
+        println!("book #{} spread {:.2}", event.book.seq, event.spread);
+        Ok(())
+    });
+
+let mut first = sender.loan();      // blocks when both buffers are in flight
+first.refill(1);                    // clear + fill preserves Vec capacity
+sender.send(first);
+let second = sender.try_loan().unwrap(); // borrow the remaining free buffer
+assert!(sender.try_loan().is_none());    // the loan budget is now exhausted
+drop(second);
+```
+
+The full program uses a tiny phase gate so the backpressure and recycling
+steps are deterministic while the graph runs in realtime. It prints from a
+`for_each` sink as values arrive; it does not park handles in `accumulate()`,
+which would consume the loan budget for the life of the run.
+
+### Output
+
+```text
+pool: 2 pre-sized books, 4 levels per side
+graph: book #1 best 100.95 x 101.05, spread 0.10
+backpressure: graph holds book #1; 1/2 buffers remain available
+backpressure: loaning the last free buffer makes try_loan() return None
+graph: book #2 best 101.95 x 102.05, spread 0.10
+recycling: book #1's buffer returned with its Vec capacity intact
+graph: book #3 best 102.95 x 103.05, spread 0.10
+```
+
+### Run
+
+```sh
+cargo run -p wingfoil --example pooled_channel
+```
+
+Read the [`pool` module docs](../../../src/pool.rs) for the full loan-budget
+ledger, empty pre-first-tick handles, pointer-identity equality, and the two
+small residual per-message allocations that remain outside the payload.

--- a/crates/wingfoil/examples/core/pooled_channel/main.rs
+++ b/crates/wingfoil/examples/core/pooled_channel/main.rs
@@ -1,0 +1,200 @@
+//! Loan-based ingress with recycled payload buffers and bounded backpressure.
+//!
+//! A producer thread loans a pre-sized [`Book`], writes into its existing
+//! vectors, and sends the unique owner into the graph. The graph receives a
+//! [`Pooled<Book>`](wingfoil::pool::Pooled): cloning that handle only bumps an
+//! `Rc`, so routing and enrichment never deep-clone the book. When the last
+//! graph-side handle drops, the buffer returns to the producer's pool.
+//!
+//! ```sh
+//! cargo run -p wingfoil --example pooled_channel
+//! ```
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, ensure};
+use wingfoil::pool::Pooled;
+use wingfoil::prelude::*;
+use wingfoil::{RunFor, RunMode};
+
+const POOL_CAPACITY: usize = 2;
+const BOOK_DEPTH: usize = 4;
+
+#[derive(Debug)]
+struct Book {
+    seq: u64,
+    bids: Vec<(f64, u64)>,
+    asks: Vec<(f64, u64)>,
+}
+
+impl Book {
+    fn with_depth() -> Self {
+        Self {
+            seq: 0,
+            bids: Vec::with_capacity(BOOK_DEPTH),
+            asks: Vec::with_capacity(BOOK_DEPTH),
+        }
+    }
+
+    /// Overwrite one recycled book without replacing either vector's heap
+    /// allocation. A real decoder would fill the same way.
+    fn refill(&mut self, seq: u64) {
+        self.seq = seq;
+        self.bids.clear();
+        self.asks.clear();
+
+        let mid = 100.0 + seq as f64;
+        for level in 0..BOOK_DEPTH {
+            let offset = 0.05 + level as f64 * 0.01;
+            self.bids.push((mid - offset, 10 + level as u64));
+            self.asks.push((mid + offset, 12 + level as u64));
+        }
+    }
+
+    fn spread(&self) -> f64 {
+        let bid = self
+            .bids
+            .first()
+            .expect("invariant: refill writes at least one bid")
+            .0;
+        let ask = self
+            .asks
+            .first()
+            .expect("invariant: refill writes at least one ask")
+            .0;
+        ask - bid
+    }
+}
+
+/// Enrichment wraps the pooled handle instead of cloning the heap-owning
+/// payload. `Book` deliberately has no `Clone` implementation.
+#[derive(Clone, Default)]
+struct EnrichedBook {
+    book: Pooled<Book>,
+    spread: f64,
+}
+
+fn wait_for_book(phase: &AtomicU64, seq: u64) -> anyhow::Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while phase.load(Ordering::Acquire) < seq {
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for graph to print book #{seq}");
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    let g = GraphBuilder::new();
+    let phase = Arc::new(AtomicU64::new(0));
+    let (books, mut sender) = g.pooled_channel_with(POOL_CAPACITY, Book::with_depth);
+
+    let printed_phase = Arc::clone(&phase);
+    let _printed = books
+        // Pick one item out of the arrival burst. This clones only the
+        // graph-side Rc handle, never Book or either Vec.
+        .map(|burst: &Burst<Pooled<Book>>| {
+            burst
+                .last()
+                .expect("invariant: a channel tick carries a non-empty burst")
+                .clone()
+        })
+        // Wrap-don't-clone: retain the handle and add derived information.
+        .map(|book: &Pooled<Book>| EnrichedBook {
+            spread: book.spread(),
+            book: book.clone(),
+        })
+        .for_each(move |event: &EnrichedBook| {
+            let best_bid = event
+                .book
+                .bids
+                .first()
+                .expect("invariant: refill writes at least one bid")
+                .0;
+            let best_ask = event
+                .book
+                .asks
+                .first()
+                .expect("invariant: refill writes at least one ask")
+                .0;
+            println!(
+                "graph: book #{} best {best_bid:.2} x {best_ask:.2}, spread {:.2}",
+                event.book.seq, event.spread
+            );
+            printed_phase.store(event.book.seq, Ordering::Release);
+            Ok(())
+        });
+
+    let producer = thread::spawn(move || {
+        let result = (|| -> anyhow::Result<()> {
+            println!("pool: {POOL_CAPACITY} pre-sized books, {BOOK_DEPTH} levels per side");
+
+            let mut first = sender.loan();
+            let first_buffer = (&*first as *const Book) as usize;
+            first.refill(1);
+            ensure!(sender.send(first), "graph receiver closed before book #1");
+            wait_for_book(&phase, 1)?;
+
+            // Book #1 is now retained by the routing/enrichment value slots,
+            // leaving one of the two pool buffers available to the producer.
+            let available = sender.available();
+            ensure!(
+                available == 1,
+                "expected one free buffer while the graph holds book #1, got {available}"
+            );
+            println!(
+                "backpressure: graph holds book #1; {available}/{POOL_CAPACITY} buffers remain available"
+            );
+
+            let mut second = sender
+                .try_loan()
+                .context("the second pool buffer should still be available")?;
+            ensure!(
+                sender.try_loan().is_none(),
+                "try_loan must fail once the bounded loan budget is exhausted"
+            );
+            println!("backpressure: loaning the last free buffer makes try_loan() return None");
+
+            second.refill(2);
+            ensure!(sender.send(second), "graph receiver closed before book #2");
+            wait_for_book(&phase, 2)?;
+
+            // Updating the graph's slots to book #2 dropped the last handle to
+            // book #1. Its original buffer is now back in the producer pool.
+            let mut recycled = sender.loan();
+            ensure!(
+                (&*recycled as *const Book) as usize == first_buffer,
+                "expected book #1's buffer to be the next recycled loan"
+            );
+            ensure!(
+                recycled.bids.capacity() >= BOOK_DEPTH && recycled.asks.capacity() >= BOOK_DEPTH,
+                "recycled Vec capacity must survive clear-and-refill"
+            );
+            println!("recycling: book #1's buffer returned with its Vec capacity intact");
+
+            recycled.refill(3);
+            ensure!(
+                sender.send(recycled),
+                "graph receiver closed before book #3"
+            );
+            sender.close();
+            Ok(())
+        })();
+
+        if let Err(error) = &result {
+            sender.send_error(anyhow::anyhow!("producer failed: {error:#}"));
+        }
+        result
+    });
+
+    let mut runner = g.build();
+    runner.run(RunMode::RealTime, RunFor::Forever)?;
+    producer
+        .join()
+        .map_err(|_| anyhow::anyhow!("producer thread panicked"))??;
+    Ok(())
+}


### PR DESCRIPTION
## What this changes

Adds a runnable `pooled_channel` core example that demonstrates a pre-sized payload pool, wrap-not-clone routing, bounded loan backpressure, and buffer recycling with preserved `Vec` capacity. It also registers and indexes the example and includes its deterministic output.

## Why

Closes #893. The loan lifecycle currently has module docs and tests, but no end-to-end worked example showing how producer-side exhaustion relates to graph-held handles or how a heap-owning payload is reused without deep clones.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` and `cargo lint-all` — `cargo lint` passes; `lint-all` reaches the optional `iceoryx2-pal-posix` bindgen build and stops because this Windows host has no `libclang.dll`
- [ ] `cargo test -p wingfoil --all-features` — same host-only `libclang.dll` prerequisite blocks the all-features build before the changed target is compiled
- [ ] New behaviour is covered by a test asserting **values and tick times** — not applicable to this documentation example; its phase gate makes the teaching output deterministic

Additional checks:

- `cargo check -p wingfoil --example pooled_channel`
- `cargo clippy -p wingfoil --example pooled_channel -- -D warnings`
- `cargo run -p wingfoil --example pooled_channel` (output matched the README in 3/3 runs)
- `cargo test -p wingfoil --test pooled_channel` (7 passed)
- `cargo test -p wingfoil` (full default-feature suite passed)
- `scripts/check-example-docs.sh` (`47` targets documented and indexed)

## Notes for the reviewer

`Book` deliberately does not implement `Clone`. A small atomic phase gate is used only to make the backpressure and pointer-reuse steps reproducible while the graph runs in realtime; the example does not retain pooled handles in `accumulate()`.