### PR TITLE
fix(pypi): publish as `wingfoil`, not `wingfoil-python`

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -119,6 +119,42 @@ a skipped job would otherwise skip the tag with it. It keeps `all-tests` in its
 `needs` so that a skip caused by a red suite is not mistaken for a skip the
 dispatcher asked for.
 
+### PyPI trusted publishing — what has to exist on PyPI
+
+The upload authenticates with OIDC, so there is no `*_PYPI_API_TOKEN` secret
+any more. 8.x published with one; the rewrite replaced it, which means the
+first release to *use* trusted publishing is the one that discovers whether it
+was ever set up. 9.0.0's upload failed with:
+
+```
+invalid-publisher: valid token, but no corresponding publisher
+```
+
+That is a PyPI-side configuration gap, not a workflow bug — nothing in this
+repo can fix it. The `wingfoil` project on PyPI needs a GitHub publisher:
+
+| Field | Value |
+|---|---|
+| Owner | `wingfoil-io` |
+| Repository | `wingfoil` |
+| Workflow name | `pypi-publish.yml` |
+| Environment | *(blank)* |
+
+**`pypi-publish.yml`, not `release.yml`**, and that is worth stating because
+npm is the other way round and the two look identical from here. PyPI looks a
+publisher up by the workflow filename in the **`job_workflow_ref`** claim —
+the workflow that *runs* the upload — and lists `workflow_ref`, which names
+the caller, among the claims it does not check
+([warehouse `GitHubPublisher.lookup_by_claims`][lookup]). npm validates
+`workflow_ref` instead, so its publisher is registered as `release.yml`
+(#912). Do not "make them consistent": doing that breaks whichever one you
+change.
+
+TestPyPI is a separate index with separate settings, so publishing there needs
+its own publisher registered the same way.
+
+[lookup]: https://github.com/pypi/warehouse/blob/main/warehouse/oidc/models/github.py
+
 ### Testing a change to how the wheels are built
 
 The wheel jobs only ever ran at release time, which is how two build breaks

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -335,6 +335,11 @@ jobs:
               ;;
           esac
 
+      # Needed by the name/version check below, which reads the version from
+      # the manifest rather than trusting the filenames it is checking.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -345,6 +350,16 @@ jobs:
       # Both the wheels and the sdist go up. Fail rather than publish a
       # half-populated release: an upload that quietly contained no wheels
       # would still report success.
+      #
+      # The name check is the other half, and it is not hypothetical: the 9.0.0
+      # release built `wingfoil_python-9.0.0-*` because `[project].name` had
+      # been set to the *crate* name, and every one of those files would have
+      # gone to a brand-new PyPI project while `pip install wingfoil` — what
+      # the READMEs and this workflow's own release notes tell users to run —
+      # stayed on 8.0.0. PyPI has no rename and no delete-and-reupload, so the
+      # cost of noticing afterwards is a burned version at best and a
+      # permanently forked package at worst. Check it here, where the failure
+      # is free.
       - name: Inspect what is about to be published
         run: |
           set -euo pipefail
@@ -356,6 +371,41 @@ jobs:
             echo "::error::expected 5 wheels and 1 sdist, got $wheels and $sdists"
             exit 1
           fi
+
+          # The distribution name is `wingfoil` while the crate is
+          # `wingfoil-python`; see the comment on `[project].name`. Both parts
+          # of every filename are checked against source, so a stale artifact
+          # from another run fails here too.
+          expected_name=wingfoil
+          expected_version=$(grep -m 1 '^version' crates/wingfoil-python/Cargo.toml | awk -F'"' '{print $2}')
+          echo "expecting ${expected_name}-${expected_version}"
+          # A prerelease version is spelled differently by Cargo and by PEP
+          # 440 (`1.0.0-beta.1` vs `1.0.0b1`), so only a plain x.y.z — all
+          # bump.yml can produce — is compared. The NAME is always compared:
+          # it is the half that cannot be undone.
+          case "$expected_version" in
+            *[!0-9.]* | '') check_version=no ;;
+            *) check_version=yes ;;
+          esac
+          for path in dist/*; do
+            file=$(basename "$path")
+            # Wheel: {name}-{version}-{python tag}-...; sdist: {name}-{version}.tar.gz.
+            # maturin writes the PEP 427 escaped name, so `-` in a name arrives
+            # as `_` — compare against the escaped form of what we expect.
+            name=${file%%-*}
+            rest=${file#*-}
+            version=${rest%%-*}
+            version=${version%.tar.gz}
+            if [ "$name" != "${expected_name//-/_}" ]; then
+              echo "::error::$file is not a ${expected_name} distribution — refusing to publish"
+              exit 1
+            fi
+            if [ "$check_version" = yes ] && [ "$version" != "$expected_version" ]; then
+              echo "::error::$file is not version ${expected_version} — refusing to publish"
+              exit 1
+            fi
+          done
+          echo "every file is ${expected_name} ${expected_version}"
 
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@v1.14.2

--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -79,8 +79,21 @@ and compose them from Python.
 
 ## Installation
 
-`wingfoil` is not on PyPI yet — the published `wingfoil` package is still
-the legacy engine. Until the cutover, install from a source checkout:
+```bash
+pip install wingfoil
+```
+
+`wingfoil` on PyPI is this engine from 9.0.0 on — the cutover took the name
+over rather than starting a second project beside it, so 8.x and earlier on
+that same name are the legacy engine. Wheels are published for Linux
+(x86_64/aarch64), macOS (Intel/Apple Silicon) and Windows x64, built against
+CPython's stable ABI, so one wheel per platform serves 3.9 and up.
+
+The Linux wheel carries every adapter. The macOS and Windows wheels carry the
+portable set — `iceoryx2` is Linux/POSIX-only and `aeron` builds a C library
+from source, so both are Linux-only in a published wheel.
+
+To build from a source checkout instead:
 
 ```bash
 git clone https://github.com/wingfoil-io/wingfoil

--- a/crates/wingfoil-python/docs/conf.py
+++ b/crates/wingfoil-python/docs/conf.py
@@ -44,7 +44,11 @@ def _release() -> str:
         from importlib.metadata import PackageNotFoundError, version
 
         try:
-            return version("wingfoil-python")
+            # The distribution is `wingfoil` (see pyproject.toml); only the
+            # crate is `wingfoil-python`. Looking the crate name up here found
+            # nothing and fell through to the module `__version__`, so the
+            # docs stamped a version without anyone noticing.
+            return version("wingfoil")
         except PackageNotFoundError:
             pass
     except ImportError:  # pragma: no cover - Python < 3.8

--- a/crates/wingfoil-python/docs/migration.rst
+++ b/crates/wingfoil-python/docs/migration.rst
@@ -25,10 +25,12 @@ The import
    - import wingfoil as wf
    + import wingfoil as wf
 
-The package is ``wingfoil-python`` on the index and ``wingfoil`` on
-``import``. The compiled extension underneath is the private
-``wingfoil._wingfoil``; the ``wingfoil`` package re-exports it
-wholesale, so you never name it.
+The package is ``wingfoil`` on the index *and* on ``import`` —
+``pip install wingfoil``, the same name 8.x published, because 9.0 takes that
+name over rather than starting a second project beside it. ``wingfoil-python``
+is the crate on crates.io, not the distribution on PyPI. The compiled
+extension underneath is the private ``wingfoil._wingfoil``; the ``wingfoil``
+package re-exports it wholesale, so you never name it.
 
 The graph is explicit
 ---------------------

--- a/crates/wingfoil-python/pyproject.toml
+++ b/crates/wingfoil-python/pyproject.toml
@@ -3,7 +3,22 @@ requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "wingfoil-python"
+# The **distribution** name, and it deliberately is not the crate name. Three
+# names are in play and only two of them match:
+#
+#   crates.io  wingfoil-python   (the crate — `crates/wingfoil-python`)
+#   PyPI       wingfoil          (this — `pip install wingfoil`)
+#   import     wingfoil          (`python/wingfoil`, see `module-name` below)
+#
+# 9.0 is a cutover, not a new line beside the old one: every name 8.x published
+# continues at 9.0.0 (docs/release-notes/9.0.0.md). Naming this distribution
+# after the crate would instead have started a *second* PyPI project and left
+# `pip install wingfoil` — which is what the root README, this crate's badges
+# and release.yml's own release notes all tell users to run — pinned to the
+# 8.0.0 legacy engine forever. PyPI has no rename and no delete-and-reupload,
+# so that mistake is not recoverable after one upload; the guard in
+# `pypi-publish.yml` fails the release rather than let it happen again.
+name = "wingfoil"
 dynamic = ["version"]
 description = "Python bindings for wingfoil (the Op-pattern stream processing engine)"
 readme = "README.md"
@@ -88,7 +103,7 @@ module-name = "wingfoil._wingfoil"
 # manifest that makes the vendored path dependencies (`wingfoil`,
 # `wingfoil-python-derive`) resolve — so an unqualified `include` of this
 # crate's own `Cargo.toml` collides with it and `maturin sdist` dies with
-# "File wingfoil_python-<v>/Cargo.toml was already added". Scoping the include
+# "File wingfoil-<v>/Cargo.toml was already added". Scoping the include
 # to the wheel keeps the manifest in the wheel, where it was wanted, and lets
 # the sdist build.
 include = [{ path = "Cargo.toml", format = "wheel" }]


### PR DESCRIPTION
## What this changes

The Python distribution publishes as **`wingfoil`** again, and the release refuses to upload anything not named that. The workflows README gains the PyPI trusted-publisher setup that `run #18` proved is missing.

## Why

With the wheels building ([run 32658083697](https://github.com/wingfoil-io/wingfoil/actions/runs/32658083697) — all 5 wheels + sdist green), the 9.0.0 upload got one step further and failed there. Two separate things behind it.

**1. `[project].name` was the crate name.** The run built:

```
wingfoil_python-9.0.0-cp39-abi3-manylinux_2_28_x86_64.whl   (+ 4 more)
wingfoil_python-9.0.0.tar.gz
```

Those would have created a *second*, empty PyPI project, while `pip install wingfoil` — what the root README, this crate's badges, `docs/release-notes/9.0.0.md` and `release.yml`'s own generated release notes all tell users to run — stayed pinned to the 8.0.0 legacy engine. 9.0 is a cutover: it takes the published names over rather than starting a line beside them.

Three names are in play and only two of them match, which is what made this easy to get wrong, so it is now stated where the name is set:

| | Name |
|---|---|
| crates.io | `wingfoil-python` |
| PyPI | `wingfoil` |
| `import` | `wingfoil` |

Two docs had already followed the crate name over: `docs/conf.py` looked the version up under `wingfoil-python`, found nothing, and silently fell through to the module's `__version__`; `migration.rst` told readers the index name was `wingfoil-python`. The README's install section still said the package was not on PyPI yet, from before the cutover.

**2. A guard, because this class of mistake is not recoverable.** PyPI has no rename and no delete-and-reupload, so a wrong name that lands costs a burned version at best and a permanently forked package at worst. The pre-upload step now checks every file in `dist/` against the name and the version in the manifest.

## How it was verified

- `maturin sdist` now writes `wingfoil-9.0.0.tar.gz` with `Name: wingfoil` in `PKG-INFO`, and the tarball still passes the workflow's own `cargo metadata` resolve check.
- The guard was extracted from the workflow and run against five cases: the exact filenames run #18 produced (fails), the fixed filenames (passes), a stale artifact from another version (fails), a short wheel count (fails), and a prerelease version (passes — Cargo and PEP 440 spell those differently, so only the name is compared there).
- `cargo fmt --all -- --check` clean. No Rust or Python source changed, so the crate test suites are untouched by this diff.

## Notes for the reviewer

**This does not make the release publishable on its own.** The upload also failed with:

```
invalid-publisher: valid token, but no corresponding publisher
```

8.x published with a `PROD_PYPI_API_TOKEN` secret; the rewrite moved to OIDC, so 9.0.0 is the first release to actually use trusted publishing — and no publisher is registered on PyPI. Nothing in this repo can fix that. The `wingfoil` project needs a GitHub publisher: owner `wingfoil-io`, repo `wingfoil`, workflow **`pypi-publish.yml`**, environment blank.

`pypi-publish.yml`, not `release.yml`, is worth double-checking because npm is the other way round: PyPI reads the workflow filename out of the `job_workflow_ref` claim (the workflow that runs the upload) and lists `workflow_ref` among the claims it does not check — see [`GitHubPublisher.lookup_by_claims`](https://github.com/pypi/warehouse/blob/main/warehouse/oidc/models/github.py); npm validates `workflow_ref`, which is why #912 registered it as `release.yml`.

Once that exists: merge this, then dispatch `release.yml` with `registries: pypi`. crates.io and npm already have 9.0.0 from run #18, no tag was cut, and nothing has been uploaded to PyPI — so 9.0.0 is still free there and no version bump is needed.

One judgment call worth confirming, since it is irreversible in one direction: I read the intended PyPI name as `wingfoil` on the strength of the badges, both READMEs, the 9.0.0 release notes table (``wingfoil-python`` | crates.io + PyPI (`pip install wingfoil`)) and `release.yml`'s notes template. If the rename to `wingfoil-python` was actually deliberate, this PR is backwards — but then the badges, the install lines and the release notes all need to change instead, and a pending publisher has to be registered for a project that does not exist yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzZ1kyQgAUqs6QVV38oNAQ)_