### PR TITLE
ci(pypi): publish without attestations

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -153,6 +153,16 @@ change.
 TestPyPI is a separate index with separate settings, so publishing there needs
 its own publisher registered the same way.
 
+That registration authenticates the upload but **cannot** also satisfy PEP 740
+attestations, which is where the reusable-workflow caveat actually bites: the
+Sigstore certificate's Build Config URI names the *caller* (`release.yml`)
+while the publisher names the workflow that runs the upload
+(`pypi-publish.yml`), and PyPI rejects the mismatch with a 400. Swapping the
+registration only moves the failure to the token exchange. So the upload runs
+with `attestations: false`, and the fix that lets them come back is to move
+the upload job into `release.yml` — where both claims name one workflow
+(#916).
+
 [lookup]: https://github.com/pypi/warehouse/blob/main/warehouse/oidc/models/github.py
 
 ### Testing a change to how the wheels are built

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -407,9 +407,24 @@ jobs:
           done
           echo "every file is ${expected_name} ${expected_version}"
 
+      # `attestations: false` is forced by this workflow being *reusable*, and
+      # it is the one thing about that structure PyPI genuinely cannot do.
+      # Two different claims name the workflow, and they disagree here:
+      #
+      #   token exchange  job_workflow_ref  -> pypi-publish.yml  (this file)
+      #   attestation     cert Build Config -> release.yml       (the caller)
+      #
+      # The publisher is registered as `pypi-publish.yml`, so auth succeeds and
+      # the upload is then rejected 400 — "Certificate's Build Config URI does
+      # not match expected Trusted Publisher". Registering `release.yml`
+      # instead just moves the failure to the token exchange
+      # (`invalid-publisher`). No single registration satisfies both, so the
+      # files publish without PEP 740 provenance until the upload moves into
+      # release.yml, where both claims name one workflow (#916).
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           packages-dir: dist
           repository-url: ${{ env.REPO_URL }}
+          attestations: false
           verbose: true


### PR DESCRIPTION
## What this changes

The PyPI upload runs with `attestations: false`. One input, plus the comment explaining why it is not a preference.

## Why

The trusted publisher is registered and **auth now works** — [run 32662094470](https://github.com/wingfoil-io/wingfoil/actions/runs/32662094470) got past the token exchange and failed one stage later, at upload:

```
400 Bad Request
Invalid attestations supplied during upload: Verification failed:
Certificate's Build Config URI (.../release.yml@refs/heads/main)
does not match expected Trusted Publisher (pypi-publish.yml @ wingfoil-io/wingfoil)
```

Two claims name the workflow, and in a reusable workflow they disagree:

| | Claim | Names |
|---|---|---|
| Token exchange | `job_workflow_ref` | `pypi-publish.yml` |
| Attestation | Sigstore cert Build Config URI | `release.yml` |

The publisher can only be registered as one of them. As `pypi-publish.yml`, auth passes and the attestation is rejected (above). As `release.yml`, the failure moves back to `invalid-publisher` at the token exchange, which is where run #19 was. So there is no registration that satisfies both — this is precisely what PyPI means when it says reusable workflows are unsupported.

Attestations off unblocks 9.0.0. The durable fix — move the upload job into `release.yml`, where both claims name one workflow and attestations verify — is #916.

## How it was verified

Not verified by a release run; that is the merge. The change is one action input, and the failure it addresses is quoted above verbatim. Everything ahead of this step already passed in run #21: web tests green, all 5 wheels and the sdist built, name/version guard passed, OIDC auth succeeded.

## Notes for the reviewer

The cost is real but narrow: the published files carry no PEP 740 provenance until #916 lands. Nothing else about the release changes, and no PyPI re-registration is needed for this PR — the publisher you added stays exactly as it is.

After merging: dispatch `release.yml` with `registries: pypi`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzZ1kyQgAUqs6QVV38oNAQ)_