### PR TITLE
ci(pypi): restore release attestations

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -125,12 +125,13 @@ Two dispatches, in this order:
    commit straight to `main`.
 2. `release.yml` — everything else, in one run.
 
-`release.yml` drives the three publish workflows itself. `crates-publish.yml`
-and `pypi-publish.yml` can be dispatched by hand for recovery;
-**`npm-publish.yml` cannot**, and is `workflow_call`-only for that reason — npm
-matches its trusted publisher against the workflow a run *entered* through, so
-only one of the two entry points can ever authenticate. `release.yml` is the
-registered one. Recover npm through the `registries` input below instead.
+`release.yml` drives all three publish paths. `pypi-publish.yml` builds the
+Python distributions, then an upload job defined in `release.yml` publishes
+them with attestations. A direct dispatch of `pypi-publish.yml` remains the
+TestPyPI rehearsal and dry-run path. **`npm-publish.yml` cannot be dispatched
+directly** because npm matches its trusted publisher against the workflow a run
+entered through. Recover a production publish through the `registries` input
+below.
 
 Its order is **publish first, tag last**:
 
@@ -140,15 +141,15 @@ preflight ─> all tests ─┬─> crates.io ─┐
                         └─> PyPI       ┘
 ```
 
-The tag used to come *before* the three publishes, which made a publish
+The tag used to come *before* the three registry publishes, which made a publish
 failure unrecoverable: the tag was already pushed, so the preflight's
 `Fail if tag already exists` check blocked every re-run until someone deleted
 the tag by hand. Nothing consumed the tag — each publish job checks out the
-dispatched commit, not the tag — so moving it after them costs nothing and
-means a failed release leaves no trace to clean up. `github-release` still
-comes last of all, because `gh release create --verify-tag` needs the tag, and
-because an announcement pointing at versions nobody can install is worse than
-no announcement.
+dispatched commit or artifacts built from that commit, not the tag — so moving
+it after them costs nothing and means a failed release leaves no trace to clean
+up. `github-release` still comes last of all, because
+`gh release create --verify-tag` needs the tag, and because an announcement
+pointing at versions nobody can install is worse than no announcement.
 
 ### Recovering a partial publish
 
@@ -159,7 +160,7 @@ uploaded".
 
 The `registries` input is the way out. Dispatch `release.yml` again with it set
 to the registry that still needs publishing (`crates`, `npm` or `pypi`) and the
-other two publish jobs skip. Preflight and the full test suite still run, and
+other two registry paths skip. Preflight and the full test suite still run, and
 the tag and GitHub release are still cut at the end — the tag was never pushed
 by the failed run, so the recovery run is what completes the release.
 
@@ -180,37 +181,22 @@ invalid-publisher: valid token, but no corresponding publisher
 ```
 
 That is a PyPI-side configuration gap, not a workflow bug — nothing in this
-repo can fix it. The `wingfoil` project on PyPI needs a GitHub publisher:
+repo can fix it. Production and test use separate indexes and entry-point
+workflows, so each needs its own GitHub publisher:
 
-| Field | Value |
-|---|---|
-| Owner | `wingfoil-io` |
-| Repository | `wingfoil` |
-| Workflow name | `pypi-publish.yml` |
-| Environment | *(blank)* |
+| Index | Owner | Repository | Workflow name | Environment |
+|---|---|---|---|---|
+| PyPI | `wingfoil-io` | `wingfoil` | `release.yml` | *(blank)* |
+| TestPyPI | `wingfoil-io` | `wingfoil` | `pypi-publish.yml` | *(blank)* |
 
-**`pypi-publish.yml`, not `release.yml`**, and that is worth stating because
-npm is the other way round and the two look identical from here. PyPI looks a
-publisher up by the workflow filename in the **`job_workflow_ref`** claim —
-the workflow that *runs* the upload — and lists `workflow_ref`, which names
-the caller, among the claims it does not check
-([warehouse `GitHubPublisher.lookup_by_claims`][lookup]). npm validates
-`workflow_ref` instead, so its publisher is registered as `release.yml`
-(#912). Do not "make them consistent": doing that breaks whichever one you
-change.
-
-TestPyPI is a separate index with separate settings, so publishing there needs
-its own publisher registered the same way.
-
-That registration authenticates the upload but **cannot** also satisfy PEP 740
-attestations, which is where the reusable-workflow caveat actually bites: the
-Sigstore certificate's Build Config URI names the *caller* (`release.yml`)
-while the publisher names the workflow that runs the upload
-(`pypi-publish.yml`), and PyPI rejects the mismatch with a 400. Swapping the
-registration only moves the failure to the token exchange. So the upload runs
-with `attestations: false`, and the fix that lets them come back is to move
-the upload job into `release.yml` — where both claims name one workflow
-(#916).
+PyPI looks a publisher up by the workflow filename in the
+**`job_workflow_ref`** claim and lists `workflow_ref`, which names the caller,
+among the claims it does not check
+([warehouse `GitHubPublisher.lookup_by_claims`][lookup]). Sigstore attestations
+identify the caller instead. Defining the production upload in `release.yml`
+makes both identities agree, so the trusted-publishing action can emit PEP 740
+attestations. The direct TestPyPI upload also has one identity because
+`pypi-publish.yml` is its entry point.
 
 [lookup]: https://github.com/pypi/warehouse/blob/main/warehouse/oidc/models/github.py
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,24 +5,17 @@ on:
     inputs:
       pypi-target:
         description: >-
-          Where to publish. `dry-run` builds every wheel and the sdist and
-          uploads nothing — what to use when changing how the wheels are BUILT,
-          because a version can only be uploaded once, to TestPyPI as much as
-          to PyPI, and a build fix should not have to spend one to prove
-          itself.
+          Whether to upload to TestPyPI. `dry-run` builds every wheel and the
+          sdist and uploads nothing — what to use when changing how the wheels
+          are BUILT, because a version can only be uploaded once and a build
+          fix should not have to spend one to prove itself.
         required: true
         default: 'test'
         type: choice
         options:
           - test
-          - prod
           - dry-run
   workflow_call:
-    inputs:
-      pypi-target:
-        description: 'Choose PyPI target (test or prod)'
-        required: true
-        type: string
 
 # Read-only by default. The upload job re-declares `id-token: write` for
 # itself; nothing else in this workflow needs a token of any kind.
@@ -287,54 +280,24 @@ jobs:
           name: dist-windows-x64
           path: dist
 
-  upload-pypi:
-    name: Upload to PyPI
+  upload-testpypi:
+    name: Upload to TestPyPI
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [sdist, linux, macos, windows]
-    # `dry-run` stops here: everything above has already run, so the wheels are
-    # proven built (and downloadable as run artifacts) without spending the
-    # version. release.yml always passes `prod`, so a release can never take
-    # this branch by accident.
-    if: ${{ inputs.pypi-target != 'dry-run' }}
+    # `pypi-target` is declared only under `workflow_dispatch`, so a non-empty
+    # value proves this file is the entry point. Under `workflow_call`,
+    # `github.event_name` reflects the caller and cannot distinguish this path.
+    if: ${{ inputs.pypi-target == 'test' }}
     # Trusted publishing (OIDC): the short-lived token is minted from this
-    # job's identity, so there is no long-lived `*_PYPI_API_TOKEN` secret to
-    # leak or rotate. Matches npm-publish.yml. `id-token: write` must ALSO be
-    # granted by the caller when this runs via `workflow_call` — reusable
-    # workflow permissions are capped by the caller — which release.yml does.
-    #
-    # Both PyPI and TestPyPI need a publisher registered for
-    # wingfoil-io/wingfoil + `pypi-publish.yml` (no environment) before this can
-    # succeed — this file's own name, because PyPI matches the workflow that
-    # *runs* the publish. npm does not: it matches the entry point, so its
-    # publisher is registered as `release.yml`. Do not "make them consistent".
+    # job's identity, so there is no long-lived API token to leak or rotate.
+    # TestPyPI needs a publisher registered for wingfoil-io/wingfoil +
+    # `pypi-publish.yml` (no environment). The production PyPI publisher is
+    # `release.yml`, where the production upload job now lives.
     permissions:
       contents: read
       id-token: write
     steps:
-      # Read `inputs.pypi-target`, NOT `github.event.inputs.pypi-target`. The
-      # `inputs` context carries the value for both triggers (workflow_dispatch
-      # *and* workflow_call). `github.event.inputs` is only populated for a
-      # direct workflow_dispatch — on a workflow_call it reflects the *caller's*
-      # triggering event, which for release.yml is a dispatch with no inputs, so
-      # the value was empty and this step silently fell through to TestPyPI while
-      # still reporting success. Fail loudly on anything unexpected instead of
-      # defaulting to test, so a misrouted release can never masquerade as green.
-      - name: Set PyPI target
-        run: |
-          case "${{ inputs.pypi-target }}" in
-            prod)
-              echo "REPO_URL=https://upload.pypi.org/legacy/" >> $GITHUB_ENV
-              ;;
-            test)
-              echo "REPO_URL=https://test.pypi.org/legacy/" >> $GITHUB_ENV
-              ;;
-            *)
-              echo "::error::pypi-target must be 'test' or 'prod', got '${{ inputs.pypi-target }}'"
-              exit 1
-              ;;
-          esac
-
       # Needed by the name/version check below, which reads the version from
       # the manifest rather than trusting the filenames it is checking.
       - name: Checkout repository
@@ -407,26 +370,14 @@ jobs:
           done
           echo "every file is ${expected_name} ${expected_version}"
 
-      # `attestations: false` is forced by this workflow being *reusable*, and
-      # it is the one thing about that structure PyPI genuinely cannot do.
-      # Two different claims name the workflow, and they disagree here:
-      #
-      #   token exchange  job_workflow_ref  -> pypi-publish.yml  (this file)
-      #   attestation     cert Build Config -> release.yml       (the caller)
-      #
-      # The publisher is registered as `pypi-publish.yml`, so auth succeeds and
-      # the upload is then rejected 400 — "Certificate's Build Config URI does
-      # not match expected Trusted Publisher". Registering `release.yml`
-      # instead just moves the failure to the token exchange
-      # (`invalid-publisher`). No single registration satisfies both, so the
-      # files publish without PEP 740 provenance until the upload moves into
-      # release.yml, where both claims name one workflow (#916).
-      - name: Upload to PyPI
+      # This job only runs when pypi-publish.yml is the entry point. Both the
+      # trusted-publisher lookup and the attestation therefore name this file,
+      # which is the publisher registered on TestPyPI.
+      - name: Upload to TestPyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist
-          repository-url: ${{ env.REPO_URL }}
-          attestations: false
+          repository-url: https://test.pypi.org/legacy/
           # An upload is not atomic: PyPI takes the files one at a time, so a
           # rejection partway through leaves the ones before it published and
           # nothing can take them back. 9.0.0's five wheels landed and its sdist
@@ -434,7 +385,6 @@ jobs:
           # instead of retrying the sdist. Skip what is already there and upload
           # the rest. What this does NOT wave through is the wrong thing being
           # published: the step above still refuses any file that is not the
-          # name and version in the manifest, and preflight still refuses a
-          # version whose tag exists.
+          # name and version in the manifest.
           skip-existing: true
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,14 @@ jobs:
 
   # --- publish, THEN tag ---------------------------------------------------
   #
-  # The three publish jobs used to `needs: tag`, which made a publish failure
+  # The three registry publishes used to `needs: tag`, which made a failure
   # unrecoverable: the tag was already pushed, so the `Fail if tag already
   # exists` preflight blocked every re-run of this workflow, and the only way
   # out was deleting a tag by hand.
   #
-  # Nothing consumed the tag. Each publish job is a reusable workflow whose
-  # `actions/checkout` takes the caller's ref — the dispatched commit — not the
-  # tag, so they build byte-identical trees whether the tag exists or not. That
+  # Nothing consumed the tag. The reusable build workflows check out the
+  # caller's ref — the dispatched commit — and the direct PyPI upload consumes
+  # artifacts from that same run, so the tag does not affect their inputs. That
   # makes the ordering free to reverse, and reversing it is the whole fix: a
   # failed publish now leaves no tag behind, and re-dispatching the workflow
   # just works.
@@ -104,8 +104,8 @@ jobs:
     # workflow, not the reusable one that runs `npm publish`. Registering
     # `npm-publish.yml` is what made every release fail here with ENEEDAUTH
     # while a direct dispatch of that same file, at the same commit, published
-    # fine. PyPI matches the called workflow instead, which is why the
-    # identically-shaped `publish-pypi` job never had this problem.
+    # fine. The production PyPI upload is defined below in this entry-point
+    # workflow so its OIDC token and attestation carry the same identity.
     #
     # The consequence for recovery: `npm-publish.yml` cannot be dispatched by
     # hand any more — it would present `npm-publish.yml` as the entry point and
@@ -117,20 +117,107 @@ jobs:
     uses: ./.github/workflows/npm-publish.yml
     secrets: inherit
 
-  publish-pypi:
-    name: Publish to PyPI
+  build-pypi:
+    name: Build PyPI distributions
     needs: [preflight, all-tests]
     if: ${{ inputs.registries == 'all' || inputs.registries == 'pypi' }}
-    # Same as publish-npm: PyPI trusted publishing is OIDC, and a reusable
-    # workflow's permissions are capped by its caller, so the grant has to be
-    # made here or the upload job cannot mint a token.
+    uses: ./.github/workflows/pypi-publish.yml
+    secrets: inherit
+
+  upload-pypi:
+    name: Upload to PyPI
+    needs: [preflight, all-tests, build-pypi]
+    if: ${{ inputs.registries == 'all' || inputs.registries == 'pypi' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Defining the upload in this entry-point workflow makes PyPI's token
+    # exchange and the Sigstore certificate name the same trusted publisher.
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/pypi-publish.yml
-    secrets: inherit
-    with:
-      pypi-target: prod
+    steps:
+      # Needed by the name/version check below, which reads the version from
+      # the manifest rather than trusting the filenames it is checking.
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: dist-*
+          merge-multiple: true
+          path: dist
+
+      # Both the wheels and the sdist go up. Fail rather than publish a
+      # half-populated release: an upload that quietly contained no wheels
+      # would still report success.
+      #
+      # The name check is the other half, and it is not hypothetical: the 9.0.0
+      # release built `wingfoil_python-9.0.0-*` because `[project].name` had
+      # been set to the *crate* name, and every one of those files would have
+      # gone to a brand-new PyPI project while `pip install wingfoil` — what
+      # the READMEs and this workflow's own release notes tell users to run —
+      # stayed on 8.0.0. PyPI has no rename and no delete-and-reupload, so the
+      # cost of noticing afterwards is a burned version at best and a
+      # permanently forked package at worst. Check it here, where the failure
+      # is free.
+      - name: Inspect what is about to be published
+        run: |
+          set -euo pipefail
+          ls -al dist
+          wheels=$(find dist -name '*.whl' | wc -l)
+          sdists=$(find dist -name '*.tar.gz' | wc -l)
+          echo "wheels=$wheels sdists=$sdists"
+          if [ "$wheels" -lt 5 ] || [ "$sdists" -ne 1 ]; then
+            echo "::error::expected 5 wheels and 1 sdist, got $wheels and $sdists"
+            exit 1
+          fi
+
+          # The distribution name is `wingfoil` while the crate is
+          # `wingfoil-python`; see the comment on `[project].name`. Both parts
+          # of every filename are checked against source, so a stale artifact
+          # from another run fails here too.
+          expected_name=wingfoil
+          expected_version=$(grep -m 1 '^version' crates/wingfoil-python/Cargo.toml | awk -F'"' '{print $2}')
+          echo "expecting ${expected_name}-${expected_version}"
+          # A prerelease version is spelled differently by Cargo and by PEP
+          # 440 (`1.0.0-beta.1` vs `1.0.0b1`), so only a plain x.y.z — all
+          # bump.yml can produce — is compared. The NAME is always compared:
+          # it is the half that cannot be undone.
+          case "$expected_version" in
+            *[!0-9.]* | '') check_version=no ;;
+            *) check_version=yes ;;
+          esac
+          for path in dist/*; do
+            file=$(basename "$path")
+            # Wheel: {name}-{version}-{python tag}-...; sdist: {name}-{version}.tar.gz.
+            # maturin writes the PEP 427 escaped name, so `-` in a name arrives
+            # as `_` — compare against the escaped form of what we expect.
+            name=${file%%-*}
+            rest=${file#*-}
+            version=${rest%%-*}
+            version=${version%.tar.gz}
+            if [ "$name" != "${expected_name//-/_}" ]; then
+              echo "::error::$file is not a ${expected_name} distribution — refusing to publish"
+              exit 1
+            fi
+            if [ "$check_version" = yes ] && [ "$version" != "$expected_version" ]; then
+              echo "::error::$file is not version ${expected_version} — refusing to publish"
+              exit 1
+            fi
+          done
+          echo "every file is ${expected_name} ${expected_version}"
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist
+          # An upload is not atomic: PyPI takes the files one at a time, so a
+          # rejection partway through leaves the ones before it published and
+          # nothing can take them back. Skip what is already there and upload
+          # the rest; the inspection step still rejects the wrong name/version.
+          skip-existing: true
+          verbose: true
 
   tag:
     name: Cut release tag
@@ -139,20 +226,21 @@ jobs:
     # failure into a manual tag deletion before anyone could retry.
     #
     # The `if` is what lets a recovery run still reach the tag. A run with
-    # `registries: npm` *skips* the other two publish jobs, and a skipped
+    # `registries: npm` *skips* the other two registry paths, and a skipped
     # `needs` would ordinarily skip this job along with it — so gate on
     # "nothing failed" rather than "everything ran". `all-tests` is in `needs`
     # purely so this can tell the two apart: if the suite goes red the publish
     # jobs skip too, and without that check a skipped-because-broken run would
     # look exactly like a skipped-because-not-asked-for one and get tagged.
-    needs: [preflight, all-tests, publish-crates, publish-npm, publish-pypi]
+    needs: [preflight, all-tests, publish-crates, publish-npm, build-pypi, upload-pypi]
     if: >-
       ${{ !cancelled()
       && needs.preflight.result == 'success'
       && needs.all-tests.result == 'success'
       && needs.publish-crates.result != 'failure'
       && needs.publish-npm.result != 'failure'
-      && needs.publish-pypi.result != 'failure' }}
+      && needs.build-pypi.result != 'failure'
+      && needs.upload-pypi.result != 'failure' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,21 +13,19 @@ and the tag is cut only once all three have the artifacts.
 Two things are configured outside this repository and are easy to forget,
 because nothing in the tree fails without them until a release run does:
 
-1. **Trusted publishers must be registered on both PyPI *and* TestPyPI.**
-   `pypi-publish.yml` uploads over OIDC — there is no `*_PYPI_API_TOKEN`
-   secret. Register a GitHub publisher on each of the two indexes for the
-   project `wingfoil`, owner `wingfoil-io`, repository `wingfoil`, workflow
-   `pypi-publish.yml`, and **no environment** (leave the environment field
-   blank — it must match the workflow, and `upload-pypi` declares no
-   `environment:`). TestPyPI matters as much as PyPI: without it the rehearsal
-   in step 2 fails at its very last step, after the whole wheel matrix has
-   built.
+1. **Trusted publishers must be registered on both PyPI *and* TestPyPI.** There
+   is no `*_PYPI_API_TOKEN` secret. For the project `wingfoil`, register owner
+   `wingfoil-io`, repository `wingfoil`, workflow `release.yml`, and **no
+   environment** on PyPI. Register the same values with workflow
+   `pypi-publish.yml` on TestPyPI. The workflows differ because the production
+   upload runs in `release.yml`, while the rehearsal is a direct dispatch of
+   `pypi-publish.yml`; each trusted publisher must name the workflow that
+   contains its upload job.
 2. **Dispatch `pypi-publish.yml` once with `pypi-target: test`.** That is the
    only way to exercise the whole PyPI path — sdist repair, five wheels, the
-   `upload-pypi` job's OIDC mint — without burning a version number on the real
-   index. `test` is the default for a manual dispatch, so this is also what you
-   get if you dispatch that workflow without thinking; only `release.yml` passes
-   `prod`. Do it after any change to that workflow, not just once ever.
+   `upload-testpypi` job's OIDC mint — without burning a version number on the
+   real index. `test` is the default for a manual dispatch. Do it after any
+   change to that workflow, not just once ever.
 
 npm and crates.io are already set up: npm publishes over OIDC too, and
 crates.io uses the `CRATES_IO_API_TOKEN` secret.
@@ -39,9 +37,9 @@ under `workflow_call` names the *calling* workflow rather than the reusable one
 that runs `npm publish`. Registering `npm-publish.yml` therefore made every
 `release.yml` run fail with `ENEEDAUTH` while a hand-dispatch of that same file
 at the same commit published fine — the release path and the recovery path
-cannot both match, because a package has one trusted publisher. PyPI matches the
-*called* workflow, which is why `pypi-publish.yml` is registered under its own
-name and never had this problem.
+cannot both match, because a package has one trusted publisher. The production
+PyPI upload now also lives directly in `release.yml`; the separate TestPyPI
+publisher is registered as `pypi-publish.yml` for its direct rehearsal runs.
 
 Do not reach for an `NPM_TOKEN` to sidestep this. npm is restricting
 2FA-bypassing tokens for direct publishing and points CI at trusted publishing
@@ -94,7 +92,7 @@ exists.
 **All tests** is `all-tests.yml`: `rust-test.yml` + `python-test.yml` + the
 whole `integration-tests.yml` fan-out.
 
-**The three publishes run in parallel**, each a reusable workflow:
+**The three publishes run in parallel**:
 
 - `crates-publish.yml` — six crates to crates.io in dependency order, with
   `sleep 30` waits for the index between tiers: `wingfoil-derive`,
@@ -111,17 +109,19 @@ whole `integration-tests.yml` fan-out.
   11.x line, because 12.0.0's bundle cannot resolve `sigstore`. It is
   `workflow_call`-only: dispatching it directly cannot authenticate, since
   `release.yml` is the registered trusted publisher.
-- `pypi-publish.yml` with `pypi-target: prod` — one sdist plus five abi3 wheels
-  (linux x86_64 + aarch64 in `manylinux_2_28` containers, macOS arm64 + x86_64,
-  windows x64), then one `upload-pypi` job over OIDC. The Linux wheels carry
-  every adapter (`--features extension-module,all-adapters`); macOS and Windows
-  take the pyproject feature list, which excludes aeron and iceoryx2. The upload
-  job refuses to publish fewer than 5 wheels or anything other than exactly 1
-  sdist.
+- `pypi-publish.yml` builds one sdist plus five abi3 wheels (linux x86_64 +
+  aarch64 in `manylinux_2_28` containers, macOS arm64 + x86_64, windows x64)
+  and uploads them as workflow artifacts. The Linux wheels carry every adapter
+  (`--features extension-module,all-adapters`); macOS and Windows take the
+  pyproject feature list, which excludes aeron and iceoryx2. An `upload-pypi`
+  job defined directly in `release.yml` downloads those artifacts, refuses to
+  publish fewer than 5 wheels or anything other than exactly 1 sdist, then
+  publishes over OIDC with PEP 740 attestations.
 
-`release.yml` grants `id-token: write` on the `publish-npm` and `publish-pypi`
-jobs itself. A reusable workflow's permissions are capped by its caller, so the
-grant has to be at the call site or the upload job cannot mint an OIDC token.
+`release.yml` grants `id-token: write` on the `publish-npm` and `upload-pypi`
+jobs. The npm grant is at the reusable workflow's call site because a called
+workflow's permissions are capped by its caller; the PyPI grant belongs to the
+upload job itself.
 
 **Then the tag**, and only then. This ordering is the fix for a real failure
 mode: the tag used to come first, so a publish failure left a pushed tag that
@@ -145,16 +145,16 @@ GitHub release exists**, so there is nothing to hand-delete and the version is
 not yet announced.
 
 The way out is to **re-dispatch `release.yml` with `registries` set to the one
-registry still missing** (`crates`, `npm` or `pypi`). The other two publish jobs
-skip, and the run goes on to cut the tag and the GitHub release — so the
+registry still missing** (`crates`, `npm` or `pypi`). The other two registry
+paths skip, and the run goes on to cut the tag and the GitHub release — so the
 recovery dispatch finishes the release rather than leaving you to tag by hand.
 Repeat it once per missing registry if more than one failed.
 
-Do not reach for the individual publish workflows instead. `npm-publish.yml` is
-not dispatchable at all (`release.yml` is its trusted publisher, so a direct
-dispatch cannot authenticate), and while `crates-publish.yml` and
-`pypi-publish.yml` still can be, using them leaves the tag and the GitHub
-release for you to do by hand.
+Do not reach for the individual publish workflows instead. `npm-publish.yml`
+is not dispatchable at all, and a direct `pypi-publish.yml` run targets
+TestPyPI rather than production. While `crates-publish.yml` can still be
+dispatched directly, doing so leaves the tag and the GitHub release for you to
+do by hand.
 
 None of the three registries lets you overwrite a published version, so a bad
 release is fixed by bumping again, not by republishing.


### PR DESCRIPTION
## What this changes

`pypi-publish.yml` now builds the distributions and stores them as workflow artifacts when called by `release.yml`, while its direct dispatch keeps the TestPyPI upload and dry-run paths. `release.yml` downloads the built distributions and performs the production upload itself, allowing the default PEP 740 attestations to be published.

The release documentation now records separate trusted publishers: `release.yml` on PyPI and `pypi-publish.yml` on TestPyPI.

## Why

PyPI cannot validate attestations from the reusable production upload because the token exchange identifies `pypi-publish.yml` while the Sigstore certificate identifies its caller, `release.yml`. Defining the production upload in the entry-point workflow makes both identities agree. This implements the workflow changes in #916.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo build --workspace --all-targets`
- [x] Both changed workflows parse as YAML
- [x] GitHub's `Test (wingfoil)` and `Lint (fmt & clippy)` jobs
- [x] GitHub's cargo audit, pnpm audit, and dependency review jobs

## Notes for the reviewer

Before the next production release, the PyPI trusted publisher must be re-registered as `release.yml` with no environment. TestPyPI should remain registered as `pypi-publish.yml`. After merge, the remaining verification is a direct `dry-run` build followed by one real release.
