### PR TITLE
ci: keep integration coverage off the PR path

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,11 +59,22 @@ The per-adapter integration workflows above are the *only* place their
 `tests/*_integration.rs` binaries are executed. `rust-test.yml` compiles them
 (so they stay type- and link-checked) but filters them out of its test run:
 without the service each one needs, they only exercise connection-timeout
-paths, and they are slow doing it. Each workflow instruments its Rust tests
-with `cargo llvm-cov` and uploads an LCOV report under a stable adapter flag;
-`codecov.yml` carries forward flags for integrations a narrower change does
-not trigger. Codecov project and patch statuses remain informational while the
-current-engine baseline settles.
+paths, and they are slow doing it.
+
+**Coverage on these runs is post-merge only**, the same rule
+`rust-test.yml`'s `Coverage (unit)` leg follows: instrumentation costs ~7.6x
+on test execution, which no cache warming touches, and nothing gates on the
+result. On a push to `main` each workflow instruments its Rust tests and
+uploads one LCOV report under a stable adapter flag; on a pull request it runs
+the identical tests uninstrumented and uploads nothing. The two paths differ
+only by the `WF_CARGO_TEST` prefix, since `cargo llvm-cov --no-report` and
+`cargo test` take identical argument tails.
+
+`codecov.yml` sets `carryforward: true`, so a flag keeps its last complete
+report on pull requests and when a narrower change does not trigger its
+workflow. Export and upload are skipped when a test step fails, so a half-run
+report never becomes that flag's baseline. Codecov project and patch statuses
+remain informational while the current-engine baseline settles.
 
 **Triggers: `push` to `main` plus `pull_request`, both path-filtered**, and
 each lists its own filename among those paths so a change to the workflow

--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -35,6 +35,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   aeron-integration:
@@ -56,9 +62,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -85,15 +93,18 @@ jobs:
 
       - name: Run aeron integration tests
         run: |
-          cargo llvm-cov --no-report --features aeron-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features aeron-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export Aeron coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload Aeron coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -33,6 +33,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   etcd-integration:
@@ -54,9 +60,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -77,15 +85,18 @@ jobs:
 
       - name: Run etcd integration tests
         run: |
-          cargo llvm-cov --no-report --features etcd-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features etcd-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export etcd coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload etcd coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/fix-integration.yml
+++ b/.github/workflows/fix-integration.yml
@@ -33,6 +33,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   fix-integration:
@@ -54,24 +60,29 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Run FIX same-process integration tests
         # Loopback TCP only — no external service or container. Serialized
         # (`--test-threads=1`) because the tests run against a live wall clock.
         run: |
-          cargo llvm-cov --no-report --features fix-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features fix-integration-test -p wingfoil \
             --test fix_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export FIX coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload FIX coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/fluvio-integration.yml
+++ b/.github/workflows/fluvio-integration.yml
@@ -33,6 +33,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   fluvio-integration:
@@ -54,9 +60,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -76,15 +84,18 @@ jobs:
 
       - name: Run fluvio integration tests
         run: |
-          cargo llvm-cov --no-report --features fluvio-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features fluvio-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export Fluvio coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload Fluvio coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -41,6 +41,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   iceoryx2-integration:
@@ -62,9 +68,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -75,15 +83,18 @@ jobs:
       # both the Local-variant suite and the cross-process Ipc suite.
       - name: Run iceoryx2 integration tests (Local + IPC)
         run: |
-          cargo llvm-cov --no-report --features iceoryx2-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features iceoryx2-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export iceoryx2 coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload iceoryx2 coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -33,6 +33,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   kafka-integration:
@@ -54,9 +60,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -76,15 +84,18 @@ jobs:
 
       - name: Run kafka integration tests
         run: |
-          cargo llvm-cov --no-report --features kafka-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features kafka-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export Kafka coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload Kafka coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -32,6 +32,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   kdb-integration:
@@ -53,9 +59,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       # KDB+ has no public, freely-licensed image, so we build our own and the
@@ -89,13 +97,16 @@ jobs:
           KDB_TEST_PORT: 5000
           RUST_LOG: INFO
         run: |
-          cargo llvm-cov --no-report --features kdb-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features kdb-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export KDB coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload KDB coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -29,6 +29,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   otlp-integration:
@@ -50,9 +56,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -74,15 +82,18 @@ jobs:
 
       - name: Run OTLP integration tests
         run: |
-          cargo llvm-cov --no-report --features otlp-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features otlp-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export OTLP coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload OTLP coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -35,6 +35,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   postgres-integration:
@@ -56,9 +62,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -78,15 +86,18 @@ jobs:
 
       - name: Run postgres integration tests
         run: |
-          cargo llvm-cov --no-report --features postgres-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features postgres-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export postgres coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload postgres coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -29,6 +29,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   prometheus-integration:
@@ -50,9 +56,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Start Grafana + Prometheus stack
@@ -76,17 +84,20 @@ jobs:
 
       - name: Run Prometheus integration tests
         run: |
-          cargo llvm-cov --no-report --features prometheus-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features prometheus-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
           PROMETHEUS_TEST_URL: http://localhost:9090
           WINGFOIL_METRICS_PORT: "9091"
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export Prometheus coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload Prometheus coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -33,6 +33,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   redis-integration:
@@ -54,9 +60,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -76,15 +84,18 @@ jobs:
 
       - name: Run redis integration tests
         run: |
-          cargo llvm-cov --no-report --features redis-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features redis-integration-test -p wingfoil \
             -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export Redis coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload Redis coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/web-integration.yml
+++ b/.github/workflows/web-integration.yml
@@ -43,6 +43,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 # The `paths` filter above matches the `release.bump` commit — it rewrites
 # `js/package.json` and `crates/wingfoil-wasm/Cargo.toml` — so all three legs
@@ -75,9 +81,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install protoc
@@ -94,15 +102,18 @@ jobs:
       # adapter end to end under the TLS feature combination.
       - name: Run web integration tests (plain + TLS)
         run: |
-          cargo llvm-cov --no-report --features web-tls-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features web-tls-integration-test -p wingfoil \
             --test web_integration --test web_adapter -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export web coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload web coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:

--- a/.github/workflows/zmq-integration.yml
+++ b/.github/workflows/zmq-integration.yml
@@ -37,6 +37,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Instrumented run is post-merge only; see README.md. Allow-list, not
+  # `!= 'pull_request'`: under `workflow_call` the event is the caller's.
+  WF_COVERAGE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  # Same condition again — `env` cannot reference itself here. Used unquoted
+  # below, so it word-splits into the command and its flags.
+  WF_CARGO_TEST: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'cargo llvm-cov --no-report' || 'cargo test' }}
 
 jobs:
   zmq-integration:
@@ -58,9 +64,11 @@ jobs:
           shared-key: integration
 
       - name: Install cargo-llvm-cov
+        if: env.WF_COVERAGE == 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Prepare coverage collection
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov clean --workspace
 
       - name: Install system dependencies
@@ -82,14 +90,14 @@ jobs:
 
       - name: Run ZMQ core pub/sub integration tests
         run: |
-          cargo llvm-cov --no-report --features zmq-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features zmq-integration-test -p wingfoil \
             --test zmq_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
       - name: Run ZMQ etcd discovery integration tests
         run: |
-          cargo llvm-cov --no-report --features zmq-etcd-integration-test -p wingfoil \
+          $WF_CARGO_TEST --features zmq-etcd-integration-test -p wingfoil \
             --test zmq_etcd_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
@@ -153,15 +161,18 @@ jobs:
           export PATH="$GITHUB_WORKSPACE/crates/wingfoil-python/.venv/bin:$PATH"
           python3 -c 'import wingfoil' \
             || (echo "bindings not importable from the venv on PATH" && exit 1)
-          cargo llvm-cov --no-report --features zmq-cross-lang-etcd-test -p wingfoil \
+          $WF_CARGO_TEST --features zmq-cross-lang-etcd-test -p wingfoil \
             --test zmq_cross_lang_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 
+      # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export combined ZMQ coverage
+        if: env.WF_COVERAGE == 'true'
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload ZMQ coverage to Codecov
+        if: env.WF_COVERAGE == 'true'
         uses: codecov/codecov-action@v5
         continue-on-error: true
         with:


### PR DESCRIPTION
## What this changes

The 13 service-backed integration workflows now instrument their Rust tests only on a push to `main`. On a pull request they run the identical tests uninstrumented and upload nothing.

## Why

Two merges combined into something neither intended. #926 instrumented every integration workflow unconditionally; #932 then gave those same workflows a `pull_request` trigger. The result put LLVM instrumentation on the pre-merge path — exactly the cost #926 was amended to keep off `rust-test.yml`, reintroduced somewhere nobody was watching.

Instrumentation measured 7.6x on test execution for the unit suite (47.4s -> 358.2s for the same 958 tests). That is runtime overhead, so no amount of cache warming touches it. Nothing gates on the result either: both Codecov statuses are `informational: true`, and #905 asks for an honest number rather than a merge gate.

Two workflow-level env vars carry it, so there is no extra step:

- `WF_CARGO_TEST` resolves to `cargo llvm-cov --no-report` on a push to `main` and plain `cargo test` everywhere else. The two take identical argument tails, so each test step differs only by that prefix rather than being duplicated behind an `if:`.
- `WF_COVERAGE` gates the llvm-cov install, `clean`, export and Codecov upload steps.

Both are allow-lists rather than `!= 'pull_request'` because under `workflow_call` the event is the *caller's* — a release reaching these files through `all-tests.yml` would otherwise carry instrumentation onto the release critical path. Same shape as the `Coverage (unit)` leg.

This also records the decision left open in review on the export/upload steps (#926, `r3883527154`): they stay **without** `if: always()` on purpose. A half-run suite's report would be recorded as that flag's new baseline and carried forward from there, which is worse than carrying the last complete one. `carryforward: true` in `codecov.yml` covers both that case and the PR path.

`CODECOV_TOKEN` is deliberately kept. Tokenless uploads are only weakly validated — anyone can post a report against a public repo's commit — and #905 asks for an honest number, so upload authenticity is worth more than removing the secret reference. #932 already closed the exposure that made it a liability by removing the unfiltered `push:` trigger.

## How it was verified

No Rust, Python or JS is touched, so `fmt` / `lint` / `test` have nothing to act on and were not run.

- [x] Every file in `.github/workflows/` parses under `yaml.safe_load`
- [x] Per-job check across all 13: each job that uses `$WF_CARGO_TEST` has exactly 4 steps gated on `WF_COVERAGE`
- [x] No `cargo llvm-cov --no-report` invocations remain outside the env var
- [x] Both branches of the ternary expand correctly, including the three-word split on the coverage path
- [x] `git diff --check`

## Notes for the reviewer

**The word-splitting is deliberate.** `$WF_CARGO_TEST` is intentionally unquoted at each use site — it has to split into the command and its flags on the coverage path.

**The condition is written twice** in each `env:` block, once per variable. GitHub does not expose the `env` context to other `env:` entries at workflow level, so `WF_CARGO_TEST` cannot be derived from `WF_COVERAGE`. The alternative was a `Select test runner` shell step in every file, which was nine lines each against two.

**`llvm-tools-preview` is still installed unconditionally.** `with:` on `dtolnay/rust-toolchain` cannot be made conditional without splitting the step in two, and the component is small. Left alone rather than adding a second toolchain step to 13 files.

**kdb was already post-merge only** (no `pull_request` trigger), so the gate is a no-op there on the push path — but it still correctly turns instrumentation off for the `workflow_call` release path, which is the point.

**What this gives up:** per-PR patch coverage on adapter changes, for the same reason the unit leg gave it up. Both statuses are informational, so nothing breaks. If you want it back selectively, appending `|| contains(github.event.pull_request.labels.*.name, 'coverage')` to both conditions makes it opt-in per PR.

**Static verification only** — I cannot execute Actions from here. The first push to `main` after merge is what proves the coverage path still produces reports.

## Before you submit

- [x] **Allow edits by maintainers** is ticked