### PR TITLE
Fix adapter integration workflows to run only their own tests

### DIFF
--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -997,9 +997,19 @@ existing hub exactly as the legacy adapters do:
    ```yaml
    - name: Run $ARGUMENTS integration tests
      run: |
-       cargo test --features $ARGUMENTS-integration-test -p wingfoil \
-         -- --test-threads=1 --nocapture
+       $WF_CARGO_TEST --features $ARGUMENTS-integration-test -p wingfoil \
+         --test $ARGUMENTS_integration -- --test-threads=1 --nocapture
    ```
+   **`--test` is not optional.** Without it, `cargo test` runs the whole
+   `-p wingfoil` test set — every unit test, adapter test and doctest that
+   `rust-test.yml` already ran on the same commit — on top of your binary.
+   Ten workflows drifted that way before it was caught; each was paying two
+   to three minutes per run for a suite it duplicated.
+
+   `WF_CARGO_TEST` is the workflow-level env var the existing workflows
+   define; copy it and its `WF_COVERAGE` sibling from the etcd workflow, so
+   the Rust tests are instrumented on a push to `main` and plain `cargo test`
+   everywhere else.
 2. Register it as a job in `.github/workflows/integration-tests.yml`
    (`uses: ./.github/workflows/$ARGUMENTS-integration.yml`,
    `secrets: inherit`). Do **not** add it to `release.yml` directly.

--- a/.claude/commands/new-adapter.md
+++ b/.claude/commands/new-adapter.md
@@ -1001,15 +1001,10 @@ existing hub exactly as the legacy adapters do:
          --test $ARGUMENTS_integration -- --test-threads=1 --nocapture
    ```
    **`--test` is not optional.** Without it, `cargo test` runs the whole
-   `-p wingfoil` test set — every unit test, adapter test and doctest that
-   `rust-test.yml` already ran on the same commit — on top of your binary.
-   Ten workflows drifted that way before it was caught; each was paying two
-   to three minutes per run for a suite it duplicated.
+   `-p wingfoil` suite that `rust-test.yml` already ran. `WF_CARGO_TEST` and
+   its `WF_COVERAGE` sibling are workflow-level env vars — copy both from the
+   etcd workflow.
 
-   `WF_CARGO_TEST` is the workflow-level env var the existing workflows
-   define; copy it and its `WF_COVERAGE` sibling from the etcd workflow, so
-   the Rust tests are instrumented on a push to `main` and plain `cargo test`
-   everywhere else.
 2. Register it as a job in `.github/workflows/integration-tests.yml`
    (`uses: ./.github/workflows/$ARGUMENTS-integration.yml`,
    `secrets: inherit`). Do **not** add it to `release.yml` directly.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -62,22 +62,15 @@ without the service each one needs, they only exercise connection-timeout
 paths, and they are slow doing it.
 
 **And the split runs the other way too: each adapter workflow names its own
-binary with `--test` and runs nothing else.** `cargo test --features
-<adapter>-integration-test -p wingfoil` with no target selector is the whole
-package — the lib unit tests, all 72 non-integration test binaries and the
-doctests, every one of which `rust-test.yml` already ran on the same commit.
-Ten of the thirteen workflows had drifted into exactly that, spending two to
-three minutes apiece re-running the shared suite (and, on a push to `main`,
-re-running it under LLVM instrumentation). The shared suite belongs to
-`rust-test.yml`; these workflows own their own binary. `web-integration.yml`
-is the one deliberate overlap — it also names `web_adapter`, to cover the
-adapter end to end under the TLS feature combination — and says so at the
-step.
+binary with `--test` and runs nothing else.** Without a target selector,
+`cargo test --features <adapter>-integration-test -p wingfoil` is the whole
+package — the shared suite `rust-test.yml` already ran on the same commit. Ten
+of the thirteen had drifted that way, at two to three minutes apiece.
+`web-integration.yml` is the one deliberate overlap, and says so at the step.
 
-Expect each adapter flag's Codecov number to *drop* the first time it reports
-after this: the flag was measuring the shared suite too, which the `unit` flag
-already counts. The project total does not move — the same lines are still
-covered, just attributed once instead of fourteen times.
+Per-adapter Codecov flags dropped when this landed: they had been measuring
+the shared suite, which the `unit` flag already counts. The project total is
+unchanged.
 
 **Coverage on these runs is post-merge only**, the same rule
 `rust-test.yml`'s `Coverage (unit)` leg follows: instrumentation costs ~7.6x

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -61,6 +61,24 @@ The per-adapter integration workflows above are the *only* place their
 without the service each one needs, they only exercise connection-timeout
 paths, and they are slow doing it.
 
+**And the split runs the other way too: each adapter workflow names its own
+binary with `--test` and runs nothing else.** `cargo test --features
+<adapter>-integration-test -p wingfoil` with no target selector is the whole
+package — the lib unit tests, all 72 non-integration test binaries and the
+doctests, every one of which `rust-test.yml` already ran on the same commit.
+Ten of the thirteen workflows had drifted into exactly that, spending two to
+three minutes apiece re-running the shared suite (and, on a push to `main`,
+re-running it under LLVM instrumentation). The shared suite belongs to
+`rust-test.yml`; these workflows own their own binary. `web-integration.yml`
+is the one deliberate overlap — it also names `web_adapter`, to cover the
+adapter end to end under the TLS feature combination — and says so at the
+step.
+
+Expect each adapter flag's Codecov number to *drop* the first time it reports
+after this: the flag was measuring the shared suite too, which the `unit` flag
+already counts. The project total does not move — the same lines are still
+covered, just attributed once instead of fourteen times.
+
 **Coverage on these runs is post-merge only**, the same rule
 `rust-test.yml`'s `Coverage (unit)` leg follows: instrumentation costs ~7.6x
 on test execution, which no cache warming touches, and nothing gates on the

--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -92,10 +92,7 @@ jobs:
           echo "failed to pull the Aeron media driver image after 3 attempts" && exit 1
 
       - name: Run aeron integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `aeron_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features aeron-integration-test -p wingfoil \
             --test aeron_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/aeron-integration.yml
+++ b/.github/workflows/aeron-integration.yml
@@ -92,9 +92,13 @@ jobs:
           echo "failed to pull the Aeron media driver image after 3 attempts" && exit 1
 
       - name: Run aeron integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `aeron_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features aeron-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test aeron_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -84,9 +84,13 @@ jobs:
           echo "failed to pull etcd image after 3 attempts" && exit 1
 
       - name: Run etcd integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `etcd_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features etcd-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test etcd_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/etcd-integration.yml
+++ b/.github/workflows/etcd-integration.yml
@@ -84,10 +84,7 @@ jobs:
           echo "failed to pull etcd image after 3 attempts" && exit 1
 
       - name: Run etcd integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `etcd_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features etcd-integration-test -p wingfoil \
             --test etcd_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/fluvio-integration.yml
+++ b/.github/workflows/fluvio-integration.yml
@@ -83,10 +83,7 @@ jobs:
           echo "failed to pull Fluvio image after 3 attempts" && exit 1
 
       - name: Run fluvio integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `fluvio_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features fluvio-integration-test -p wingfoil \
             --test fluvio_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/fluvio-integration.yml
+++ b/.github/workflows/fluvio-integration.yml
@@ -83,9 +83,13 @@ jobs:
           echo "failed to pull Fluvio image after 3 attempts" && exit 1
 
       - name: Run fluvio integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `fluvio_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features fluvio-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test fluvio_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -82,10 +82,7 @@ jobs:
       # runner provides, so there is no service or container to start. This runs
       # both the Local-variant suite and the cross-process Ipc suite.
       - name: Run iceoryx2 integration tests (Local + IPC)
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `iceoryx2_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features iceoryx2-integration-test -p wingfoil \
             --test iceoryx2_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/iceoryx2-integration.yml
+++ b/.github/workflows/iceoryx2-integration.yml
@@ -82,9 +82,13 @@ jobs:
       # runner provides, so there is no service or container to start. This runs
       # both the Local-variant suite and the cross-process Ipc suite.
       - name: Run iceoryx2 integration tests (Local + IPC)
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `iceoryx2_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features iceoryx2-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test iceoryx2_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -83,10 +83,7 @@ jobs:
           echo "failed to pull Redpanda image after 3 attempts" && exit 1
 
       - name: Run kafka integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `kafka_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features kafka-integration-test -p wingfoil \
             --test kafka_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -83,9 +83,13 @@ jobs:
           echo "failed to pull Redpanda image after 3 attempts" && exit 1
 
       - name: Run kafka integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `kafka_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features kafka-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test kafka_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -96,10 +96,7 @@ jobs:
           KDB_TEST_HOST: localhost
           KDB_TEST_PORT: 5000
           RUST_LOG: INFO
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `kdb_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features kdb-integration-test -p wingfoil \
             --test kdb_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/kdb-integration.yml
+++ b/.github/workflows/kdb-integration.yml
@@ -96,9 +96,13 @@ jobs:
           KDB_TEST_HOST: localhost
           KDB_TEST_PORT: 5000
           RUST_LOG: INFO
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `kdb_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features kdb-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test kdb_integration -- --test-threads=1 --nocapture
 
       # No `if: always()`: a half-run report would become this flag's baseline.
       - name: Export KDB coverage

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -81,10 +81,7 @@ jobs:
           echo "failed to pull OTel collector image after 3 attempts" && exit 1
 
       - name: Run OTLP integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `otlp_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features otlp-integration-test -p wingfoil \
             --test otlp_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/otlp-integration.yml
+++ b/.github/workflows/otlp-integration.yml
@@ -81,9 +81,13 @@ jobs:
           echo "failed to pull OTel collector image after 3 attempts" && exit 1
 
       - name: Run OTLP integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `otlp_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features otlp-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test otlp_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -85,10 +85,7 @@ jobs:
           echo "failed to pull postgres image after 3 attempts" && exit 1
 
       - name: Run postgres integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `postgres_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features postgres-integration-test -p wingfoil \
             --test postgres_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -85,9 +85,13 @@ jobs:
           echo "failed to pull postgres image after 3 attempts" && exit 1
 
       - name: Run postgres integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `postgres_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features postgres-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test postgres_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -83,10 +83,7 @@ jobs:
           curl -sf http://localhost:9090/-/healthy || (echo "Prometheus never became healthy" && exit 1)
 
       - name: Run Prometheus integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `prometheus_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features prometheus-integration-test -p wingfoil \
             --test prometheus_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/prometheus-integration.yml
+++ b/.github/workflows/prometheus-integration.yml
@@ -83,9 +83,13 @@ jobs:
           curl -sf http://localhost:9090/-/healthy || (echo "Prometheus never became healthy" && exit 1)
 
       - name: Run Prometheus integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `prometheus_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features prometheus-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test prometheus_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
           PROMETHEUS_TEST_URL: http://localhost:9090

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -83,10 +83,7 @@ jobs:
           echo "failed to pull redis image after 3 attempts" && exit 1
 
       - name: Run redis integration tests
-        # Name the binary. Without `--test` this is the whole `-p wingfoil`
-        # test set — every unit test, adapter test and doctest `rust-test.yml`
-        # already ran on this commit — re-run here, and instrumented on `main`.
-        # Only `redis_integration` needs the service this job stands up.
+        # Just this binary — the shared suite is rust-test.yml's job.
         run: |
           $WF_CARGO_TEST --features redis-integration-test -p wingfoil \
             --test redis_integration -- --test-threads=1 --nocapture

--- a/.github/workflows/redis-integration.yml
+++ b/.github/workflows/redis-integration.yml
@@ -83,9 +83,13 @@ jobs:
           echo "failed to pull redis image after 3 attempts" && exit 1
 
       - name: Run redis integration tests
+        # Name the binary. Without `--test` this is the whole `-p wingfoil`
+        # test set — every unit test, adapter test and doctest `rust-test.yml`
+        # already ran on this commit — re-run here, and instrumented on `main`.
+        # Only `redis_integration` needs the service this job stands up.
         run: |
           $WF_CARGO_TEST --features redis-integration-test -p wingfoil \
-            -- --test-threads=1 --nocapture
+            --test redis_integration -- --test-threads=1 --nocapture
         env:
           RUST_LOG: INFO
 


### PR DESCRIPTION
## What this changes

Adapter integration workflows now run only their own integration test binary instead of re-running the entire wingfoil test suite (unit tests, all 72 integration test binaries, and doctests). Each workflow adds `--test <adapter>_integration` to its `cargo test` invocation to name the specific binary it owns.

## Why

Ten of the thirteen adapter workflows had drifted into running the full `-p wingfoil` test set without a target selector. This meant:

- Re-running the shared suite that `rust-test.yml` already ran on the same commit
- On pushes to `main`, re-running it under LLVM instrumentation (7.6x slowdown)
- Spending 2–3 minutes per workflow on duplicate work

The split should run both ways: `rust-test.yml` owns the shared suite; each adapter workflow owns only its own binary. `web-integration.yml` is the one deliberate overlap — it also names `web_adapter` to cover the adapter end-to-end under the TLS feature combination.

Codecov flags will show a one-time drop in coverage numbers for each adapter (the shared suite was being counted 14 times; now it counts once in the `unit` flag). The project total does not move — the same lines are still covered, just attributed correctly.

## How it was verified

- [ ] `cargo fmt --all`
- [ ] `cargo lint` and `cargo lint-all`
- [ ] `cargo test -p wingfoil --all-features`
- [ ] New behaviour is covered by a test asserting **values and tick times**

## Notes for the reviewer

This is a workflow and documentation fix with no code changes. The `--test` flag is now mandatory in the template and all existing workflows; the comments explain why (without it, the full test set runs). `WF_CARGO_TEST` and `WF_COVERAGE` are already defined in the existing workflows and are copied into the template for new adapters.

The README and template changes document the split and warn against the drift that happened before.

## Before you submit

- [ ] **Allow edits by maintainers** is ticked

https://claude.ai/code/session_01XmcWsQW4JNMG9E9pfarPrH