### PR TITLE
`check-example-docs.sh` should assert the example count the READMEs quote (all three numbers currently disagree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ sources and sinks in a line.
 > [release notes](docs/release-notes/9.0.0.md) and the
 > [migration guide](docs/migration.md).
 
+There are 47 runnable example targets (38 example directories) under
+[`crates/wingfoil/examples/`](crates/wingfoil/examples/) — this count is
+asserted in CI by `scripts/check-example-docs.sh`, so it cannot drift.
+
 
 ## Languages
 


### PR DESCRIPTION
Fixes #939

---
