### PR TITLE
Add devcontainer for one-click contributor setup

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,6 +1,41 @@
 #!/bin/sh
 set -e
 
+# `WINGFOIL_HOOKS` chooses how much of CI this hook reproduces locally.
+#
+#   full (default)  what CI runs: fmt across the workspace, then clippy over
+#                   every target with `-D warnings`.
+#   fast            fmt, plus clippy over the libraries and binaries only.
+#                   Skips linking the ~69 example and bench binaries, which is
+#                   where the minutes go. Right for a docs-only or
+#                   single-crate change; it will not catch a broken example
+#                   or bench, so expect CI to be the thing that does.
+#   off             skip entirely. CI still runs the full set on the PR — this
+#                   trades a slow commit for a slower feedback loop, not for a
+#                   lower bar.
+#
+# fmt runs in every mode that runs at all: it is seconds, and a reformat
+# landing in a later commit is noise in someone else's diff.
+mode="${WINGFOIL_HOOKS:-full}"
+
+case "$mode" in
+    off)
+        echo "pre-commit: skipped (WINGFOIL_HOOKS=off). CI still runs fmt, clippy and the tests."
+        exit 0
+        ;;
+    fast)
+        cargo fmt --all
+        cargo clippy --workspace --lib --bins -- -D warnings
+        echo "pre-commit: fast mode — examples, benches and tests were not linted. CI lints them."
+        exit 0
+        ;;
+    full) ;;
+    *)
+        echo "pre-commit: unknown WINGFOIL_HOOKS='$mode' (expected full, fast or off)" >&2
+        exit 1
+        ;;
+esac
+
 # `--all-targets` below links ~69 example and bench binaries, each statically
 # carrying the whole dependency graph — the single largest thing this repo does
 # to a disk. Reclaim first if headroom is already low; `auto` is a no-op above

--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,6 +1,34 @@
 #!/bin/sh
 set -e
 
+# See the note in pre-commit for what `WINGFOIL_HOOKS` selects.
+#
+#   full (default)  build every target across the workspace, then run the
+#                   whole test suite — what CI does.
+#   fast            `cargo test -p wingfoil` only: the engine's unit,
+#                   integration and doc tests, without building the examples,
+#                   benches or the other crates. It does not cover
+#                   wingfoil-derive or the Python bindings.
+#   off             skip. CI is then the first thing that runs your tests.
+mode="${WINGFOIL_HOOKS:-full}"
+
+case "$mode" in
+    off)
+        echo "pre-push: skipped (WINGFOIL_HOOKS=off). CI runs the full workspace build and test suite."
+        exit 0
+        ;;
+    fast)
+        cargo test -p wingfoil
+        echo "pre-push: fast mode — only -p wingfoil ran. CI builds and tests the whole workspace."
+        exit 0
+        ;;
+    full) ;;
+    *)
+        echo "pre-push: unknown WINGFOIL_HOOKS='$mode' (expected full, fast or off)" >&2
+        exit 1
+        ;;
+esac
+
 # See the note in pre-commit: make room before the `--all-targets` build rather
 # than discovering there is none partway through the link step.
 scripts/disk.sh auto

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,63 @@
+# Devcontainer
+
+A container with everything a first contribution needs: current stable Rust
+with `rustfmt` and `clippy`, `protoc`, Python 3.11 with `maturin` and `pytest`,
+and a Docker daemon for the adapter integration tests.
+
+## Two ways in
+
+**GitHub Codespaces** — *Code → Codespaces → Create codespace on main*. Nothing
+to install locally.
+
+**Locally** — Docker plus the [Dev
+Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+extension, then *Dev Containers: Reopen in Container*. Any devcontainer-aware
+editor works; the config is not VS Code-specific beyond the `customizations`
+block.
+
+Either way, when it finishes:
+
+```bash
+cargo test -p wingfoil
+cargo run  -p wingfoil --example hello_graph
+```
+
+## What is in it, and why
+
+| | |
+|---|---|
+| `mcr.microsoft.com/devcontainers/rust:1-bookworm` | Rust, cargo, rustfmt, clippy |
+| `post-create.sh` → `rustup update stable` | The image pins the stable of its build date; CI runs today's stable, and newer clippy emits lints the older one does not. That gap is documented in `CLAUDE.md` and this closes it |
+| `post-create.sh` → `scripts/setup-dev.sh` | `protoc`, which a plain workspace build needs — a transitive dependency compiles proto files |
+| `post-create.sh` → `cargo fetch --locked` | So the first build is compile-bound, not network-bound |
+| Python 3.11 feature + a venv in `crates/wingfoil-python/.venv` | Same layout `python-test.yml` uses, so the local and CI commands match |
+| docker-in-docker feature | `tests/<name>_integration.rs` for etcd, redis, postgres, kafka, fluvio, otlp and aeron start their own containers through `testcontainers` |
+
+**It does not build the tree.** A `--all-targets` dev build is ~9.2GB and
+several minutes, and most first contributions touch one crate. If you want that
+warmed up, a [Codespaces
+prebuild](https://docs.github.com/en/codespaces/prebuilding-your-codespaces)
+is the place for it — add a `cargo build -p wingfoil --all-targets` step there
+rather than to `post-create.sh`, so everyone else keeps a fast create.
+
+## Disk
+
+`hostRequirements` asks for 64GB, and that is not padding: `cargo lint` and
+`cargo lint-all` cannot share artifacts (different feature sets hash to
+different metadata), incremental adds ~2.6GB, and a default 32GB codespace runs
+out partway through the second lint. On "no space left on device":
+
+```bash
+scripts/disk.sh          # what is using it
+scripts/disk.sh light    # drop examples/benches/incremental, keep deps/
+```
+
+`light` keeps `target/*/deps`, so the next build relinks instead of
+recompiling 700+ crates. Deletes still succeed while writes are failing, so
+the container is recoverable — you do not need a fresh one.
+
+## Not what the maintainers use
+
+This is a convenience for contributors, not a pinned build environment. CI in
+`.github/workflows/` is the authority on what a green build is; if the two ever
+disagree, CI is right.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,71 @@
+// Wingfoil development container.
+//
+// One click to a tree that builds: `cargo test -p wingfoil` and
+// `cargo run -p wingfoil --example hello_graph` work as soon as the container
+// finishes creating, with no host setup at all.
+//
+// Works in GitHub Codespaces ("Code -> Codespaces -> Create codespace") and in
+// VS Code / any devcontainer-aware editor locally ("Dev Containers: Reopen in
+// Container").
+{
+    "name": "Wingfoil",
+
+    // Debian bookworm with rustup, cargo, rustfmt and clippy already on the
+    // image. `post-create.sh` pulls the toolchain up to current stable, which
+    // is what CI runs — see the toolchain-gap note in CLAUDE.md.
+    "image": "mcr.microsoft.com/devcontainers/rust:1-bookworm",
+
+    "features": {
+        // The Python crate is built with maturin and tested with pytest.
+        // 3.11 matches the version python-test.yml uses.
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "3.11"
+        },
+        // Tier-2 adapter tests (etcd, redis, postgres, kafka, fluvio, otlp,
+        // aeron) start their own containers through `testcontainers`, so they
+        // need a working Docker daemon inside this one. Without it they fail
+        // with `Socket not found: /var/run/docker.sock`.
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+
+    // Sized off what this repo actually does to a disk: an `--all-targets` dev
+    // build lands around 9.2GB, `cargo lint` and `cargo lint-all` cannot share
+    // artifacts (different feature set, different metadata hash), and
+    // incremental adds another ~2.6GB. A default 32GB codespace runs out
+    // halfway through the second lint. See the "Disk space" section of
+    // CLAUDE.md, and `scripts/disk.sh` for reclaiming it.
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "8gb",
+        "storage": "64gb"
+    },
+
+    "containerEnv": {
+        "CARGO_TERM_COLOR": "always"
+    },
+
+    "postCreateCommand": ".devcontainer/post-create.sh",
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "rust-lang.rust-analyzer",
+                "tamasfe.even-better-toml",
+                "vadimcn.vscode-lldb",
+                "ms-python.python"
+            ],
+            "settings": {
+                // Match the `cargo lint` alias in .cargo/config.toml, which
+                // mirrors CI. Checking on save with clippy rather than `cargo
+                // check` means the lints that gate a PR show up while editing.
+                "rust-analyzer.check.command": "clippy",
+                "editor.formatOnSave": true,
+                // target/ is large enough that watching it slows the editor
+                // down for no benefit.
+                "files.watcherExclude": {
+                    "**/target/**": true
+                }
+            }
+        }
+    }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Runs once, when the devcontainer is created. Everything here is idempotent,
+# so re-running it by hand after a rebuild is safe.
+#
+# What it deliberately does NOT do is build the tree. A `--all-targets` dev
+# build is ~9.2GB and several minutes, and most first contributions need one
+# crate, not 79 binaries. `cargo fetch` below means the first real build is
+# compile-bound rather than network-bound. (In Codespaces, a prebuild is the
+# right place to warm the artifact cache — see .devcontainer/README.md.)
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+step() { printf '\n=== %s\n' "$1"; }
+
+# --- Rust toolchain ----------------------------------------------------------
+# The base image pins whatever stable was current when it was built. CI runs
+# `dtolnay/rust-toolchain@stable`, i.e. *today's* stable, and newer clippy adds
+# lints the older one does not emit — the toolchain gap documented in
+# CLAUDE.md, where local `cargo lint` passes and CI fails with `-D warnings`.
+# Pulling up to stable here closes it.
+step "Rust toolchain"
+rustup update stable
+rustup default stable
+rustup component add rustfmt clippy
+rustc --version && cargo --version && cargo clippy --version
+
+# --- Native build prerequisites ---------------------------------------------
+# protoc: a transitive dependency builds proto files, so a plain workspace
+# build needs it — not just `--features full`.
+step "Native prerequisites"
+scripts/setup-dev.sh
+
+# --- Warm the cargo registry -------------------------------------------------
+step "Fetching dependencies"
+cargo fetch --locked
+
+# --- Python bindings ---------------------------------------------------------
+# Same layout the python-test workflow uses (a venv inside the crate), so the
+# commands in CONTRIBUTING.md and in CI are the same commands. `maturin
+# develop` itself is left to you: it compiles the extension module, which is
+# minutes, and only matters if you are working on the bindings.
+step "Python toolchain"
+if command -v python3 >/dev/null 2>&1; then
+    python3 -m venv crates/wingfoil-python/.venv
+    crates/wingfoil-python/.venv/bin/pip install --quiet --upgrade pip maturin pytest
+    echo "venv ready: crates/wingfoil-python/.venv (run 'maturin develop' inside it when you need the module)"
+else
+    echo "python3 not found, skipping the Python venv"
+fi
+
+cat <<'EOF'
+
+=== Ready.
+
+Check the tree builds and runs:
+
+    cargo test -p wingfoil
+    cargo run  -p wingfoil --example hello_graph
+
+Before you push (these mirror CI):
+
+    cargo fmt --all
+    cargo lint          # default features
+    cargo lint-all      # all features
+
+Git hooks run fmt + clippy on commit and build + test on push, which is
+minutes. For a docs-only or single-crate change:
+
+    WINGFOIL_HOOKS=fast git commit ...   # fmt + a lib-only clippy
+    WINGFOIL_HOOKS=off  git commit ...   # skip them; CI still gates the PR
+
+Builds are large. `scripts/disk.sh` reports and reclaims space; `scripts/disk.sh
+light` keeps target/*/deps so the next build relinks instead of recompiling.
+
+Where to start: docs/wingfoil-architecture.md, then the `good first issue`
+label. CONTRIBUTING.md has the full loop.
+EOF

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,19 @@ commit and push rebuilds, so expect commits to take minutes, not seconds — and
 both now open with `scripts/disk.sh auto`, because that `--all-targets` step is
 the largest single demand this repo makes on a disk.
 
+**`WINGFOIL_HOOKS` scales that down when the change does not warrant it.**
+`fast` runs fmt plus `clippy --workspace --lib --bins` (26s on a warm tree
+against minutes, because it does not link the ~69 example and bench binaries)
+and, on push, `cargo test -p wingfoil`; `off` skips both hooks. Default is
+`full`, which is the behaviour above. Use `fast` for a docs-, shell- or
+config-only change and `full` for anything touching Rust that CI would lint as
+a target — the modes trade feedback latency, not the bar, since CI runs the
+whole set either way.
+
+Contributors have a one-click path to the same toolchain: `.devcontainer/`
+(Codespaces or local Docker) carries current stable Rust, `protoc`, Python and
+a Docker daemon, and `post-create.sh` deliberately does not build the tree.
+
 **Toolchain gap (clippy):** CI runs clippy on the current **stable** rustc,
 which can be *newer* than the toolchain in a dev sandbox. Newer clippy adds
 lints (e.g. `collapsible_match`) that the older one doesn't emit, so a local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,22 @@ on any issue you fancy.
 
 ## Getting set up
 
+### In one click
+
+The repository ships a devcontainer with current stable Rust, `protoc`, Python
+and a Docker daemon already in it, so there is nothing to install on your
+machine:
+
+- **GitHub Codespaces** — *Code → Codespaces → Create codespace on main*.
+- **Locally** — Docker plus the Dev Containers extension, then *Dev Containers:
+  Reopen in Container*.
+
+[`.devcontainer/README.md`](.devcontainer/README.md) says what is in it and
+why. Skip to [What contributions look like here](#what-contributions-look-like-here)
+once it finishes.
+
+### Or set it up yourself
+
 You need the Rust toolchain (latest stable, with `rustfmt` and `clippy`) and
 `protoc` — a transitive dependency builds proto files, so a plain workspace
 build needs it:
@@ -144,6 +160,31 @@ Because they run against a live wall clock, integration tests generally assert
 *values* rather than exact tick times; the deterministic
 `HistoricalFrom(NanoTime::ZERO)` value-and-tick-time assertions belong in the
 `_adapter.rs` half.
+
+### The git hooks, and how to make them cheaper
+
+`cargo build` installs two hooks (via `cargo-husky`, so they appear after your
+first build, not at clone time): **pre-commit** runs `cargo fmt --all` and
+clippy over every target, and **pre-push** builds and tests the whole
+workspace. That is the same gate CI applies, and on a change to the engine it
+is worth the minutes.
+
+On a docs-only or single-crate change it is not, so `WINGFOIL_HOOKS` picks how
+much of it to run:
+
+```bash
+WINGFOIL_HOOKS=fast git commit ...   # fmt + clippy over libs and bins only
+WINGFOIL_HOOKS=off  git commit ...   # skip; CI still gates the PR
+```
+
+`fast` skips linking the ~69 example and bench binaries, which is where the
+time goes — so it will not catch a broken example, and CI will. Both modes
+apply to `git push` as well: `fast` there runs `cargo test -p wingfoil` instead
+of the full workspace build and test.
+
+**Neither mode lowers the bar for a PR.** CI runs fmt, both clippy feature
+sets, the test suite, the doctests and the derive crate's own tests regardless.
+The knob trades a slow commit for a slower feedback loop, nothing else.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ every one names the file to change and an existing piece of code to copy.
 [`docs/adding-an-op.md`](docs/adding-an-op.md) is the recipe if the issue you
 pick is a new op.
 
+**Nothing to install:** [open the repo in a
+codespace](https://codespaces.new/wingfoil-io/wingfoil) and you get current
+stable Rust, `protoc`, Python and Docker already set up — `cargo test -p
+wingfoil` works as soon as it finishes. The same container runs locally under
+Docker; see [`.devcontainer/README.md`](.devcontainer/README.md).
+
 We want to hear from you! Especially if you:
 - are interested in [contributing](CONTRIBUTING.md)
 - know of a project that Wingfoil would be well-suited for


### PR DESCRIPTION
## What this changes

Contributors can now set up a complete development environment in one click — either via GitHub Codespaces or locally with Docker and the Dev Containers extension. The devcontainer carries current stable Rust, `protoc`, Python 3.11 and Docker-in-Docker for the testcontainers adapter tests, with no host setup required.

## Why

First contribution to this tree currently costs a host setup — the right stable Rust, `protoc` (needed for a plain workspace build, not just `--all-features`), Python and maturin for the bindings, Docker for the tier-2 adapter tests — and then a commit that takes minutes, because pre-commit lints every target and pre-push builds and tests the workspace. Both are quit points for someone fixing a doc line.

`post-create.sh` also pulls rustup up to *current* stable, which closes the gap documented in `CLAUDE.md` where CI's newer clippy fails what an older local one passed. It deliberately does **not** build the tree: `--all-targets` is ~9.2GB and several minutes, and a Codespaces prebuild is the right place for that.

The second half is `WINGFOIL_HOOKS`, which scales the git hooks to the change: `fast` keeps fmt and lints libs and bins only, `off` skips them. Default stays `full`.

## How it was verified

Run in this session:

- `cargo clippy --workspace --lib --bins -- -D warnings` — clean, 26s from cold (this is the `fast` path itself).
- All three hook modes exercised directly against `.cargo-husky/hooks/pre-commit`: `full` (unchanged), `fast` (26s cold / 1.2s warm), `off`, plus the unknown-value guard, which exits 1 rather than silently falling through to a mode.
- `scripts/setup-dev.sh` on a clean container — installed protoc 3.21.12, so the `post-create.sh` prerequisite step is known good.
- `devcontainer.json` parsed as JSONC (comments stripped, `json.loads`).
- `scripts/check-example-docs.sh` — passes.

**Not verified, and worth a reviewer's eye:** the container image itself has not been built, so `post-create.sh` has not run end to end — the `rustup update`, `cargo fetch --locked` and venv steps are each idempotent by construction but unexercised as a whole. No Rust changed in this branch, so the full workspace build and test suite were not run locally; CI covers both.

## Notes for the reviewer

**Disk sizing.** `hostRequirements` asks for 64GB because `cargo lint` and `cargo lint-all` cannot share artifacts (different feature sets hash to different metadata), incremental adds ~2.6GB, and a default 32GB codespace runs out partway through the second lint. `scripts/disk.sh` is documented in `.devcontainer/README.md` for reclaiming it.

**Hook modes do not lower the bar.** `full` remains the default and is byte-for-byte the previous behaviour. CI runs fmt, both clippy feature sets, the tests, the doctests and the derive crate's own tests on every PR regardless of which mode was used locally — the knob trades feedback latency, nothing else. `fast` will not catch a broken example or bench; that is stated where it is documented.

**Docker-in-docker is a judgement call.** It costs container create time for everyone to serve adapter contributors specifically. It is in because adapter work is one of the three contribution shapes `CONTRIBUTING.md` calls out, and without it the `testcontainers` suites fail with `Socket not found: /var/run/docker.sock`. Easy to drop if you disagree.

**Not a pinned build environment.** This is a convenience for contributors; CI in `.github/workflows/` remains the authority on what a green build is, and `.devcontainer/README.md` says so.

https://claude.ai/code/session_01L2wj5hhggYr1iqSGioWhEZ