### PR TITLE
dual_mode: stream output via log tap, commit expanded code

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ No services, no feature flags — these run with a plain `cargo run`.
 | [`ema_crossover`](crates/wingfoil/examples/core/ema_crossover/) | A backtest-shaped graph — fold, join, map and filter over a price series. |
 | [`order_book`](crates/wingfoil/examples/core/order_book/) | Load NASDAQ AAPL limit orders from CSV, maintain an order book, derive trades and two-way prices, write both back out. |
 | [`run_mode`](crates/wingfoil/examples/core/run_mode/) | Swap `RunMode::RealTime` and `RunMode::HistoricalFrom` over the same wiring, for backtesting. |
-| [`dual_mode`](crates/wingfoil/examples/core/dual_mode/) | One wiring, three execution tiers — interpreted, compiled, and a compiled island — proven to agree. |
+| [`dual_mode`](crates/wingfoil/examples/core/dual_mode/) | One wiring, three execution tiers — interpreted, compiled, and a compiled island — with the generated code committed beside it. |
 | [`topological_sort`](crates/wingfoil/examples/core/topological_sort/) | Why topologically sorted execution avoids the O(2^N) node explosion of naive per-path propagation. |
 | [`dynamism`](crates/wingfoil/examples/core/dynamism/) | Add and remove nodes on a running graph — one price book, four wirings. |
 | [`feedback`](crates/wingfoil/examples/core/feedback/) | Close a loop between two nodes with `feedback` — a proportional control loop a plain DAG cannot express. |

--- a/crates/wingfoil-derive/README.md
+++ b/crates/wingfoil-derive/README.md
@@ -59,8 +59,8 @@ depend on runtime values, though values and per-element logic can be as
 procedural as you like.
 
 [`examples/core/dual_mode/`](../wingfoil/examples/core/dual_mode/) is the
-reference for exactly what is and isn't accepted, and prints an abridged copy of
-the generated code.
+reference for exactly what is and isn't accepted, and carries the full
+generated code, committed verbatim in its `expanded/` subfolder.
 
 ## `#[op]` — no macro table to edit
 

--- a/crates/wingfoil/examples/core/README.md
+++ b/crates/wingfoil/examples/core/README.md
@@ -35,10 +35,11 @@ it costs you in expressiveness.
 
 | Example | Features | What it teaches |
 |---|---|---|
-| [`dual_mode`](dual_mode/) | — | A split/recombine DAG through `nitro!` with both engines asserted equal, **the reference for what the macro accepts** — allowed vs rejected wiring, choosing an engine with `run(tier, ..)`, plus the generated code. |
+| [`dual_mode`](dual_mode/) | — | A split/recombine DAG through `nitro!`, streaming its labels through a log tap, **the reference for what the macro accepts** — allowed vs rejected wiring, choosing an engine with `run(tier, ..)`, plus the generated code committed verbatim in `dual_mode/expanded/`. The engines' agreement is pinned by `tests/macro_parity.rs`. |
 
 The measured cost of each tier is in [`../../benches/`](../../benches/) —
-`tiers.rs` runs this shape and the 100-node fan-out through all three.
+`tiers.rs` runs a dispatch-bound chain and the 100-node fan-out through all
+three.
 
 ## Concurrency
 

--- a/crates/wingfoil/examples/core/dual_mode/README.md
+++ b/crates/wingfoil/examples/core/dual_mode/README.md
@@ -17,13 +17,47 @@ two labelled branches, merged back into one stream:
              \     /
               merge                 (recombine — at most one fires/tick)
                 |
-              print
+              log tap               (emit as the run progresses)
 ```
 
-The run asserts *that* the two engines agree. The rest of this example is the
-reference for *what you are allowed to write* to get that guarantee — and it
-ends with an abridged rendering of the generated code, so "straight-line wiring
+The example *runs* that graph on whichever tier `Tier::default()` resolves to,
+streaming each label out through the `log` crate as it ticks. It does **not**
+tie the engines out against each other — that assertion needs both runs' whole
+output held as a value, which is `accumulate()`'s job and a test's place:
+[`tests/macro_parity.rs`](../../../tests/macro_parity.rs) pins this same
+diamond's interpreted and compiled outputs equal (values and count, cycle-bound
+and duration-bound), tailing it with `accumulate` — the test instrument whose
+job is exactly that holding. The rest of this example is the reference for *what you
+are allowed to write* to get that guarantee — and the generated code is
+committed verbatim in [`expanded/`](expanded/), so "straight-line wiring
 becomes a static schedule" is something you can read rather than take on faith.
+
+### The tail: why a closure sink, not `.logged(..)`
+
+House rule: examples emit as the run progresses; collecting into a `Vec` to
+print after the run is the anti-pattern (and stops the same wiring being
+pointed at a live feed). The interpreted-only
+[`odds_evens`](../odds_evens/) example taps its merge with `.logged(..)` — but
+`logged` is deliberately **fluent-only**: its op `Cfg` is
+`(String, log::Level)` while the fluent method takes `&str`, and
+`nitro!`/compiled uses the call-site argument types as the `Cfg` verbatim, so
+the same tokens cannot satisfy both (see `tests/op_completeness.rs`,
+category 2b).
+
+The dual-mode spelling of the same tap is a closure sink — closures are opaque
+config, identical on every tier:
+
+```rust,ignore
+let sink = labelled.with_time().for_each(|(t, s): &(NanoTime, String)| {
+    log::info!(target: "wingfoil", "{} odds/evens {s:?}", t.pretty());
+    Ok(())
+});
+```
+
+`with_time` stamps each value with the engine time it ticked at, and `for_each`
+is the fallible side-effect sink (`Err` aborts the run). `sink` is bound but
+not in the tail — a side-effect-only node nothing reads, which the compiled
+expansion still schedules like any other node.
 
 ### Choosing an engine: `run(tier, ..)`
 
@@ -64,9 +98,8 @@ nested        island node 5 (odd_str: map) cycle: <the op's error>
 ```
 
 Intermediate (unnamed) nodes fall back to their `wf_anon_N` slot name, which is
-the same name the generated code and the node table below use. The label is a
-`&'static str` baked in at expansion time, so it costs nothing until something
-actually fails.
+the same name the generated code uses. The label is a `&'static str` baked in
+at expansion time, so it costs nothing until something actually fails.
 
 ### The one rule
 
@@ -177,47 +210,54 @@ design removes — see [`docs/decisions/macro-extensibility-decision.md`](../../
 
 ### Reading the generated code
 
-The bottom of [`main.rs`](main.rs) carries an abridged rendering of the full
-expansion — `wire`, `interpreted`, `compiled`, and `nested`. The DAG is 10 nodes,
-indexed in wiring order; intermediate (unnamed) nodes get `wf_anon_N` slots while
-your `let` names are kept verbatim. Every op — built-in or user-defined — is
-dispatched through naming-convention forwarders, so the macro never names an op
-type: rustc's inference resolves each from the argument types at the call site,
-and the per-op activation consts fold into the tick gates after monomorphization.
-That is why `#[op]` gives a user-defined op compiled coverage with no macro table
-to edit.
-
-For the unabridged version:
-
-```sh
-cargo expand -p wingfoil --example dual_mode
-```
+The full expansion — `wire`, `interpreted`, `compiled`, `run`, and `nested` —
+is committed **verbatim** in
+[`expanded/main.expanded.rs`](expanded/main.expanded.rs);
+[`expanded/README.md`](expanded/README.md) says what to look at and how to
+regenerate it. The DAG is 10 nodes, indexed in wiring order; intermediate
+(unnamed) nodes get `wf_anon_N` slots while your `let` names are kept verbatim.
+Every op — built-in or user-defined — is dispatched through naming-convention
+forwarders, so the macro never names an op type: rustc's inference resolves
+each from the argument types at the call site, and the per-op activation consts
+fold into the tick gates after monomorphization. That is why `#[op]` gives a
+user-defined op compiled coverage with no macro table to edit.
 
 ### Output
 
-```text
-1 is odd
-2 is even
-3 is odd
-...
+`log` output rendered by `env_logger` (the volatile wall-clock prefix shown as
+`[..]`); the timestamps in each line are the **engine** time the label ticked
+at:
 
-10 labels over 10 cycles — interpreted and compiled engines agree.
-`run(Tier::default(), ..)` resolved to the compiled tier and matched them.
+```text
+[.. INFO  wingfoil] 0.000_000 odds/evens "1 is odd"
+[.. INFO  wingfoil] 0.010_000 odds/evens "2 is even"
+[.. INFO  wingfoil] 0.020_000 odds/evens "3 is odd"
+[.. INFO  wingfoil] 0.030_000 odds/evens "4 is even"
+[.. INFO  wingfoil] 0.040_000 odds/evens "5 is odd"
+[.. INFO  wingfoil] 0.050_000 odds/evens "6 is even"
+[.. INFO  wingfoil] 0.060_000 odds/evens "7 is odd"
+[.. INFO  wingfoil] 0.070_000 odds/evens "8 is even"
+[.. INFO  wingfoil] 0.080_000 odds/evens "9 is odd"
+[.. INFO  wingfoil] 0.090_000 odds/evens "10 is even"
+ran 10 cycles on the compiled tier; last label: "10 is even"
 ```
 
 (That last line reads `interpreted` in a debug build, or under
-`WINGFOIL_TIER=interpreted` — same values either way, which is the point.)
+`WINGFOIL_TIER=interpreted` — same log lines either way, which is the point.)
 
 ### Run
 
 ```sh
-cargo run -p wingfoil --release --example dual_mode
+RUST_LOG=info cargo run -p wingfoil --release --example dual_mode
 ```
 
 ### Where to go next
 
+- [`tests/macro_parity.rs`](../../../tests/macro_parity.rs) — the tie-out:
+  this diamond's interpreted and compiled outputs asserted equal, plus the
+  wiring-fn-is-reusable case and the rest of the macro's parity suite.
 - [`../../benches/tiers.rs`](../../../benches/tiers.rs) — the measured cost of
-  each tier, over this graph and the 100-node fan-out shape in
+  each tier, over a dispatch-bound chain and the 100-node fan-out shape in
   [`../../bench_support/fanout_10x10.rs`](../../../bench_support/fanout_10x10.rs)
   (which is also the worked example of `map_n` / `fan`, the static repetition
   sugar the ❌ list above points at).

--- a/crates/wingfoil/examples/core/dual_mode/expanded/README.md
+++ b/crates/wingfoil/examples/core/dual_mode/expanded/README.md
@@ -1,0 +1,45 @@
+# The generated code, verbatim
+
+[`main.expanded.rs`](main.expanded.rs) is the **unedited** output of expanding
+[`../main.rs`](../main.rs) — the whole example file with the `nitro!` block
+replaced by the module it generates: `wire` (the wiring function, verbatim),
+`interpreted`, `compiled`, `run`, and `nested`. It is committed so "straight-line
+wiring becomes a static schedule" is something you can read in real emitted
+code, not an abridged rendering.
+
+It is a **reference snapshot, not a build target** — nothing compiles it (the
+example's only declared target is `../main.rs`), and the pretty-printer's output
+is not valid stable Rust anyway (it opens with `#![feature(prelude_import)]`
+and names `::alloc` paths). Two artifacts of `-Zunpretty=expanded` to read
+around: `format!` and `log::info!` appear pre-expanded into
+`::alloc::fmt::format(format_args!(..))` / `::log::__private_api::log(..)`
+forms, and comments from the source file are dropped or relocated.
+
+## What to look at
+
+- **`compiled`** — no graph object at all: one `(cfg?, state, value)` triple of
+  stack locals per node, seeded through `__wf_op_<op>_seed_*` forwarders; the
+  cycle loop is the whole schedule, straight-line, with tick propagation as
+  plain `bool`s and every closure inlined at its call site. The
+  `__WF_OP_<OP>_{ACTIVATION,PASSIVE}` consts fold into the tick gates after
+  monomorphization.
+- **`nested`** — the same 10-node schedule mounted as a *single* compiled node
+  inside an interpreted graph (`__g.__composite(..)`), with a private
+  `TimeQueue` demultiplexing the ticker's inner schedules.
+- The macro never names an op type: rustc's inference resolves each forwarder
+  from the argument types at the call site, which is why `#[op]` gives a
+  user-defined op the identical path with no macro table to edit.
+
+## Regenerating
+
+The snapshot is pinned to the `main.rs` beside it — regenerate it whenever that
+file changes (a nightly toolchain is required, as macro expansion is a nightly
+`rustc` flag):
+
+```sh
+cargo +nightly rustc -p wingfoil --example dual_mode --profile check \
+    -- -Zunpretty=expanded > crates/wingfoil/examples/core/dual_mode/expanded/main.expanded.rs
+```
+
+(`cargo expand -p wingfoil --example dual_mode` prints the same thing with
+syntax highlighting, if you have `cargo-expand` installed.)

--- a/crates/wingfoil/examples/core/dual_mode/expanded/main.expanded.rs
+++ b/crates/wingfoil/examples/core/dual_mode/expanded/main.expanded.rs
@@ -1,0 +1,1730 @@
+#![feature(prelude_import)]
+//! The dual-mode thesis, completed by the `nitro!` macro: **one** wiring
+//! definition expands to both an interpreted runner and a fully
+//! monomorphized compiled runner. The two cannot drift — same tokens, same
+//! `Op` semantics — and the compiled one gets the compiler's full
+//! optimization across node boundaries.
+//!
+//! The wiring is a **split/recombine** DAG: a counter is split on parity into
+//! two labelled branches which are then merged back into one stream — so this
+//! also shows the macro deriving a non-linear graph (a shared apex node and a
+//! recombine) for both engines:
+//!
+//! ```text
+//!               count                 (apex — shared node, once/cycle)
+//!              /     \
+//!       is_odd?      is_even?         (split on parity)
+//!            |          |
+//!      "{i} is odd" "{i} is even"     (format each branch)
+//!              \     /
+//!               merge                 (recombine — at most one fires/tick)
+//!                 |
+//!               log tap               (emit as the run progresses)
+//! ```
+//!
+//! The tail emits as the run progresses — a closure sink over the `log` crate,
+//! per the house rule that examples stream their output rather than collect it.
+//! Two things worth knowing about that tap:
+//!
+//! - It is spelled `with_time().for_each(|(t, s)| { log::info!(..); Ok(()) })`
+//!   rather than `.logged(..)`, because `logged` is deliberately
+//!   **fluent-only**: its op `Cfg` is `(String, log::Level)` while the fluent
+//!   method takes `&str`, and `nitro!` uses the call-site argument types as
+//!   the `Cfg` verbatim — the same tokens cannot satisfy both (see
+//!   `tests/op_completeness.rs`, category 2b). A closure sink is the same tap
+//!   and works identically on every tier, because closures are opaque config.
+//! - This example **runs** the graph; it does not tie the engines out against
+//!   each other. That assertion needs both runs' whole output held as a value,
+//!   which is `accumulate()`'s job and a test's place —
+//!   [`tests/macro_parity.rs`](../../../tests/macro_parity.rs) pins this same
+//!   diamond's interpreted and compiled outputs equal (with an `accumulate`
+//!   tail in place of the log tap, which is what lets it hold the output).
+//!
+//! `log` output is rendered by `env_logger`, so run with `RUST_LOG=info`:
+//!
+//! ```sh
+//! RUST_LOG=info cargo run -p wingfoil --release --example dual_mode
+//! ```
+//!
+//! # What procedural code you can write inside `nitro!`
+//!
+//! The macro parses its body as a plain Rust `fn`, but it does not *run* that
+//! code — it reads the tokens to derive a **static DAG** at expansion time,
+//! then re-emits the whole schedule three ways (`interpreted` / `compiled` /
+//! `nested`). Because `compiled()` monomorphizes one local per node (see the
+//! committed expansion in [`expanded/`](expanded/)), the node list must be
+//! complete and fixed after parsing. That is the one rule everything below
+//! follows: **wiring must be straight-line — the shape of the graph cannot
+//! depend on runtime values.** Values and per-element logic can be as
+//! procedural as you like; the *topology* cannot.
+//!
+//! Each top-level statement is sorted into one of three buckets: a **wiring**
+//! `let name = <chain>;` (rooted at the builder or an already-bound stream),
+//! the **tail** expression naming the outputs, or **passthrough** (anything
+//! else, re-emitted verbatim into every engine). The builder and stream names
+//! may appear *only* in wiring statements and the tail.
+//!
+//! ## ✅ Allowed
+//!
+//! ```rust,ignore
+//! // Straight-line wiring: each `let` is one fluent chain.
+//! let count  = g.ticker(PERIOD).count();
+//! let parity = count.map(|i| i % 2);
+//!
+//! // Passthrough: ordinary Rust that does NOT mention `g` or a stream —
+//! // compute a config, declare a local a closure will capture, etc.
+//! let base = 2;
+//! let threshold = base * 4;
+//! let tagged = count.filter(&parity).map(move |i| i + threshold);
+//!
+//! // Any control flow you want *inside* an op closure — it is opaque config
+//! // the macro passes straight through, never topology.
+//! let label = count.map(|i| if i % 2 == 0 { "even" } else { "odd" });
+//!
+//! // Static repetition sugar with a LITERAL count: `map_n` chains N maps,
+//! // `fan` builds N branches and merges them. The DAG stays static.
+//! let chained = count.map_n(3, |i| i + 1);
+//! let fanned  = count.fan(2, |s| s.map(|i| i * 10));
+//! ```
+//!
+//! ## ❌ Not allowed
+//!
+//! ```rust,ignore
+//! // A helper that does wiring — the macro cannot see the nodes it builds,
+//! // so `compiled()` would be blind to them. (Compose by NESTING nitro!s
+//! // instead: each nitro! fn is itself reusable wiring via its `wire`.)
+//! let x = build_subgraph(g, &count);
+//!
+//! // A loop that wires — the node count would be a runtime value, which
+//! // `compiled()` cannot monomorphize. Use `.map_n`/`.fan` with a literal.
+//! for _ in 0..n { count = count.map(|i| i + 1); }
+//!
+//! // A conditional that picks the TOPOLOGY — one branch or the other would
+//! // exist depending on a runtime flag. (Branch *inside* a closure instead,
+//! // or build both and select at runtime.)
+//! let s = if fast { count.ema(2) } else { count.ema(8) };
+//!
+//! // A non-literal repeat count — the unrolled DAG must be known statically.
+//! let chained = count.map_n(n, |i| i + 1);
+//! ```
+//!
+//! The full expansion of the `nitro!` block below — `wire`, `interpreted`,
+//! `compiled`, `run`, and `nested` — is committed **verbatim** in
+//! [`expanded/main.expanded.rs`](expanded/main.expanded.rs), so you can read
+//! exactly what "straight-line wiring becomes a static schedule" means in
+//! emitted code. `expanded/README.md` has the command that regenerates it.
+extern crate std;
+#[prelude_import]
+use std::prelude::rust_2024::*;
+
+use std::time::Duration;
+
+use wingfoil::{NanoTime, RunFor, RunMode, Tier};
+
+const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+const CYCLES: u32 = 10;
+const PERIOD: Duration = Duration::from_millis(10);
+
+// One definition — a valid fluent wiring function whose DAG is a
+// split/recombine. The macro parses it to derive the DAG and expands to a
+// module: `odds_evens::wire` (this function, verbatim),
+// `odds_evens::interpreted()` (built through wire), `odds_evens::compiled()`
+// (the monomorphized schedule derived from the same tokens), and
+// `odds_evens::run(tier, ..)` (either engine behind one signature).
+//
+// `count` is referenced three times, so it is a *shared* apex node: the
+// interpreted engine runs it once per cycle and fans the tick out, and the
+// compiled engine emits it once and feeds every reader from the same slot.
+// `merge` is the recombine — since a number is either odd or even, at most
+// one branch fires on any tick. `sink` is a side-effect-only node (nothing
+// reads it, it is not in the tail): the log tap that streams each label out
+// through the `log` crate, stamped with the engine time it ticked at.
+mod odds_evens {
+    #![allow(clippy :: redundant_closure_call, clippy :: let_and_return)]
+    use super::*;
+    use ::wingfoil::fluent::*;
+    #[allow(unused_imports)]
+    use ::wingfoil::ops::*;
+    #[allow(unused_variables)]
+    pub fn wire(g: &GraphBuilder) -> Stream<String> {
+        let count = g.ticker(PERIOD).count();
+        let is_even = count.map(|i| i.is_multiple_of(2));
+        let is_odd = is_even.map(|b| !b);
+        let odd_str =
+            count.filter(&is_odd).map(|i|
+
+                    // `Tier::default()` resolves from `WINGFOIL_TIER` if it is set and
+                    // otherwise from the build profile (interpreted in debug, compiled in
+                    // release), so the usual workflow — develop interpreted, deploy compiled —
+                    // needs no call-site change at all. The log lines are identical either
+                    // way; that the tiers *agree* is pinned by `tests/macro_parity.rs`.
+
+                    ::alloc::__export::must_use({
+                            ::alloc::fmt::format(format_args!("{0} is odd", i))
+                        }));
+        let even_str =
+            count.filter(&is_even).map(|i|
+                    ::alloc::__export::must_use({
+                            ::alloc::fmt::format(format_args!("{0} is even", i))
+                        }));
+        let labelled = odd_str.merge(&even_str);
+        let sink =
+            labelled.with_time().for_each(|(t, s): &(NanoTime, String)|
+                    {
+                        {
+                            {
+                                {
+                                    let lvl = ::log::Level::Info;
+                                    if lvl <= ::log::STATIC_MAX_LEVEL &&
+                                            lvl <= ::log::max_level() {
+                                        ::log::__private_api::log({
+                                                ::log::__private_api::GlobalLogger
+                                            }, format_args!("{0} odds/evens {1:?}", t.pretty(), s), lvl,
+                                            &("wingfoil", "dual_mode::odds_evens",
+                                                    ::log::__private_api::loc()), ());
+                                    }
+                                }
+                            }
+                        };
+                        Ok(())
+                    });
+        labelled
+    }
+    #[doc = r" The graph built through [`wire`] — the function as written."]
+    #[doc = r" Returns the runner plus a typed handle per output stream."]
+    pub fn interpreted()
+        -> (::wingfoil::interp::Runner, ::wingfoil::interp::Handle<String>) {
+        let __g = ::wingfoil::fluent::GraphBuilder::new();
+        let labelled = wire(&__g);
+        let __runner = __g.build();
+        (__runner, labelled.handle())
+    }
+    #[doc =
+    r" The same graph, fully monomorphized: node state in locals, tick"]
+    #[doc = r" propagation as bools, every `Op::cycle` (closures included)"]
+    #[doc = r" visible to the compiler. Derived from the same tokens as"]
+    #[doc = r" `interpreted`, so the two cannot drift."]
+    #[allow(unused_mut, unused_variables, unused_assignments)]
+    pub fn compiled(run_mode: ::wingfoil::RunMode,
+        run_for: ::wingfoil::RunFor)
+        -> ::wingfoil::anyhow::Result<(String,)> {
+        if (false || __WF_OP_TICKER_ACTIVATION.always ||
+                                                            __WF_OP_COUNT_ACTIVATION.always ||
+                                                        __WF_OP_MAP_ACTIVATION.always ||
+                                                    __WF_OP_MAP_ACTIVATION.always ||
+                                                __WF_OP_FILTER_ACTIVATION.always ||
+                                            __WF_OP_MAP_ACTIVATION.always ||
+                                        __WF_OP_FILTER_ACTIVATION.always ||
+                                    __WF_OP_MAP_ACTIVATION.always ||
+                                __WF_OP_MERGE_ACTIVATION.always ||
+                            __WF_OP_WITH_TIME_ACTIVATION.always ||
+                        __WF_OP_FOR_EACH_ACTIVATION.always) &&
+                !#[allow(non_exhaustive_omitted_patterns)] match run_mode {
+                        ::wingfoil::RunMode::RealTime => true,
+                        _ => false,
+                    } {
+            return ::anyhow::__private::Err({
+                        let error =
+                            ::anyhow::__private::format_err(format_args!("graphs with poll sources require RunMode::RealTime — there is nothing to busy-poll in a deterministic historical replay"));
+                        error
+                    });
+        }
+        let mut __k = ::wingfoil::Kernel::new(run_mode, run_for);
+        if (false || __WF_OP_TICKER_ACTIVATION.always ||
+                                                        __WF_OP_COUNT_ACTIVATION.always ||
+                                                    __WF_OP_MAP_ACTIVATION.always ||
+                                                __WF_OP_MAP_ACTIVATION.always ||
+                                            __WF_OP_FILTER_ACTIVATION.always ||
+                                        __WF_OP_MAP_ACTIVATION.always ||
+                                    __WF_OP_FILTER_ACTIVATION.always ||
+                                __WF_OP_MAP_ACTIVATION.always ||
+                            __WF_OP_MERGE_ACTIVATION.always ||
+                        __WF_OP_WITH_TIME_ACTIVATION.always ||
+                    __WF_OP_FOR_EACH_ACTIVATION.always) {
+            __k.set_spin(true);
+        }
+        let mut __cfg_wf_anon_1 = PERIOD;
+        let mut __state_wf_anon_1 =
+            __wf_op_ticker_seed_state(&__cfg_wf_anon_1);
+        let mut __v_wf_anon_1 = __wf_op_ticker_seed_value(&__cfg_wf_anon_1);
+        let mut __state_count = __wf_op_count_seed_state(&());
+        let mut __v_count = __wf_op_count_seed_value(&());
+        let mut __state_is_even = __wf_op_map_seed_state(&());
+        let mut __v_is_even = __wf_op_map_seed_value(&());
+        let mut __state_is_odd = __wf_op_map_seed_state(&());
+        let mut __v_is_odd = __wf_op_map_seed_value(&());
+        let mut __state_wf_anon_2 = __wf_op_filter_seed_state(&());
+        let mut __v_wf_anon_2 = __wf_op_filter_seed_value(&());
+        let mut __state_odd_str = __wf_op_map_seed_state(&());
+        let mut __v_odd_str = __wf_op_map_seed_value(&());
+        let mut __state_wf_anon_3 = __wf_op_filter_seed_state(&());
+        let mut __v_wf_anon_3 = __wf_op_filter_seed_value(&());
+        let mut __state_even_str = __wf_op_map_seed_state(&());
+        let mut __v_even_str = __wf_op_map_seed_value(&());
+        let mut __state_labelled = __wf_op_merge_seed_state(&());
+        let mut __v_labelled = __wf_op_merge_seed_value(&());
+        let mut __state_wf_anon_4 = __wf_op_with_time_seed_state(&());
+        let mut __v_wf_anon_4 = __wf_op_with_time_seed_value(&());
+        let mut __state_sink = __wf_op_for_each_seed_state(&());
+        let mut __v_sink = __wf_op_for_each_seed_value(&());
+        let mut __first_err:
+                ::core::option::Option<::wingfoil::anyhow::Error> =
+            ::core::option::Option::None;
+        let __run =
+            (|| -> ::wingfoil::anyhow::Result<()>
+                        {
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 0usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_ticker_start(&mut __cfg_wf_anon_1,
+                                            &mut __state_wf_anon_1, &mut __ctx),
+                                        "node 0 (wf_anon_1: ticker) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 1usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_count_start(&mut (),
+                                            &mut __state_count, &mut __ctx),
+                                        "node 1 (count: count) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 2usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_is_even, &mut __ctx),
+                                        "node 2 (is_even: map) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 3usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_is_odd, &mut __ctx),
+                                        "node 3 (is_odd: map) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 4usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_filter_start(&mut (),
+                                            &mut __state_wf_anon_2, &mut __ctx),
+                                        "node 4 (wf_anon_2: filter) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 5usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_odd_str, &mut __ctx),
+                                        "node 5 (odd_str: map) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 6usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_filter_start(&mut (),
+                                            &mut __state_wf_anon_3, &mut __ctx),
+                                        "node 6 (wf_anon_3: filter) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 7usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_even_str, &mut __ctx),
+                                        "node 7 (even_str: map) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 8usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_merge_start(&mut (),
+                                            &mut __state_labelled, &mut __ctx),
+                                        "node 8 (labelled: merge) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 9usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_with_time_start(&mut (),
+                                            &mut __state_wf_anon_4, &mut __ctx),
+                                        "node 9 (wf_anon_4: with_time) start")?;
+                            }
+                            {
+                                let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 10usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_for_each_start_owned(&mut (),
+                                            &mut __state_sink, &mut __ctx),
+                                        "node 10 (sink: for_each) start")?;
+                            }
+                            let mut __dirty = [false; 11usize];
+                            while __k.begin_cycle(&mut __dirty) {
+                                let __t_wf_anon_1 =
+                                    (__WF_OP_TICKER_ACTIVATION.always ||
+                                                (__WF_OP_TICKER_ACTIVATION.callback_activated() &&
+                                                        __dirty[0usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 0usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_ticker_cycle(&mut __cfg_wf_anon_1,
+                                                            &mut __state_wf_anon_1, (), &mut __ctx),
+                                                        "node 0 (wf_anon_1: ticker) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_wf_anon_1 = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_wf_anon_1 = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_wf_anon_1;
+                                let __t_count =
+                                    ((((__WF_OP_COUNT_PASSIVE >> 0u32) & 1) == 0 &&
+                                                            __t_wf_anon_1) || __WF_OP_COUNT_ACTIVATION.always ||
+                                                (__WF_OP_COUNT_ACTIVATION.callback_activated() &&
+                                                        __dirty[1usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 1usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_count_cycle(&mut (),
+                                                            &mut __state_count, ((&__v_wf_anon_1, __t_wf_anon_1),),
+                                                            &mut __ctx), "node 1 (count: count) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_count = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_count = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_count;
+                                let __t_is_even =
+                                    ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_count) ||
+                                                    __WF_OP_MAP_ACTIVATION.always ||
+                                                (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                                        __dirty[2usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 2usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|i|
+                                                                i.is_multiple_of(2), &mut (), &mut __state_is_even,
+                                                            ((&__v_count, __t_count),), &mut __ctx),
+                                                        "node 2 (is_even: map) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_is_even = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_is_even = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_is_even;
+                                let __t_is_odd =
+                                    ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_is_even)
+                                                    || __WF_OP_MAP_ACTIVATION.always ||
+                                                (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                                        __dirty[3usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 3usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|b|
+                                                                !b, &mut (), &mut __state_is_odd,
+                                                            ((&__v_is_even, __t_is_even),), &mut __ctx),
+                                                        "node 3 (is_odd: map) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_is_odd = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_is_odd = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_is_odd;
+                                let __t_wf_anon_2 =
+                                    ((((__WF_OP_FILTER_PASSIVE >> 0u32) & 1) == 0 && __t_count)
+                                                        ||
+                                                        (((__WF_OP_FILTER_PASSIVE >> 1u32) & 1) == 0 && __t_is_odd)
+                                                    || __WF_OP_FILTER_ACTIVATION.always ||
+                                                (__WF_OP_FILTER_ACTIVATION.callback_activated() &&
+                                                        __dirty[4usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 4usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_filter_cycle(&mut (),
+                                                            &mut __state_wf_anon_2,
+                                                            ((&__v_count, __t_count), (&__v_is_odd, __t_is_odd)),
+                                                            &mut __ctx), "node 4 (wf_anon_2: filter) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_wf_anon_2 = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_wf_anon_2 = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_wf_anon_2;
+                                let __t_odd_str =
+                                    ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_wf_anon_2)
+                                                    || __WF_OP_MAP_ACTIVATION.always ||
+                                                (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                                        __dirty[5usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 5usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|i|
+                                                                ::alloc::__export::must_use({
+                                                                        ::alloc::fmt::format(format_args!("{0} is odd", i))
+                                                                    }), &mut (), &mut __state_odd_str,
+                                                            ((&__v_wf_anon_2, __t_wf_anon_2),), &mut __ctx),
+                                                        "node 5 (odd_str: map) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_odd_str = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_odd_str = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_odd_str;
+                                let __t_wf_anon_3 =
+                                    ((((__WF_OP_FILTER_PASSIVE >> 0u32) & 1) == 0 && __t_count)
+                                                        ||
+                                                        (((__WF_OP_FILTER_PASSIVE >> 1u32) & 1) == 0 && __t_is_even)
+                                                    || __WF_OP_FILTER_ACTIVATION.always ||
+                                                (__WF_OP_FILTER_ACTIVATION.callback_activated() &&
+                                                        __dirty[6usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 6usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_filter_cycle(&mut (),
+                                                            &mut __state_wf_anon_3,
+                                                            ((&__v_count, __t_count), (&__v_is_even, __t_is_even)),
+                                                            &mut __ctx), "node 6 (wf_anon_3: filter) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_wf_anon_3 = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_wf_anon_3 = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_wf_anon_3;
+                                let __t_even_str =
+                                    ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_wf_anon_3)
+                                                    || __WF_OP_MAP_ACTIVATION.always ||
+                                                (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                                        __dirty[7usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 7usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|i|
+                                                                ::alloc::__export::must_use({
+                                                                        ::alloc::fmt::format(format_args!("{0} is even", i))
+                                                                    }), &mut (), &mut __state_even_str,
+                                                            ((&__v_wf_anon_3, __t_wf_anon_3),), &mut __ctx),
+                                                        "node 7 (even_str: map) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_even_str = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_even_str = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_even_str;
+                                let __t_labelled =
+                                    ((((__WF_OP_MERGE_PASSIVE >> 0u32) & 1) == 0 && __t_odd_str)
+                                                        ||
+                                                        (((__WF_OP_MERGE_PASSIVE >> 1u32) & 1) == 0 && __t_even_str)
+                                                    || __WF_OP_MERGE_ACTIVATION.always ||
+                                                (__WF_OP_MERGE_ACTIVATION.callback_activated() &&
+                                                        __dirty[8usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 8usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_merge_cycle(&mut (),
+                                                            &mut __state_labelled,
+                                                            ((&__v_odd_str, __t_odd_str),
+                                                                (&__v_even_str, __t_even_str)), &mut __ctx),
+                                                        "node 8 (labelled: merge) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_labelled = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_labelled = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_labelled;
+                                let __t_wf_anon_4 =
+                                    ((((__WF_OP_WITH_TIME_PASSIVE >> 0u32) & 1) == 0 &&
+                                                            __t_labelled) || __WF_OP_WITH_TIME_ACTIVATION.always ||
+                                                (__WF_OP_WITH_TIME_ACTIVATION.callback_activated() &&
+                                                        __dirty[9usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 9usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_with_time_cycle(&mut (),
+                                                            &mut __state_wf_anon_4, ((&__v_labelled, __t_labelled),),
+                                                            &mut __ctx), "node 9 (wf_anon_4: with_time) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_wf_anon_4 = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_wf_anon_4 = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_wf_anon_4;
+                                let __t_sink =
+                                    ((((__WF_OP_FOR_EACH_PASSIVE >> 0u32) & 1) == 0 &&
+                                                            __t_wf_anon_4) || __WF_OP_FOR_EACH_ACTIVATION.always ||
+                                                (__WF_OP_FOR_EACH_ACTIVATION.callback_activated() &&
+                                                        __dirty[10usize])) &&
+                                        {
+                                            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 10usize);
+                                            match ::wingfoil::anyhow::Context::context(__wf_op_for_each_cycle_owned(|(t,
+                                                                    s): &(NanoTime, String)|
+                                                                {
+                                                                    {
+                                                                        {
+                                                                            {
+                                                                                let lvl = ::log::Level::Info;
+                                                                                if lvl <= ::log::STATIC_MAX_LEVEL &&
+                                                                                        lvl <= ::log::max_level() {
+                                                                                    ::log::__private_api::log({
+                                                                                            ::log::__private_api::GlobalLogger
+                                                                                        }, format_args!("{0} odds/evens {1:?}", t.pretty(), s), lvl,
+                                                                                        &("wingfoil", "dual_mode::odds_evens",
+                                                                                                ::log::__private_api::loc()), ());
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    };
+                                                                    Ok(())
+                                                                }, &mut (), &mut __state_sink,
+                                                            ((&__v_wf_anon_4, __t_wf_anon_4),), &mut __ctx),
+                                                        "node 10 (sink: for_each) cycle")? {
+                                                ::wingfoil::op::Tick::Value(__val) => {
+                                                    __v_sink = __val;
+                                                    true
+                                                }
+                                                ::wingfoil::op::Tick::Silent(__val) => {
+                                                    __v_sink = __val;
+                                                    false
+                                                }
+                                                ::wingfoil::op::Tick::Quiet => false,
+                                            }
+                                        };
+                                let _ = __t_sink;
+                                __k.end_cycle(&mut __dirty);
+                            }
+                            ::core::result::Result::Ok(())
+                        })();
+        if let ::core::result::Result::Err(__e) = __run {
+            __first_err = ::core::option::Option::Some(__e);
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 0usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_ticker_stop(&mut __cfg_wf_anon_1,
+                            &mut __state_wf_anon_1, (), &mut __ctx),
+                        "node 0 (wf_anon_1: ticker) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 1usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_count_stop(&mut (),
+                            &mut __state_count, ((&__v_wf_anon_1, false),), &mut __ctx),
+                        "node 1 (count: count) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 2usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|i|
+                                i.is_multiple_of(2), &mut (), &mut __state_is_even,
+                            ((&__v_count, false),), &mut __ctx),
+                        "node 2 (is_even: map) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 3usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|b|
+                                !b, &mut (), &mut __state_is_odd, ((&__v_is_even, false),),
+                            &mut __ctx), "node 3 (is_odd: map) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 4usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_filter_stop(&mut (),
+                            &mut __state_wf_anon_2,
+                            ((&__v_count, false), (&__v_is_odd, false)), &mut __ctx),
+                        "node 4 (wf_anon_2: filter) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 5usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|i|
+                                ::alloc::__export::must_use({
+                                        ::alloc::fmt::format(format_args!("{0} is odd", i))
+                                    }), &mut (), &mut __state_odd_str,
+                            ((&__v_wf_anon_2, false),), &mut __ctx),
+                        "node 5 (odd_str: map) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 6usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_filter_stop(&mut (),
+                            &mut __state_wf_anon_3,
+                            ((&__v_count, false), (&__v_is_even, false)), &mut __ctx),
+                        "node 6 (wf_anon_3: filter) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 7usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|i|
+                                ::alloc::__export::must_use({
+                                        ::alloc::fmt::format(format_args!("{0} is even", i))
+                                    }), &mut (), &mut __state_even_str,
+                            ((&__v_wf_anon_3, false),), &mut __ctx),
+                        "node 7 (even_str: map) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 8usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_merge_stop(&mut (),
+                            &mut __state_labelled,
+                            ((&__v_odd_str, false), (&__v_even_str, false)),
+                            &mut __ctx), "node 8 (labelled: merge) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 9usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_with_time_stop(&mut (),
+                            &mut __state_wf_anon_4, ((&__v_labelled, false),),
+                            &mut __ctx), "node 9 (wf_anon_4: with_time) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 10usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_for_each_stop_owned(|(t,
+                                    s): &(NanoTime, String)|
+                                {
+                                    {
+                                        {
+                                            {
+                                                let lvl = ::log::Level::Info;
+                                                if lvl <= ::log::STATIC_MAX_LEVEL &&
+                                                        lvl <= ::log::max_level() {
+                                                    ::log::__private_api::log({
+                                                            ::log::__private_api::GlobalLogger
+                                                        }, format_args!("{0} odds/evens {1:?}", t.pretty(), s), lvl,
+                                                        &("wingfoil", "dual_mode::odds_evens",
+                                                                ::log::__private_api::loc()), ());
+                                                }
+                                            }
+                                        }
+                                    };
+                                    Ok(())
+                                }, &mut (), &mut __state_sink, ((&__v_wf_anon_4, false),),
+                            &mut __ctx), "node 10 (sink: for_each) stop") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 0usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_ticker_teardown(&mut __cfg_wf_anon_1,
+                            &mut __state_wf_anon_1, (), &mut __ctx),
+                        "node 0 (wf_anon_1: ticker) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 1usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_count_teardown(&mut (),
+                            &mut __state_count, ((&__v_wf_anon_1, false),), &mut __ctx),
+                        "node 1 (count: count) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 2usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|i|
+                                i.is_multiple_of(2), &mut (), &mut __state_is_even,
+                            ((&__v_count, false),), &mut __ctx),
+                        "node 2 (is_even: map) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 3usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|b|
+                                !b, &mut (), &mut __state_is_odd, ((&__v_is_even, false),),
+                            &mut __ctx), "node 3 (is_odd: map) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 4usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_filter_teardown(&mut (),
+                            &mut __state_wf_anon_2,
+                            ((&__v_count, false), (&__v_is_odd, false)), &mut __ctx),
+                        "node 4 (wf_anon_2: filter) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 5usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|i|
+                                ::alloc::__export::must_use({
+                                        ::alloc::fmt::format(format_args!("{0} is odd", i))
+                                    }), &mut (), &mut __state_odd_str,
+                            ((&__v_wf_anon_2, false),), &mut __ctx),
+                        "node 5 (odd_str: map) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 6usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_filter_teardown(&mut (),
+                            &mut __state_wf_anon_3,
+                            ((&__v_count, false), (&__v_is_even, false)), &mut __ctx),
+                        "node 6 (wf_anon_3: filter) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 7usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|i|
+                                ::alloc::__export::must_use({
+                                        ::alloc::fmt::format(format_args!("{0} is even", i))
+                                    }), &mut (), &mut __state_even_str,
+                            ((&__v_wf_anon_3, false),), &mut __ctx),
+                        "node 7 (even_str: map) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 8usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_merge_teardown(&mut (),
+                            &mut __state_labelled,
+                            ((&__v_odd_str, false), (&__v_even_str, false)),
+                            &mut __ctx), "node 8 (labelled: merge) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 9usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_with_time_teardown(&mut (),
+                            &mut __state_wf_anon_4, ((&__v_labelled, false),),
+                            &mut __ctx), "node 9 (wf_anon_4: with_time) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        {
+            let mut __ctx = ::wingfoil::op::Ctx::new(&mut __k, 10usize);
+            if let ::core::result::Result::Err(__e) =
+                    ::wingfoil::anyhow::Context::context(__wf_op_for_each_teardown_owned(|(t,
+                                    s): &(NanoTime, String)|
+                                {
+                                    {
+                                        {
+                                            {
+                                                let lvl = ::log::Level::Info;
+                                                if lvl <= ::log::STATIC_MAX_LEVEL &&
+                                                        lvl <= ::log::max_level() {
+                                                    ::log::__private_api::log({
+                                                            ::log::__private_api::GlobalLogger
+                                                        }, format_args!("{0} odds/evens {1:?}", t.pretty(), s), lvl,
+                                                        &("wingfoil", "dual_mode::odds_evens",
+                                                                ::log::__private_api::loc()), ());
+                                                }
+                                            }
+                                        }
+                                    };
+                                    Ok(())
+                                }, &mut (), &mut __state_sink, ((&__v_wf_anon_4, false),),
+                            &mut __ctx), "node 10 (sink: for_each) teardown") {
+                __first_err.get_or_insert(__e);
+            }
+        }
+        match __first_err {
+            ::core::option::Option::Some(__e) =>
+                ::core::result::Result::Err(__e),
+            ::core::option::Option::None => {
+                ::core::result::Result::Ok((__v_labelled,))
+            }
+        }
+    }
+    #[doc = r" Run the graph on `tier`, returning each output's final value."]
+    #[doc = r""]
+    #[doc =
+    r" The two engines are held to identical values *and* tick times, so"]
+    #[doc = r" the tier changes only *how* the graph runs. Develop against"]
+    #[doc =
+    r" [`Tier::Interpreted`](::wingfoil::Tier::Interpreted) — it carries"]
+    #[doc =
+    r" per-node error context and honours the `instrument-*` span features"]
+    #[doc = r" — and deploy on"]
+    #[doc = r" [`Tier::Compiled`](::wingfoil::Tier::Compiled);"]
+    #[doc =
+    r" `Tier::default()` picks between them from `WINGFOIL_TIER` and the"]
+    #[doc = r" build profile."]
+    pub fn run(tier: ::wingfoil::Tier, run_mode: ::wingfoil::RunMode,
+        run_for: ::wingfoil::RunFor)
+        -> ::wingfoil::anyhow::Result<(String,)> {
+        let __run_mode = run_mode;
+        let __run_for = run_for;
+        match tier {
+            ::wingfoil::Tier::Interpreted => {
+                let (mut __runner, labelled) = interpreted();
+                __runner.run(__run_mode, __run_for)?;
+                ::core::result::Result::Ok((__runner.value(labelled),))
+            }
+            ::wingfoil::Tier::Compiled => compiled(__run_mode, __run_for),
+        }
+    }
+    #[doc = r" The whole graph mounted as a **single compiled node** in an"]
+    #[doc =
+    r" interpreted graph under construction. The outer engine pays one"]
+    #[doc =
+    r" dyn call per activation for the entire sub-graph; inside, state"]
+    #[doc =
+    r" lives in one closure and dispatch is monomorphized straight-line"]
+    #[doc =
+    r" code — the same code `compiled` emits. Inner schedules (tickers,"]
+    #[doc = r" delays) are demultiplexed through a private queue; only the"]
+    #[doc = r" earliest is forwarded to the outer kernel."]
+    #[allow(unused_mut, unused_variables, unused_assignments)]
+    pub fn nested(__g: &::wingfoil::fluent::GraphBuilder)
+        -> ::wingfoil::fluent::Stream<String> {
+        let mut __cfg_wf_anon_1 = PERIOD;
+        let mut __state_wf_anon_1 =
+            __wf_op_ticker_seed_state(&__cfg_wf_anon_1);
+        let mut __v_wf_anon_1 = __wf_op_ticker_seed_value(&__cfg_wf_anon_1);
+        let mut __state_count = __wf_op_count_seed_state(&());
+        let mut __v_count = __wf_op_count_seed_value(&());
+        let mut __state_is_even = __wf_op_map_seed_state(&());
+        let mut __v_is_even = __wf_op_map_seed_value(&());
+        let mut __state_is_odd = __wf_op_map_seed_state(&());
+        let mut __v_is_odd = __wf_op_map_seed_value(&());
+        let mut __state_wf_anon_2 = __wf_op_filter_seed_state(&());
+        let mut __v_wf_anon_2 = __wf_op_filter_seed_value(&());
+        let mut __state_odd_str = __wf_op_map_seed_state(&());
+        let mut __v_odd_str = __wf_op_map_seed_value(&());
+        let mut __state_wf_anon_3 = __wf_op_filter_seed_state(&());
+        let mut __v_wf_anon_3 = __wf_op_filter_seed_value(&());
+        let mut __state_even_str = __wf_op_map_seed_state(&());
+        let mut __v_even_str = __wf_op_map_seed_value(&());
+        let mut __state_labelled = __wf_op_merge_seed_state(&());
+        let mut __v_labelled = __wf_op_merge_seed_value(&());
+        let mut __state_wf_anon_4 = __wf_op_with_time_seed_state(&());
+        let mut __v_wf_anon_4 = __wf_op_with_time_seed_value(&());
+        let mut __state_sink = __wf_op_for_each_seed_state(&());
+        let mut __v_sink = __wf_op_for_each_seed_value(&());
+        let mut __q = ::wingfoil::TimeQueue::<usize>::new();
+        let mut __dirty = [false; 11usize];
+        let mut __active: ::std::vec::Vec<usize> = ::std::vec::Vec::new();
+        let mut __passive: ::std::vec::Vec<usize> = ::std::vec::Vec::new();
+        __g.__composite(__active, __passive,
+            false || __WF_OP_TICKER_ACTIVATION.callback_activated() ||
+                                                    __WF_OP_COUNT_ACTIVATION.callback_activated() ||
+                                                __WF_OP_MAP_ACTIVATION.callback_activated() ||
+                                            __WF_OP_MAP_ACTIVATION.callback_activated() ||
+                                        __WF_OP_FILTER_ACTIVATION.callback_activated() ||
+                                    __WF_OP_MAP_ACTIVATION.callback_activated() ||
+                                __WF_OP_FILTER_ACTIVATION.callback_activated() ||
+                            __WF_OP_MAP_ACTIVATION.callback_activated() ||
+                        __WF_OP_MERGE_ACTIVATION.callback_activated() ||
+                    __WF_OP_WITH_TIME_ACTIVATION.callback_activated() ||
+                __WF_OP_FOR_EACH_ACTIVATION.callback_activated(),
+            (false || __WF_OP_TICKER_ACTIVATION.always ||
+                                                        __WF_OP_COUNT_ACTIVATION.always ||
+                                                    __WF_OP_MAP_ACTIVATION.always ||
+                                                __WF_OP_MAP_ACTIVATION.always ||
+                                            __WF_OP_FILTER_ACTIVATION.always ||
+                                        __WF_OP_MAP_ACTIVATION.always ||
+                                    __WF_OP_FILTER_ACTIVATION.always ||
+                                __WF_OP_MAP_ACTIVATION.always ||
+                            __WF_OP_MERGE_ACTIVATION.always ||
+                        __WF_OP_WITH_TIME_ACTIVATION.always ||
+                    __WF_OP_FOR_EACH_ACTIVATION.always),
+            move |__ctx, __phase|
+                {
+                    let __now = __ctx.time();
+                    let __wall_time = __ctx.wall_time();
+                    let __start_time = __ctx.start_time();
+                    match __phase {
+                        ::wingfoil::op::CompositePhase::Start => {
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 0usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_ticker_start(&mut __cfg_wf_anon_1,
+                                            &mut __state_wf_anon_1, &mut __ctx),
+                                        "island node 0 (wf_anon_1: ticker) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 1usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_count_start(&mut (),
+                                            &mut __state_count, &mut __ctx),
+                                        "island node 1 (count: count) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 2usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_is_even, &mut __ctx),
+                                        "island node 2 (is_even: map) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 3usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_is_odd, &mut __ctx),
+                                        "island node 3 (is_odd: map) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 4usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_filter_start(&mut (),
+                                            &mut __state_wf_anon_2, &mut __ctx),
+                                        "island node 4 (wf_anon_2: filter) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 5usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_odd_str, &mut __ctx),
+                                        "island node 5 (odd_str: map) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 6usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_filter_start(&mut (),
+                                            &mut __state_wf_anon_3, &mut __ctx),
+                                        "island node 6 (wf_anon_3: filter) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 7usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_map_start_owned(&mut (),
+                                            &mut __state_even_str, &mut __ctx),
+                                        "island node 7 (even_str: map) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 8usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_merge_start(&mut (),
+                                            &mut __state_labelled, &mut __ctx),
+                                        "island node 8 (labelled: merge) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 9usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_with_time_start(&mut (),
+                                            &mut __state_wf_anon_4, &mut __ctx),
+                                        "island node 9 (wf_anon_4: with_time) start")?;
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 10usize);
+                                ::wingfoil::anyhow::Context::context(__wf_op_for_each_start_owned(&mut (),
+                                            &mut __state_sink, &mut __ctx),
+                                        "island node 10 (sink: for_each) start")?;
+                            }
+                            if let Some(__t) = __q.next_time() { __ctx.schedule(__t); }
+                            return ::core::result::Result::Ok(::wingfoil::op::Tick::Quiet);
+                        }
+                        ::wingfoil::op::CompositePhase::Stop => {
+                            let mut __first_err:
+                                    ::core::option::Option<::wingfoil::anyhow::Error> =
+                                ::core::option::Option::None;
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 0usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_ticker_stop(&mut __cfg_wf_anon_1,
+                                                &mut __state_wf_anon_1, (), &mut __ctx),
+                                            "island node 0 (wf_anon_1: ticker) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 1usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_count_stop(&mut (),
+                                                &mut __state_count, ((&__v_wf_anon_1, false),), &mut __ctx),
+                                            "island node 1 (count: count) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 2usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|i|
+                                                    i.is_multiple_of(2), &mut (), &mut __state_is_even,
+                                                ((&__v_count, false),), &mut __ctx),
+                                            "island node 2 (is_even: map) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 3usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|b|
+                                                    !b, &mut (), &mut __state_is_odd, ((&__v_is_even, false),),
+                                                &mut __ctx), "island node 3 (is_odd: map) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 4usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_filter_stop(&mut (),
+                                                &mut __state_wf_anon_2,
+                                                ((&__v_count, false), (&__v_is_odd, false)), &mut __ctx),
+                                            "island node 4 (wf_anon_2: filter) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 5usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|i|
+                                                    ::alloc::__export::must_use({
+                                                            ::alloc::fmt::format(format_args!("{0} is odd", i))
+                                                        }), &mut (), &mut __state_odd_str,
+                                                ((&__v_wf_anon_2, false),), &mut __ctx),
+                                            "island node 5 (odd_str: map) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 6usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_filter_stop(&mut (),
+                                                &mut __state_wf_anon_3,
+                                                ((&__v_count, false), (&__v_is_even, false)), &mut __ctx),
+                                            "island node 6 (wf_anon_3: filter) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 7usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_stop_owned(|i|
+                                                    ::alloc::__export::must_use({
+                                                            ::alloc::fmt::format(format_args!("{0} is even", i))
+                                                        }), &mut (), &mut __state_even_str,
+                                                ((&__v_wf_anon_3, false),), &mut __ctx),
+                                            "island node 7 (even_str: map) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 8usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_merge_stop(&mut (),
+                                                &mut __state_labelled,
+                                                ((&__v_odd_str, false), (&__v_even_str, false)),
+                                                &mut __ctx), "island node 8 (labelled: merge) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 9usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_with_time_stop(&mut (),
+                                                &mut __state_wf_anon_4, ((&__v_labelled, false),),
+                                                &mut __ctx), "island node 9 (wf_anon_4: with_time) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 10usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_for_each_stop_owned(|(t,
+                                                        s): &(NanoTime, String)|
+                                                    {
+                                                        {
+                                                            {
+                                                                {
+                                                                    let lvl = ::log::Level::Info;
+                                                                    if lvl <= ::log::STATIC_MAX_LEVEL &&
+                                                                            lvl <= ::log::max_level() {
+                                                                        ::log::__private_api::log({
+                                                                                ::log::__private_api::GlobalLogger
+                                                                            }, format_args!("{0} odds/evens {1:?}", t.pretty(), s), lvl,
+                                                                            &("wingfoil", "dual_mode::odds_evens",
+                                                                                    ::log::__private_api::loc()), ());
+                                                                    }
+                                                                }
+                                                            }
+                                                        };
+                                                        Ok(())
+                                                    }, &mut (), &mut __state_sink, ((&__v_wf_anon_4, false),),
+                                                &mut __ctx), "island node 10 (sink: for_each) stop") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            return match __first_err {
+                                    ::core::option::Option::Some(__e) => {
+                                        ::core::result::Result::Err(__e)
+                                    }
+                                    ::core::option::Option::None => {
+                                        ::core::result::Result::Ok(::wingfoil::op::Tick::Quiet)
+                                    }
+                                };
+                        }
+                        ::wingfoil::op::CompositePhase::Teardown => {
+                            let mut __first_err:
+                                    ::core::option::Option<::wingfoil::anyhow::Error> =
+                                ::core::option::Option::None;
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 0usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_ticker_teardown(&mut __cfg_wf_anon_1,
+                                                &mut __state_wf_anon_1, (), &mut __ctx),
+                                            "island node 0 (wf_anon_1: ticker) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 1usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_count_teardown(&mut (),
+                                                &mut __state_count, ((&__v_wf_anon_1, false),), &mut __ctx),
+                                            "island node 1 (count: count) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 2usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|i|
+                                                    i.is_multiple_of(2), &mut (), &mut __state_is_even,
+                                                ((&__v_count, false),), &mut __ctx),
+                                            "island node 2 (is_even: map) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 3usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|b|
+                                                    !b, &mut (), &mut __state_is_odd, ((&__v_is_even, false),),
+                                                &mut __ctx), "island node 3 (is_odd: map) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 4usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_filter_teardown(&mut (),
+                                                &mut __state_wf_anon_2,
+                                                ((&__v_count, false), (&__v_is_odd, false)), &mut __ctx),
+                                            "island node 4 (wf_anon_2: filter) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 5usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|i|
+                                                    ::alloc::__export::must_use({
+                                                            ::alloc::fmt::format(format_args!("{0} is odd", i))
+                                                        }), &mut (), &mut __state_odd_str,
+                                                ((&__v_wf_anon_2, false),), &mut __ctx),
+                                            "island node 5 (odd_str: map) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 6usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_filter_teardown(&mut (),
+                                                &mut __state_wf_anon_3,
+                                                ((&__v_count, false), (&__v_is_even, false)), &mut __ctx),
+                                            "island node 6 (wf_anon_3: filter) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 7usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_map_teardown_owned(|i|
+                                                    ::alloc::__export::must_use({
+                                                            ::alloc::fmt::format(format_args!("{0} is even", i))
+                                                        }), &mut (), &mut __state_even_str,
+                                                ((&__v_wf_anon_3, false),), &mut __ctx),
+                                            "island node 7 (even_str: map) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 8usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_merge_teardown(&mut (),
+                                                &mut __state_labelled,
+                                                ((&__v_odd_str, false), (&__v_even_str, false)),
+                                                &mut __ctx), "island node 8 (labelled: merge) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 9usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_with_time_teardown(&mut (),
+                                                &mut __state_wf_anon_4, ((&__v_labelled, false),),
+                                                &mut __ctx),
+                                            "island node 9 (wf_anon_4: with_time) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 10usize);
+                                if let ::core::result::Result::Err(__e) =
+                                        ::wingfoil::anyhow::Context::context(__wf_op_for_each_teardown_owned(|(t,
+                                                        s): &(NanoTime, String)|
+                                                    {
+                                                        {
+                                                            {
+                                                                {
+                                                                    let lvl = ::log::Level::Info;
+                                                                    if lvl <= ::log::STATIC_MAX_LEVEL &&
+                                                                            lvl <= ::log::max_level() {
+                                                                        ::log::__private_api::log({
+                                                                                ::log::__private_api::GlobalLogger
+                                                                            }, format_args!("{0} odds/evens {1:?}", t.pretty(), s), lvl,
+                                                                            &("wingfoil", "dual_mode::odds_evens",
+                                                                                    ::log::__private_api::loc()), ());
+                                                                    }
+                                                                }
+                                                            }
+                                                        };
+                                                        Ok(())
+                                                    }, &mut (), &mut __state_sink, ((&__v_wf_anon_4, false),),
+                                                &mut __ctx), "island node 10 (sink: for_each) teardown") {
+                                    __first_err.get_or_insert(__e);
+                                }
+                            }
+                            return match __first_err {
+                                    ::core::option::Option::Some(__e) => {
+                                        ::core::result::Result::Err(__e)
+                                    }
+                                    ::core::option::Option::None => {
+                                        ::core::result::Result::Ok(::wingfoil::op::Tick::Quiet)
+                                    }
+                                };
+                        }
+                        ::wingfoil::op::CompositePhase::Cycle => {}
+                    }
+                    for __d in __dirty.iter_mut() { *__d = false; }
+                    while let Some(__ix) = __q.pop_if_pending(__now) {
+                        __dirty[__ix] = true;
+                    }
+                    let __t_wf_anon_1 =
+                        (__WF_OP_TICKER_ACTIVATION.always ||
+                                    (__WF_OP_TICKER_ACTIVATION.callback_activated() &&
+                                            __dirty[0usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 0usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_ticker_cycle(&mut __cfg_wf_anon_1,
+                                                &mut __state_wf_anon_1, (), &mut __ctx),
+                                            "island node 0 (wf_anon_1: ticker) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_wf_anon_1 = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_wf_anon_1 = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_wf_anon_1;
+                    let __t_count =
+                        ((((__WF_OP_COUNT_PASSIVE >> 0u32) & 1) == 0 &&
+                                                __t_wf_anon_1) || __WF_OP_COUNT_ACTIVATION.always ||
+                                    (__WF_OP_COUNT_ACTIVATION.callback_activated() &&
+                                            __dirty[1usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 1usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_count_cycle(&mut (),
+                                                &mut __state_count, ((&__v_wf_anon_1, __t_wf_anon_1),),
+                                                &mut __ctx), "island node 1 (count: count) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_count = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_count = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_count;
+                    let __t_is_even =
+                        ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_count) ||
+                                        __WF_OP_MAP_ACTIVATION.always ||
+                                    (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                            __dirty[2usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 2usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|i|
+                                                    i.is_multiple_of(2), &mut (), &mut __state_is_even,
+                                                ((&__v_count, __t_count),), &mut __ctx),
+                                            "island node 2 (is_even: map) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_is_even = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_is_even = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_is_even;
+                    let __t_is_odd =
+                        ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_is_even)
+                                        || __WF_OP_MAP_ACTIVATION.always ||
+                                    (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                            __dirty[3usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 3usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|b|
+                                                    !b, &mut (), &mut __state_is_odd,
+                                                ((&__v_is_even, __t_is_even),), &mut __ctx),
+                                            "island node 3 (is_odd: map) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_is_odd = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_is_odd = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_is_odd;
+                    let __t_wf_anon_2 =
+                        ((((__WF_OP_FILTER_PASSIVE >> 0u32) & 1) == 0 && __t_count)
+                                            ||
+                                            (((__WF_OP_FILTER_PASSIVE >> 1u32) & 1) == 0 && __t_is_odd)
+                                        || __WF_OP_FILTER_ACTIVATION.always ||
+                                    (__WF_OP_FILTER_ACTIVATION.callback_activated() &&
+                                            __dirty[4usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 4usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_filter_cycle(&mut (),
+                                                &mut __state_wf_anon_2,
+                                                ((&__v_count, __t_count), (&__v_is_odd, __t_is_odd)),
+                                                &mut __ctx), "island node 4 (wf_anon_2: filter) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_wf_anon_2 = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_wf_anon_2 = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_wf_anon_2;
+                    let __t_odd_str =
+                        ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_wf_anon_2)
+                                        || __WF_OP_MAP_ACTIVATION.always ||
+                                    (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                            __dirty[5usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 5usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|i|
+                                                    ::alloc::__export::must_use({
+                                                            ::alloc::fmt::format(format_args!("{0} is odd", i))
+                                                        }), &mut (), &mut __state_odd_str,
+                                                ((&__v_wf_anon_2, __t_wf_anon_2),), &mut __ctx),
+                                            "island node 5 (odd_str: map) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_odd_str = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_odd_str = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_odd_str;
+                    let __t_wf_anon_3 =
+                        ((((__WF_OP_FILTER_PASSIVE >> 0u32) & 1) == 0 && __t_count)
+                                            ||
+                                            (((__WF_OP_FILTER_PASSIVE >> 1u32) & 1) == 0 && __t_is_even)
+                                        || __WF_OP_FILTER_ACTIVATION.always ||
+                                    (__WF_OP_FILTER_ACTIVATION.callback_activated() &&
+                                            __dirty[6usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 6usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_filter_cycle(&mut (),
+                                                &mut __state_wf_anon_3,
+                                                ((&__v_count, __t_count), (&__v_is_even, __t_is_even)),
+                                                &mut __ctx), "island node 6 (wf_anon_3: filter) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_wf_anon_3 = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_wf_anon_3 = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_wf_anon_3;
+                    let __t_even_str =
+                        ((((__WF_OP_MAP_PASSIVE >> 0u32) & 1) == 0 && __t_wf_anon_3)
+                                        || __WF_OP_MAP_ACTIVATION.always ||
+                                    (__WF_OP_MAP_ACTIVATION.callback_activated() &&
+                                            __dirty[7usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 7usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_map_cycle_owned(|i|
+                                                    ::alloc::__export::must_use({
+                                                            ::alloc::fmt::format(format_args!("{0} is even", i))
+                                                        }), &mut (), &mut __state_even_str,
+                                                ((&__v_wf_anon_3, __t_wf_anon_3),), &mut __ctx),
+                                            "island node 7 (even_str: map) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_even_str = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_even_str = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_even_str;
+                    let __t_labelled =
+                        ((((__WF_OP_MERGE_PASSIVE >> 0u32) & 1) == 0 && __t_odd_str)
+                                            ||
+                                            (((__WF_OP_MERGE_PASSIVE >> 1u32) & 1) == 0 && __t_even_str)
+                                        || __WF_OP_MERGE_ACTIVATION.always ||
+                                    (__WF_OP_MERGE_ACTIVATION.callback_activated() &&
+                                            __dirty[8usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 8usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_merge_cycle(&mut (),
+                                                &mut __state_labelled,
+                                                ((&__v_odd_str, __t_odd_str),
+                                                    (&__v_even_str, __t_even_str)), &mut __ctx),
+                                            "island node 8 (labelled: merge) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_labelled = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_labelled = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_labelled;
+                    let __t_wf_anon_4 =
+                        ((((__WF_OP_WITH_TIME_PASSIVE >> 0u32) & 1) == 0 &&
+                                                __t_labelled) || __WF_OP_WITH_TIME_ACTIVATION.always ||
+                                    (__WF_OP_WITH_TIME_ACTIVATION.callback_activated() &&
+                                            __dirty[9usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 9usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_with_time_cycle(&mut (),
+                                                &mut __state_wf_anon_4, ((&__v_labelled, __t_labelled),),
+                                                &mut __ctx), "island node 9 (wf_anon_4: with_time) cycle")?
+                                    {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_wf_anon_4 = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_wf_anon_4 = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_wf_anon_4;
+                    let __t_sink =
+                        ((((__WF_OP_FOR_EACH_PASSIVE >> 0u32) & 1) == 0 &&
+                                                __t_wf_anon_4) || __WF_OP_FOR_EACH_ACTIVATION.always ||
+                                    (__WF_OP_FOR_EACH_ACTIVATION.callback_activated() &&
+                                            __dirty[10usize])) &&
+                            {
+                                let mut __ctx =
+                                    ::wingfoil::op::Ctx::nested(__now, __wall_time,
+                                        __start_time, &mut __q, 10usize);
+                                match ::wingfoil::anyhow::Context::context(__wf_op_for_each_cycle_owned(|(t,
+                                                        s): &(NanoTime, String)|
+                                                    {
+                                                        {
+                                                            {
+                                                                {
+                                                                    let lvl = ::log::Level::Info;
+                                                                    if lvl <= ::log::STATIC_MAX_LEVEL &&
+                                                                            lvl <= ::log::max_level() {
+                                                                        ::log::__private_api::log({
+                                                                                ::log::__private_api::GlobalLogger
+                                                                            }, format_args!("{0} odds/evens {1:?}", t.pretty(), s), lvl,
+                                                                            &("wingfoil", "dual_mode::odds_evens",
+                                                                                    ::log::__private_api::loc()), ());
+                                                                    }
+                                                                }
+                                                            }
+                                                        };
+                                                        Ok(())
+                                                    }, &mut (), &mut __state_sink,
+                                                ((&__v_wf_anon_4, __t_wf_anon_4),), &mut __ctx),
+                                            "island node 10 (sink: for_each) cycle")? {
+                                    ::wingfoil::op::Tick::Value(__val) => {
+                                        __v_sink = __val;
+                                        true
+                                    }
+                                    ::wingfoil::op::Tick::Silent(__val) => {
+                                        __v_sink = __val;
+                                        false
+                                    }
+                                    ::wingfoil::op::Tick::Quiet => false,
+                                }
+                            };
+                    let _ = __t_sink;
+                    if let Some(__t) = __q.next_time() { __ctx.schedule(__t); }
+                    ::core::result::Result::Ok(if __t_labelled {
+                            ::wingfoil::op::Tick::Value(::core::clone::Clone::clone(&__v_labelled))
+                        } else { ::wingfoil::op::Tick::Quiet })
+                })
+    }
+}
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let tier = Tier::default();
+    let (last,) = odds_evens::run(tier, HISTORICAL, RunFor::Cycles(CYCLES))?;
+    {
+        ::std::io::_print(format_args!("ran {0} cycles on the {1} tier; last label: {2:?}\n",
+                CYCLES, tier, last));
+    };
+    Ok(())
+}

--- a/crates/wingfoil/examples/core/dual_mode/main.rs
+++ b/crates/wingfoil/examples/core/dual_mode/main.rs
@@ -18,19 +18,31 @@
 //!              \     /
 //!               merge                 (recombine — at most one fires/tick)
 //!                 |
-//!               acc                   (accumulate — see the note below)
+//!               log tap               (emit as the run progresses)
 //! ```
 //!
-//! The tail node is [`accumulate`](wingfoil::fluent::StreamOps::accumulate)
-//! rather than a `print`/`for_each` sink for the one reason that justifies it:
-//! this example's claim is that the two engines *agree*, and comparing them
-//! means holding both runs' whole output as a value. The run is bounded to
-//! `CYCLES`. In a graph that emits rather than asserts, the tail is a streaming
-//! sink — see [`hello_graph`](../hello_graph/) and
-//! [`ema_crossover`](../ema_crossover/).
+//! The tail emits as the run progresses — a closure sink over the `log` crate,
+//! per the house rule that examples stream their output rather than collect it.
+//! Two things worth knowing about that tap:
+//!
+//! - It is spelled `with_time().for_each(|(t, s)| { log::info!(..); Ok(()) })`
+//!   rather than `.logged(..)`, because `logged` is deliberately
+//!   **fluent-only**: its op `Cfg` is `(String, log::Level)` while the fluent
+//!   method takes `&str`, and `nitro!` uses the call-site argument types as
+//!   the `Cfg` verbatim — the same tokens cannot satisfy both (see
+//!   `tests/op_completeness.rs`, category 2b). A closure sink is the same tap
+//!   and works identically on every tier, because closures are opaque config.
+//! - This example **runs** the graph; it does not tie the engines out against
+//!   each other. That assertion needs both runs' whole output held as a value,
+//!   which is `accumulate()`'s job and a test's place —
+//!   [`tests/macro_parity.rs`](../../../tests/macro_parity.rs) pins this same
+//!   diamond's interpreted and compiled outputs equal (with an `accumulate`
+//!   tail in place of the log tap, which is what lets it hold the output).
+//!
+//! `log` output is rendered by `env_logger`, so run with `RUST_LOG=info`:
 //!
 //! ```sh
-//! cargo run -p wingfoil --release --example dual_mode
+//! RUST_LOG=info cargo run -p wingfoil --release --example dual_mode
 //! ```
 //!
 //! # What procedural code you can write inside `nitro!`
@@ -39,11 +51,11 @@
 //! code — it reads the tokens to derive a **static DAG** at expansion time,
 //! then re-emits the whole schedule three ways (`interpreted` / `compiled` /
 //! `nested`). Because `compiled()` monomorphizes one local per node (see the
-//! generated code at the bottom of this file), the node list must be complete
-//! and fixed after parsing. That is the one rule everything below follows:
-//! **wiring must be straight-line — the shape of the graph cannot depend on
-//! runtime values.** Values and per-element logic can be as procedural as you
-//! like; the *topology* cannot.
+//! committed expansion in [`expanded/`](expanded/)), the node list must be
+//! complete and fixed after parsing. That is the one rule everything below
+//! follows: **wiring must be straight-line — the shape of the graph cannot
+//! depend on runtime values.** Values and per-element logic can be as
+//! procedural as you like; the *topology* cannot.
 //!
 //! Each top-level statement is sorted into one of three buckets: a **wiring**
 //! `let name = <chain>;` (rooted at the builder or an already-bound stream),
@@ -96,9 +108,10 @@
 //! ```
 //!
 //! The full expansion of the `nitro!` block below — `wire`, `interpreted`,
-//! `compiled`, and `nested` — is reproduced (abridged) in a block comment at
-//! the end of this file, so you can see exactly what "straight-line wiring
-//! becomes a static schedule" means in emitted code.
+//! `compiled`, `run`, and `nested` — is committed **verbatim** in
+//! [`expanded/main.expanded.rs`](expanded/main.expanded.rs), so you can read
+//! exactly what "straight-line wiring becomes a static schedule" means in
+//! emitted code. `expanded/README.md` has the command that regenerates it.
 
 use std::time::Duration;
 
@@ -111,206 +124,44 @@ const PERIOD: Duration = Duration::from_millis(10);
 // One definition — a valid fluent wiring function whose DAG is a
 // split/recombine. The macro parses it to derive the DAG and expands to a
 // module: `odds_evens::wire` (this function, verbatim),
-// `odds_evens::interpreted()` (built through wire), and
-// `odds_evens::compiled()` (the monomorphized schedule derived from the same
-// tokens).
+// `odds_evens::interpreted()` (built through wire), `odds_evens::compiled()`
+// (the monomorphized schedule derived from the same tokens), and
+// `odds_evens::run(tier, ..)` (either engine behind one signature).
 //
 // `count` is referenced three times, so it is a *shared* apex node: the
 // interpreted engine runs it once per cycle and fans the tick out, and the
 // compiled engine emits it once and feeds every reader from the same slot.
 // `merge` is the recombine — since a number is either odd or even, at most
-// one branch fires on any tick.
+// one branch fires on any tick. `sink` is a side-effect-only node (nothing
+// reads it, it is not in the tail): the log tap that streams each label out
+// through the `log` crate, stamped with the engine time it ticked at.
 wingfoil::nitro! {
-    fn odds_evens(g: &GraphBuilder) -> Stream<Vec<String>> {
+    fn odds_evens(g: &GraphBuilder) -> Stream<String> {
         let count = g.ticker(PERIOD).count();
         let is_even = count.map(|i| i.is_multiple_of(2));
         let is_odd = is_even.map(|b| !b);
         let odd_str = count.filter(&is_odd).map(|i| format!("{i} is odd"));
         let even_str = count.filter(&is_even).map(|i| format!("{i} is even"));
-        let acc = odd_str.merge(&even_str).accumulate();
-        acc
+        let labelled = odd_str.merge(&even_str);
+        let sink = labelled.with_time().for_each(|(t, s): &(NanoTime, String)| {
+            log::info!(target: "wingfoil", "{} odds/evens {s:?}", t.pretty());
+            Ok(())
+        });
+        labelled
     }
 }
 
-fn main() {
-    let run_for = RunFor::Cycles(CYCLES);
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
 
-    // Interpreted: build the graph, run it, read the accumulated labels.
-    let (mut runner, acc) = odds_evens::interpreted();
-    runner.run(HISTORICAL, run_for).unwrap();
-    let interpreted = runner.value(acc);
-
-    // Compiled: the same tokens, monomorphized into a standalone runner.
-    let (compiled,) = odds_evens::compiled(HISTORICAL, run_for).unwrap();
-
-    assert_eq!(interpreted, compiled, "engines must agree");
-
-    // The two entry points above are shaped differently — a runner plus
-    // handles to read *after* running, versus run bounds in and values out —
-    // which is what would otherwise stop you swapping engines behind a flag.
-    // `run` reconciles them: same signature, same outputs, tier as an
-    // argument. `Tier::default()` resolves from `WINGFOIL_TIER` if it is set
-    // and otherwise from the build profile (interpreted in debug, compiled in
+    // `Tier::default()` resolves from `WINGFOIL_TIER` if it is set and
+    // otherwise from the build profile (interpreted in debug, compiled in
     // release), so the usual workflow — develop interpreted, deploy compiled —
-    // needs no call-site change at all.
+    // needs no call-site change at all. The log lines are identical either
+    // way; that the tiers *agree* is pinned by `tests/macro_parity.rs`.
     let tier = Tier::default();
-    let (via_run,) = odds_evens::run(tier, HISTORICAL, run_for).unwrap();
-    assert_eq!(via_run, interpreted, "`run` must agree with both engines");
+    let (last,) = odds_evens::run(tier, HISTORICAL, RunFor::Cycles(CYCLES))?;
 
-    for line in &interpreted {
-        println!("{line}");
-    }
-    println!(
-        "\n{} labels over {CYCLES} cycles — interpreted and compiled engines agree.",
-        interpreted.len()
-    );
-    println!("`run(Tier::default(), ..)` resolved to the {tier} tier and matched them.");
+    println!("ran {CYCLES} cycles on the {tier} tier; last label: {last:?}");
+    Ok(())
 }
-
-// ===========================================================================
-// Generated code (abridged)
-// ===========================================================================
-//
-// `cargo expand -p wingfoil --example dual_mode` prints the full ~1.5k
-// lines. Below is a faithful, abridged rendering of what the `nitro!` block
-// above expands into: a module `odds_evens` with four entry points. The DAG is
-// 10 nodes, indexed in wiring order:
-//
-//   0 ticker(wf_anon_1)  1 count   2 is_even  3 is_odd  4 filter(wf_anon_2)
-//   5 odd_str  6 filter(wf_anon_3)  7 even_str  8 merge(wf_anon_4)  9 acc
-//
-// Intermediate (unnamed) nodes get `wf_anon_N` slots; user `let` names are
-// kept verbatim. Every op — built-in or user — is dispatched through
-// naming-convention forwarders `__wf_op_<method>_{cycle,start,stop,teardown,
-// seed_state,seed_value}` (+ `_owned` variants for literal-closure configs),
-// plus the per-op consts `__WF_OP_<METHOD>_{ACTIVATION,PASSIVE}`. The macro
-// never names an op type — rustc's inference resolves each from the argument
-// types at the call site, and the consts fold into the tick gates after
-// monomorphization.
-//
-// ---------------------------------------------------------------------------
-// mod odds_evens {
-//
-//     // (a) `wire` — the wiring fn, verbatim. This is the ONLY human-written
-//     //     form; the other three are derived from these same tokens, so they
-//     //     cannot drift. A nitro! fn with inputs is reusable by calling
-//     //     `wire(g)` from another graph (composition = nesting).
-//     pub fn wire(g: &GraphBuilder) -> Stream<Vec<String>> {
-//         let count = g.ticker(PERIOD).count();
-//         let is_even = count.map(|i| i.is_multiple_of(2));
-//         let is_odd = is_even.map(|b| !b);
-//         let odd_str = count.filter(&is_odd).map(|i| format!("{i} is odd"));
-//         let even_str = count.filter(&is_even).map(|i| format!("{i} is even"));
-//         let acc = odd_str.merge(&even_str).accumulate();
-//         acc
-//     }
-//
-//     // (b) `interpreted` — build the graph through `wire` against a runtime
-//     //     builder, hand back the runner + a typed handle per output.
-//     pub fn interpreted() -> (interp::Runner, interp::Handle<Vec<String>>) {
-//         let __g = GraphBuilder::new();
-//         let acc = wire(&__g);
-//         let __runner = __g.build();
-//         (__runner, acc.handle())
-//     }
-//
-//     // (c) `compiled` — the same DAG, fully monomorphized: one local per
-//     //     node, tick propagation as bools, every Op::cycle (closures
-//     //     included) visible to the optimizer. No heap, no dyn, no table.
-//     pub fn compiled(run_mode, run_for) -> anyhow::Result<(Vec<String>,)> {
-//         let mut __k = codegen::Kernel::new(run_mode, run_for);
-//
-//         // One (cfg?/state/value) slot per node, seeded via forwarders.
-//         let mut __cfg_wf_anon_1   = PERIOD;                              // ticker cfg
-//         let mut __state_wf_anon_1 = __wf_op_ticker_seed_state(&__cfg_wf_anon_1);
-//         let mut __v_wf_anon_1     = __wf_op_ticker_seed_value(&__cfg_wf_anon_1);
-//         let mut __state_count = __wf_op_count_seed_state(&());
-//         let mut __v_count     = __wf_op_count_seed_value(&());
-//         // … is_even, is_odd, wf_anon_2, odd_str, wf_anon_3, even_str,
-//         //   wf_anon_4, acc — same shape …
-//
-//         let mut __first_err = None;
-//         let __run = (|| -> anyhow::Result<()> {
-//             // start(), nodes 0..=9 in wiring order (no-op starts inline away)
-//             { let mut __ctx = Ctx::new(&mut __k, 0);
-//               __wf_op_ticker_start(&mut __cfg_wf_anon_1, &mut __state_wf_anon_1, &mut __ctx)?; }
-//             // … starts for nodes 1..=9 …
-//
-//             // The cycle loop IS the whole schedule, straight-line.
-//             let mut __dirty = [false; 10];
-//             while __k.begin_cycle(&mut __dirty) {
-//                 // node 0 — ticker (a source: fires only when scheduled).
-//                 let __t_wf_anon_1 = (__WF_OP_TICKER_ACTIVATION.always
-//                     || (__WF_OP_TICKER_ACTIVATION.callback_activated() && __dirty[0]))
-//                     && { let mut __ctx = Ctx::new(&mut __k, 0);
-//                          match __wf_op_ticker_cycle(&mut __cfg_wf_anon_1,
-//                                  &mut __state_wf_anon_1, (), &mut __ctx)? {
-//                              Tick::Value(v)  => { __v_wf_anon_1 = v; true }
-//                              Tick::Silent(v) => { __v_wf_anon_1 = v; false }
-//                              Tick::Quiet     => false,
-//                          } };
-//
-//                 // node 1 — count. Its gate: "an active input ticked" (built
-//                 // from the upstream tick flag masked by PASSIVE), or the op
-//                 // is `always`, or it was scheduled (`callback_activated` +
-//                 // dirty). Inputs arrive as (&value, ticked) pairs.
-//                 let __t_count = ((((__WF_OP_COUNT_PASSIVE >> 0) & 1) == 0 && __t_wf_anon_1)
-//                     || __WF_OP_COUNT_ACTIVATION.always
-//                     || (__WF_OP_COUNT_ACTIVATION.callback_activated() && __dirty[1]))
-//                     && { let mut __ctx = Ctx::new(&mut __k, 1);
-//                          match __wf_op_count_cycle(&mut (), &mut __state_count,
-//                                  ((&__v_wf_anon_1, __t_wf_anon_1),), &mut __ctx)? {
-//                              Tick::Value(v)  => { __v_count = v; true }
-//                              Tick::Silent(v) => { __v_count = v; false }
-//                              Tick::Quiet     => false,
-//                          } };
-//
-//                 // nodes 2..=9 — identical shape. A two-input op (filter,
-//                 // merge) gets one (&value, ticked) pair per edge in call
-//                 // order, e.g. the odd-branch filter (node 4):
-//                 //   __wf_op_filter_cycle(&mut (), &mut __state_wf_anon_2,
-//                 //       ((&__v_count, __t_count), (&__v_is_odd, __t_is_odd)),
-//                 //       &mut __ctx)?
-//                 // …
-//
-//                 __k.end_cycle(&mut __dirty);
-//             }
-//             Ok(())
-//         })();
-//         if let Err(e) = __run { __first_err = Some(e); }
-//
-//         // stop() then teardown() for every node, first error wins (abridged).
-//         // …
-//
-//         match __first_err {
-//             Some(e) => Err(e),
-//             None    => Ok((__v_acc,)),   // the tail binding(s), by value
-//         }
-//     }
-//
-//     // (d) `nested` — the whole graph mounted as ONE compiled node inside an
-//     //     interpreted graph. The outer engine pays one dyn call per
-//     //     activation for the entire sub-graph; inside, it is the same
-//     //     straight-line schedule as `compiled`. Inner schedules (the ticker)
-//     //     run through a private TimeQueue; only the earliest is forwarded to
-//     //     the outer kernel, and only the tail's tick is emitted downstream.
-//     pub fn nested(__g: &GraphBuilder) -> Stream<Vec<String>> {
-//         // … same per-node slots as compiled(), captured by the closure …
-//         let mut __q = TimeQueue::<usize>::new();
-//         let mut __dirty = [false; 10];
-//         __g.__composite(__active, __passive, /* any inner op callback-activated? */ …,
-//             move |__ctx, __phase| {
-//                 match __phase {
-//                     CompositePhase::Start    => { /* start all; schedule earliest */ }
-//                     CompositePhase::Stop     => { /* stop all */ }
-//                     CompositePhase::Teardown => { /* teardown all */ }
-//                     CompositePhase::Cycle    => {}
-//                 }
-//                 // drain the private queue into __dirty, then run the SAME
-//                 // node-0..=9 schedule as compiled() (via Ctx::nested(.., ix)),
-//                 // re-arm the queue, and forward only the tail:
-//                 Ok(if __t_acc { Tick::Value(__v_acc.clone()) } else { Tick::Quiet })
-//             })
-//     }
-// }
-// ---------------------------------------------------------------------------

--- a/crates/wingfoil/examples/core/odds_evens/README.md
+++ b/crates/wingfoil/examples/core/odds_evens/README.md
@@ -54,6 +54,7 @@ RUST_LOG=info cargo run -p wingfoil --example odds_evens
 ### Where to go next
 
 - [`dual_mode`](../dual_mode/) — the same split/recombine shape through `nitro!`,
-  run interpreted vs compiled and asserted equal.
+  runnable on any of the three tiers (the engines' agreement is pinned by
+  `tests/macro_parity.rs`).
 - [`topological_sort`](../topological_sort/) — why the shared apex node matters.
 - [`hello_graph`](../hello_graph/) — the linear starter graph.

--- a/crates/wingfoil/tests/macro_parity.rs
+++ b/crates/wingfoil/tests/macro_parity.rs
@@ -4,6 +4,13 @@
 //! `interpreted()` (built through `wire`), and `compiled()` (fully
 //! monomorphized) — so the engines cannot drift. These tests assert the two
 //! expansions agree, and match the values the hand-written engines produced.
+//!
+//! The `odds_evens` block below is the same split/recombine diamond as
+//! `examples/core/dual_mode/`, which links here as *the* tie-out: the example
+//! streams its labels out through a log tap, and this test is where the
+//! engines' agreement over that diamond is actually asserted — tailed with
+//! `accumulate`, the test instrument whose job is holding a bounded run's
+//! whole output as one value.
 
 use std::time::Duration;
 


### PR DESCRIPTION
## What this changes

The `dual_mode` example now streams its output through the `log` crate (via a closure sink) as the graph runs, rather than collecting it into a `Vec`. The full, unedited expansion of the `nitro!` macro is committed to `expanded/main.expanded.rs` as a reference snapshot, so the claim that "straight-line wiring becomes a static schedule" can be verified in real emitted code.

## Why

**Output streaming:** The house rule is that examples emit as they run rather than collecting into a `Vec` to print after. This keeps the same wiring usable against live feeds and matches the pattern in other examples like `hello_graph` and `ema_crossover`. The tail was changed from `accumulate()` (which collects the whole output) to a closure sink that logs each label with its engine time.

**Expanded code reference:** The macro expansion was previously described in an abridged block comment at the end of the file. Committing the full, verbatim expansion makes the generated code readable and auditable without abbreviation. This is a reference snapshot (not a build target), so it documents exactly what the macro produces on this codebase.

**Clarified test/example split:** The documentation now makes clear that `dual_mode` *runs* the graph and streams output, while the assertion that both engines agree is the job of `tests/macro_parity.rs` (which uses `accumulate()` to hold both outputs as values for comparison).

## How it was verified

- `cargo fmt --all`
- `cargo test -p wingfoil --all-features` (existing tests pass; `macro_parity.rs` still asserts engine parity with the same diamond DAG)
- Example runs with `RUST_LOG=info cargo run -p wingfoil --release --example dual_mode` and streams output as expected

## Notes for the reviewer

The closure sink spelling (`with_time().for_each(|(t, s)| { log::info!(..); Ok(()) })`) is necessary because `logged(..)` is fluent-only — its `Cfg` is `(String, log::Level)` while the fluent method takes `&str`, and `nitro!` uses call-site argument types verbatim, so the same tokens cannot satisfy both. Closures are opaque config and work identically on every tier. This is explained in the updated README and in a comment in the code.

The expanded code file is large (~1730 lines) but is committed as-is from `-Zunpretty=expanded` output. It includes artifacts of the pretty-printer (e.g., `#![feature(prelude_import)]`, pre-expanded `format!` and `log::info!` calls) that are documented in `expanded/README.md`.

https://claude.ai/code/session_01VmEYBsv1C8LHvk8ycnPKEK