### PR TITLE
ci: restore current-engine coverage

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,9 +2,10 @@
 
 ## CI (run on push / PR)
 
-* `rust-test.yml` — two parallel jobs: `Test (wingfoil)` and
-  `Lint (fmt & clippy)`. They were one serial job until they were split; the
-  legs share no build artifacts, so serialising them bought nothing.
+* `rust-test.yml` — three parallel jobs: `Coverage (unit)`, `Test (wingfoil)`
+  and `Lint (fmt & clippy)`. The coverage leg measures the current engine with
+  service-backed integration binaries excluded; those binaries are measured
+  by their dedicated workflows below.
 * `python-test.yml` — Python (`wingfoil-python`) build + pytest with coverage.
 * `security-audit.yml` — fails on dependencies with known advisories
   (`cargo audit` for Cargo, `pnpm audit` for `wingfoil-js`, and
@@ -60,7 +61,11 @@ The per-adapter integration workflows above are the *only* place their
 `tests/*_integration.rs` binaries are executed. `rust-test.yml` compiles them
 (so they stay type- and link-checked) but filters them out of its test run:
 without the service each one needs, they only exercise connection-timeout
-paths, and they are slow doing it.
+paths, and they are slow doing it. Each workflow instruments its Rust tests
+with `cargo llvm-cov` and uploads an LCOV report under a stable adapter flag;
+`codecov.yml` carries forward flags for integrations a narrower change does
+not trigger. Codecov project and patch statuses remain informational while the
+current-engine baseline settles.
 
 Every push/PR workflow declares a `concurrency` group so a superseded PR push
 cancels its predecessor. The group name is a literal per file rather than

--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -36,11 +36,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -66,10 +74,22 @@ jobs:
 
       - name: Run aeron integration tests
         run: |
-          cargo test --features aeron-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features aeron-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export Aeron coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload Aeron coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: aeron
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The Rust tests drive the driver container through testcontainers; the

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -35,11 +35,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -59,10 +67,22 @@ jobs:
 
       - name: Run etcd integration tests
         run: |
-          cargo test --features etcd-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features etcd-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export etcd coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload etcd coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: etcd
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The Rust tests above use testcontainers (per-test container); the Python

--- a/.github/workflows/fix-integration.yml
+++ b/.github/workflows/fix-integration.yml
@@ -35,20 +35,40 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
+
       - name: Run FIX same-process integration tests
         # Loopback TCP only — no external service or container. Serialized
         # (`--test-threads=1`) because the tests run against a live wall clock.
         run: |
-          cargo test --features fix-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features fix-integration-test -p wingfoil \
             --test fix_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export FIX coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload FIX coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: fix
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # Same shape as the Rust leg: loopback TCP only, no service to start.

--- a/.github/workflows/fluvio-integration.yml
+++ b/.github/workflows/fluvio-integration.yml
@@ -35,11 +35,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -58,10 +66,22 @@ jobs:
 
       - name: Run fluvio integration tests
         run: |
-          cargo test --features fluvio-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features fluvio-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export Fluvio coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload Fluvio coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: fluvio
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The Rust tests above run their cluster inside a testcontainer that is

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -39,11 +39,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -53,10 +61,22 @@ jobs:
       # both the Local-variant suite and the cross-process Ipc suite.
       - name: Run iceoryx2 integration tests (Local + IPC)
         run: |
-          cargo test --features iceoryx2-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features iceoryx2-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export iceoryx2 coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload iceoryx2 coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: iceoryx2
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # Daemonless here too: nothing to start, the marker only keeps a live-clock

--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -35,11 +35,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -58,10 +66,22 @@ jobs:
 
       - name: Run kafka integration tests
         run: |
-          cargo test --features kafka-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features kafka-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export Kafka coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload Kafka coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: kafka
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The Rust tests above use testcontainers (per-test container); the Python

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -37,11 +37,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       # KDB+ has no public, freely-licensed image, so we build our own and the
       # tests probe that instance (skipping if unreachable — but in CI it must
@@ -74,8 +82,20 @@ jobs:
           KDB_TEST_PORT: 5000
           RUST_LOG: INFO
         run: |
-          cargo test --features kdb-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features kdb-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
+
+      - name: Export KDB coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload KDB coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: kdb
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The same container serves both legs: the Rust tests probe

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -33,11 +33,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         # opentelemetry-otlp's http-proto exporter builds prost-generated code,
@@ -58,7 +66,19 @@ jobs:
 
       - name: Run OTLP integration tests
         run: |
-          cargo test --features otlp-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features otlp-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export OTLP coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload OTLP coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: otlp
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -36,11 +36,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -59,10 +67,22 @@ jobs:
 
       - name: Run postgres integration tests
         run: |
-          cargo test --features postgres-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features postgres-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export postgres coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload postgres coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: postgres
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The Rust tests above use testcontainers (per-test container); the Python

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -33,11 +33,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Start Grafana + Prometheus stack
         # The telemetry example's stack: same Prometheus config, scraping
@@ -60,12 +68,24 @@ jobs:
 
       - name: Run Prometheus integration tests
         run: |
-          cargo test --features prometheus-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features prometheus-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
           PROMETHEUS_TEST_URL: http://localhost:9090
           WINGFOIL_METRICS_PORT: "9091"
+
+      - name: Export Prometheus coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload Prometheus coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: prometheus
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Dump logs on failure
         if: failure()

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -35,11 +35,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -58,10 +66,22 @@ jobs:
 
       - name: Run redis integration tests
         run: |
-          cargo test --features redis-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features redis-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export Redis coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload Redis coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: redis
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The Rust tests above use testcontainers (per-test container); the Python

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -58,10 +58,18 @@ defaults:
 jobs:
   coverage:
     name: Coverage (unit)
-    # Skips the release.bump commit — see the note above `jobs:`.
+    # Coverage runs only on a real merge to `main`, never on a PR.
+    # Instrumentation costs 7.6x on test execution for the same suite, and
+    # both Codecov statuses are informational. Keeping this off PRs preserves
+    # the fast uninstrumented gate while tracking coverage on every main push.
+    #
+    # This is an allow-list because `workflow_call` inherits the caller's
+    # dispatch event and must not add coverage to the release critical path.
+    # Also skips the release.bump commit, as the other legs do.
     if: >-
-      ${{ github.event_name != 'push'
-      || !(startsWith(github.event.head_commit.message, 'bump: ')
+      ${{ github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && !(startsWith(github.event.head_commit.message, 'bump: ')
       && contains(github.event.head_commit.message, ' version to ')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -139,10 +147,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
 
       - name: Run wingfoil tests
-        # The coverage job is scoped to `-p wingfoil`, so the wingfoil crate's
-        # tests — the adapter parity suites (lines/csv/augurs) and the trybuild
-        # cases — would otherwise never execute in CI. Run them here with all
-        # features so the feature-gated csv/augurs adapters are exercised.
+        # This is the fast uninstrumented PR gate. The main-only coverage job
+        # deliberately runs the same wingfoil selection with LLVM coverage.
+        # Run with all features so the feature-gated csv/augurs adapters are
+        # exercised.
         # `--lib --tests` skips the example binaries (already compile-checked by
         # the workspace clippy job).
         #

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -56,6 +56,60 @@ defaults:
 # workflow, which reaches these legs through test.all.
 
 jobs:
+  coverage:
+    name: Coverage (unit)
+    # Skips the release.bump commit — see the note above `jobs:`.
+    if: >-
+      ${{ github.event_name != 'push'
+      || !(startsWith(github.event.head_commit.message, 'bump: ')
+      && contains(github.event.head_commit.message, ' version to ')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache Rust Build Artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-coverage
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
+
+      - name: Run current-engine tests with coverage
+        # Keep the service-backed integration binaries out of this leg: each is
+        # measured by its own workflow and uploaded under an adapter flag.
+        # Examples are compile-checked by clippy and contain no tests, so
+        # instrumenting their wide dependency graph would only consume disk.
+        run: |
+          cargo llvm-cov nextest -p wingfoil --all-features --lib --tests \
+            -E 'not binary(/_integration$/)' \
+            --lcov --output-path lcov.info
+        env:
+          RUST_LOG: INFO
+
+      - name: Upload unit coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
   test:
     name: Test (wingfoil)
     # Skips the release.bump commit — see the note above `jobs:`.

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -66,11 +66,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -86,10 +94,22 @@ jobs:
       # adapter end to end under the TLS feature combination.
       - name: Run web integration tests (plain + TLS)
         run: |
-          cargo test --features web-tls-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features web-tls-integration-test -p wingfoil \
             --test web_integration --test web_adapter -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export web coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload web coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: web
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # --- Python bindings (wingfoil-python) ---
       # The server is in-process here too; `websockets` is the only extra, and

--- a/.github/workflows/zmq-integration.yml
+++ b/.github/workflows/zmq-integration.yml
@@ -37,11 +37,19 @@ jobs:
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust Build Artifacts
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: integration
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Prepare coverage collection
+        run: cargo llvm-cov clean --workspace
 
       - name: Install system dependencies
         # `libzmq` is linked by the `zmq` crate; `protoc` is needed by a
@@ -62,14 +70,14 @@ jobs:
 
       - name: Run ZMQ core pub/sub integration tests
         run: |
-          cargo test --features zmq-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features zmq-integration-test -p wingfoil \
             --test zmq_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
       - name: Run ZMQ etcd discovery integration tests
         run: |
-          cargo test --features zmq-etcd-integration-test -p wingfoil \
+          cargo llvm-cov --no-report --features zmq-etcd-integration-test -p wingfoil \
             --test zmq_etcd_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
@@ -133,10 +141,22 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/crates/wingfoil-python/.venv/bin:$PATH"
           python3 -c 'import wingfoil' \
             || (echo "bindings not importable from the venv on PATH" && exit 1)
-          cargo test --features zmq-cross-lang-etcd-test -p wingfoil \
+          cargo llvm-cov --no-report --features zmq-cross-lang-etcd-test -p wingfoil \
             --test zmq_cross_lang_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
+
+      - name: Export combined ZMQ coverage
+        run: cargo llvm-cov report --lcov --output-path lcov.info
+
+      - name: Upload ZMQ coverage to Codecov
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+          files: lcov.info
+          flags: zmq
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Dump etcd logs on failure
         if: failure()


### PR DESCRIPTION
## What this changes

Adds a dedicated current-engine unit coverage job and instruments the Rust tests in all 13 service-backed integration workflows. Each integration exports one LCOV report under a stable adapter flag; the workflow guide now documents the split and Codecov carryforward behavior.

## Why

Coverage uploads stopped when the legacy tree and its only coverage job were deleted, leaving the README badge pinned to an obsolete engine. The replacement must measure both the current core engine and the adapter behavior that only runs against real services.

Closes #905.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [ ] `cargo lint` and `cargo lint-all` — both stop before Wingfoil code because this Windows host has no MSVC `link.exe`
- [ ] `cargo test -p wingfoil --all-features` and `cargo test -p wingfoil-derive` — same pre-crate linker blocker
- [x] actionlint 1.7.12 on all 14 changed workflow files
- [x] Deterministic contract check: unit plus 13 unique adapter flags, each with toolchain support, cleanup, instrumented test invocation, one LCOV export, and one Codecov upload
- [x] `cargo metadata --no-deps --format-version 1`
- [x] `git diff --check`

## Notes for the reviewer

The unit leg retains the existing exclusion for service-backed `*_integration` binaries. Integration workflows use cargo-llvm-cov's documented `--no-report` / final `report` flow, which also combines the three ZMQ Rust invocations into one flag. Codecov project and patch statuses remain informational, and upload errors remain non-blocking while the new baseline settles.