### PR TITLE
docs: close the 9.0.0 release-note gaps the capture rework and introspect left

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ parity and was deleted at the cutover (`docs/planning/cutover-plan.md`).
 crates/                     # every Cargo crate in the tree
   wingfoil/            # The engine: op.rs, interp.rs, fluent.rs, ops.rs,
                             #   stats.rs, adapters/, channel.rs, async_source.rs,
-                            #   signal.rs, runtime/, examples/, tests/, benches/
+                            #   introspect.rs, latency.rs, runtime/, examples/,
+                            #   tests/, benches/
   wingfoil-derive/     # nitro! / #[op] proc macros
   wingfoil-python/     # PyO3 Python bindings (built with maturin)
   wingfoil-python-derive/

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -218,7 +218,10 @@ the pair of them was how a stage got stamped twice.
 and nowhere else. The second element of the return is a `LatencyHandle`: it
 reads out as labelled `HopStats` (`hops()`, `total()`), resets (`reset()` /
 `take()`, without which one outlier pins a p99 for the life of the process),
-and wires to a `Stream<LatencySnapshot>` with `windows(&g, period)`.
+and wires to a `Stream<LatencySnapshot>` with `windows(&g, period)` — at most
+one per handle, because the windowed read is destructive: a second `windows`
+stream would steal samples from the first, so wiring it panics. Branch the
+returned stream to fan a window out to several consumers.
 
 **One behavioural difference to know about, because it changes numbers you may
 have been reading.** Legacy recorded a same-cycle hop — two stages sharing

--- a/docs/release-notes/9.0.0.md
+++ b/docs/release-notes/9.0.0.md
@@ -32,10 +32,13 @@ dead beside a new line. MSRV is 1.88.
 
 The 9.0 engine is a **superset** of 8.x — every op, every adapter, both run
 modes, the examples, the benchmarks and both language bindings. The deliberate
-exceptions are few and all listed [below](#what-is-gone): exactly one public
-API is removed with **no** replacement, and a handful of removals and
-signature changes have one-line replacements beside them. That was the
-governing constraint of the whole port, audited adapter by adapter in
+exceptions are few and all listed [below](#what-is-gone). Two of them stand
+alone: three of `NanoTime`'s `From` impls go with **no** drop-in replacement,
+because each was an unsound `as` cast, and `RunFor::done` goes because it was a
+dead predicate that disagreed with the kernel. Everything else that moved —
+`Graph::export`, the `_if` stamps, two signature changes — has its replacement
+named beside it. That was the governing constraint of the whole port, audited
+adapter by adapter in
 [`deviation-register.md`](../planning/deviation-register.md).
 
 ## Why the engine was replaced
@@ -266,12 +269,21 @@ can feed a subscriber on the new one while you migrate process by process.
 
 ## What is gone
 
-**`Graph::export`** — the GML topology dump. It is the only public 8.x API with
-no replacement in 9.0, and the drop is deliberate: we want a designed
-introspection and visualisation story rather than a same-shape port of a
-debug-only helper. Nothing in the engine blocks bringing it back — the builder
-holds the full topology plus debug labels — so if you depend on it, say so and
-it can come back as part of that work.
+**`Graph::export`** — the GML topology dump. The *name* is gone; the capability
+is not, and it is now strictly larger. The drop was deliberate — we wanted a
+designed introspection and visualisation story rather than a same-shape port of
+a debug-only helper — and that story has since landed as
+[`introspect`](../../crates/wingfoil/src/introspect.rs):
+
+| 8.x | 9.0 |
+|---|---|
+| `graph.export("g.gml")?` | `runner.snapshot().to_gml()` (or `g.snapshot()` before `build`) |
+
+`GraphSnapshot` is a value rather than a side effect on a file path, so a test
+can assert on it; it distinguishes active from passive edges, which GML cannot
+express; and it renders to text, Mermaid, Graphviz DOT and JSON as well as GML.
+See `examples/core/introspect/` and
+[`introspection-plan.md`](../planning/introspection-plan.md).
 
 **`RunFor::done`** — the "has the run finished?" predicate on the run bound. It
 had no callers in the tree and, more to the point, it disagreed with the engine:

--- a/docs/release-notes/9.0.0.md
+++ b/docs/release-notes/9.0.0.md
@@ -31,9 +31,11 @@ starting a new line beside them, so every name 8.x published — `wingfoil`,
 dead beside a new line. MSRV is 1.88.
 
 The 9.0 engine is a **superset** of 8.x — every op, every adapter, both run
-modes, the examples, the benchmarks and both language bindings — with exactly
-one public API removed ([below](#what-is-gone)). That was the governing
-constraint of the whole port, audited adapter by adapter in
+modes, the examples, the benchmarks and both language bindings. The deliberate
+exceptions are few and all listed [below](#what-is-gone): exactly one public
+API is removed with **no** replacement, and a handful of removals and
+signature changes have one-line replacements beside them. That was the
+governing constraint of the whole port, audited adapter by adapter in
 [`deviation-register.md`](../planning/deviation-register.md).
 
 ## Why the engine was replaced
@@ -278,6 +280,18 @@ its cycle test was `cycle > cycles` where `Kernel::begin_cycle` uses
 cycle long. `RunFor` now only *declares* the bound; the single implementation of
 evaluating it lives in the kernel. Nothing needs to replace this — the runner
 already stops at the bound you gave it.
+
+**`stamp_if` and `stamp_precise_if`** — the conditional latency stamps on
+`LatencyStreamOps`, replaced by `stamp_as::<S>(mode)` taking a `Stamping`
+argument: `stamp_if(on)` becomes `stamp_as(Stamping::on_if(on))`, and
+`stamp_precise_if(on)` becomes `stamp_as(Stamping::new(on, true))`. The `_if`
+pair could not express "precise or not, decided at runtime" — the shape a
+config flag has — so that case took two calls with opposite polarities, which
+double-stamps the stage the moment one `!` is dropped. The capability is
+untouched (`Stamping::Off` wires no node, exactly as `_if(false)` did); only
+the spelling is withdrawn, and the Python `stamp_if` / `stamp_precise_if`
+free functions stay. Recorded as deviation **D28**; the full surface is in the
+migration guide's [Latency capture](../migration.md#latency-capture) section.
 
 **`limit` and `skip` count in `usize`**, not `u32` — matching `buffer`'s
 capacity, `fan`'s width and every rolling window in the catalog. Literal call


### PR DESCRIPTION
## What this changes

Three documentation corrections, all of them cases where the 9.0.0 release
page drifted behind work that had already landed on `main`:

- **`stamp_if` / `stamp_precise_if` are now listed in "What is gone"**
  (deviation **D28**), with their one-line `stamp_as` replacements, and the
  note that `Stamping::Off` wires no node exactly as `_if(false)` did and the
  Python free functions survive.
- **The `Graph::export` entry no longer claims there is no replacement.**
  There is one: `introspect` has landed, and the entry now reads as
  `docs/migration.md` already does — a rename with a mapping table
  (`runner.snapshot().to_gml()`), plus what `GraphSnapshot` buys over GML.
  The intro's "exactly one public API removed" count followed from that
  entry, so it was rewritten too.
- **`LatencyHandle::windows` is documented as one-stream-per-handle** in the
  migration guide, because the windowed read is destructive and wiring a
  second one panics.

Also drops the deleted `signal.rs` from `CLAUDE.md`'s engine file list.

## Why

Each item is a migrant hitting a dead end.

Someone grepping the release page for `stamp_if` — withdrawn by the latency
capture rework (#860) — found nothing, though removals of comparable weight
(#859's `usize` counts, #861's `collapse` bound) were already listed.

The `Graph::export` claim was outright stale. Both `deviation-register.md`
(**C6**) and `cutover-plan.md` (row **2.1**) record the drop as *superseded,
not restored* — "no longer a removal at all" — and the migration guide has
carried the mapping table for some time. The release notes were the last
place still telling readers the capability was gone and inviting them to ask
for it back.

`windows()` panics on a second call per handle. That was worth a sentence
before someone wires two.

## How it was verified

Documentation only — no Rust, Python or TypeScript source is touched, so the
test and lint checklist has nothing to gate. What was checked instead:

- [x] `scripts/check-example-docs.sh` — OK, 47 example targets
- [x] Every claim re-read against `main`: `Stamping` / `on_if` / `stamp_as`
      exist in `crates/wingfoil/src/latency.rs`; the `_if` trait methods are
      gone; the Python `stamp_if` / `stamp_precise_if` free functions are
      still registered in `python.rs`; `windows()` asserts on
      `windows_wired.replace(true)`; `GraphSnapshot::to_gml()` is reachable
      from both `GraphBuilder::snapshot()` and `Runner::snapshot()`
- [x] All four new/changed relative links resolve, and the `#what-is-gone`
      anchor still matches its heading

## Notes for the reviewer

**One thing deliberately not folded in.** The `Signal` facade withdrawal
(deviation **D29**, #887) gets no "What is gone" entry, and that is a
judgement call worth a look. `wingfoil::signal` was never published — 9.0.0
is unreleased and the facade was an in-development compat spelling — so
listing it as removed 8.x surface would be wrong by the same standard the
section applies to everything else in it. The 8.x idiom it emulated
(`ticker(d).count().run(..)`, `peek_value()`) is already covered by step 2 of
the migration steps further up the same page. Happy to add an entry if you
read that differently.

The first commit is the pre-existing `latency-capture` work, unchanged; the
second is the corrections above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSf9iyMwear5vQ2JTxagdu)_