### PR TITLE
ci: fix the two wheel builds the release run broke on

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -119,6 +119,17 @@ a skipped job would otherwise skip the tag with it. It keeps `all-tests` in its
 `needs` so that a skip caused by a red suite is not mistaken for a skip the
 dispatcher asked for.
 
+### Testing a change to how the wheels are built
+
+The wheel jobs only ever ran at release time, which is how two build breaks
+(a missing `rustfmt` component in the manylinux container, librdkafka's
+`./configure` on MSVC) got to be discovered by a release rather than by CI.
+Dispatch `pypi-publish.yml` with `pypi-target: dry-run` to build all five
+wheels and the sdist and upload none of them — the artifacts are attached to
+the run. `test` is not a substitute: TestPyPI takes a given version exactly
+once too, so a build fix that needs two attempts has nowhere to land the
+second.
+
 `crates-publish.yml` publishes six crates in dependency order, `wingfoil-wasm`
 among them — it is excluded from the root workspace, so it never appears in a
 `--workspace` build and was missed for several releases. Its verification build

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,13 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       pypi-target:
-        description: 'Choose PyPI target'
+        description: >-
+          Where to publish. `dry-run` builds every wheel and the sdist and
+          uploads nothing — what to use when changing how the wheels are BUILT,
+          because a version can only be uploaded once, to TestPyPI as much as
+          to PyPI, and a build fix should not have to spend one to prove
+          itself.
         required: true
         default: 'test'
         type: choice
         options:
           - test
           - prod
+          - dry-run
   workflow_call:
     inputs:
       pypi-target:
@@ -128,6 +134,16 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: '2_28'
+          # rustfmt, in a *build* job, because a build dependency shells out to
+          # it: rusteron-client's build.rs pipes its generated aeron bindings
+          # through rustfmt and panics outright when the component is missing
+          # ("rustfmt failed - likely syntax error in generated code: Broken
+          # pipe"). Nothing else in CI hit this because every other job takes
+          # its toolchain from dtolnay/rust-toolchain, whose default profile
+          # carries rustfmt — maturin-action installs the container's toolchain
+          # with `--profile minimal`, which does not. Only this leg needs it:
+          # aeron ships in the Linux wheel alone.
+          rustup-components: rustfmt
           # `--features` REPLACES the pyproject list rather than adding to it,
           # so `extension-module` has to be named again here. `all-adapters` is
           # the single source of truth for the full set — see Cargo.toml. The
@@ -276,6 +292,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [sdist, linux, macos, windows]
+    # `dry-run` stops here: everything above has already run, so the wheels are
+    # proven built (and downloadable as run artifacts) without spending the
+    # version. release.yml always passes `prod`, so a release can never take
+    # this branch by accident.
+    if: ${{ inputs.pypi-target != 'dry-run' }}
     # Trusted publishing (OIDC): the short-lived token is minted from this
     # job's identity, so there is no long-lived `*_PYPI_API_TOKEN` secret to
     # leak or rotate. Matches npm-publish.yml. `id-token: write` must ALSO be

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ version = "4.10.0+2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e234cf318915c1059d4921ef7f75616b5219b10b46e9f3a511a15eb4b56a3f77"
 dependencies = [
+ "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/crates/wingfoil/Cargo.toml
+++ b/crates/wingfoil/Cargo.toml
@@ -130,9 +130,11 @@ redis = { version = "0.27", features = [
 # (`rdkafka` is a tokio client). Version mirrors the legacy `wingfoil` crate's
 # kafka adapter so the two trees don't drift. As legacy does, the bundled
 # `librdkafka` uses rdkafka's default build path (`./configure` + `make`); the
-# `cmake-build` feature is deliberately not enabled (its curl.h dependency breaks
-# CI). `testcontainers` (used only by the integration tests) is already an
-# optional [dependencies] entry above, shared with the etcd adapter.
+# `cmake-build` feature is deliberately not enabled *on unix* (its curl.h
+# dependency breaks CI); the Windows override below is the exception, because
+# there the default path cannot work at all. `testcontainers` (used only by the
+# integration tests) is already an optional [dependencies] entry above, shared
+# with the etcd adapter.
 rdkafka = { version = "0.37", optional = true }
 
 # `web` feature: bidirectional WebSocket streaming between the graph and one or
@@ -285,6 +287,27 @@ tracing = { workspace = true, features = ["log", "attributes"], optional = true 
 # rather than the bench targets, so it cannot come from dev-dependencies.
 # Mirrors legacy wingfoil's optional `criterion` + `bench` feature exactly.
 criterion = { version = "0.8.1", optional = true }
+
+# --- Windows -----------------------------------------------------------------
+#
+# The same optional dependency as above, with one extra feature. A target table
+# does not *replace* the `[dependencies]` entry, it unions with it, so
+# `dep:rdkafka` still activates exactly one crate — this only adds
+# `cmake-build` when the target is Windows.
+#
+# It has to be added here, because rdkafka's default build path is
+# `./configure` + `make`, and `configure` is a shell script: MSVC runs it and
+# dies with `%1 is not a valid Win32 application (os error 193)`, which is what
+# broke the Windows wheel in the release job. `cmake-build` drives librdkafka's
+# own CMakeLists instead, and cmake is on the windows runners.
+#
+# The curl.h problem that keeps `cmake-build` off everywhere else does not
+# apply here: rdkafka-sys only looks for curl when its `curl`/`curl-static`
+# features are on, and passes `-DWITH_CURL=0` otherwise — which is the case for
+# us. Keep this Windows-only anyway; on unix the default path works and is what
+# every other job in CI has built.
+[target.'cfg(windows)'.dependencies]
+rdkafka = { version = "0.37", features = ["cmake-build"], optional = true }
 
 [dev-dependencies]
 # Installs the repo's git hooks from `.cargo-husky/hooks/` (pre-commit: fmt +

--- a/crates/wingfoil/src/adapters/kafka/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/kafka/CLAUDE.md
@@ -23,6 +23,15 @@ kafka-integration-test = ["kafka", "dep:testcontainers"]
 (`./configure` + `make`), **not** `cmake-build` — same as legacy; the cmake
 path's `curl.h` dependency breaks CI.
 
+**Windows is the exception**, and it is not a preference: `configure` is a
+shell script, so MSVC dies on it with `%1 is not a valid Win32 application`.
+A `[target.'cfg(windows)'.dependencies]` entry in `crates/wingfoil/Cargo.toml`
+adds `cmake-build` there and nowhere else (target tables union with
+`[dependencies]`, so it is still one crate). The curl.h problem does not follow
+it over: rdkafka-sys only looks for curl when its own `curl`/`curl-static`
+features are on, and passes `-DWITH_CURL=0` otherwise. This is what the
+Windows wheel in `pypi-publish.yml` builds against.
+
 ## Entry points
 
 | Item | Kind | Notes |


### PR DESCRIPTION
`release` #18 published crates.io and npm and then died in the PyPI leg with
three of five wheels red, so 9.0.0 exists in two registries, is absent from
the third, and has no tag. Two independent causes, one per platform.

**Linux (both arches) — rustfmt.** `rusteron-client`'s build.rs pipes its
generated aeron bindings through rustfmt and panics outright when the
component is missing ("rustfmt failed - likely syntax error in generated
code: Broken pipe"). Every other job in CI takes its toolchain from
dtolnay/rust-toolchain, whose default profile carries rustfmt;
maturin-action installs the container's toolchain with `--profile minimal`,
which does not. Ask for the component via `rustup-components`. Only this leg
needs it — aeron ships in the Linux wheel alone.

**Windows — librdkafka.** rdkafka's default build path is `./configure` +
`make`, and `configure` is a shell script, so MSVC dies on it with `%1 is not
a valid Win32 application (os error 193)`. Add rdkafka's `cmake-build`
feature through a `[target.'cfg(windows)'.dependencies]` entry, which unions
with the existing `[dependencies]` one rather than replacing it, so it is
still a single optional crate and unix keeps the default path. The curl.h
problem that keeps `cmake-build` off elsewhere does not follow it over:
rdkafka-sys looks for curl only when its own `curl`/`curl-static` features
are on and passes `-DWITH_CURL=0` otherwise. Verified with `cargo tree
-e features`: `cmake-build` resolves for x86_64-pc-windows-msvc and for no
other target.

Both breaks reached a release because the wheel jobs only ever run at release
time, and neither TestPyPI nor PyPI will take a version twice, so there was
nowhere to prove a build fix. Add a third `pypi-target`, `dry-run`, that
builds all five wheels and the sdist and skips the upload job; the wheels
come back as run artifacts. release.yml always passes `prod`, so a release
cannot take that branch by accident.