### PR TITLE
perf(zmq): avoid publisher hot-path polling and cloning

### DIFF
--- a/crates/wingfoil/src/adapters/zmq.rs
+++ b/crates/wingfoil/src/adapters/zmq.rs
@@ -107,7 +107,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use wingfoil::RunMode;
 
 use crate::Burst;
@@ -211,6 +211,25 @@ enum WireMessage<T> {
     /// [`run_subscriber`]) to route the error through the same match arm, and
     /// a legacy peer may send it.
     Error(String),
+}
+
+/// Borrowed encoding of [`WireMessage::Value`].
+///
+/// `bincode` serializes enum variants by index, so this wrapper emits index 3
+/// directly while borrowing the stream value instead of cloning it into an
+/// owned [`WireMessage`].
+struct BorrowedValue<'a, T>(&'a T);
+
+impl<T> Serialize for BorrowedValue<'_, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_newtype_variant("WireMessage", 3, "Value", self.0)
+    }
 }
 
 /// Serialize the payload-free `EndOfStream` frame. The variant carries no `T`,
@@ -546,7 +565,9 @@ impl ZmqPubState {
 
     /// Publish (or buffer) one already-serialized message.
     fn publish(&mut self, data: Vec<u8>) -> Result<()> {
-        self.check_monitor();
+        if !self.subscriber_connected {
+            self.check_monitor();
+        }
         if !self.subscriber_connected
             && let Some(accepted_at) = self.accepted_at
         {
@@ -663,7 +684,7 @@ where
                       _s: &mut (),
                       value: &T,
                       _ctx: &mut Ctx<'_>| {
-                    let data = bincode::serialize(&WireMessage::Value(value.clone()))
+                    let data = bincode::serialize(&BorrowedValue(value))
                         .context("zmq_pub: serializing message")?;
                     state.borrow_mut().publish(data)?;
                     Ok(Tick::Value(()))
@@ -721,12 +742,11 @@ mod tests {
     /// level.
     ///
     /// The expected bytes are written out longhand rather than compared against
-    /// legacy's encoder, because legacy's `Message` is `pub(crate)` and cannot
-    /// be reached from here — and because a golden encoding catches a drift on
-    /// *either* side, where a cross-check against the neighbouring crate would
-    /// silently follow it if both moved together. The behavioural half of this
-    /// (a real legacy socket at the other end) is
-    /// `tests/zmq_cross_engine_integration.rs`.
+    /// legacy's encoder, because that retired type was `pub(crate)` and cannot
+    /// be reached from here — and because a golden encoding catches drift
+    /// without following a neighbouring implementation. The current
+    /// behavioural half is `tests/zmq_cross_lang_integration.rs`, which sends
+    /// these frames over real sockets between Rust and Python peers.
     ///
     /// bincode 1.x encodes an enum as a little-endian u32 variant index
     /// followed by the payload, so these indices *are* legacy's declaration
@@ -736,6 +756,11 @@ mod tests {
         // RealtimeValue(7u64) — index 3, then the u64 little-endian.
         let value = bincode::serialize(&WireMessage::Value(7u64)).unwrap();
         assert_eq!(value, vec![3, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0]);
+
+        // The publisher's borrowed encoding must be byte-identical without
+        // cloning the payload into an owned WireMessage.
+        let borrowed_value = bincode::serialize(&BorrowedValue(&7u64)).unwrap();
+        assert_eq!(borrowed_value, value);
 
         // EndOfStream — index 1, no payload.
         assert_eq!(end_of_stream_bytes().unwrap(), vec![1, 0, 0, 0]);

--- a/crates/wingfoil/src/adapters/zmq/CLAUDE.md
+++ b/crates/wingfoil/src/adapters/zmq/CLAUDE.md
@@ -19,14 +19,14 @@ adapters/
 ## Feature gating
 
 ```toml
-zmq = ["dep:zmq", "dep:bincode", "dep:serde"]
+zmq = ["dep:zmq", "dep:bincode"]
 zmq-integration-test = ["zmq"]                              # real sockets, no service
 zmq-etcd-integration-test = ["zmq", "etcd", "dep:testcontainers"]
 ```
 
 **No `async`** — deliberately, matching legacy: ZeroMQ sockets are synchronous
 and poll-based, so the subscriber uses a background thread over the `channel`
-layer. The `zmq` crate links the system `libzmq`.
+layer. `zmq-sys` 0.12 builds its bundled libzmq through `zeromq-src`.
 
 Discovery is a **pluggable backend** behind the `ZmqRegistry` trait: `zmq`
 alone works for direct addresses; with the `etcd` feature also on,
@@ -76,25 +76,32 @@ zmq_sub::<Vec<u8>>(&g, RunMode::RealTime, ("quotes", EtcdRegistry::new(conn)))?;
   compressed the whole handshake into the first publish and made
   `first_message_not_dropped` flaky under CI load (register **A6** — the same
   bug, diagnosed).
+- **The publisher monitor is startup-only.** Poll it while
+  `subscriber_connected` is false; after the first accepted connection and
+  propagation delay, polling it again adds a `zmq::poll` syscall to every
+  published message without observing any state the publisher uses.
+- **Value frames borrow their payload.** `BorrowedValue` writes bincode variant
+  index 3 directly, avoiding a payload clone on every publish. Keep that index
+  aligned with `WireMessage::Value` and the golden wire-format test.
 - **The publisher errors under historical replay**, it does not no-op. That is
   legacy parity and a deliberate exception to the skill's exporter default:
   publishing fast-forwarded historical data to a live socket is meaningless.
   The abort happens at `start()`, naming the run mode, **before** touching the
   registry.
-- **The wire envelope is `bincode` and wingfoil-local** — a wingfoil publisher
-  interoperates with a wingfoil subscriber but is **not** wire-compatible with a
-  legacy/Python `wingfoil` peer (register **C2**, deferred with the Python
-  bindings).
+- **The wire envelope is `bincode` and legacy-compatible.** Variant order is
+  the wire format: the golden-byte unit test pins it, and the cross-language
+  integration test proves current Rust/Python interoperability.
 - No locks on the graph path: the subscriber thread talks to the graph only
   through `ChannelSender`.
 
 ## Deviations from legacy
 
-Canonical list: the `# Deviations from legacy` block in `zmq.rs` — three
+Canonical list: the `# Deviations from legacy` block in `zmq.rs` — two
 items: `zmq_sub` takes a `GraphBuilder` + `RunMode` (needed for the wiring
-rejection, since wingfoil's channel is bimodal); `zmq_pub` returns `Stream<()>`
-with bind/registration/run-mode-check at `start()`; and the wingfoil-local wire
-envelope (C2). Two smaller reductions: `ZmqEvent<T>` is private here (legacy
+rejection, since wingfoil's channel is bimodal), and `zmq_pub` returns
+`Stream<()>` with bind/registration/run-mode-check at `start()`. The wire
+envelope is byte-compatible and resolved deviation C2. Two smaller reductions:
+`ZmqEvent<T>` is private here (legacy
 exposed it, but it is purely an internal transport detail), and `ZmqStatus`
 additionally derives `Eq`. Every legacy capability — sub with a status stream,
 pub with slow-joiner buffering, the `ZmqRegistry`/`EtcdRegistry` backend,
@@ -107,7 +114,6 @@ pub with slow-joiner buffering, the `ZmqRegistry`/`EtcdRegistry` backend,
 | `tests/zmq_adapter.rs` | `#![cfg(feature = "zmq")]` | nothing |
 | `tests/zmq_integration.rs` | `#![cfg(feature = "zmq-integration-test")]` | real loopback sockets, no service |
 | `tests/zmq_etcd_integration.rs` | `#![cfg(feature = "zmq-etcd-integration-test")]` | an etcd container |
-| `tests/zmq_cross_engine_integration.rs` | `#![cfg(feature = "zmq-cross-engine-test")]` | real sockets + the legacy crate's zmq adapter |
 | `tests/zmq_cross_lang_integration.rs` | `#![cfg(feature = "zmq-cross-lang-test")]` | real sockets + `maturin develop`; the `etcd` half also needs a container |
 
 Port allocation, so tests never collide when run in parallel:
@@ -117,7 +123,6 @@ Port allocation, so tests never collide when run in parallel:
 | 5701–5702 | `zmq_adapter.rs` |
 | 5711–5716 | `zmq_integration.rs` |
 | 5721–5724 | `zmq_etcd_integration.rs` |
-| 5731–5732 | `zmq_cross_engine_integration.rs` |
 | 5741–5744 | `zmq_cross_lang_integration.rs` |
 | 5599–5602 | `wingfoil-python`'s `test_zmq.py` |
 
@@ -125,7 +130,6 @@ Port allocation, so tests never collide when run in parallel:
 cargo test -p wingfoil --features zmq --test zmq_adapter
 cargo test -p wingfoil --features zmq-integration-test -- --test-threads=1
 cargo test -p wingfoil --features zmq-etcd-integration-test -- --test-threads=1
-cargo test -p wingfoil --features zmq-cross-engine-test -- --test-threads=1
 # needs `maturin develop` in crates/wingfoil-python first
 cargo test -p wingfoil --features zmq-cross-lang-test -- --test-threads=1
 cargo test -p wingfoil --features zmq-cross-lang-etcd-test -- --test-threads=1
@@ -136,18 +140,17 @@ cargo test -p wingfoil --features zmq-cross-lang-etcd-test -- --test-threads=1
 module. `first_message_not_dropped` is the slow-joiner regression guard — if
 you touch bind timing, run it repeatedly under load.
 
-### The wire contract, and the two files that hold it
+### The wire contract, and the tests that hold it
 
 `WireMessage<T>` is **byte-compatible with legacy's `channel::Message<T>`**, so
 a wingfoil publisher is read by a legacy or legacy-Python subscriber and vice
 versa. `bincode` encodes an enum as an index into declaration order, so
 **reordering those variants silently reinterprets every message** — no error,
-just wrong values. Three tiers guard it:
+just wrong values. Two tiers guard it:
 
 | Where | What it proves |
 |---|---|
-| `wire_format_matches_legacy_message` (unit) | wingfoil's own encoding, against golden bytes |
-| `zmq_cross_engine_integration.rs` | legacy actually agrees — real sockets, both directions. **Retires with the legacy tree** |
+| `wire_format_matches_legacy_message` (unit) | owned and borrowed value encodings against golden legacy bytes |
 | `zmq_cross_lang_integration.rs` | Rust ↔ Python agree. Survives the cutover |
 
 The golden-bytes test is deliberately longhand rather than a cross-check
@@ -160,13 +163,14 @@ does not work — a silently-skipped interop test is how a broken binding reache
 a release green.
 
 **Workflow:** `.github/workflows/zmq-integration.yml` (in
-`integration-tests.yml`) runs the integration, cross-engine and cross-language
-feature sets. The cross-language leg builds the Python bindings with `maturin
-develop` first.
+`integration-tests.yml`) runs the core, etcd-discovery, Python, and
+cross-language feature sets. The cross-language leg builds the Python bindings
+with `maturin develop` first.
 
 ## Example
 
-`examples/zmq_adapter.rs`, `required-features = ["zmq"]`.
+`examples/adapters/zmq/main.rs`, registered as `zmq_adapter` with
+`required-features = ["zmq"]`.
 
 ## Python
 

--- a/crates/wingfoil/tests/zmq_cross_lang_integration.rs
+++ b/crates/wingfoil/tests/zmq_cross_lang_integration.rs
@@ -6,13 +6,10 @@
 //! with legacy's `wingfoil` module swapped for `wingfoil` and its
 //! wiring translated to wingfoil's `Graph`-first Python API.
 //!
-//! Together with `zmq_cross_engine_integration.rs` these close deviation-
-//! register **C2** (cutover-plan row 2.3). The split is worth keeping straight:
-//!
-//! - *cross-engine* proves wingfoil and **legacy** agree on the wire, and dies with
-//!   the legacy tree.
-//! - *cross-language* (this file) proves Rust and **Python** agree,
-//!   and survives the cutover as the permanent interop test.
+//! This is the permanent interop coverage for resolved deviation-register
+//! **C2** (cutover-plan row 2.3): the former cross-engine test retired with the
+//! legacy tree, while this file continues to prove Rust and Python agree on the
+//! wire.
 //!
 //! Requires the Python module to be importable — run
 //! `maturin develop` in `crates/wingfoil-python` first. A missing module is


### PR DESCRIPTION
## What this changes

- Stops polling the publisher monitor after the first subscriber has completed its connection propagation window.
- Serializes `WireMessage::Value` through a borrowed wrapper, removing the per-message payload clone while preserving bincode variant index 3.
- Extends the golden wire-format regression and refreshes the ZMQ maintenance notes that describe the active test and compatibility contract.

## Why

The publisher hot path kept performing a non-blocking `zmq::poll` after the only event it consumes had already been observed, and cloned every payload solely to construct an owned serialization envelope. Restoring the legacy one-shot monitor guard and borrowing the serialized value removes both costs without changing socket, buffering, or wire behavior.

Closes #826.

## How it was verified

- [x] `cargo fmt --all`
- [x] Upstream Linux `Test (wingfoil)`
- [x] Upstream Linux `Lint (fmt & clippy)`
- [x] Upstream Python interop and security checks
- [x] Fork-dispatched [ZMQ integration workflow](https://github.com/maxi-maxima/wingfoil/actions/runs/32683109779): core pub/sub, etcd discovery, Python discovery, and Rust ↔ Python cross-language tests
- [x] New behavior is covered by a golden byte regression
- [x] `cargo metadata --no-deps --format-version 1`
- [x] `git diff --check`

The Windows host lacks the MSVC `link.exe`, so local Cargo commands that compile dependencies stop before project code. The upstream Linux matrix and the adapter-specific workflow provide the build, lint, and runtime evidence instead.

## Notes for the reviewer

`BorrowedValue` deliberately uses `Serializer::serialize_newtype_variant("WireMessage", 3, "Value", value)`. The unit test compares that encoding to the owned enum encoding, which is independently pinned to the longhand legacy bytes.

The ZMQ maintenance guide already contained stale post-cutover references (the retired cross-engine test, resolved C2 deviation, old example path, and old feature list). They are corrected here because this change adds the new hot-path invariants to that living document.
