### PR TITLE
docs(python): note that `timed` writes its summary to stderr

### DIFF
--- a/crates/wingfoil-python/README.md
+++ b/crates/wingfoil-python/README.md
@@ -292,7 +292,7 @@ I/O sources are module-level functions taking the graph first — see
 | `.for_each(f)` | Call `f(value)` for every tick and emit `None` per call. |
 | `.finally_(f)` | Call `f(last_value)` once when the graph run tears down. The suffix avoids Python's `finally` keyword. |
 | `.print()` | Print each value to stdout, passing it through. |
-| `.timed()` | Pass values through and print one performance summary at the end of the run. |
+| `.timed()` | Pass values through and print one performance summary to stderr at the end of the run. |
 | `.logged(label, level="info")` | Log `"{time} {label} {value}"` and pass through. `level` is `"trace"`/`"debug"`/`"info"`/`"warn"`/`"error"`. |
 | `.value()` | After the run, the stream's last value (legacy's `peek_value`). |
 

--- a/crates/wingfoil-python/src/graph.rs
+++ b/crates/wingfoil-python/src/graph.rs
@@ -664,7 +664,9 @@ impl PyStream {
     }
 
     /// Pass each value through unchanged and print one performance summary at
-    /// the end of the run (the legacy `timed` tap), not once per tick.
+    /// the end of the run (the legacy `timed` tap), not once per tick. The
+    /// summary goes to `stderr` — see the `Timed` op's deviation note — so it
+    /// is not captured by anything redirecting stdout.
     pub fn timed(&self) -> PyStream {
         self.wrap(self.stream.timed())
     }

--- a/crates/wingfoil-python/src/python.rs
+++ b/crates/wingfoil-python/src/python.rs
@@ -280,8 +280,9 @@ impl Stream {
         Stream(self.0.print())
     }
 
-    /// Pass each value through unchanged and print one performance summary at
-    /// the end of the run, not once per tick.
+    /// Pass each value through unchanged and print one performance summary to
+    /// `stderr` at the end of the run, not once per tick. Unlike `print`, the
+    /// summary is not written to stdout.
     fn timed(&self) -> Stream {
         Stream(self.0.timed())
     }


### PR DESCRIPTION
## What this changes

Corrects the three Python-side docs for `Stream.timed()` that #948 added, to say the end-of-run performance summary goes to **stderr**: the README operator row, the `PyStream::timed` docstring in `graph.rs`, and the `Stream::timed` docstring in `python.rs`.

## Why

The core `Timed` op writes its summary via `eprintln!` — a deviation recorded explicitly on the op in `crates/wingfoil/src/ops.rs`. The new Python docs sat directly beneath the `.print()` row that says "to stdout" and did not mention it, so a user capturing stdout (`capsys.readouterr().out`, or `python app.py > perf.log`) would get nothing and have no way to tell why from the docs.

Follow-up to #948, which was merged before this was caught; the fix could not be pushed to that PR's fork branch from this session.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [ ] `cargo lint` / `cargo lint-all` / `cargo test` — doc-comment text only, no code change; CI is authoritative
- [x] `git diff --stat` confirms the change is confined to comment and Markdown text

## Notes for the reviewer

Documentation only — no behaviour change, and `Timed` itself is untouched. The equivalent Rust fluent docstring (`fluent.rs:1339`) is also silent on stderr; left alone here to keep the diff to what #948 introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhhhnKfpB4NGeN1qiT5m5b)_