### PR TITLE
docs(test): classify start_with in the stateful-ops module doc

### DIFF
--- a/crates/wingfoil/tests/compiled_stateful_ops.rs
+++ b/crates/wingfoil/tests/compiled_stateful_ops.rs
@@ -10,8 +10,8 @@
 //! - `skip` / `skip_while` / `step_by` / `take_while` / `throttle` /
 //!   `start_with` / `audit` / `window` — stateful single-input ops. `throttle`
 //!   and `window` are timer ops (`ACTIVATION::NONE`, they read
-//!   `ctx.time()`/`is_last_cycle()` but never self-schedule); `audit` uses
-//!   `ACTIVATION::SCHEDULES`. `audit` and `window`
+//!   `ctx.time()`/`is_last_cycle()` but never self-schedule); `start_with` and
+//!   `audit` use `ACTIVATION::SCHEDULES`. `start_with`, `audit` and `window`
 //!   also exercise `#[op]`'s `start`-hook forwarding. Tick **times** are
 //!   asserted via `.ticked_at()` or `.with_time()`, and the runs are sized to
 //!   end on a natural flush boundary so `is_last_cycle` is a no-op — that signal is


### PR DESCRIPTION
## What this changes

A two-line doc-comment fix in `crates/wingfoil/tests/compiled_stateful_ops.rs`. Follow-up to #950.

`start_with` was added to the module doc's op list but left out of both classification sentences — which ops use `ACTIVATION::SCHEDULES`, and which exercise `#[op]`'s `start`-hook forwarding. `StartWith` is `SCHEDULES` and overrides `start`, so it belongs in each.

## Why

The module doc is the map for auditing three-engine coverage of this file. As written, a reader checking which ops exercise the `start`-hook forwarding path would skip `start_with`, even though it is one of them.

## How it was verified

- [x] `cargo fmt --all -- --check`
- [x] Comment-only change — no code, no test expectations touched
- [x] Rebased onto `main` after #950 merged, so the diff is exactly the two lines

## Notes for the reviewer

This branch originally carried #950's commits as its base; now that #950 has been squash-merged, it has been rebased onto `main` and force-pushed, leaving only the doc commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sd3uVNgJEBi12vxvCUgDHP