### PR TITLE
perf(core): trim demux hot-path overhead

### DIFF
--- a/crates/wingfoil/src/interp.rs
+++ b/crates/wingfoil/src/interp.rs
@@ -4234,9 +4234,9 @@ impl Builder {
         let idxs_cycle = child_indices.clone();
         let publish = parent_out.clone();
         let cycle: CycleFn = Box::new(move |_k| {
-            let value = source_slot.borrow().clone();
-            *publish.borrow_mut() = value.clone();
-            let slot = route(&value).min(size); // `>= size` → overflow (last entry)
+            let source = source_slot.borrow();
+            let slot = route(&source).min(size); // `>= size` → overflow (last entry)
+            *publish.borrow_mut() = source.clone();
             let target = idxs_cycle.borrow()[slot];
             marks.borrow_mut().push(target);
             Ok(false)
@@ -4360,6 +4360,8 @@ impl Builder {
             for row in rows.iter_mut() {
                 row.clear();
             }
+            let child_indices = idxs_cycle.borrow();
+            let mut marks = marks.borrow_mut();
             for item in items {
                 let (key, event) = func(&item);
                 let slot = match event {
@@ -4368,8 +4370,8 @@ impl Builder {
                 }
                 .unwrap_or(capacity); // overflow slot == capacity (last row)
                 rows[slot].push(item);
-                let target = idxs_cycle.borrow()[slot];
-                marks.borrow_mut().push(target);
+                let target = child_indices[slot];
+                marks.push(target);
             }
             Ok(false)
         });

--- a/crates/wingfoil/tests/demux.rs
+++ b/crates/wingfoil/tests/demux.rs
@@ -7,6 +7,8 @@
 //! so it is available (and must stay tested) on default features, exactly as
 //! legacy's ungated `nodes/demux.rs` is.
 
+use std::cell::Cell;
+use std::rc::Rc;
 use std::time::Duration;
 
 use wingfoil::interp::DemuxEvent;
@@ -14,6 +16,31 @@ use wingfoil::prelude::*;
 use wingfoil::{NanoTime, RunFor, RunMode};
 
 const HISTORICAL: RunMode = RunMode::HistoricalFrom(NanoTime::ZERO);
+
+#[derive(Debug)]
+struct CloneCounted {
+    value: usize,
+    clones: Rc<Cell<usize>>,
+}
+
+impl Clone for CloneCounted {
+    fn clone(&self) -> Self {
+        self.clones.set(self.clones.get() + 1);
+        Self {
+            value: self.value,
+            clones: self.clones.clone(),
+        }
+    }
+}
+
+impl Default for CloneCounted {
+    fn default() -> Self {
+        Self {
+            value: 0,
+            clones: Rc::new(Cell::new(0)),
+        }
+    }
+}
 
 /// `demux` fixed-topology routing (twin of legacy `demux`, `nodes/demux.rs`):
 /// the parent marks exactly the routed child each cycle — same-cycle, via the
@@ -35,6 +62,42 @@ fn demux_routes_each_value_to_its_child() {
     // selected cycles (accumulate collects only ticked values).
     assert_eq!(runner.value(&c0), vec![2u64, 4, 6], "child 0 (even)");
     assert_eq!(runner.value(&c1), vec![1u64, 3, 5], "child 1 (odd)");
+}
+
+/// Routing borrows the source value before publishing it. A single activation
+/// therefore clones the payload only once into the parent slot and once into
+/// the selected child slot; routing itself does not require an owned copy.
+#[test]
+fn demux_routes_before_cloning_the_source_value() {
+    let clones = Rc::new(Cell::new(0));
+    let clones_for_source = clones.clone();
+    let clones_seen_by_route = Rc::new(Cell::new(None));
+    let route_observation = clones_seen_by_route.clone();
+
+    let g = GraphBuilder::new();
+    let source = g
+        .ticker(Duration::from_nanos(1))
+        .map(move |_| CloneCounted {
+            value: 0,
+            clones: clones_for_source.clone(),
+        })
+        .handle();
+    let _ = g.with_builder(|b| {
+        b.demux(source, 1, move |value: &CloneCounted| {
+            route_observation.set(Some(value.clones.get()));
+            value.value
+        })
+    });
+
+    let mut runner = g.build();
+    runner.run(HISTORICAL, RunFor::Cycles(1)).unwrap();
+
+    assert_eq!(
+        clones_seen_by_route.get(),
+        Some(0),
+        "route runs on a borrow"
+    );
+    assert_eq!(clones.get(), 2, "one parent clone and one child clone");
 }
 
 /// `demux` overflow: a routed slot `>= size` lands on the overflow child.


### PR DESCRIPTION
## What this changes

Routes `demux` directly from the borrowed source value so each activation performs only the publication clone, and hoists `demux_it`'s child-index and mark-buffer `RefCell` borrows out of the per-item loop. Adds a clone-count regression that pins the hot-path invariant.

## Why

`demux` previously cloned every routed payload twice in its parent node, while `demux_it` reacquired two loop-invariant borrows for every item in a burst. Both costs sit on the deliberately ungated routing path.

Closes #827.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [x] `cargo metadata --no-deps --format-version 1`
- [x] `git diff --check`
- [x] Upstream `Test (wingfoil)` (includes `--all-features`)
- [x] Upstream `Lint (fmt & clippy)`
- [x] Upstream Python Interop, Cargo/pnpm audits, and dependency review

The focused local test attempt was blocked before project code compiled because this Windows host has no MSVC `link.exe`; the upstream Linux matrix compiled and ran the change successfully.

## Notes for the reviewer

The route closure still receives `&T`; the source `Ref` remains live only through routing and the single publication clone. `demux_it` holds the two loop-invariant borrows for the duration of the burst, with no additional aliasing surface inside the loop.
