### PR TITLE
feat(dev): install all-feature native toolchain

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -256,6 +256,9 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
 
+      - name: Check developer setup script
+        run: scripts/test-setup-dev.sh
+
       - name: Run rustfmt
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -254,7 +254,7 @@ jobs:
           tool: sarif-fmt
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
+        run: scripts/setup-dev.sh --all-features
 
       - name: Check developer setup script
         run: scripts/test-setup-dev.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,26 +306,18 @@ files). On Debian/Ubuntu: `sudo apt-get install -y protobuf-compiler`, or run
 `scripts/setup-dev.sh`. Note this is needed for a *plain* `cargo build
 --workspace`, not just `lint-all` — see the feature-unification note below.
 
-### Aeron adapter system dependencies
+### All-features system dependencies
 
-The Aeron adapter requires clang, libuuid, libbsd, and a recent CMake
-(**>=3.30** — the vendored `rusteron-media-driver` Aeron sources set that floor
-in their own `cmake_minimum_required`, so 3.28 fails the build script outright
-with `CMake 3.30 or higher is required`):
+Use the setup script for the native Aeron and ZeroMQ build dependencies:
 
 ```bash
-sudo apt update
-sudo apt install clang libclang-dev uuid-dev libbsd-dev
-
-# CMake 3.31 (apt version is too old on many distros)
-wget https://github.com/Kitware/CMake/releases/download/v3.31.0/cmake-3.31.0-linux-x86_64.sh
-sudo ./cmake-3.31.0-linux-x86_64.sh --prefix=/usr/local --skip-license
+scripts/setup-dev.sh --all-features
 ```
 
-`libbsd-dev` is the one that is easy to miss, because nothing fails until
-**link** time and only on an `--all-features` target: the vendored Aeron C
-client emits `-lbsd`, so a long, apparently successful build ends with
-`rust-lld: error: unable to find library -lbsd`.
+This keeps the ordinary protoc-only setup small. The explicit mode also checks
+that CMake is at least 3.30; older Linux packages are replaced with the pinned
+Kitware build required by the vendored Aeron sources. Missing libbsd otherwise
+surfaces only at link time as `rust-lld: error: unable to find library -lbsd`.
 
 ### Disk space
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,8 +315,9 @@ scripts/setup-dev.sh --all-features
 ```
 
 This keeps the ordinary protoc-only setup small. The explicit mode also checks
-that CMake is at least 3.30; older Linux packages are replaced with the pinned
-Kitware build required by the vendored Aeron sources. Missing libbsd otherwise
+that CMake is at least 3.30 because the vendored `rusteron-media-driver` Aeron
+sources set that floor in their own `cmake_minimum_required`; older Linux
+packages are replaced with the pinned Kitware build. Missing libbsd otherwise
 surfaces only at link time as `rust-lld: error: unable to find library -lbsd`.
 
 ### Disk space

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ You need the Rust toolchain (latest stable, with `rustfmt` and `clippy`) and
 build needs it:
 
 ```bash
-scripts/setup-dev.sh              # installs protoc; Debian/Ubuntu and macOS
+scripts/setup-dev.sh                 # protoc only
+scripts/setup-dev.sh --all-features  # also Aeron/ZeroMQ native dependencies
 ```
 
 Then check everything works end to end:
@@ -38,9 +39,9 @@ cargo test -p wingfoil
 cargo run  -p wingfoil --example hello_graph
 ```
 
-A few adapters need more (Aeron wants clang, libuuid and CMake ≥ 3.30; some
-adapter tests want a live service) — [`CLAUDE.md`](CLAUDE.md) has the details,
-and none of it is needed to work on the engine.
+The `--all-features` mode is idempotent and supports apt, dnf, pacman and
+Homebrew. Some adapter tests still want a live service; [`CLAUDE.md`](CLAUDE.md)
+has those details. None of it is needed to work on the engine.
 
 **Where to start:** the
 [`good first issue`](https://github.com/wingfoil-io/wingfoil/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -8,12 +8,15 @@ set -euo pipefail
 
 CMAKE_MIN_VERSION=3.30.0
 CMAKE_INSTALL_VERSION=3.31.0
+# These pins are trusted only after checking Kitware's published
+# cmake-${CMAKE_INSTALL_VERSION}-SHA-256.txt; the mocked regression test cannot
+# independently authenticate them.
 CMAKE_SHA256_AARCH64=45bb6140132427c398437f96bd78820724baa868617470ca40a8c382a8c9e965
 CMAKE_SHA256_X86_64=7cfdf4a411c71d13c027199952fd25e8245d85c932ff452e2b9a9e0f6dfe368a
 ALL_FEATURES=false
 
 usage() {
-    echo "Usage: scripts/setup-dev.sh [--all-features]"
+    echo "Usage: scripts/setup-dev.sh [--all-features | --help]"
 }
 
 run_as_root() {
@@ -30,12 +33,17 @@ run_as_root() {
 case $# in
     0) ;;
     1)
-        if [[ $1 == "--all-features" ]]; then
-            ALL_FEATURES=true
-        else
-            usage >&2
-            exit 2
-        fi
+        case $1 in
+            --all-features) ALL_FEATURES=true ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                usage >&2
+                exit 2
+                ;;
+        esac
         ;;
     *)
         usage >&2
@@ -347,3 +355,6 @@ clang_version=
 read -r clang_version < <(clang --version)
 zmq_version=$(pkg-config --modversion libzmq)
 echo "Native all-features toolchain ready: $clang_version; libzmq $zmq_version"
+if [[ $PACKAGE_MANAGER == brew ]]; then
+    echo "Homebrew LLVM is keg-only; if bindgen cannot find libclang, set LIBCLANG_PATH=\"$(brew --prefix llvm)/lib\"."
+fi

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,51 +1,349 @@
 #!/usr/bin/env bash
-# Install non-cargo build prerequisites (currently just protoc, needed when
-# building with `--features full` or any of: etcd, otlp, fluvio).
+# Install non-cargo build prerequisites. The default installs protoc; pass
+# --all-features for the native Aeron and ZeroMQ toolchain as well.
 #
 # Idempotent: skips anything already installed.
 
 set -euo pipefail
 
-if command -v protoc >/dev/null 2>&1; then
-    echo "protoc already installed: $(protoc --version)"
-    exit 0
-fi
+CMAKE_MIN_VERSION=3.30.0
+CMAKE_INSTALL_VERSION=3.31.0
+CMAKE_SHA256_AARCH64=45bb6140132427c398437f96bd78820724baa868617470ca40a8c382a8c9e965
+CMAKE_SHA256_X86_64=7cfdf4a411c71d13c027199952fd25e8245d85c932ff452e2b9a9e0f6dfe368a
+ALL_FEATURES=false
 
-echo "protoc not found, installing..."
+usage() {
+    echo "Usage: scripts/setup-dev.sh [--all-features]"
+}
 
-case "$(uname -s)" in
-    Linux*)
-        if command -v apt-get >/dev/null 2>&1; then
-            # A third-party PPA that has gone unsigned/403 makes `update` exit
-            # non-zero even though the archives we need refreshed fine, and
-            # `set -e` would abort before we ever try the install. Let the
-            # install itself be the thing that decides whether we have protoc.
-            sudo apt-get update || echo "apt-get update reported errors, continuing"
-            sudo apt-get install -y protobuf-compiler
-        elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y protobuf-compiler
-        elif command -v pacman >/dev/null 2>&1; then
-            sudo pacman -S --noconfirm protobuf
+run_as_root() {
+    if ((EUID == 0)); then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        echo "Root privileges are required; install sudo or run this script as root." >&2
+        return 1
+    fi
+}
+
+case $# in
+    0) ;;
+    1)
+        if [[ $1 == "--all-features" ]]; then
+            ALL_FEATURES=true
         else
-            echo "Unsupported Linux distribution. Install protoc manually:"
-            echo "  https://github.com/protocolbuffers/protobuf/releases"
-            exit 1
-        fi
-        ;;
-    Darwin*)
-        if command -v brew >/dev/null 2>&1; then
-            brew install protobuf
-        else
-            echo "Homebrew not found. Install it from https://brew.sh, or install protoc manually:"
-            echo "  https://github.com/protocolbuffers/protobuf/releases"
-            exit 1
+            usage >&2
+            exit 2
         fi
         ;;
     *)
-        echo "Unsupported OS: $(uname -s). Install protoc manually:"
-        echo "  https://github.com/protocolbuffers/protobuf/releases"
-        exit 1
+        usage >&2
+        exit 2
         ;;
 esac
 
-echo "Installed: $(protoc --version)"
+detect_package_manager() {
+    case "$(uname -s)" in
+        Linux*)
+            if command -v apt-get >/dev/null 2>&1; then
+                echo apt-get
+            elif command -v dnf >/dev/null 2>&1; then
+                echo dnf
+            elif command -v pacman >/dev/null 2>&1; then
+                echo pacman
+            else
+                echo "Unsupported Linux distribution. Install prerequisites manually." >&2
+                return 1
+            fi
+            ;;
+        Darwin*)
+            if command -v brew >/dev/null 2>&1; then
+                echo brew
+            else
+                echo "Homebrew not found. Install it from https://brew.sh, or install prerequisites manually." >&2
+                return 1
+            fi
+            ;;
+        *)
+            echo "Unsupported OS: $(uname -s). Install prerequisites manually." >&2
+            return 1
+            ;;
+    esac
+}
+
+install_protoc() {
+    if command -v protoc >/dev/null 2>&1; then
+        echo "protoc already installed: $(protoc --version)"
+        return
+    fi
+
+    echo "protoc not found, installing..."
+
+    case "$(uname -s)" in
+        Linux*)
+            if command -v apt-get >/dev/null 2>&1; then
+                # A third-party PPA that has gone unsigned/403 makes `update`
+                # exit non-zero even though the archives we need refreshed
+                # fine. Let install decide whether protoc is available.
+                run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update || echo "apt-get update reported errors, continuing"
+                run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y protobuf-compiler
+            elif command -v dnf >/dev/null 2>&1; then
+                run_as_root dnf install -y protobuf-compiler
+            elif command -v pacman >/dev/null 2>&1; then
+                run_as_root pacman -S --noconfirm protobuf
+            else
+                echo "Unsupported Linux distribution. Install protoc manually:"
+                echo "  https://github.com/protocolbuffers/protobuf/releases"
+                exit 1
+            fi
+            ;;
+        Darwin*)
+            if command -v brew >/dev/null 2>&1; then
+                brew install protobuf
+            else
+                echo "Homebrew not found. Install it from https://brew.sh, or install protoc manually:"
+                echo "  https://github.com/protocolbuffers/protobuf/releases"
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Unsupported OS: $(uname -s). Install protoc manually:"
+            echo "  https://github.com/protocolbuffers/protobuf/releases"
+            exit 1
+            ;;
+    esac
+
+    echo "Installed: $(protoc --version)"
+}
+
+package_installed() {
+    local package_manager=$1
+    local package=$2
+    local status
+
+    case "$package_manager" in
+        apt-get)
+            status=$(dpkg-query -W -f='${Status}' "$package" 2>/dev/null || true)
+            [[ $status == "install ok installed" ]]
+            ;;
+        dnf) dnf list --installed "$package" >/dev/null 2>&1 ;;
+        pacman) pacman -Q "$package" >/dev/null 2>&1 ;;
+        brew) brew list --versions "$package" >/dev/null 2>&1 ;;
+    esac
+}
+
+ensure_dnf_libbsd_repo() {
+    local rhel_major
+
+    if package_installed dnf libbsd-devel || dnf list --available libbsd-devel >/dev/null 2>&1; then
+        return
+    fi
+
+    echo "libbsd-devel is not in the enabled dnf repositories; enabling EPEL"
+    if run_as_root dnf install -y epel-release; then
+        :
+    else
+        rhel_major=$(rpm -E '%{rhel}' 2>/dev/null || true)
+        if [[ ! $rhel_major =~ ^[0-9]+$ ]]; then
+            echo "Unable to determine the Enterprise Linux version needed for EPEL." >&2
+            return 1
+        fi
+        run_as_root dnf install -y \
+            "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${rhel_major}.noarch.rpm"
+    fi
+
+    if ! dnf list --available libbsd-devel >/dev/null 2>&1; then
+        echo "EPEL was enabled, but libbsd-devel is still unavailable." >&2
+        return 1
+    fi
+}
+
+install_native_packages() {
+    local package_manager=$1
+    local -a packages
+    local package
+    local all_installed=true
+
+    case "$package_manager" in
+        apt-get)
+            packages=(build-essential ca-certificates curl clang libclang-dev uuid-dev libbsd-dev cmake libzmq3-dev libssl-dev pkg-config)
+            ;;
+        dnf)
+            packages=(gcc-c++ make ca-certificates curl clang clang-devel libuuid-devel libbsd-devel cmake zeromq-devel openssl-devel pkgconf-pkg-config)
+            ;;
+        pacman)
+            packages=(base-devel ca-certificates curl clang util-linux-libs libbsd cmake zeromq openssl pkgconf)
+            ;;
+        brew)
+            # macOS supplies UUID and BSD APIs; Homebrew provides libclang and
+            # the ZeroMQ development files.
+            packages=(llvm cmake zeromq openssl@3 pkgconf)
+            ;;
+    esac
+
+    if [[ $package_manager == dnf ]]; then
+        ensure_dnf_libbsd_repo
+    fi
+
+    for package in "${packages[@]}"; do
+        if ! package_installed "$package_manager" "$package"; then
+            all_installed=false
+            break
+        fi
+    done
+
+    if $all_installed; then
+        echo "Native packages already installed: ${packages[*]}"
+        return
+    fi
+
+    echo "Installing native all-features packages: ${packages[*]}"
+    case "$package_manager" in
+        apt-get)
+            run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update || echo "apt-get update reported errors, continuing"
+            run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
+            ;;
+        dnf) run_as_root dnf install -y "${packages[@]}" ;;
+        pacman) run_as_root pacman -S --noconfirm "${packages[@]}" ;;
+        brew) brew install "${packages[@]}" ;;
+    esac
+}
+
+cmake_version() {
+    local version
+    read -r _ _ version < <(cmake --version)
+    echo "$version"
+}
+
+version_at_least() {
+    local current=$1
+    local required=$2
+    local -a current_parts required_parts
+    local current_part required_part
+    local i
+
+    IFS=. read -r -a current_parts <<<"$current"
+    IFS=. read -r -a required_parts <<<"$required"
+    for i in 0 1 2; do
+        current_part=${current_parts[$i]:-0}
+        required_part=${required_parts[$i]:-0}
+        current_part=${current_part%%[!0-9]*}
+        required_part=${required_part%%[!0-9]*}
+        current_part=${current_part:-0}
+        required_part=${required_part:-0}
+        if ((10#$current_part > 10#$required_part)); then
+            return 0
+        elif ((10#$current_part < 10#$required_part)); then
+            return 1
+        fi
+    done
+    return 0
+}
+
+install_kitware_cmake() {
+    local architecture
+    local actual_sha256
+    local expected_sha256
+    local installer
+    local url
+
+    case "$(uname -m)" in
+        x86_64|amd64)
+            architecture=x86_64
+            expected_sha256=$CMAKE_SHA256_X86_64
+            ;;
+        aarch64|arm64)
+            architecture=aarch64
+            expected_sha256=$CMAKE_SHA256_AARCH64
+            ;;
+        *)
+            echo "No CMake installer is configured for architecture $(uname -m)." >&2
+            echo "Install CMake >= $CMAKE_MIN_VERSION manually: https://cmake.org/download/" >&2
+            return 1
+            ;;
+    esac
+
+    installer=$(mktemp)
+    url="https://github.com/Kitware/CMake/releases/download/v${CMAKE_INSTALL_VERSION}/cmake-${CMAKE_INSTALL_VERSION}-linux-${architecture}.sh"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$installer"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q "$url" -O "$installer"
+    else
+        echo "curl or wget is required to install CMake $CMAKE_INSTALL_VERSION." >&2
+        rm -f "$installer"
+        return 1
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual_sha256=$(sha256sum "$installer")
+    elif command -v shasum >/dev/null 2>&1; then
+        actual_sha256=$(shasum -a 256 "$installer")
+    else
+        echo "sha256sum or shasum is required to verify the CMake installer." >&2
+        rm -f "$installer"
+        return 1
+    fi
+    actual_sha256=${actual_sha256%% *}
+    if [[ $actual_sha256 != "$expected_sha256" ]]; then
+        echo "CMake installer checksum mismatch for linux-${architecture}." >&2
+        rm -f "$installer"
+        return 1
+    fi
+    echo "Verified CMake $CMAKE_INSTALL_VERSION installer SHA-256"
+    run_as_root sh "$installer" --prefix=/usr/local --skip-license --exclude-subdir
+    rm -f "$installer"
+}
+
+ensure_recent_cmake() {
+    local package_manager=$1
+    local installed_version
+
+    if command -v cmake >/dev/null 2>&1; then
+        installed_version=$(cmake_version)
+        if version_at_least "$installed_version" "$CMAKE_MIN_VERSION"; then
+            echo "CMake already installed: $installed_version"
+            return
+        fi
+        echo "CMake $installed_version is too old; installing CMake $CMAKE_INSTALL_VERSION"
+    else
+        echo "CMake not found; installing CMake $CMAKE_INSTALL_VERSION"
+    fi
+
+    if [[ $package_manager == brew ]]; then
+        if brew list --versions cmake >/dev/null 2>&1; then
+            brew upgrade cmake
+        else
+            brew install cmake
+        fi
+    else
+        install_kitware_cmake
+    fi
+
+    if ! command -v cmake >/dev/null 2>&1; then
+        echo "CMake installation completed but cmake is not on PATH." >&2
+        return 1
+    fi
+    installed_version=$(cmake_version)
+    if ! version_at_least "$installed_version" "$CMAKE_MIN_VERSION"; then
+        echo "CMake $installed_version is still below the required $CMAKE_MIN_VERSION." >&2
+        return 1
+    fi
+    echo "Installed CMake: $installed_version"
+}
+
+install_protoc
+
+if ! $ALL_FEATURES; then
+    exit 0
+fi
+
+PACKAGE_MANAGER=$(detect_package_manager)
+install_native_packages "$PACKAGE_MANAGER"
+ensure_recent_cmake "$PACKAGE_MANAGER"
+
+clang_version=
+read -r clang_version < <(clang --version)
+zmq_version=$(pkg-config --modversion libzmq)
+echo "Native all-features toolchain ready: $clang_version; libzmq $zmq_version"

--- a/scripts/test-setup-dev.sh
+++ b/scripts/test-setup-dev.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SCRIPT="$SCRIPT_DIR/setup-dev.sh"
+TEST_ROOT="$(mktemp -d)"
+REAL_BASH=$(command -v bash)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local haystack=$1
+    local needle=$2
+    [[ "$haystack" == *"$needle"* ]] || fail "expected '$needle' in '$haystack'"
+}
+
+assert_not_contains() {
+    local haystack=$1
+    local needle=$2
+    [[ "$haystack" != *"$needle"* ]] || fail "did not expect '$needle' in '$haystack'"
+}
+
+write_mock() {
+    local name=$1
+    cat >"$MOCK_BIN/$name"
+    chmod +x "$MOCK_BIN/$name"
+}
+
+new_case() {
+    local name=$1
+    CASE_DIR="$TEST_ROOT/$name"
+    MOCK_BIN="$CASE_DIR/bin"
+    MOCK_STATE="$CASE_DIR/state"
+    MOCK_LOG="$CASE_DIR/calls.log"
+    mkdir -p "$MOCK_BIN" "$MOCK_STATE"
+    : >"$MOCK_LOG"
+
+    write_mock uname <<'MOCK'
+#!/bin/bash
+case "${1:-}" in
+    -m) printf '%s\n' "${MOCK_ARCH:-x86_64}" ;;
+    *) printf '%s\n' "${MOCK_OS:-Linux}" ;;
+esac
+MOCK
+
+    write_mock protoc <<'MOCK'
+#!/bin/bash
+echo "libprotoc 29.0"
+MOCK
+
+    write_mock clang <<'MOCK'
+#!/bin/bash
+echo "clang version 18.1.0"
+MOCK
+
+    write_mock cmake <<'MOCK'
+#!/bin/bash
+if [[ -f "$MOCK_STATE/cmake-new" ]]; then
+    echo "cmake version 3.31.0"
+else
+    echo "cmake version ${MOCK_CMAKE_VERSION:-3.31.0}"
+fi
+MOCK
+
+    write_mock pkg-config <<'MOCK'
+#!/bin/bash
+if [[ "${1:-}" == "--modversion" ]]; then
+    [[ -f "$MOCK_STATE/native-installed" ]] || exit 1
+    echo "4.3.5"
+    exit 0
+fi
+[[ -f "$MOCK_STATE/native-installed" ]]
+MOCK
+
+    write_mock dpkg-query <<'MOCK'
+#!/bin/bash
+[[ -f "$MOCK_STATE/native-installed" ]] || exit 1
+echo "install ok installed"
+MOCK
+
+    write_mock sudo <<'MOCK'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >>"$MOCK_LOG"
+"$@"
+MOCK
+
+    write_mock env <<'MOCK'
+#!/bin/bash
+while (($#)) && [[ $1 == *=* ]]; do
+    export "$1"
+    shift
+done
+exec "$@"
+MOCK
+
+    write_mock sh <<'MOCK'
+#!/bin/bash
+exec /bin/bash "$@"
+MOCK
+
+    write_mock mktemp <<'MOCK'
+#!/bin/bash
+echo "$MOCK_STATE/cmake-installer.sh"
+MOCK
+
+    write_mock rm <<'MOCK'
+#!/bin/bash
+for target in "$@"; do
+    [[ "$target" == -* ]] || : >"$target.removed"
+done
+MOCK
+
+    write_mock curl <<'MOCK'
+#!/bin/bash
+printf 'curl %s\n' "$*" >>"$MOCK_LOG"
+output=
+while (($#)); do
+    if [[ "$1" == "-o" ]]; then
+        shift
+        output=$1
+    fi
+    shift
+done
+[[ -n "$output" ]]
+printf '#!/bin/bash\n: >"$MOCK_STATE/cmake-new"\n' >"$output"
+MOCK
+
+    write_mock sha256sum <<'MOCK'
+#!/bin/bash
+printf 'sha256sum %s\n' "$*" >>"$MOCK_LOG"
+if [[ ${MOCK_BAD_CHECKSUM:-false} == true ]]; then
+    printf '%064d  %s\n' 0 "$1"
+else
+    echo "7cfdf4a411c71d13c027199952fd25e8245d85c932ff452e2b9a9e0f6dfe368a  $1"
+fi
+MOCK
+}
+
+add_package_manager() {
+    local name=$1
+    write_mock "$name" <<'MOCK'
+#!/bin/bash
+command_name=${0##*/}
+printf '%s %s\n' "$command_name" "$*" >>"$MOCK_LOG"
+case "$command_name $*" in
+    "dnf list --installed "*|"pacman -Q "*|"brew list --versions "*)
+        [[ -f "$MOCK_STATE/native-installed" ]]
+        exit
+        ;;
+esac
+case " $* " in
+    *" install "*|*" -S "*)
+        : >"$MOCK_STATE/native-installed"
+        ;;
+esac
+MOCK
+}
+
+run_setup() {
+    set +e
+    RUN_OUTPUT=$(env \
+        PATH="$MOCK_BIN" \
+        MOCK_ARCH="${MOCK_ARCH:-x86_64}" \
+        MOCK_BAD_CHECKSUM="${MOCK_BAD_CHECKSUM:-false}" \
+        MOCK_CMAKE_VERSION="${MOCK_CMAKE_VERSION:-3.31.0}" \
+        MOCK_LOG="$MOCK_LOG" \
+        MOCK_OS="${MOCK_OS:-Linux}" \
+        MOCK_STATE="$MOCK_STATE" \
+        "$REAL_BASH" "$SETUP_SCRIPT" "$@" 2>&1)
+    RUN_STATUS=$?
+    set -e
+}
+
+new_case bare
+run_setup
+[[ $RUN_STATUS -eq 0 ]] || fail "bare setup failed with $RUN_STATUS: $RUN_OUTPUT"
+[[ "$RUN_OUTPUT" == "protoc already installed: libprotoc 29.0" ]] || \
+    fail "bare setup output changed: $RUN_OUTPUT"
+[[ ! -s "$MOCK_LOG" ]] || fail "bare setup attempted native installation"
+
+new_case apt-old-cmake
+add_package_manager apt-get
+MOCK_CMAKE_VERSION=3.28.3 run_setup --all-features
+[[ $RUN_STATUS -eq 0 ]] || fail "apt all-features setup failed: $RUN_OUTPUT"
+CALLS=$(<"$MOCK_LOG")
+assert_contains "$CALLS" "apt-get update"
+assert_contains "$CALLS" "apt-get install -y build-essential ca-certificates curl clang libclang-dev uuid-dev libbsd-dev cmake libzmq3-dev libssl-dev pkg-config"
+assert_contains "$CALLS" "curl -fsSL"
+assert_contains "$CALLS" "sha256sum $MOCK_STATE/cmake-installer.sh"
+assert_contains "$CALLS" "sudo sh $MOCK_STATE/cmake-installer.sh --prefix=/usr/local --skip-license --exclude-subdir"
+assert_contains "$RUN_OUTPUT" "CMake 3.28.3 is too old; installing CMake 3.31.0"
+assert_contains "$RUN_OUTPUT" "Verified CMake 3.31.0 installer SHA-256"
+assert_contains "$RUN_OUTPUT" "Native all-features toolchain ready"
+
+: >"$MOCK_LOG"
+run_setup --all-features
+[[ $RUN_STATUS -eq 0 ]] || fail "idempotent apt rerun failed: $RUN_OUTPUT"
+[[ ! -s "$MOCK_LOG" ]] || fail "idempotent apt rerun attempted installation: $(<"$MOCK_LOG")"
+assert_contains "$RUN_OUTPUT" "Native packages already installed"
+assert_contains "$RUN_OUTPUT" "CMake already installed: 3.31.0"
+
+for package_manager in dnf pacman; do
+    new_case "$package_manager"
+    add_package_manager "$package_manager"
+    run_setup --all-features
+    [[ $RUN_STATUS -eq 0 ]] || fail "$package_manager all-features setup failed: $RUN_OUTPUT"
+    CALLS=$(<"$MOCK_LOG")
+    case "$package_manager" in
+        dnf)
+            assert_contains "$CALLS" "dnf install -y gcc-c++ make ca-certificates curl clang clang-devel libuuid-devel libbsd-devel cmake zeromq-devel openssl-devel pkgconf-pkg-config"
+            ;;
+        pacman)
+            assert_contains "$CALLS" "pacman -S --noconfirm base-devel ca-certificates curl clang util-linux-libs libbsd cmake zeromq openssl pkgconf"
+            ;;
+    esac
+done
+
+new_case dnf-epel
+write_mock dnf <<'MOCK'
+#!/bin/bash
+printf 'dnf %s\n' "$*" >>"$MOCK_LOG"
+case "$*" in
+    "list --installed "*) [[ -f "$MOCK_STATE/native-installed" ]] ;;
+    "list --available libbsd-devel") [[ -f "$MOCK_STATE/epel-enabled" ]] ;;
+    "install -y epel-release") : >"$MOCK_STATE/epel-enabled" ;;
+    "install -y "*) : >"$MOCK_STATE/native-installed" ;;
+esac
+MOCK
+run_setup --all-features
+[[ $RUN_STATUS -eq 0 ]] || fail "dnf EPEL setup failed: $RUN_OUTPUT"
+CALLS=$(<"$MOCK_LOG")
+assert_contains "$CALLS" "dnf install -y epel-release"
+assert_contains "$CALLS" "dnf install -y gcc-c++ make ca-certificates curl clang clang-devel libuuid-devel libbsd-devel cmake zeromq-devel openssl-devel pkgconf-pkg-config"
+
+new_case bad-cmake-checksum
+add_package_manager apt-get
+MOCK_CMAKE_VERSION=3.28.3 MOCK_BAD_CHECKSUM=true run_setup --all-features
+[[ $RUN_STATUS -ne 0 ]] || fail "bad CMake checksum unexpectedly succeeded"
+CALLS=$(<"$MOCK_LOG")
+assert_contains "$RUN_OUTPUT" "CMake installer checksum mismatch"
+assert_not_contains "$CALLS" "sudo sh"
+
+new_case brew
+add_package_manager brew
+MOCK_OS=Darwin run_setup --all-features
+[[ $RUN_STATUS -eq 0 ]] || fail "brew all-features setup failed: $RUN_OUTPUT"
+CALLS=$(<"$MOCK_LOG")
+assert_contains "$CALLS" "brew install llvm cmake zeromq openssl@3 pkgconf"
+assert_not_contains "$CALLS" "sudo brew"
+
+new_case invalid-argument
+run_setup --everything
+[[ $RUN_STATUS -eq 2 ]] || fail "unknown argument returned $RUN_STATUS instead of 2"
+assert_contains "$RUN_OUTPUT" "Usage: scripts/setup-dev.sh [--all-features]"
+
+echo "setup-dev tests passed"

--- a/scripts/test-setup-dev.sh
+++ b/scripts/test-setup-dev.sh
@@ -100,6 +100,7 @@ MOCK
 
     write_mock sh <<'MOCK'
 #!/bin/bash
+printf 'sh %s\n' "$*" >>"$MOCK_LOG"
 exec /bin/bash "$@"
 MOCK
 
@@ -148,6 +149,10 @@ add_package_manager() {
 command_name=${0##*/}
 printf '%s %s\n' "$command_name" "$*" >>"$MOCK_LOG"
 case "$command_name $*" in
+    "brew --prefix llvm")
+        echo /opt/homebrew/opt/llvm
+        exit
+        ;;
     "dnf list --installed "*|"pacman -Q "*|"brew list --versions "*)
         [[ -f "$MOCK_STATE/native-installed" ]]
         exit
@@ -192,7 +197,10 @@ assert_contains "$CALLS" "apt-get update"
 assert_contains "$CALLS" "apt-get install -y build-essential ca-certificates curl clang libclang-dev uuid-dev libbsd-dev cmake libzmq3-dev libssl-dev pkg-config"
 assert_contains "$CALLS" "curl -fsSL"
 assert_contains "$CALLS" "sha256sum $MOCK_STATE/cmake-installer.sh"
-assert_contains "$CALLS" "sudo sh $MOCK_STATE/cmake-installer.sh --prefix=/usr/local --skip-license --exclude-subdir"
+assert_contains "$CALLS" "sh $MOCK_STATE/cmake-installer.sh --prefix=/usr/local --skip-license --exclude-subdir"
+if ((EUID != 0)); then
+    assert_contains "$CALLS" "sudo sh $MOCK_STATE/cmake-installer.sh --prefix=/usr/local --skip-license --exclude-subdir"
+fi
 assert_contains "$RUN_OUTPUT" "CMake 3.28.3 is too old; installing CMake 3.31.0"
 assert_contains "$RUN_OUTPUT" "Verified CMake 3.31.0 installer SHA-256"
 assert_contains "$RUN_OUTPUT" "Native all-features toolchain ready"
@@ -243,7 +251,7 @@ MOCK_CMAKE_VERSION=3.28.3 MOCK_BAD_CHECKSUM=true run_setup --all-features
 [[ $RUN_STATUS -ne 0 ]] || fail "bad CMake checksum unexpectedly succeeded"
 CALLS=$(<"$MOCK_LOG")
 assert_contains "$RUN_OUTPUT" "CMake installer checksum mismatch"
-assert_not_contains "$CALLS" "sudo sh"
+assert_not_contains "$CALLS" "sh $MOCK_STATE/cmake-installer.sh"
 
 new_case brew
 add_package_manager brew
@@ -251,11 +259,19 @@ MOCK_OS=Darwin run_setup --all-features
 [[ $RUN_STATUS -eq 0 ]] || fail "brew all-features setup failed: $RUN_OUTPUT"
 CALLS=$(<"$MOCK_LOG")
 assert_contains "$CALLS" "brew install llvm cmake zeromq openssl@3 pkgconf"
+assert_contains "$CALLS" "brew --prefix llvm"
 assert_not_contains "$CALLS" "sudo brew"
+assert_contains "$RUN_OUTPUT" 'set LIBCLANG_PATH="/opt/homebrew/opt/llvm/lib"'
+
+new_case help
+run_setup --help
+[[ $RUN_STATUS -eq 0 ]] || fail "--help returned $RUN_STATUS instead of 0"
+[[ "$RUN_OUTPUT" == "Usage: scripts/setup-dev.sh [--all-features | --help]" ]] || \
+    fail "--help output changed: $RUN_OUTPUT"
 
 new_case invalid-argument
 run_setup --everything
 [[ $RUN_STATUS -eq 2 ]] || fail "unknown argument returned $RUN_STATUS instead of 2"
-assert_contains "$RUN_OUTPUT" "Usage: scripts/setup-dev.sh [--all-features]"
+assert_contains "$RUN_OUTPUT" "Usage: scripts/setup-dev.sh [--all-features | --help]"
 
 echo "setup-dev tests passed"


### PR DESCRIPTION
## What this changes

Adds an idempotent `scripts/setup-dev.sh --all-features` mode for the native Aeron and ZeroMQ toolchain while preserving the existing protoc-only default. It supports apt, dnf, pacman, and Homebrew, including a checked CMake >= 3.30 fallback.

## Why

Closes #940. Contributors should not have to discover the all-features native dependencies after a long build fails at CMake or link time.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` and `cargo lint-all` (no Rust changed; clean-container all-features build used instead)
- [ ] `cargo test -p wingfoil --all-features` (no Rust changed; shell regression and build used instead)
- [ ] New behaviour is covered by a test asserting **values and tick times** (not applicable to a setup script)
- `scripts/test-setup-dev.sh`
- ShellCheck (stable) on both shell scripts
- actionlint v1.7.12 on the updated workflow
- Clean Ubuntu 24.04: ran the setup twice, then `cargo build --locked -p wingfoil --all-features`

## Notes for the reviewer

The all-features package set also includes ZeroMQ/pkg-config and OpenSSL headers because the real clean-container build requires them. The pinned Kitware installers are SHA-256 verified before elevation; dnf enables EPEL only when `libbsd-devel` is unavailable.

## Before you submit

- [x] **Allow edits by maintainers** is ticked