### PR TITLE
docs(core): demonstrate multi-input tick semantics

### DIFF
--- a/crates/wingfoil/src/fluent.rs
+++ b/crates/wingfoil/src/fluent.rs
@@ -1046,6 +1046,25 @@ pub trait StreamOps<T>: Sized {
         T: Clone + Default + 'static;
 
     /// Combine with another stream; ticks when either input ticks.
+    ///
+    /// Compare the same inputs under [`join_passive`](StreamOps::join_passive):
+    /// here the fast input also triggers output, reading the slow held value.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use wingfoil::prelude::*;
+    /// use wingfoil::{NanoTime, RunFor, RunMode};
+    /// let g = GraphBuilder::new();
+    /// let slow = g.ticker(Duration::from_nanos(20)).count();
+    /// let fast = g.ticker(Duration::from_nanos(10)).count();
+    /// let joined = slow.join(&fast, |s, f| (*s, *f)).with_time().accumulate();
+    /// let mut r = g.build();
+    /// r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(4)).unwrap();
+    /// assert_eq!(r.value(&joined), vec![
+    ///     (NanoTime::new(0), (1, 1)), (NanoTime::new(10), (1, 2)),
+    ///     (NanoTime::new(20), (2, 3)), (NanoTime::new(30), (2, 4)),
+    /// ]);
+    /// ```
     #[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
     fn join<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
     where
@@ -1056,6 +1075,25 @@ pub trait StreamOps<T>: Sized {
     /// Combine with another stream read *passively*: this stream triggers the
     /// combine, `other`'s current value is read but does not trigger — the
     /// `bimap(Active, Passive)` shape a feedback input takes.
+    ///
+    /// Unlike [`join`](StreamOps::join) on these same inputs, the fast ticks
+    /// at 10ns and 30ns do not emit. At 20ns both tick, so the fresh fast value
+    /// is read rather than its previous value.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use wingfoil::prelude::*;
+    /// use wingfoil::{NanoTime, RunFor, RunMode};
+    /// let g = GraphBuilder::new();
+    /// let slow = g.ticker(Duration::from_nanos(20)).count();
+    /// let fast = g.ticker(Duration::from_nanos(10)).count();
+    /// let joined = slow.join_passive(&fast, |s, f| (*s, *f)).with_time().accumulate();
+    /// let mut r = g.build();
+    /// r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(4)).unwrap();
+    /// assert_eq!(r.value(&joined), vec![
+    ///     (NanoTime::new(0), (1, 1)), (NanoTime::new(20), (2, 3)),
+    /// ]);
+    /// ```
     #[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
     fn join_passive<B, C, F>(&self, other: &Stream<B>, f: F) -> Stream<C>
     where
@@ -1110,6 +1148,25 @@ pub trait StreamOps<T>: Sized {
     /// Gates on a *stream*. When the test is a pure function of this stream's
     /// own value, [`filter_value`](StreamOps::filter_value) says it in one
     /// node and without a second stream.
+    ///
+    /// The true condition cannot emit before the first source tick. At 30ns
+    /// the source ticks while the condition is false; at 40ns the condition
+    /// alone ticks true and emits that held value.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use wingfoil::prelude::*;
+    /// use wingfoil::{NanoTime, RunFor, RunMode};
+    /// let g = GraphBuilder::new();
+    /// let source = g.ticker(Duration::from_nanos(30)).count().skip(1);
+    /// let condition = g.ticker(Duration::from_nanos(10)).count().map(|n| n % 2 == 1);
+    /// let filtered = source.filter(&condition).with_time().accumulate();
+    /// let mut r = g.build();
+    /// r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(7)).unwrap();
+    /// assert_eq!(r.value(&filtered), vec![
+    ///     (NanoTime::new(40), 2), (NanoTime::new(60), 3),
+    /// ]);
+    /// ```
     #[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
     fn filter(&self, condition: &Stream<bool>) -> Stream<T>
     where
@@ -1137,6 +1194,25 @@ pub trait StreamOps<T>: Sized {
         F: Fn(&T) -> bool + 'static;
 
     /// Emit the current value whenever `trigger` ticks (passive read).
+    ///
+    /// The trigger does not wait for the source's first tick: here it reads
+    /// the initial zero. Source-only ticks at 20ns and 40ns do not emit;
+    /// when both tick at 60ns, the trigger reads the fresh source value.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use wingfoil::prelude::*;
+    /// use wingfoil::{NanoTime, RunFor, RunMode};
+    /// let g = GraphBuilder::new();
+    /// let source = g.ticker(Duration::from_nanos(20)).count().skip(1);
+    /// let trigger = g.ticker(Duration::from_nanos(30));
+    /// let sampled = source.sample(&trigger).with_time().accumulate();
+    /// let mut r = g.build();
+    /// r.run(RunMode::HistoricalFrom(NanoTime::ZERO), RunFor::Cycles(5)).unwrap();
+    /// assert_eq!(r.value(&sampled), vec![
+    ///     (NanoTime::new(0), 0), (NanoTime::new(30), 2), (NanoTime::new(60), 4),
+    /// ]);
+    /// ```
     #[must_use = "a dropped stream stays wired and cycles every tick, producing an unread value"]
     fn sample(&self, trigger: &Stream<()>) -> Stream<T>
     where


### PR DESCRIPTION
## What this changes

Adds four runnable rustdoc examples for `StreamOps::join`, `join_passive`,
`sample`, and `filter`. Each is a small historical graph with exact output
values and tick-time assertions. There are no runtime or dependency changes.

## Why

Partially addresses #937. The join pair uses identical inputs to show which
ticks trigger output. The sample and filter examples distinguish passive
sampling (including a read before the source first ticks) from a condition
stream that resamples a held value only after the source has ticked.

The examples also assert that a same-cycle read sees the newly updated input.
This turns the scheduling contract into copyable examples checked by rustdoc,
rather than leaving readers to infer it from the prose.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [x] `cargo lint` and `cargo lint-all`
- [x] `cargo test --locked --doc -p wingfoil --all-features`: 23 passed,
  including all four new examples; the remaining examples retain their existing
  ignore markers.
- [x] `cargo test --locked -p wingfoil --test catalog --test catalog_filter_value_scan --test engine_semantics`:
  52 passed.
- [x] `cargo test --locked -p wingfoil-derive`: 3 passed.

Local checks ran in Ubuntu 24.04 with Rust 1.98.0. A broader default-feature
`cargo test -p wingfoil` hit the unchanged
`latency::stamp_all_takes_one_clock_read_per_stage_when_precise` assertion
(successive clock reads can be equal on this Docker Desktop host). The same
latency suite fails on unmodified `main` here, while the single test passes in
isolation. No runtime code or test expectation was changed to hide it.

The repository's official [fork CI run](https://github.com/maxi-maxima/wingfoil/actions/runs/33829679344)
passed on this exact commit: all-feature nextest (excluding live integration
binaries per repository policy), derive tests, doctests, fmt, and Clippy.

## Notes for the reviewer

This is the four-method slice claimed on the issue. `join3`, the three fallible
join variants, and `merge`/`merge_all` remain outside this PR, so #937 should stay
open. Each new runnable fence is 13 lines and uses only the public API.

## Before you submit

- [x] **Allow edits by maintainers** is ticked
