### PR TITLE
docs: ask contributors to allow maintainer edits on fork PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,3 +29,26 @@ The pre-commit hook covers fmt and clippy; tests are the part worth naming.
 Anything that would be hard to see from the diff: a deliberate performance
 trade-off, a follow-up you chose not to fold in.
 -->
+
+## Before you submit
+
+<!--
+One box, and it is the one most likely to cost you the merge. It applies to
+PRs opened from a fork, which is most of them.
+-->
+
+- [ ] **Allow edits by maintainers** is ticked
+
+<!--
+Why this earns a section of its own: ops land at the same insertion points in
+`ops.rs`, `fluent.rs` and `op_completeness.rs`, so an approved PR can pick up a
+conflict within a day of a sibling merging. With this ticked, a maintainer
+rebases your branch in one click and it lands as yours.
+
+Without it GitHub refuses with "user doesn't have permission to update head
+repository", and the ways out are asking you to rebase or carrying your commit
+onto a fresh PR by hand. #896 was reviewed, approved, and then conflicted
+across six files; it had to be re-landed as #902.
+
+You can tick it after opening, too — it is in the PR's right-hand sidebar.
+-->


### PR DESCRIPTION
## What this changes

Adds a **Before you submit** section to `.github/pull_request_template.md` with a single checkbox: *Allow edits by maintainers*.

## Why

Every op lands at the same insertion points in `ops.rs`, `fluent.rs` and `op_completeness.rs`, so an approved PR can pick up a conflict within a day of a sibling merging. When the head branch is on a fork and that box is unticked, GitHub refuses the update-branch call with `user doesn't have permission to update head repository` — so a maintainer cannot rebase it, and the only ways out are asking the contributor to redo the work or carrying their commit onto a fresh PR by hand.

That is what #896 cost: reviewed, approved, then conflicted across six files, and re-landed as #902. The contributor did nothing wrong and still ended up with a closed PR on their profile.

The rate this bites at is set by throughput, not by carelessness — `take_while` (#886), `enumerate` (#892) and `step_by` (#894) all landing in the same window is what conflicted #896 — so it gets worse as contribution volume goes up, which is the direction we want it to go. One ticked box removes the class.

The comment block explains the reasoning inline and notes the box can still be ticked after opening, from the PR's right-hand sidebar.

## How it was verified

Markdown only — no Rust, JS or Python touched, so `fmt`/`lint`/`test` have nothing to act on and were not run. Checked by reading: section spacing matches the surrounding template (one blank line between headings), and the comment blocks follow the file's existing explain-the-why style.

## Notes for the reviewer

Deliberately scoped to the one mechanical fix. Two adjacent things it does **not** do:

- **No claim convention.** #892 and #899 both implemented `enumerate` because no issue carries an assignee. That needs a line in `CONTRIBUTING.md` plus the habit of actually assigning, and it is a separate change.
- **No wording change to the existing checklist.** The `cargo lint` / `cargo test` boxes are untouched.

Companion change, already applied and not part of this diff: `help wanted` now exists as a label and is on #803, #380 and #392 — the first `size: medium` rung between the `good first issue` queue and the `size: large` projects.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dVN957aZvGcCDbwBf9N3D

---
_Generated by [Claude Code](https://claude.ai/code/session_019dVN957aZvGcCDbwBf9N3D)_