### PR TITLE
docs: real output for the latency example, and a count check that bites

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ sources and sinks in a line.
 > [release notes](docs/release-notes/9.0.0.md) and the
 > [migration guide](docs/migration.md).
 
-There are 47 runnable example targets (38 example directories) under
-[`crates/wingfoil/examples/`](crates/wingfoil/examples/) — this count is
-asserted in CI by `scripts/check-example-docs.sh`, so it cannot drift.
+There are 48 runnable example targets (43 directories) under
+[`crates/wingfoil/examples/`](crates/wingfoil/examples/).
 
 
 ## Languages

--- a/crates/wingfoil/examples/core/latency/README.md
+++ b/crates/wingfoil/examples/core/latency/README.md
@@ -16,9 +16,13 @@ let decisions = g
     .count()
     .map(|n: &u64| Traced::<u64, PipelineLatency>::new(*n))
     .stamp_precise::<pipeline_latency::received>()
-    .map(normalize)
+    .map(|sample: &Traced<u64, PipelineLatency>| {
+        Traced::with_latency(sample.payload * 10, sample.latency)
+    })
     .stamp_precise::<pipeline_latency::normalized>()
-    .map(decide)
+    .map(|sample: &Traced<u64, PipelineLatency>| {
+        Traced::with_latency(sample.payload >= 20, sample.latency)
+    })
     .stamp_precise::<pipeline_latency::decided>();
 
 let (_sink, latency) = decisions.latency_report(ReportOutput::Stdout);
@@ -30,32 +34,38 @@ Run it without feature flags or external services:
 cargo run -p wingfoil --example latency
 ```
 
-The report has two adjacent hops and one end-to-end row. This is the shape of
-a real run; the timing columns are deliberately elided because stamps read the
-wall clock even under `HistoricalFrom`, so their values depend on the machine:
+The report has two adjacent hops and one end-to-end row:
 
 ```text
 latency report (delta from previous stage, nanoseconds):
-  stage                            count          min         mean          p50          p99        p99.9          max
-  received -> normalized             ...          ...          ...          ...          ...          ...          ...
-  normalized -> decided               ...          ...          ...          ...          ...          ...          ...
-  received -> decided (end to end)    ...          ...          ...          ...          ...          ...          ...
+  stage                                 count          min         mean          p50          p99        p99.9          max
+  received -> normalized                    5          540         2470          596        10046        10046        10046
+  normalized -> decided                     5          536          794          600         1680         1680         1684
+  received -> decided (end to end)          5         1076         3265         1192        11648        11648        11730
 captured 2 named hops
 ```
 
+Captured from a debug build on a shared cloud VM, so the nanosecond columns
+are a reading of *that* machine — `min` is the closest thing here to the work
+itself. What does not vary is the shape: the stage names, their order, the
+three rows, and `count 5` on every one of them.
+
 `HistoricalFrom` makes the graph's engine-time schedule reproducible, but
-latency measurement intentionally uses wall time: it is measuring how long
-the work took, not when the source says the event occurred. The stage names,
-their order, the three report rows, and the five source observations stay
-fixed; the measured counts and nanosecond figures do not. On a coarse clock,
-two precise reads can still collide, in which case the affected row reports a
-`same-cycle` note and `count + same-cycle` accounts for all five observations.
+latency measurement intentionally uses wall time: it is measuring how long the
+work took, not when the source says the event occurred. That is why the
+figures move between runs while the schedule does not.
+
+`Traced::with_latency` is what carries the stamps across a `map`: the payload
+changes type — `u64`, then `bool` — while the accumulated latency rides along
+untouched.
 
 `stamp_precise` takes a fresh clock reading at each stage. The cheaper `stamp`
-uses one wall-clock snapshot per engine cycle, so stages reached in the same
-cycle would be reported as unmeasured rather than as a false zero-duration
-hop. Use the precise form for in-process work like this, and the cycle form for
-cross-cycle or cross-process boundaries where one read per cycle is enough.
+uses one wall-clock snapshot per engine cycle, so these three stages, all
+reached in one cycle, would be reported as unmeasured rather than as a false
+zero-duration hop. Use the precise form for in-process work like this, and the
+cycle form for cross-cycle or cross-process boundaries where one read per cycle
+is enough — [`showcase/latency`](../../showcase/latency/) is that case, over a
+real transport, and its report shows exactly what `stamp` elides.
 
 The returned `LatencyHandle` is not print-only. Here it supplies the final hop
 count; applications can also read snapshots or expose rolling windows to

--- a/scripts/check-example-docs.sh
+++ b/scripts/check-example-docs.sh
@@ -105,5 +105,42 @@ if [[ $fail -ne 0 ]]; then
     exit 1
 fi
 
-count=$(wc -l <<< "$targets")
-echo "OK — $count example targets, all documented and indexed."
+# --- 4: the count stated in the repository README must be true ---------------
+# README.md says how many examples there are out loud, which is exactly the
+# kind of claim that goes stale the moment someone adds one — and a new example
+# is a new *file*, so nothing else in this check notices. The README sentence is
+# the only place the number is written down; this compares it against what the
+# manifest actually declares, so there is no second constant to keep in sync.
+#
+# The README deliberately does NOT mention this check — a reader counting the
+# examples does not care how the number is kept honest, and the note was in the
+# way of the sentence that matters. That is why the sed pattern below is the
+# contract: it is the only thing tying the two together, so keep it and the
+# README wording in step, and prefer editing both here over quietly relaxing it.
+# `tr -d` because BSD `wc` pads its output with spaces and these are compared
+# as strings, not just printed.
+count=$(wc -l <<< "$targets" | tr -d '[:space:]')
+dirs=$(while read -r _ path; do [[ -n "$path" ]] && dirname "$path"; done <<< "$targets" | sort -u | wc -l | tr -d '[:space:]')
+
+readme="$repo_root/README.md"
+claimed=$(sed -n 's/^There are \([0-9][0-9]*\) runnable example targets (\([0-9][0-9]*\) directories).*/\1 \2/p' "$readme")
+
+if [[ -z "$claimed" ]]; then
+    echo
+    echo "Example documentation check FAILED."
+    echo "README.md no longer states the example count in the form this check reads:"
+    echo "  There are N runnable example targets (M directories) ..."
+    echo "Restore that sentence, or update the pattern here — do not just delete it."
+    exit 1
+fi
+
+if [[ "$claimed" != "$count $dirs" ]]; then
+    echo
+    echo "Example documentation check FAILED."
+    echo "README.md claims $(cut -d' ' -f1 <<< "$claimed") targets in $(cut -d' ' -f2 <<< "$claimed") directories;"
+    echo "crates/wingfoil/Cargo.toml declares $count targets in $dirs directories."
+    echo "Update the sentence near the top of README.md."
+    exit 1
+fi
+
+echo "OK — $count example targets in $dirs directories, all documented and indexed."


### PR DESCRIPTION
## What this changes

Follow-up to #946, merged as 6bdd82d. Three documentation fixes — two of them that PR's, one of them ours.

**The example's output block was not real.** Its header line was copied verbatim from `showcase/latency/README.md`, but `format_latency_report` sizes the label column to the widest label — 27 characters there, `received -> decided (end to end)` is 32 here — so every numeric column sat five characters off, and the elided `...` cells moved them further again. Replaced with a captured run, plus the caveat naming which columns are a reading of one machine. That retires the paragraph hedging about a `same-cycle` reconciliation the reader will never see: `stamp_precise` re-reads the clock per stage, so all five observations get measured on any normal clock, and the pasted run shows `count 5` on every row.

**The snippet named two functions that do not exist.** `main.rs` uses inline closures, and those closures are the interesting half of the example — `Traced::with_latency` is what carries the stamps across a `map` while the payload changes type from `u64` to `bool`. Pasted the real ones and added a sentence saying what they demonstrate. Also cross-linked `showcase/latency` from the `stamp` vs `stamp_precise` paragraph, since that example is the cross-process case the paragraph describes.

**And ours: the example count check did not check anything.** #945 added a sentence to `README.md` claiming a count "asserted in CI by `scripts/check-example-docs.sh`, so it cannot drift" — but that script only ever *printed* the count. It compared it to nothing, which is #939, still open. #946 duly added a 48th target under a README still saying 47, in a different hunk, and merged green.

So the script now parses the numbers back out of the README sentence and fails when they disagree with the manifest — and the sentence goes back to saying only what a reader wants, which is how many examples there are. How the number is kept honest is the script's business and does not belong in the README's opening lines; the sed pattern is the contract between the two, and it is documented as such where it lives. The sentence remains the single source of truth, so there is no second constant to keep in sync, and deleting it to dodge the check is itself a failure with its own message.

Turning it on immediately found the other half of the drift: the parenthetical claimed 38 directories where the manifest declares 43. #945's figure had counted `[[bench]]` paths alongside the `[[example]]` ones.

## Why

#946 is a good example and the code needed nothing, but `CLAUDE.md` is explicit that sample output must be real — *"Several adapter READMEs were written from invented output and had to be corrected against the actual `println!`s; do not repeat that."* Merging it and fixing the docs here was the cheaper path than a round trip with the contributor, especially for the half that was our churn landing under their branch.

Closes #939.

## How it was verified

- [x] `scripts/check-example-docs.sh` — passes: `OK — 48 example targets in 43 directories, all documented and indexed`
- [x] The assertion actually fires, re-checked after the README wording was trimmed. Stale count → exit 1 naming both figures; sentence deleted → exit 1 telling you to restore it; correct → exit 0. Confirmed by exit code, not just output.
- [x] `bash -n scripts/check-example-docs.sh`
- [x] `cargo run -p wingfoil --example latency` — the block in the README is that run's stdout, pasted
- [x] `cargo fmt --all` + `cargo clippy --workspace --lib --bins` via the pre-commit hook
- [x] `git diff --check`

`wc -l` output is piped through `tr -d` before it is compared, because BSD `wc` pads with spaces and these are string comparisons now rather than just `echo` arguments.

## Notes for the reviewer

`cargo test -p wingfoil` fails on this machine at `tests/trybuild/must_use_combinators.rs` with a snapshot mismatch under rustc 1.94.1. **It fails identically on a clean `origin/main` worktree** — I checked before pushing — so it is the local-toolchain gap `CLAUDE.md` describes rather than anything in this diff, and the snapshot is correct for the rustc CI pins. This PR touches no Rust. The contributor on #924 hit the same wall and reported it the same way, which suggests it is worth an issue of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016E4AhS4mKjvR8HmS6cDx7k