### PR TITLE
fix(pypi): put the sdist's license files where its metadata says

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -427,4 +427,14 @@ jobs:
           packages-dir: dist
           repository-url: ${{ env.REPO_URL }}
           attestations: false
+          # An upload is not atomic: PyPI takes the files one at a time, so a
+          # rejection partway through leaves the ones before it published and
+          # nothing can take them back. 9.0.0's five wheels landed and its sdist
+          # was rejected, which left every re-dispatch failing on the wheels
+          # instead of retrying the sdist. Skip what is already there and upload
+          # the rest. What this does NOT wave through is the wrong thing being
+          # published: the step above still refuses any file that is not the
+          # name and version in the manifest, and preflight still refuses a
+          # version whose tag exists.
+          skip-existing: true
           verbose: true

--- a/crates/wingfoil-python/pyproject.toml
+++ b/crates/wingfoil-python/pyproject.toml
@@ -28,6 +28,13 @@ readme = "README.md"
 # interpreter the shipped wheel can load.
 requires-python = ">=3.9"
 license = "Apache-2.0"
+# Explicit, and load-bearing for the **sdist**. Left implicit, maturin still
+# writes `License-File: LICENSE.txt` / `NOTICE` into the metadata — paths PyPI
+# reads relative to the archive root — but lays the sdist out as the workspace,
+# so the files themselves land under `crates/wingfoil-python/` and the upload is
+# rejected 400: "License-File LICENSE.txt does not exist in distribution file".
+# Naming them here makes maturin copy them to the root the metadata promises.
+license-files = ["LICENSE.txt", "NOTICE"]
 # The `Python :: X.Y` entries are what PyPI (and the README's
 # `pypi/pyversions` badge) read to report supported interpreters — neither
 # looks at `requires-python`. There is no longer a per-version build matrix to


### PR DESCRIPTION
## What this changes

`license-files` is declared explicitly, so the sdist carries `LICENSE.txt` and `NOTICE` at its root. The upload also gains `skip-existing`.

## Why

**The five wheels published.** `pip install wingfoil` now gets 9.0.0 on Linux x86_64/aarch64, macOS Intel/Apple Silicon and Windows x64. The sdist was rejected, and it was the last file:

```
400 Bad Request
License-File LICENSE.txt does not exist in distribution file
wingfoil-9.0.0.tar.gz at wingfoil-9.0.0/LICENSE.txt
```

Both halves of that are maturin's, and they disagree with each other. It finds `LICENSE.txt` and `NOTICE` beside the crate's `pyproject.toml` and records them in the metadata — where PyPI reads them relative to the **archive root** — but it lays the sdist out as the workspace, so the files land under `crates/wingfoil-python/` and the root has neither:

```
wingfoil-9.0.0/PKG-INFO                              License-File: LICENSE.txt
                                                     License-File: NOTICE
wingfoil-9.0.0/crates/wingfoil-python/LICENSE.txt    <- actually here
wingfoil-9.0.0/crates/wingfoil-python/NOTICE
```

Naming them in `[project] license-files` makes maturin copy them to the root the metadata promises. The wheels were never affected — their copies go into `.dist-info/licenses/` — which is exactly why five files uploaded and the sixth did not.

`skip-existing` is for the state this leaves behind. An upload is not atomic: PyPI takes the files one at a time and cannot take back the ones it accepted, so with the wheels already published every re-dispatch would fail on them rather than retry the sdist. It does not loosen what may be published — the inspect step still refuses any file that is not the name and version in the manifest, and preflight still refuses a version whose tag already exists.

## How it was verified

Rebuilt the sdist and ran PyPI's own rule over it — every `License-File` in `PKG-INFO` must resolve inside the tarball:

```
declares 'LICENSE.txt' -> wingfoil-9.0.0/LICENSE.txt PRESENT
declares 'NOTICE'      -> wingfoil-9.0.0/NOTICE      PRESENT
warehouse license-file check: PASS
```

Both were MISSING before the change. Also `twine check`: PASSED, and the workflow's own `cargo metadata` resolve against the unpacked tarball still succeeds. `Name: wingfoil`, `Version: 9.0.0`, `License-Expression: Apache-2.0` unchanged.

## Notes for the reviewer

After merging, dispatch `release.yml` with `registries: pypi`. The wheels skip as already-present, the sdist uploads, and the tag and GitHub release — still not cut — follow.

One consequence worth naming: the published 9.0.0 wheels were built from `cd23862`, so they do not contain this commit. That is invisible to users (the change only moves two files inside the sdist) but it does mean the tag will not be byte-identical to what the wheels were built from.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzZ1kyQgAUqs6QVV38oNAQ)_