### PR TITLE
docs(core): document final-cycle flush contract

### DIFF
--- a/crates/wingfoil/tests/catalog.rs
+++ b/crates/wingfoil/tests/catalog.rs
@@ -514,11 +514,18 @@ fn zero_length_window_flushes_every_cycle_rather_than_hanging() {
 fn buffer_flushes_by_capacity() {
     let g = GraphBuilder::new();
     let count = g.ticker(Duration::from_nanos(10)).count(); // 1..=7
-    let acc = count.buffer(3).accumulate();
+    let acc = count.buffer(3).with_time().accumulate();
     let mut r = g.build();
     r.run(HISTORICAL, RunFor::Cycles(7)).unwrap();
-    // [1,2,3], [4,5,6], then the final partial [7] on the last cycle.
-    assert_eq!(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7]], r.value(&acc));
+    assert_eq!(
+        vec![
+            (NanoTime::new(20), vec![1, 2, 3]),
+            (NanoTime::new(50), vec![4, 5, 6]),
+            // Final partial buffer, emitted on the last cycle rather than lost.
+            (NanoTime::new(60), vec![7]),
+        ],
+        r.value(&acc)
+    );
 }
 
 /// `join3` (trimap) combines three streams — mirrors legacy

--- a/crates/wingfoil/tests/nested_islands.rs
+++ b/crates/wingfoil/tests/nested_islands.rs
@@ -75,6 +75,38 @@ fn island_delay_schedules_through_outer_kernel() {
 }
 
 wingfoil::nitro! {
+    fn buffered(g: &GraphBuilder, src: &Stream<u64>) -> Stream<Vec<u64>> {
+        let out = src.buffer(3);
+        out
+    }
+}
+
+/// The outer runner's final-cycle signal flushes a flat partial buffer, but it
+/// is deliberately not propagated into an island. The island therefore emits
+/// only its capacity-sized buffer and retains the final two values when the
+/// outer run stops.
+#[test]
+fn outer_last_cycle_does_not_flush_buffer_inside_island() {
+    let g = GraphBuilder::new();
+    let count = g.ticker(Duration::from_nanos(10)).count();
+
+    let island = buffered::nested(&g, &count).with_time().accumulate();
+    let flat = count.buffer(3).with_time().accumulate();
+
+    let mut r = g.build();
+    r.run(HISTORICAL, RunFor::Cycles(5)).unwrap();
+
+    assert_eq!(vec![(NanoTime::new(20), vec![1, 2, 3])], r.value(&island));
+    assert_eq!(
+        vec![
+            (NanoTime::new(20), vec![1, 2, 3]),
+            (NanoTime::new(40), vec![4, 5]),
+        ],
+        r.value(&flat)
+    );
+}
+
+wingfoil::nitro! {
     fn pulse(g: &GraphBuilder) -> Stream<u64> {
         let count = g.ticker(Duration::from_nanos(50)).count();
         let scaled = count.map(|i| i * 10);

--- a/docs/adding-an-op.md
+++ b/docs/adding-an-op.md
@@ -50,6 +50,21 @@ Per node, in this order, no exceptions:
 4. write the tests as parity tests — values **and** tick times. If a legacy
    node is the twin, its unit tests are the oracle.
 
+## Flush pending state on the final cycle
+
+If an op holds pending state that represents a value the user would otherwise
+never receive, flush it when [`Ctx::is_last_cycle()`](../crates/wingfoil/src/op.rs)
+is true. `Window` and `Buffer` in `crates/wingfoil/src/ops.rs` are the worked
+examples: each emits a final partial collection instead of silently dropping it
+when a bounded run ends between its normal boundaries.
+
+The flag deliberately does **not** propagate into a `nested()` island.
+`Ctx::nested` reports `is_last_cycle: false` because the island owns its inner
+schedule, so an op inside one flushes only on its own boundary or capacity —
+never merely because the outer run has reached its final cycle. Pin both the
+ordinary final flush and this island limitation with bounded historical tests,
+including exact tick times.
+
 ## Why there is any per-op cost at all
 
 Two mechanisms single-source most of the boilerplate; the residual per-op cost


### PR DESCRIPTION
## What this changes

Documents the final-cycle flush contract for ops that retain pending state, including the nested-island limitation. It also strengthens the existing Buffer test with exact tick times and adds a nested Buffer regression test.

## Why

Closes #927. Op authors need one discoverable rule for pending values at bounded-run shutdown, plus the island exception that can otherwise silently drop a value.

## How it was verified

- [x] `cargo fmt --all`
- [ ] `cargo lint` and `cargo lint-all` (`cargo lint` passes; `cargo lint-all` is blocked on this Windows host because `iceoryx2` bindgen cannot find `libclang`)
- [ ] `cargo test -p wingfoil --all-features` (the complete default-feature package suite passes; all-features has the same native-toolchain boundary)
- [x] New behaviour is covered by a test asserting **values and tick times**
- `cargo test --locked -p wingfoil`
- `cargo test --locked -p wingfoil-derive`

## Notes for the reviewer

An existing Buffer test already covered the final partial batch, so this change strengthens it with exact tick times. I kept the flush rule out of the touch-point table because it is a runtime semantic and testing obligation, not a new op shape.

## Before you submit

- [x] **Allow edits by maintainers** is ticked
