### PR TITLE
ci: gate the integration suites on PRs, not on arbitrary branch pushes

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -51,9 +51,7 @@ workflows below. `all-tests.yml` runs `rust-test.yml` + `python-test.yml` +
   WebSocket tests, plus the browser half: the `wingfoil-wasm` codec build and
   the `js/` (`@wingfoil/client`) typecheck, build and `vitest` suite. Both
   halves speak the same `wingfoil-wire-types` contract, so they share a
-  trigger. Unlike the service-backed integration workflows above, this one
-  also runs on pull requests because it needs no license secret or external
-  service. This is the only place `js/tests/` runs on push/PR; `pnpm test` runs
+  trigger. This is the only place `js/tests/` runs on push/PR; `pnpm test` runs
   again as a preflight inside `npm-publish.yml`.
 
 The per-adapter integration workflows above are the *only* place their
@@ -61,6 +59,30 @@ The per-adapter integration workflows above are the *only* place their
 (so they stay type- and link-checked) but filters them out of its test run:
 without the service each one needs, they only exercise connection-timeout
 paths, and they are slow doing it.
+
+**Triggers: `push` to `main` plus `pull_request`, both path-filtered**, and
+each lists its own filename among those paths so a change to the workflow
+exercises it.
+
+The `pull_request` half is what makes them a pre-merge gate, and it is new.
+These were `push`-triggered with no branch filter and no `pull_request` trigger
+at all, which meant they never ran on a contributor's PR: contributors work
+from forks, and a push to a fork does not trigger this repository's workflows.
+Since these are the only place the `*_integration.rs` binaries execute, an
+adapter change was type- and link-checked and nothing more until it was already
+on `main`.
+
+The branch filter is the other half. A `push:` with no `branches:` ran on every
+branch pushed here, and such a run executes the workflow file *from the pushed
+branch* with repository secrets in scope — so anyone who could push a branch
+could read any secret a push-triggered workflow touches, with no review in the
+way. These should be reachable from `main`, a PR, `workflow_call` or a
+dispatch, and not from an arbitrary branch push.
+
+`kdb-integration.yml` is the single exception and stays post-merge only: it
+needs `KDB_LICENSE_B64` to build its image, and a `pull_request` run from a
+fork gets no secrets, so mirroring it would fail every external PR while
+passing internal ones.
 
 Every push/PR workflow declares a `concurrency` group so a superseded PR push
 cancels its predecessor. The group name is a literal per file rather than

--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -4,7 +4,18 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/aeron-integration.yml'
+      - 'crates/wingfoil/src/adapters/aeron/**'
+      - 'crates/wingfoil/tests/aeron_adapter.rs'
+      - 'crates/wingfoil/tests/aeron_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/aeron.rs'
+      - 'crates/wingfoil-python/tests/test_aeron.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/aeron-integration.yml'
       - 'crates/wingfoil/src/adapters/aeron/**'
       - 'crates/wingfoil/tests/aeron_adapter.rs'
       - 'crates/wingfoil/tests/aeron_integration.rs'

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -4,7 +4,17 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/etcd-integration.yml'
+      - 'crates/wingfoil/src/adapters/etcd**'
+      - 'crates/wingfoil/tests/etcd_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/etcd.rs'
+      - 'crates/wingfoil-python/tests/test_etcd.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/etcd-integration.yml'
       - 'crates/wingfoil/src/adapters/etcd**'
       - 'crates/wingfoil/tests/etcd_integration.rs'
       - 'crates/wingfoil-python/src/adapters/etcd.rs'

--- a/.github/workflows/fix-integration.yml
+++ b/.github/workflows/fix-integration.yml
@@ -4,7 +4,17 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/fix-integration.yml'
+      - 'crates/wingfoil/src/adapters/fix**'
+      - 'crates/wingfoil/tests/fix_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/fix.rs'
+      - 'crates/wingfoil-python/tests/test_fix.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/fix-integration.yml'
       - 'crates/wingfoil/src/adapters/fix**'
       - 'crates/wingfoil/tests/fix_integration.rs'
       - 'crates/wingfoil-python/src/adapters/fix.rs'

--- a/.github/workflows/fluvio-integration.yml
+++ b/.github/workflows/fluvio-integration.yml
@@ -4,7 +4,17 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/fluvio-integration.yml'
+      - 'crates/wingfoil/src/adapters/fluvio**'
+      - 'crates/wingfoil/tests/fluvio_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/fluvio.rs'
+      - 'crates/wingfoil-python/tests/test_fluvio.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/fluvio-integration.yml'
       - 'crates/wingfoil/src/adapters/fluvio**'
       - 'crates/wingfoil/tests/fluvio_integration.rs'
       - 'crates/wingfoil-python/src/adapters/fluvio.rs'

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -4,7 +4,21 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/iceoryx2-integration.yml'
+      - 'crates/wingfoil/src/adapters/iceoryx2/**'
+      - 'crates/wingfoil/tests/iceoryx2_adapter.rs'
+      - 'crates/wingfoil/tests/iceoryx2_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/iceoryx2.rs'
+      # The binding's `stages` path splits and packs its wire header through
+      # this module, and only the marked tier below round-trips it.
+      - 'crates/wingfoil-python/src/latency.rs'
+      - 'crates/wingfoil-python/tests/test_iceoryx2.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/iceoryx2-integration.yml'
       - 'crates/wingfoil/src/adapters/iceoryx2/**'
       - 'crates/wingfoil/tests/iceoryx2_adapter.rs'
       - 'crates/wingfoil/tests/iceoryx2_integration.rs'

--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -4,7 +4,17 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/kafka-integration.yml'
+      - 'crates/wingfoil/src/adapters/kafka**'
+      - 'crates/wingfoil/tests/kafka_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/kafka.rs'
+      - 'crates/wingfoil-python/tests/test_kafka.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/kafka-integration.yml'
       - 'crates/wingfoil/src/adapters/kafka**'
       - 'crates/wingfoil/tests/kafka_integration.rs'
       - 'crates/wingfoil-python/src/adapters/kafka.rs'

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -4,7 +4,14 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    # Branch-filtered but NOT mirrored to `pull_request`, unlike its sibling
+    # integration workflows. This job needs KDB_LICENSE_B64 to build the
+    # container, and a pull_request run from a fork gets no secrets — it would
+    # fail every external PR while passing internal ones. So the kdb suite
+    # stays a post-merge check until the licence can be supplied another way.
+    branches: [ "main" ]
     paths:
+      - ".github/workflows/kdb-integration.yml"
       - "crates/wingfoil/src/adapters/kdb**"
       - "crates/wingfoil/src/adapters/cache.rs"
       - "crates/wingfoil/src/adapters/common.rs"

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -4,7 +4,15 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/otlp-integration.yml'
+      - 'crates/wingfoil/src/adapters/otlp**'
+      - 'crates/wingfoil/tests/otlp_integration.rs'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/otlp-integration.yml'
       - 'crates/wingfoil/src/adapters/otlp**'
       - 'crates/wingfoil/tests/otlp_integration.rs'
 

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -4,7 +4,18 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/postgres-integration.yml'
+      - 'crates/wingfoil/src/adapters/postgres**'
+      - 'crates/wingfoil/src/adapters/common.rs'
+      - 'crates/wingfoil/tests/postgres_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/postgres.rs'
+      - 'crates/wingfoil-python/tests/test_postgres.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/postgres-integration.yml'
       - 'crates/wingfoil/src/adapters/postgres**'
       - 'crates/wingfoil/src/adapters/common.rs'
       - 'crates/wingfoil/tests/postgres_integration.rs'

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -4,7 +4,15 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/prometheus-integration.yml'
+      - 'crates/wingfoil/src/adapters/prometheus**'
+      - 'crates/wingfoil/tests/prometheus_integration.rs'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/prometheus-integration.yml'
       - 'crates/wingfoil/src/adapters/prometheus**'
       - 'crates/wingfoil/tests/prometheus_integration.rs'
 

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -4,7 +4,17 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/redis-integration.yml'
+      - 'crates/wingfoil/src/adapters/redis**'
+      - 'crates/wingfoil/tests/redis_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/redis.rs'
+      - 'crates/wingfoil-python/tests/test_redis.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/redis-integration.yml'
       - 'crates/wingfoil/src/adapters/redis**'
       - 'crates/wingfoil/tests/redis_integration.rs'
       - 'crates/wingfoil-python/src/adapters/redis.rs'

--- a/.github/workflows/zmq-integration.yml
+++ b/.github/workflows/zmq-integration.yml
@@ -4,7 +4,19 @@ on:
   workflow_call:
   workflow_dispatch:
   push:
+    branches: [ "main" ]
     paths:
+      - '.github/workflows/zmq-integration.yml'
+      - 'crates/wingfoil/src/adapters/zmq**'
+      - 'crates/wingfoil/tests/zmq_integration.rs'
+      - 'crates/wingfoil/tests/zmq_etcd_integration.rs'
+      - 'crates/wingfoil/tests/zmq_cross_lang_integration.rs'
+      - 'crates/wingfoil-python/src/adapters/zmq.rs'
+      - 'crates/wingfoil-python/tests/test_zmq.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/zmq-integration.yml'
       - 'crates/wingfoil/src/adapters/zmq**'
       - 'crates/wingfoil/tests/zmq_integration.rs'
       - 'crates/wingfoil/tests/zmq_etcd_integration.rs'


### PR DESCRIPTION
## What this changes

Every per-adapter integration workflow gets `branches: [ "main" ]` on its `push` trigger and a mirrored `pull_request` trigger with the same paths. Each workflow's own filename is added to those paths so a change to it exercises it. `kdb-integration.yml` gets the branch filter only.

Follows the shape #878 already established for `web-integration.yml`.

## Why

These twelve workflows triggered on `push` with no `branches:` filter and no `pull_request` trigger at all. Two consequences.

**They never ran on a contributor's PR.** Contributors work from forks, and a push to a fork does not trigger this repository's workflows — so the only runs these ever got were pushes to branches here. Since these workflows are the *only* place the `*_integration.rs` binaries execute (`rust-test.yml` compiles them, then filters them out of its run), an adapter change was type- and link-checked and nothing more until it had already landed on `main`. #919 changed the zmq publisher hot path and `zmq-integration.yml` never saw it.

**And an unfiltered `push:` is a secret-read primitive.** A run started that way executes the workflow file *from the pushed branch*, with repository secrets in scope. Anyone able to push a branch here could therefore read any secret a push-triggered workflow touches, with no review in the way — `kdb-integration.yml` carries `KDB_LICENSE_B64`. This is worth closing independently of who currently holds write access, since it also means a compromise of any one collaborator account reaches the secrets directly.

After this, no workflow in the tree triggers on an unfiltered push.

## How it was verified

I cannot execute Actions from here, so this is static verification:

- Every file in `.github/workflows/` parses under `yaml.safe_load` — 0 failures.
- Trigger matrix dumped from the parsed YAML: all 15 push-triggered workflows now report `push=['main']`, and every integration workflow except kdb reports `pr=['main']`.
- A scan for `push:` without `branches:` across the directory returns empty.
- The diff is pure insertion apart from three stale README lines (`+146 −3`). An earlier pass of my edit script dropped an explanatory comment inside iceoryx2's paths block; it was redone to copy the block verbatim, and that comment is present in both triggers.

No Rust, Python or JS touched, so `fmt`/`lint`/`test` have nothing to act on and were not run.

## Notes for the reviewer

**Conflict risk with #926.** That PR (still open) edits all thirteen of these files, adding `cargo llvm-cov` steps under `jobs:`. This one only touches the `on:` block at the top of each, so they should merge cleanly, but #926 is the one to land first if you'd rather not find out — it has been waiting since the 26th, and it's the fix for #905.

**kdb is deliberately not mirrored.** It needs `KDB_LICENSE_B64` to build its image, and a `pull_request` run from a fork gets no secrets, so mirroring it would fail every external PR while passing internal ones. It stays a post-merge check and the reason is recorded in the file. If that gap matters, the fix is a licence-free path for the container rather than a trigger change.

**This will start real CI on PRs that touch adapters** — that is the point, but it is a change in cost and in how often a contributor sees red. Path filters keep it to the one adapter a PR touches.

Not addressed here, from the same review: the long-lived `CRATES_IO_API_TOKEN` (npm and PyPI are on OIDC; crates.io is not), `WF_REBASE_PAT` reachable via `workflow_dispatch` on `bump.yml` / `bulk-rebase.yml` / `rust-fmt.yml`, and unpinned third-party actions. Those belong with #461.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dVN957aZvGcCDbwBf9N3D

---
_Generated by [Claude Code](https://claude.ai/code/session_019dVN957aZvGcCDbwBf9N3D)_