### PR TITLE
docs: add a single-process latency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ No services, no feature flags — these run with a plain `cargo run`.
 | [`pooled_channel`](crates/wingfoil/examples/core/pooled_channel/) | Recycle pre-sized payload buffers through a loan-based channel with a bounded backpressure budget. |
 | [`spawn`](crates/wingfoil/examples/core/spawn/) | Offload slow work off the graph thread with `spawn` / `spawn_map`. |
 | [`tracing`](crates/wingfoil/examples/core/tracing/) | Observability: the `logged` debug tap and the engine's own spans. |
+| [`latency`](crates/wingfoil/examples/core/latency/) | Per-hop wall-clock stamping and an end-of-run report in a dependency-free, single-process graph. |
 | [`introspect`](crates/wingfoil/examples/core/introspect/) | Read back the graph you wired — text, Mermaid, DOT, JSON or GML. |
 
 ### Adapters

--- a/crates/wingfoil/Cargo.toml
+++ b/crates/wingfoil/Cargo.toml
@@ -740,6 +740,12 @@ required-features = ["statistics"]
 name = "tracing"
 path = "examples/core/tracing/main.rs"
 
+# Single-process latency stamping and an end-of-run per-hop report. Uses only
+# default features; unlike the showcase latency example it needs no transport.
+[[example]]
+name = "latency"
+path = "examples/core/latency/main.rs"
+
 # Multi-threaded execution: a producer sub-graph on a worker thread feeds the
 # main graph through the channel layer (wingfoil's take on classic `producer()` /
 # `mapper()`). Uses only default features.

--- a/crates/wingfoil/examples/README.md
+++ b/crates/wingfoil/examples/README.md
@@ -36,7 +36,7 @@ Then pick a direction:
 
 **Start**: [`hello_graph`](core/hello_graph/) · [`ema_crossover`](core/ema_crossover/) · [`order_book`](core/order_book/)
 
-**Execution model**: [`run_mode`](core/run_mode/) · [`topological_sort`](core/topological_sort/) · [`feedback`](core/feedback/) · [`statistics`](core/statistics/) · [`tracing`](core/tracing/)
+**Execution model**: [`run_mode`](core/run_mode/) · [`topological_sort`](core/topological_sort/) · [`feedback`](core/feedback/) · [`statistics`](core/statistics/) · [`tracing`](core/tracing/) · [`latency`](core/latency/)
 
 **Tiers (`nitro!`)**: [`dual_mode`](core/dual_mode/)
 

--- a/crates/wingfoil/examples/core/README.md
+++ b/crates/wingfoil/examples/core/README.md
@@ -25,6 +25,7 @@ between them.
 | [`feedback`](feedback/) | — | Closing a loop with a `feedback` channel — a control loop a plain DAG cannot express. |
 | [`statistics`](statistics/) | `statistics` | The `StatisticsOps` trait: EWMA, cumulative and rolling mean/variance/std/min/max/median. |
 | [`tracing`](tracing/) | — | The `logged` debug tap and the engine's spans — three instrumentation modes. |
+| [`latency`](latency/) | — | Stamp named pipeline stages and print an end-of-run per-hop latency report in one process. |
 | [`introspect`](introspect/) | — | Seeing the graph you wired: `snapshot()` to text / Mermaid / Graphviz / JSON, with active and passive edges drawn apart. |
 
 ## Execution tiers — Nitro (`nitro!`)

--- a/crates/wingfoil/examples/core/latency/README.md
+++ b/crates/wingfoil/examples/core/latency/README.md
@@ -1,0 +1,62 @@
+## Per-hop latency in one process
+
+Latency stamps travel with a value, so the same pipeline can explain where it
+spent time during a historical replay or a live run. This example keeps the
+whole path in one process: it declares three named stages, performs two small
+transformations between them, and prints the two hop distributions when the
+run ends.
+
+```rust
+latency_stages! {
+    pub PipelineLatency { received, normalized, decided }
+}
+
+let decisions = g
+    .ticker(Duration::from_millis(1))
+    .count()
+    .map(|n: &u64| Traced::<u64, PipelineLatency>::new(*n))
+    .stamp_precise::<pipeline_latency::received>()
+    .map(normalize)
+    .stamp_precise::<pipeline_latency::normalized>()
+    .map(decide)
+    .stamp_precise::<pipeline_latency::decided>();
+
+let (_sink, latency) = decisions.latency_report(ReportOutput::Stdout);
+```
+
+Run it without feature flags or external services:
+
+```sh
+cargo run -p wingfoil --example latency
+```
+
+The report has two adjacent hops and one end-to-end row. This is the shape of
+a real run; the timing columns are deliberately elided because stamps read the
+wall clock even under `HistoricalFrom`, so their values depend on the machine:
+
+```text
+latency report (delta from previous stage, nanoseconds):
+  stage                            count          min         mean          p50          p99        p99.9          max
+  received -> normalized             ...          ...          ...          ...          ...          ...          ...
+  normalized -> decided               ...          ...          ...          ...          ...          ...          ...
+  received -> decided (end to end)    ...          ...          ...          ...          ...          ...          ...
+captured 2 named hops
+```
+
+`HistoricalFrom` makes the graph's engine-time schedule reproducible, but
+latency measurement intentionally uses wall time: it is measuring how long
+the work took, not when the source says the event occurred. The stage names,
+their order, the three report rows, and the five source observations stay
+fixed; the measured counts and nanosecond figures do not. On a coarse clock,
+two precise reads can still collide, in which case the affected row reports a
+`same-cycle` note and `count + same-cycle` accounts for all five observations.
+
+`stamp_precise` takes a fresh clock reading at each stage. The cheaper `stamp`
+uses one wall-clock snapshot per engine cycle, so stages reached in the same
+cycle would be reported as unmeasured rather than as a false zero-duration
+hop. Use the precise form for in-process work like this, and the cycle form for
+cross-cycle or cross-process boundaries where one read per cycle is enough.
+
+The returned `LatencyHandle` is not print-only. Here it supplies the final hop
+count; applications can also read snapshots or expose rolling windows to
+metrics and alerting code.

--- a/crates/wingfoil/examples/core/latency/main.rs
+++ b/crates/wingfoil/examples/core/latency/main.rs
@@ -1,0 +1,49 @@
+#![doc = include_str!("./README.md")]
+//!
+//! ```sh
+//! cargo run -p wingfoil --example latency
+//! ```
+
+use std::time::Duration;
+
+use wingfoil::latency::{LatencyReportOps, LatencyStreamOps, ReportOutput, Traced, latency_stages};
+use wingfoil::prelude::*;
+use wingfoil::{NanoTime, RunFor, RunMode};
+
+latency_stages! {
+    pub PipelineLatency {
+        received,
+        normalized,
+        decided,
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let g = GraphBuilder::new();
+
+    let decisions = g
+        .ticker(Duration::from_millis(1))
+        .count()
+        .map(|n: &u64| Traced::<u64, PipelineLatency>::new(*n))
+        .stamp_precise::<pipeline_latency::received>()
+        .map(|sample: &Traced<u64, PipelineLatency>| {
+            Traced::with_latency(sample.payload * 10, sample.latency)
+        })
+        .stamp_precise::<pipeline_latency::normalized>()
+        .map(|sample: &Traced<u64, PipelineLatency>| {
+            Traced::with_latency(sample.payload >= 20, sample.latency)
+        })
+        .stamp_precise::<pipeline_latency::decided>();
+
+    // The report sink observes every traced value and prints once, when the
+    // bounded run tears down. The handle is also available for programmatic
+    // snapshots, alerts, or windowed metrics.
+    let (_report_sink, latency) = decisions.latency_report(ReportOutput::Stdout);
+
+    let mut runner = g.build();
+    runner.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5))?;
+
+    println!("captured {} named hops", latency.hops().len());
+
+    Ok(())
+}


### PR DESCRIPTION
## What this changes

Adds a dependency-free `core/latency` example that carries three named wall-clock stamps through two transformations and prints a per-hop teardown report. It registers the target and links it from the core, examples, and repository indexes.

## Why

Closes #941. The latency API previously had only multi-process showcase coverage, so a user had to read transport and deployment code to learn the basic `stamp -> hops -> report` path.

## How it was verified

- [x] `cargo fmt --all`
- [x] `cargo lint` and `cargo lint-all` — upstream Linux CI
- [x] `cargo test -p wingfoil --all-features` — upstream Linux CI
- [ ] New behaviour is covered by a test asserting **values and tick times**

Additional checks passed:

- `cargo metadata --no-deps --format-version 1`
- `scripts/check-example-docs.sh` — 48 targets documented and indexed
- `git diff --check`
- `cargo run -p wingfoil --example latency` — isolated Ubuntu run [33289700815](https://github.com/maxi-maxima/wingfoil/actions/runs/33289700815), 5 samples / 2 hops / 3 report rows
- independent review of the stage/report contract and machine-dependent output boundary

The Rust build commands are not claimed locally: this Windows host has Rust but no MSVC linker or Windows SDK, so dependency build scripts stop before Wingfoil code (`link.exe` missing; `rust-lld` also lacks `kernel32.lib`). The upstream Linux matrix is the compile/test authority for this branch. No runtime value or scheduling semantics are changed; the new example itself is the exercised target.

## Notes for the reviewer

`stamp_precise` is intentional for same-cycle in-process hops. The README fixes only the stable report shape: five source observations are generated, while measured counts can be lower on coarse clocks and are reconciled by the report's `same-cycle` tally.

## Before you submit

- [x] **Allow edits by maintainers** is ticked
