### PR TITLE
ci: run setup-dev.sh in the remaining rust-test jobs

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -95,7 +95,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
+        run: scripts/setup-dev.sh --all-features
 
       - name: Run current-engine tests with coverage
         # Keep the service-backed integration binaries out of this leg: each is
@@ -152,7 +152,7 @@ jobs:
         run: cargo metadata --locked --format-version 1 > /dev/null
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake clang libclang-dev uuid-dev libbsd-dev
+        run: scripts/setup-dev.sh --all-features
 
       - name: Run wingfoil tests
         # This is the fast uninstrumented PR gate. The main-only coverage job


### PR DESCRIPTION
#952 moved the Lint job onto `scripts/setup-dev.sh --all-features` but left
`Coverage (unit)` and `Test (wingfoil)` carrying the literal apt list the
script exists to replace — three copies of the same packages, which is the
drift that issue was about. Both are the identical list with no extras, so
they switch cleanly.

Two consequences beyond removing the duplication. The script's package set is
a superset: it adds `libzmq3-dev`, `libssl-dev` and `pkg-config`, so the `zmq`
feature no longer links against a libzmq that merely happened to be in the
runner image, and it checks CMake against the 3.30 floor the vendored Aeron
sources require rather than assuming the image's version clears it. And the
script now gets exercised by three real jobs instead of one, on every PR.

`python-test.yml` and `crates-publish.yml` still carry copies;
python-test's list differs (patchelf, no cmake), so it is left for a
follow-up.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017Xh9Mfn1SuoD6DyfCDtg5d