### PR TITLE
fix(js): surface client boot failures

### DIFF
--- a/crates/wingfoil-wasm/src/lib.rs
+++ b/crates/wingfoil-wasm/src/lib.rs
@@ -266,7 +266,7 @@ mod tests {
     #[test]
     fn parse_codec_accepts_bincode_and_json() {
         // `JsError::new` panics off-wasm, so only verify the success
-        // path here; the error path is covered by `wasm-pack test`.
+        // path here; the error path requires a wasm target.
         assert!(matches!(parse_codec("bincode"), Ok(CodecKind::Bincode)));
         assert!(matches!(parse_codec("json"), Ok(CodecKind::Json)));
     }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -66,7 +66,7 @@ export type ConnectionState =
   | { kind: "connecting" }
   | { kind: "open"; codec: CodecKind; version: number }
   | { kind: "closed"; code: number; reason: string }
-  | { kind: "error"; error: Event };
+  | { kind: "error"; error: Event | Error };
 
 export interface ClientOptions {
   /** WebSocket URL, e.g. `ws://localhost:8080/ws`. */
@@ -229,7 +229,12 @@ export class WingfoilClient {
       wasmUrl: options.wasmUrl ?? "",
     };
     this.codecKind = this.opts.codec;
-    void this.boot();
+    void this.boot().catch((error: unknown) => {
+      this.emitConn({
+        kind: "error",
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    });
   }
 
   /** Close the socket and stop reconnecting. */

--- a/js/tests/client.test.ts
+++ b/js/tests/client.test.ts
@@ -3,11 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const wasm = vi.hoisted(() => ({
   control: {} as { Hello?: { codec: string; version: number } },
   encodePayload: vi.fn(() => new Uint8Array([1, 2, 3])),
+  init: vi.fn(() => Promise.resolve()),
   wireVersion: vi.fn(() => 2),
 }));
 
 vi.mock("../src/wasm/wingfoil_wasm.js", () => ({
-  default: () => Promise.resolve(),
+  default: wasm.init,
   init_panic_hook: () => {},
   wireVersion: wasm.wireVersion,
   controlTopic: () => "$ctrl",
@@ -63,12 +64,58 @@ async function connectedClient(): Promise<{
   return { client, socket: FakeSocket.instances[0] };
 }
 
+describe("WingfoilClient boot", () => {
+  beforeEach(() => {
+    FakeSocket.instances.length = 0;
+    wasm.init.mockReset();
+    wasm.init.mockResolvedValue(undefined);
+    vi.stubGlobal("WebSocket", FakeSocket);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("emits the initialization error without opening a socket", async () => {
+    const error = new Error("wasm initialization failed");
+    wasm.init.mockRejectedValueOnce(error);
+    const client = new WingfoilClient({ url: "ws://localhost:8080/ws" });
+    const states: ConnectionState[] = [];
+    client.onConnection((state) => states.push(state));
+
+    await vi.waitFor(() => {
+      expect(states).toContainEqual({ kind: "error", error });
+    });
+    expect(FakeSocket.instances).toHaveLength(0);
+    client.close();
+  });
+
+  it("normalizes a non-Error initialization rejection", async () => {
+    wasm.init.mockRejectedValueOnce("wasm unavailable");
+    const client = new WingfoilClient({ url: "ws://localhost:8080/ws" });
+    const states: ConnectionState[] = [];
+    client.onConnection((state) => states.push(state));
+
+    await vi.waitFor(() => {
+      expect(states).toContainEqual({
+        kind: "error",
+        error: new Error("wasm unavailable"),
+      });
+    });
+    expect(FakeSocket.instances).toHaveLength(0);
+    client.close();
+  });
+});
+
 describe("WingfoilClient.publish", () => {
   beforeEach(() => {
     FakeSocket.instances.length = 0;
     wasm.control = {};
     wasm.encodePayload.mockReset();
     wasm.encodePayload.mockReturnValue(new Uint8Array([1, 2, 3]));
+    wasm.init.mockReset();
+    wasm.init.mockResolvedValue(undefined);
     wasm.wireVersion.mockReturnValue(2);
     vi.stubGlobal("WebSocket", FakeSocket);
   });
@@ -127,6 +174,8 @@ describe("WingfoilClient Hello version handling", () => {
     wasm.control = {};
     wasm.encodePayload.mockReset();
     wasm.encodePayload.mockReturnValue(new Uint8Array());
+    wasm.init.mockReset();
+    wasm.init.mockResolvedValue(undefined);
     wasm.wireVersion.mockReturnValue(2);
     vi.stubGlobal("WebSocket", FakeSocket);
   });


### PR DESCRIPTION
### Summary

- catch asynchronous `WingfoilClient.boot()` failures and emit an error connection state instead of leaving an unhandled rejection
- preserve the original `Error`, normalize non-Error rejection values, and avoid opening a WebSocket after initialization fails
- add focused initialization-failure tests and correct the stale native-test coverage comment

Closes #457

### Validation

- `pnpm test` — 42 passed
- `pnpm run lint`
- `pnpm run build:ts`
- `cargo test --manifest-path crates/wingfoil-wasm/Cargo.toml` — 8 passed
- `cargo fmt --all -- --check`
- `cargo lint`
- `cargo lint-all`
- `cargo nextest run -p wingfoil --all-features --lib --tests -E "not binary(/_integration$/)"` — 952 passed
- `cargo test --doc -p wingfoil --all-features` — 19 passed, 22 ignored
- `cargo test -p wingfoil-derive` — 3 passed
- repository pre-commit and pre-push hooks

A direct `cargo test -p wingfoil --all-features` also passed the 345 library tests and 20 Aeron adapter tests before entering the service-backed `aeron_integration` binary; that binary requires a Docker socket, which was unavailable locally. The CI-equivalent nextest command above compiles but filters service-backed integration binaries and passed completely.

### AI assistance

Implementation and test orchestration used OpenAI Codex assistance. The resulting patch was validated with the commands listed above.